### PR TITLE
feat: add interactive settings UI

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ type KeybindingsConfig struct {
 	Palette        string `json:"palette"`
 	Help           string `json:"help"`
 	TmuxHelp       string `json:"tmux_help"`
+	Settings       string `json:"settings"`
 	Quit           string `json:"quit"`
 	QuitKill       string `json:"quit_kill"`
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -46,6 +46,7 @@ func DefaultConfig() Config {
 			Palette:        "ctrl+p",
 			Help:           "?",
 			TmuxHelp:       "H",
+			Settings:       "S",
 			Quit:           "q",
 			QuitKill:       "Q",
 		},

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -464,12 +464,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// --- Settings ---
 	case components.SettingsSaveRequestMsg:
 		newCfg := msg.Config
-		m.cfg = newCfg
 		if err := config.Save(newCfg); err != nil {
 			return m, func() tea.Msg {
 				return ErrorMsg{Err: fmt.Errorf("save settings: %w", err)}
 			}
 		}
+		m.cfg = newCfg
+		m.keys = NewKeyMap(newCfg.Keybindings)
 		return m, func() tea.Msg { return ConfigSavedMsg{Config: newCfg} }
 
 	case components.SettingsClosedMsg:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -50,6 +50,7 @@ type Model struct {
 	confirm     components.Confirm
 	gridView    components.GridView
 	orphanPicker components.OrphanPicker
+	settings    components.SettingsView
 	nameInput   textinput.Model // for project name / directory input
 	// UI sub-states
 	inputMode           string // "project-name", "project-dir", "new-session", "worktree-branch", ""
@@ -98,6 +99,7 @@ func New(cfg config.Config, appState state.AppState) Model {
 		titleEditor:      components.NewTitleEditor(),
 		agentPicker:      components.NewAgentPicker(),
 		teamBuilder:      components.NewTeamBuilder(),
+		settings:         components.NewSettingsView(),
 		orphanPicker:     components.NewOrphanPicker(appState.OrphanSessions),
 		nameInput:        ni,
 		contentSnapshots: make(map[string]string),
@@ -459,6 +461,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.killAllSessions()
 		return m, tea.Quit
 
+	// --- Settings ---
+	case components.SettingsSaveRequestMsg:
+		newCfg := msg.Config
+		m.cfg = newCfg
+		if err := config.Save(newCfg); err != nil {
+			return m, func() tea.Msg {
+				return ErrorMsg{Err: fmt.Errorf("save settings: %w", err)}
+			}
+		}
+		return m, func() tea.Msg { return ConfigSavedMsg{Config: newCfg} }
+
+	case components.SettingsClosedMsg:
+		m.settings.Close()
+
+	case ConfigSavedMsg:
+		m.appState.LastError = "" // clear any previous error
+
 	// --- Key events ---
 	case tea.KeyMsg:
 		return m.handleKey(msg)
@@ -468,6 +487,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the full UI.
 func (m Model) View() string {
+	// Settings screen fills the full terminal.
+	if m.settings.Active {
+		m.settings.Width = m.appState.TermWidth
+		m.settings.Height = m.appState.TermHeight
+		return m.settings.View()
+	}
 	// Grid overview fills the full terminal.
 	if m.gridView.Active {
 		m.gridView.Width = m.appState.TermWidth
@@ -597,7 +622,13 @@ func (m Model) View() string {
 
 // --- Key handler ---
 
+// handleKey handles keyboard events.
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Settings screen consumes all keys while active.
+	if m.settings.Active {
+		cmd, _ := m.settings.Update(msg)
+		return m, cmd
+	}
 	// Grid overview consumes all keys while active.
 	if m.gridView.Active {
 		m.gridView.Width = m.appState.TermWidth
@@ -681,6 +712,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Help):
 		m.appState.ShowHelp = !m.appState.ShowHelp
 		m.appState.ShowTmuxHelp = false
+		return m, nil
+
+	case key.Matches(msg, m.keys.Settings):
+		m.settings.Width = m.appState.TermWidth
+		m.settings.Height = m.appState.TermHeight
+		m.settings.Open(m.cfg)
 		return m, nil
 
 	case key.Matches(msg, m.keys.TmuxHelp):
@@ -1907,6 +1944,7 @@ func (m Model) helpView() string {
 		{"ctrl+p", "command palette"},
 		{"g", "grid overview (all sessions)"},
 		{"1-9", "jump to project by number"},
+		{"S", "open settings"},
 		{"?", "toggle this help"},
 		{"H", "tmux shortcuts reference"},
 		{"q", "quit (sessions persist in tmux)"},

--- a/internal/tui/components/settings.go
+++ b/internal/tui/components/settings.go
@@ -1,7 +1,6 @@
 package components
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -9,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/lucascaro/hive/internal/config"
 	"github.com/lucascaro/hive/internal/tui/styles"
 )
@@ -61,6 +61,7 @@ type SettingsView struct {
 
 	cursor       int // index into fieldIdxs
 	scrollOffset int // lines to skip from top
+	dirty        bool // true when cfg differs from original
 
 	editing        bool
 	editInput      textinput.Model
@@ -84,6 +85,7 @@ func (sv *SettingsView) Open(cfg config.Config) {
 	sv.original = cfg
 	sv.cursor = 0
 	sv.scrollOffset = 0
+	sv.dirty = false
 	sv.editing = false
 	sv.editErr = ""
 	sv.pendingDiscard = false
@@ -98,14 +100,11 @@ func (sv *SettingsView) Close() {
 	sv.editInput.Blur()
 	sv.pendingDiscard = false
 	sv.pendingSave = false
+	sv.dirty = false
 }
 
 // IsDirty returns true if any setting has been changed from the original.
-func (sv *SettingsView) IsDirty() bool {
-	a, _ := json.Marshal(sv.cfg)
-	b, _ := json.Marshal(sv.original)
-	return string(a) != string(b)
-}
+func (sv *SettingsView) IsDirty() bool { return sv.dirty }
 
 // GetConfig returns the current (possibly modified) working config.
 func (sv *SettingsView) GetConfig() config.Config { return sv.cfg }
@@ -183,6 +182,7 @@ func (sv *SettingsView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 			} else {
 				_ = f.set(&sv.cfg, "true")
 			}
+			sv.dirty = true
 		case fieldSelect:
 			cur := f.get(sv.cfg)
 			matched := false
@@ -196,6 +196,7 @@ func (sv *SettingsView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 			if !matched && len(f.options) > 0 {
 				_ = f.set(&sv.cfg, f.options[0])
 			}
+			sv.dirty = true
 		case fieldString, fieldInt:
 			sv.startEditing(f)
 		}
@@ -214,6 +215,7 @@ func (sv *SettingsView) handleEditKey(msg tea.KeyMsg) (tea.Cmd, bool) {
 				sv.editErr = err.Error()
 				return nil, true
 			}
+			sv.dirty = true
 		}
 		sv.editing = false
 		sv.editInput.Blur()
@@ -254,19 +256,20 @@ func (sv *SettingsView) View() string {
 	}
 	innerW := w - 4
 
-	// Header bar
+	// Header bar — truncate to avoid wrapping on narrow terminals.
 	configPath := styles.MutedStyle.Render(config.ConfigPath())
+	rawHeader := styles.TitleStyle.Render("⚙  Settings") + "  " + configPath
 	header := lipgloss.NewStyle().
 		Background(lipgloss.Color("#1F2937")).
 		Width(w).
 		Padding(0, 1).
-		Render(styles.TitleStyle.Render("⚙  Settings") + "  " + configPath)
+		Render(ansi.Truncate(rawHeader, w-2, "…"))
 
-	// Footer hints
+	// Footer hints — build content then truncate before styling.
 	var footerParts []string
 	if sv.pendingSave {
 		footerParts = []string{
-			lipgloss.NewStyle().Foreground(styles.ColorWarning).Bold(true).Render("Save changes to " + config.ConfigPath() + "?"),
+			lipgloss.NewStyle().Foreground(styles.ColorWarning).Bold(true).Render("Save to " + config.ConfigPath() + "?"),
 			styles.HelpKeyStyle.Render("y/enter") + ":" + styles.HelpDescStyle.Render("confirm"),
 			styles.HelpKeyStyle.Render("any other key") + ":" + styles.HelpDescStyle.Render("cancel"),
 		}
@@ -301,7 +304,7 @@ func (sv *SettingsView) View() string {
 			}()),
 		)
 	}
-	footer := styles.StatusBarStyle.Width(w).Render(strings.Join(footerParts, "  "))
+	footer := styles.StatusBarStyle.Width(w).Render(ansi.Truncate(strings.Join(footerParts, "  "), w, "…"))
 
 	// Content area height (header=1 line + footer=1 line)
 	contentH := h - 2
@@ -385,10 +388,12 @@ func (sv *SettingsView) renderLines(innerW int, anchorLine *int) []string {
 		}
 		label := prefix + f.label
 
-		// Use fixed widths: label fills left, value aligns right
-		valW := lipgloss.Width(valDisplay)
+		// Use fixed widths: label fills left, value aligns right.
+		// Truncate valDisplay to at most innerW-4 visible chars to prevent wrapping.
+		valW := ansi.StringWidth(valDisplay)
 		if valW > innerW-4 {
 			valW = innerW - 4
+			valDisplay = ansi.Truncate(valDisplay, valW, "…")
 		}
 		labelW := innerW - valW - 1
 		if labelW < 0 {
@@ -421,7 +426,9 @@ func (sv *SettingsView) renderLines(innerW int, anchorLine *int) []string {
 				switch f.kind {
 				case fieldSelect:
 					optsStr := strings.Join(f.options, " · ")
-					lines = append(lines, styles.MutedStyle.Render("    Options: "+optsStr))
+					for _, oline := range wrapText("Options: "+optsStr, innerW-4) {
+						lines = append(lines, styles.MutedStyle.Render("    "+oline))
+					}
 				case fieldBool:
 					lines = append(lines, styles.MutedStyle.Render("    [enter/space] to toggle"))
 				case fieldString, fieldInt:
@@ -650,6 +657,10 @@ func buildSettingEntries() []settingEntry {
 
 		// ── Keybindings ───────────────────────────────────────────────────────
 		{isHeader: true, header: "  Keybindings"},
+		{field: keybindField("Toggle Collapse", "Collapse or expand the selected project in the sidebar.", func(c config.Config) string { return c.Keybindings.ToggleCollapse }, func(c *config.Config, v string) { c.Keybindings.ToggleCollapse = v })},
+		{field: keybindField("Focus Preview", "Move focus to the preview pane.", func(c config.Config) string { return c.Keybindings.FocusPreview }, func(c *config.Config, v string) { c.Keybindings.FocusPreview = v })},
+		{field: keybindField("Focus Sidebar", "Move focus back to the sidebar.", func(c config.Config) string { return c.Keybindings.FocusSidebar }, func(c *config.Config, v string) { c.Keybindings.FocusSidebar = v })},
+		{field: keybindField("Jump to Project 1", "Jump directly to the first project (repeatable pattern for 2–9).", func(c config.Config) string { return c.Keybindings.JumpProject1 }, func(c *config.Config, v string) { c.Keybindings.JumpProject1 = v })},
 		{field: keybindField("New Project", "Create a new project.", func(c config.Config) string { return c.Keybindings.NewProject }, func(c *config.Config, v string) { c.Keybindings.NewProject = v })},
 		{field: keybindField("New Session", "Open the agent picker to start a new session.", func(c config.Config) string { return c.Keybindings.NewSession }, func(c *config.Config, v string) { c.Keybindings.NewSession = v })},
 		{field: keybindField("New Team", "Open the team builder wizard.", func(c config.Config) string { return c.Keybindings.NewTeam }, func(c *config.Config, v string) { c.Keybindings.NewTeam = v })},
@@ -669,6 +680,7 @@ func buildSettingEntries() []settingEntry {
 		{field: keybindField("Tmux Help", "Toggle the tmux shortcuts reference.", func(c config.Config) string { return c.Keybindings.TmuxHelp }, func(c *config.Config, v string) { c.Keybindings.TmuxHelp = v })},
 		{field: keybindField("Quit", "Quit hive (sessions keep running in tmux).", func(c config.Config) string { return c.Keybindings.Quit }, func(c *config.Config, v string) { c.Keybindings.Quit = v })},
 		{field: keybindField("Quit and Kill All", "Quit and terminate all managed sessions.", func(c config.Config) string { return c.Keybindings.QuitKill }, func(c *config.Config, v string) { c.Keybindings.QuitKill = v })},
+		{field: keybindField("Open Settings", "Open this settings screen.", func(c config.Config) string { return c.Keybindings.Settings }, func(c *config.Config, v string) { c.Keybindings.Settings = v })},
 	}
 }
 

--- a/internal/tui/components/settings.go
+++ b/internal/tui/components/settings.go
@@ -1,0 +1,691 @@
+package components
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/lucascaro/hive/internal/config"
+	"github.com/lucascaro/hive/internal/tui/styles"
+)
+
+// SettingsSaveRequestMsg is sent when the user confirms they want to save settings.
+type SettingsSaveRequestMsg struct {
+	Config config.Config
+}
+
+// SettingsClosedMsg is sent when the settings screen is closed.
+type SettingsClosedMsg struct{}
+
+type fieldKind int
+
+const (
+	fieldBool   fieldKind = iota
+	fieldString fieldKind = iota
+	fieldInt    fieldKind = iota
+	fieldSelect fieldKind = iota
+)
+
+// settingField describes a single editable setting.
+type settingField struct {
+	label       string
+	description string
+	kind        fieldKind
+	options     []string // for fieldSelect
+	get         func(config.Config) string
+	set         func(*config.Config, string) error
+}
+
+// settingEntry is either a non-selectable category header or a selectable field.
+type settingEntry struct {
+	isHeader bool
+	header   string
+	field    *settingField
+}
+
+// SettingsView is a full-screen interactive settings overlay.
+type SettingsView struct {
+	Active  bool
+	Width   int
+	Height  int
+
+	cfg      config.Config
+	original config.Config
+
+	entries   []settingEntry
+	fieldIdxs []int // indices of non-header entries within entries
+
+	cursor       int // index into fieldIdxs
+	scrollOffset int // lines to skip from top
+
+	editing        bool
+	editInput      textinput.Model
+	editErr        string
+	pendingDiscard bool // true after first esc with dirty state
+	pendingSave    bool // true when waiting for save confirmation
+}
+
+// NewSettingsView creates a SettingsView.
+func NewSettingsView() SettingsView {
+	ti := textinput.New()
+	ti.CharLimit = 256
+	ti.Width = 46
+	return SettingsView{editInput: ti}
+}
+
+// Open activates the settings view with a copy of the given config.
+func (sv *SettingsView) Open(cfg config.Config) {
+	sv.Active = true
+	sv.cfg = cfg
+	sv.original = cfg
+	sv.cursor = 0
+	sv.scrollOffset = 0
+	sv.editing = false
+	sv.editErr = ""
+	sv.pendingDiscard = false
+	sv.entries = buildSettingEntries()
+	sv.rebuildFieldIdxs()
+}
+
+// Close deactivates the settings view.
+func (sv *SettingsView) Close() {
+	sv.Active = false
+	sv.editing = false
+	sv.editInput.Blur()
+	sv.pendingDiscard = false
+	sv.pendingSave = false
+}
+
+// IsDirty returns true if any setting has been changed from the original.
+func (sv *SettingsView) IsDirty() bool {
+	a, _ := json.Marshal(sv.cfg)
+	b, _ := json.Marshal(sv.original)
+	return string(a) != string(b)
+}
+
+// GetConfig returns the current (possibly modified) working config.
+func (sv *SettingsView) GetConfig() config.Config { return sv.cfg }
+
+// Update handles key messages. Returns (cmd, consumed).
+func (sv *SettingsView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
+	if !sv.Active {
+		return nil, false
+	}
+
+	if sv.editing {
+		return sv.handleEditKey(msg)
+	}
+
+	// Handle pending save confirmation inline (no app-level overlay needed).
+	if sv.pendingSave {
+		switch msg.String() {
+		case "y", "enter":
+			sv.pendingSave = false
+			cfg := sv.cfg
+			sv.Close()
+			return func() tea.Msg { return SettingsSaveRequestMsg{Config: cfg} }, true
+		default:
+			sv.pendingSave = false
+		}
+		return nil, true
+	}
+
+	// Any key other than esc clears the pending-discard warning.
+	if msg.String() != "esc" {
+		sv.pendingDiscard = false
+	}
+
+	switch msg.String() {
+	case "esc":
+		if sv.IsDirty() {
+			if sv.pendingDiscard {
+				sv.Close()
+				return func() tea.Msg { return SettingsClosedMsg{} }, true
+			}
+			sv.pendingDiscard = true
+			return nil, true
+		}
+		sv.Close()
+		return func() tea.Msg { return SettingsClosedMsg{} }, true
+
+	case "s":
+		if !sv.IsDirty() {
+			sv.Close()
+			return func() tea.Msg { return SettingsClosedMsg{} }, true
+		}
+		sv.pendingSave = true
+		return nil, true
+
+	case "j", "down":
+		if sv.cursor < len(sv.fieldIdxs)-1 {
+			sv.cursor++
+		}
+
+	case "k", "up":
+		if sv.cursor > 0 {
+			sv.cursor--
+		}
+
+	case "enter", " ":
+		f := sv.selectedField()
+		if f == nil {
+			break
+		}
+		switch f.kind {
+		case fieldBool:
+			cur := f.get(sv.cfg)
+			if cur == "true" {
+				_ = f.set(&sv.cfg, "false")
+			} else {
+				_ = f.set(&sv.cfg, "true")
+			}
+		case fieldSelect:
+			cur := f.get(sv.cfg)
+			matched := false
+			for i, opt := range f.options {
+				if opt == cur {
+					_ = f.set(&sv.cfg, f.options[(i+1)%len(f.options)])
+					matched = true
+					break
+				}
+			}
+			if !matched && len(f.options) > 0 {
+				_ = f.set(&sv.cfg, f.options[0])
+			}
+		case fieldString, fieldInt:
+			sv.startEditing(f)
+		}
+	}
+
+	return nil, true
+}
+
+func (sv *SettingsView) handleEditKey(msg tea.KeyMsg) (tea.Cmd, bool) {
+	switch msg.String() {
+	case "enter":
+		val := sv.editInput.Value()
+		f := sv.selectedField()
+		if f != nil {
+			if err := f.set(&sv.cfg, val); err != nil {
+				sv.editErr = err.Error()
+				return nil, true
+			}
+		}
+		sv.editing = false
+		sv.editInput.Blur()
+		sv.editErr = ""
+		return nil, true
+	case "esc":
+		sv.editing = false
+		sv.editInput.Blur()
+		sv.editErr = ""
+		return nil, true
+	}
+	var cmd tea.Cmd
+	sv.editInput, cmd = sv.editInput.Update(msg)
+	return cmd, true
+}
+
+func (sv *SettingsView) startEditing(f *settingField) {
+	sv.editing = true
+	sv.editErr = ""
+	sv.editInput.SetValue(f.get(sv.cfg))
+	sv.editInput.CursorEnd()
+	sv.editInput.Focus()
+}
+
+// View renders the full-screen settings panel.
+func (sv *SettingsView) View() string {
+	if !sv.Active {
+		return ""
+	}
+
+	w := sv.Width
+	h := sv.Height
+	if w <= 0 {
+		w = 80
+	}
+	if h <= 0 {
+		h = 24
+	}
+	innerW := w - 4
+
+	// Header bar
+	configPath := styles.MutedStyle.Render(config.ConfigPath())
+	header := lipgloss.NewStyle().
+		Background(lipgloss.Color("#1F2937")).
+		Width(w).
+		Padding(0, 1).
+		Render(styles.TitleStyle.Render("⚙  Settings") + "  " + configPath)
+
+	// Footer hints
+	var footerParts []string
+	if sv.pendingSave {
+		footerParts = []string{
+			lipgloss.NewStyle().Foreground(styles.ColorWarning).Bold(true).Render("Save changes to " + config.ConfigPath() + "?"),
+			styles.HelpKeyStyle.Render("y/enter") + ":" + styles.HelpDescStyle.Render("confirm"),
+			styles.HelpKeyStyle.Render("any other key") + ":" + styles.HelpDescStyle.Render("cancel"),
+		}
+	} else if sv.pendingDiscard {
+		footerParts = []string{
+			styles.ErrorStyle.Render("Unsaved changes! Press"),
+			styles.HelpKeyStyle.Render("esc"),
+			styles.ErrorStyle.Render("again to discard, or"),
+			styles.HelpKeyStyle.Render("s"),
+			styles.ErrorStyle.Render("to save"),
+		}
+	} else {
+		if sv.IsDirty() {
+			footerParts = append(footerParts,
+				lipgloss.NewStyle().Foreground(styles.ColorWarning).Render("● unsaved  "),
+			)
+		}
+		footerParts = append(footerParts,
+			hint("j/k", "navigate"),
+			hint("enter/space", "edit/toggle"),
+			hint("s", func() string {
+				if sv.IsDirty() {
+					return "save"
+				}
+				return "close"
+			}()),
+			hint("esc", func() string {
+				if sv.IsDirty() {
+					return "discard (×2)"
+				}
+				return "close"
+			}()),
+		)
+	}
+	footer := styles.StatusBarStyle.Width(w).Render(strings.Join(footerParts, "  "))
+
+	// Content area height (header=1 line + footer=1 line)
+	contentH := h - 2
+	if contentH < 1 {
+		contentH = 1
+	}
+
+	// Render all entry lines and track anchor for scrolling.
+	anchorLine := 0
+	lines := sv.renderLines(innerW, &anchorLine)
+
+	// Scroll so the selected entry is always visible.
+	// The selected block can be up to ~4 lines tall; keep it fully visible.
+	const selectedBlockMaxH = 5
+	if anchorLine < sv.scrollOffset {
+		sv.scrollOffset = anchorLine
+	}
+	if anchorLine+selectedBlockMaxH > sv.scrollOffset+contentH {
+		sv.scrollOffset = anchorLine + selectedBlockMaxH - contentH
+	}
+	if sv.scrollOffset < 0 {
+		sv.scrollOffset = 0
+	}
+	maxOff := len(lines) - contentH
+	if maxOff < 0 {
+		maxOff = 0
+	}
+	if sv.scrollOffset > maxOff {
+		sv.scrollOffset = maxOff
+	}
+
+	// Window into lines.
+	start := sv.scrollOffset
+	end := start + contentH
+	if end > len(lines) {
+		end = len(lines)
+	}
+	visible := lines[start:end]
+	for len(visible) < contentH {
+		visible = append(visible, strings.Repeat(" ", innerW))
+	}
+
+	body := lipgloss.NewStyle().
+		Background(styles.ColorBg).
+		Width(w).
+		Height(contentH).
+		Padding(0, 2).
+		Render(strings.Join(visible, "\n"))
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+}
+
+// renderLines produces a flat []string of display lines and sets *anchorLine
+// to the line index where the currently selected field begins.
+func (sv *SettingsView) renderLines(innerW int, anchorLine *int) []string {
+	var lines []string
+	selectedEntryIdx := sv.selectedEntryIdx()
+
+	for entryIdx, entry := range sv.entries {
+		if entry.isHeader {
+			lines = append(lines, "")
+			lines = append(lines, styles.TitleStyle.Render(entry.header))
+			lines = append(lines, styles.MutedStyle.Render(strings.Repeat("─", innerW)))
+			continue
+		}
+
+		if entryIdx == selectedEntryIdx {
+			*anchorLine = len(lines)
+		}
+
+		f := entry.field
+		isSelected := entryIdx == selectedEntryIdx
+
+		// Build label + value row
+		val := f.get(sv.cfg)
+		valDisplay := renderFieldValue(f, val)
+
+		prefix := "  "
+		if isSelected {
+			prefix = styles.HelpKeyStyle.Render("▶ ")
+		}
+		label := prefix + f.label
+
+		// Use fixed widths: label fills left, value aligns right
+		valW := lipgloss.Width(valDisplay)
+		if valW > innerW-4 {
+			valW = innerW - 4
+		}
+		labelW := innerW - valW - 1
+		if labelW < 0 {
+			labelW = 0
+		}
+
+		row := lipgloss.JoinHorizontal(
+			lipgloss.Left,
+			lipgloss.NewStyle().Width(labelW).Render(label),
+			valDisplay,
+		)
+		if isSelected {
+			row = lipgloss.NewStyle().Background(styles.ColorSelected).Width(innerW).Render(row)
+		}
+		lines = append(lines, row)
+
+		if isSelected {
+			if sv.editing {
+				lines = append(lines, "    "+sv.editInput.View())
+				if sv.editErr != "" {
+					lines = append(lines, "    "+styles.ErrorStyle.Render("⚠ "+sv.editErr))
+				}
+			} else {
+				if f.description != "" {
+					// Word-wrap description to innerW-4
+					for _, dline := range wrapText(f.description, innerW-4) {
+						lines = append(lines, styles.MutedStyle.Render("    "+dline))
+					}
+				}
+				switch f.kind {
+				case fieldSelect:
+					optsStr := strings.Join(f.options, " · ")
+					lines = append(lines, styles.MutedStyle.Render("    Options: "+optsStr))
+				case fieldBool:
+					lines = append(lines, styles.MutedStyle.Render("    [enter/space] to toggle"))
+				case fieldString, fieldInt:
+					lines = append(lines, styles.MutedStyle.Render("    [enter] to edit"))
+				}
+			}
+		}
+
+		lines = append(lines, "") // spacer between fields
+	}
+
+	return lines
+}
+
+// --- Helpers ---
+
+func (sv *SettingsView) rebuildFieldIdxs() {
+	sv.fieldIdxs = nil
+	for i, e := range sv.entries {
+		if !e.isHeader {
+			sv.fieldIdxs = append(sv.fieldIdxs, i)
+		}
+	}
+}
+
+func (sv *SettingsView) selectedEntryIdx() int {
+	if len(sv.fieldIdxs) == 0 {
+		return -1
+	}
+	if sv.cursor >= len(sv.fieldIdxs) {
+		sv.cursor = len(sv.fieldIdxs) - 1
+	}
+	return sv.fieldIdxs[sv.cursor]
+}
+
+func (sv *SettingsView) selectedField() *settingField {
+	idx := sv.selectedEntryIdx()
+	if idx < 0 {
+		return nil
+	}
+	return sv.entries[idx].field
+}
+
+func renderFieldValue(f *settingField, val string) string {
+	switch f.kind {
+	case fieldBool:
+		if val == "true" {
+			return lipgloss.NewStyle().Foreground(styles.ColorSuccess).Render("[on]")
+		}
+		return lipgloss.NewStyle().Foreground(styles.ColorMuted).Render("[off]")
+	default:
+		return lipgloss.NewStyle().Foreground(styles.ColorAccent).Render("[" + val + "]")
+	}
+}
+
+func hint(key, desc string) string {
+	return styles.HelpKeyStyle.Render(key) + ":" + styles.HelpDescStyle.Render(desc)
+}
+
+// wrapText wraps s to lines of at most maxW characters.
+func wrapText(s string, maxW int) []string {
+	if maxW <= 0 {
+		return []string{s}
+	}
+	words := strings.Fields(s)
+	var lines []string
+	cur := ""
+	for _, w := range words {
+		if cur == "" {
+			cur = w
+		} else if len(cur)+1+len(w) <= maxW {
+			cur += " " + w
+		} else {
+			lines = append(lines, cur)
+			cur = w
+		}
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	return lines
+}
+
+// --- Field definitions ---
+
+func buildSettingEntries() []settingEntry {
+	return []settingEntry{
+		// ── General ──────────────────────────────────────────────────────────
+		{isHeader: true, header: "  General"},
+		{field: &settingField{
+			label:       "Theme",
+			description: "Color scheme for the UI.",
+			kind:        fieldSelect,
+			options:     []string{"dark", "light"},
+			get:         func(c config.Config) string { return c.Theme },
+			set: func(c *config.Config, v string) error {
+				c.Theme = v
+				return nil
+			},
+		}},
+		{field: &settingField{
+			label:       "Multiplexer",
+			description: "Backend for managing terminal sessions. 'tmux' uses the external tmux binary. 'native' uses a built-in PTY daemon (no external binary needed).",
+			kind:        fieldSelect,
+			options:     []string{"tmux", "native"},
+			get:         func(c config.Config) string { return c.Multiplexer },
+			set: func(c *config.Config, v string) error {
+				c.Multiplexer = v
+				return nil
+			},
+		}},
+		{field: &settingField{
+			label:       "Preview Refresh (ms)",
+			description: "How often the session preview pane refreshes, in milliseconds. Lower values feel more responsive but use more CPU.",
+			kind:        fieldInt,
+			get:         func(c config.Config) string { return strconv.Itoa(c.PreviewRefreshMs) },
+			set: func(c *config.Config, v string) error {
+				n, err := strconv.Atoi(strings.TrimSpace(v))
+				if err != nil || n < 50 || n > 30000 {
+					return fmt.Errorf("must be a number between 50 and 30000")
+				}
+				c.PreviewRefreshMs = n
+				return nil
+			},
+		}},
+		{field: &settingField{
+			label:       "Agent Title Overrides User Title",
+			description: "When enabled, agent-detected session titles overwrite titles you set manually.",
+			kind:        fieldBool,
+			get: func(c config.Config) string {
+				return strconv.FormatBool(c.AgentTitleOverridesUserTitle)
+			},
+			set: func(c *config.Config, v string) error {
+				b, err := strconv.ParseBool(v)
+				if err != nil {
+					return fmt.Errorf("must be true or false")
+				}
+				c.AgentTitleOverridesUserTitle = b
+				return nil
+			},
+		}},
+		{field: &settingField{
+			label:       "Hide Attach Hint",
+			description: "When enabled, skip the informational dialog shown before attaching to a session.",
+			kind:        fieldBool,
+			get:         func(c config.Config) string { return strconv.FormatBool(c.HideAttachHint) },
+			set: func(c *config.Config, v string) error {
+				b, err := strconv.ParseBool(v)
+				if err != nil {
+					return fmt.Errorf("must be true or false")
+				}
+				c.HideAttachHint = b
+				return nil
+			},
+		}},
+
+		// ── Team Defaults ─────────────────────────────────────────────────────
+		{isHeader: true, header: "  Team Defaults"},
+		{field: &settingField{
+			label:       "Orchestrator Agent",
+			description: "Default agent type for the orchestrator role when creating a new team.",
+			kind:        fieldSelect,
+			options:     []string{"claude", "codex", "gemini", "copilot", "aider", "opencode"},
+			get:         func(c config.Config) string { return c.TeamDefaults.Orchestrator },
+			set: func(c *config.Config, v string) error {
+				c.TeamDefaults.Orchestrator = v
+				return nil
+			},
+		}},
+		{field: &settingField{
+			label:       "Default Worker Count",
+			description: "Number of worker sessions created when spawning a new team.",
+			kind:        fieldInt,
+			get:         func(c config.Config) string { return strconv.Itoa(c.TeamDefaults.WorkerCount) },
+			set: func(c *config.Config, v string) error {
+				n, err := strconv.Atoi(strings.TrimSpace(v))
+				if err != nil || n < 1 || n > 20 {
+					return fmt.Errorf("must be a number between 1 and 20")
+				}
+				c.TeamDefaults.WorkerCount = n
+				return nil
+			},
+		}},
+		{field: &settingField{
+			label:       "Default Worker Agent",
+			description: "Default agent type for worker sessions in a new team.",
+			kind:        fieldSelect,
+			options:     []string{"claude", "codex", "gemini", "copilot", "aider", "opencode"},
+			get:         func(c config.Config) string { return c.TeamDefaults.WorkerAgent },
+			set: func(c *config.Config, v string) error {
+				c.TeamDefaults.WorkerAgent = v
+				return nil
+			},
+		}},
+
+		// ── Hooks ─────────────────────────────────────────────────────────────
+		{isHeader: true, header: "  Hooks"},
+		{field: &settingField{
+			label:       "Hooks Enabled",
+			description: "When enabled, shell scripts in the hooks directory are executed on lifecycle events (session create, kill, attach, etc.).",
+			kind:        fieldBool,
+			get:         func(c config.Config) string { return strconv.FormatBool(c.Hooks.Enabled) },
+			set: func(c *config.Config, v string) error {
+				b, err := strconv.ParseBool(v)
+				if err != nil {
+					return fmt.Errorf("must be true or false")
+				}
+				c.Hooks.Enabled = b
+				return nil
+			},
+		}},
+		{field: &settingField{
+			label:       "Hooks Directory",
+			description: "Directory containing hook scripts. Supports ~ for home directory.",
+			kind:        fieldString,
+			get:         func(c config.Config) string { return c.Hooks.Dir },
+			set: func(c *config.Config, v string) error {
+				v = strings.TrimSpace(v)
+				if v == "" {
+					return fmt.Errorf("directory cannot be empty")
+				}
+				c.Hooks.Dir = v
+				return nil
+			},
+		}},
+
+		// ── Keybindings ───────────────────────────────────────────────────────
+		{isHeader: true, header: "  Keybindings"},
+		{field: keybindField("New Project", "Create a new project.", func(c config.Config) string { return c.Keybindings.NewProject }, func(c *config.Config, v string) { c.Keybindings.NewProject = v })},
+		{field: keybindField("New Session", "Open the agent picker to start a new session.", func(c config.Config) string { return c.Keybindings.NewSession }, func(c *config.Config, v string) { c.Keybindings.NewSession = v })},
+		{field: keybindField("New Team", "Open the team builder wizard.", func(c config.Config) string { return c.Keybindings.NewTeam }, func(c *config.Config, v string) { c.Keybindings.NewTeam = v })},
+		{field: keybindField("New Worktree Session", "Create a session in a new git worktree.", func(c config.Config) string { return c.Keybindings.NewWorktreeSession }, func(c *config.Config, v string) { c.Keybindings.NewWorktreeSession = v })},
+		{field: keybindField("Attach to Session", "Attach to the selected session.", func(c config.Config) string { return c.Keybindings.Attach }, func(c *config.Config, v string) { c.Keybindings.Attach = v })},
+		{field: keybindField("Kill Session", "Kill the selected session or project.", func(c config.Config) string { return c.Keybindings.KillSession }, func(c *config.Config, v string) { c.Keybindings.KillSession = v })},
+		{field: keybindField("Kill Team", "Kill the selected team and all its sessions.", func(c config.Config) string { return c.Keybindings.KillTeam }, func(c *config.Config, v string) { c.Keybindings.KillTeam = v })},
+		{field: keybindField("Rename", "Rename the selected session or team.", func(c config.Config) string { return c.Keybindings.Rename }, func(c *config.Config, v string) { c.Keybindings.Rename = v })},
+		{field: keybindField("Navigate Up", "Move cursor up in the sidebar.", func(c config.Config) string { return c.Keybindings.NavUp }, func(c *config.Config, v string) { c.Keybindings.NavUp = v })},
+		{field: keybindField("Navigate Down", "Move cursor down in the sidebar.", func(c config.Config) string { return c.Keybindings.NavDown }, func(c *config.Config, v string) { c.Keybindings.NavDown = v })},
+		{field: keybindField("Previous Project", "Jump to the previous project in the sidebar.", func(c config.Config) string { return c.Keybindings.NavProjectUp }, func(c *config.Config, v string) { c.Keybindings.NavProjectUp = v })},
+		{field: keybindField("Next Project", "Jump to the next project in the sidebar.", func(c config.Config) string { return c.Keybindings.NavProjectDown }, func(c *config.Config, v string) { c.Keybindings.NavProjectDown = v })},
+		{field: keybindField("Filter", "Open the session filter.", func(c config.Config) string { return c.Keybindings.Filter }, func(c *config.Config, v string) { c.Keybindings.Filter = v })},
+		{field: keybindField("Grid Overview", "Switch to grid view (current project).", func(c config.Config) string { return c.Keybindings.GridOverview }, func(c *config.Config, v string) { c.Keybindings.GridOverview = v })},
+		{field: keybindField("Command Palette", "Open the command palette.", func(c config.Config) string { return c.Keybindings.Palette }, func(c *config.Config, v string) { c.Keybindings.Palette = v })},
+		{field: keybindField("Help", "Toggle the keyboard shortcuts overlay.", func(c config.Config) string { return c.Keybindings.Help }, func(c *config.Config, v string) { c.Keybindings.Help = v })},
+		{field: keybindField("Tmux Help", "Toggle the tmux shortcuts reference.", func(c config.Config) string { return c.Keybindings.TmuxHelp }, func(c *config.Config, v string) { c.Keybindings.TmuxHelp = v })},
+		{field: keybindField("Quit", "Quit hive (sessions keep running in tmux).", func(c config.Config) string { return c.Keybindings.Quit }, func(c *config.Config, v string) { c.Keybindings.Quit = v })},
+		{field: keybindField("Quit and Kill All", "Quit and terminate all managed sessions.", func(c config.Config) string { return c.Keybindings.QuitKill }, func(c *config.Config, v string) { c.Keybindings.QuitKill = v })},
+	}
+}
+
+// keybindField builds a settingField for a single keybinding.
+func keybindField(label, desc string, get func(config.Config) string, set func(*config.Config, string)) *settingField {
+	return &settingField{
+		label:       label,
+		description: desc,
+		kind:        fieldString,
+		get:         get,
+		set: func(c *config.Config, v string) error {
+			v = strings.TrimSpace(v)
+			if v == "" {
+				return fmt.Errorf("keybinding cannot be empty")
+			}
+			set(c, v)
+			return nil
+		},
+	}
+}

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -139,6 +139,7 @@ func buildHints(s *state.AppState, focused state.Pane, filterActive bool, filter
 			{"g/G", "grid view"},
 			{"r", "rename"},
 			{"x", "kill"},
+			{"S", "settings"},
 			{"tab", "preview"},
 			{"q", "quit"},
 		}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -28,6 +28,7 @@ type KeyMap struct {
 	Palette        key.Binding
 	Help           key.Binding
 	TmuxHelp       key.Binding
+	Settings       key.Binding
 	Quit           key.Binding
 	QuitKill       key.Binding
 	Confirm        key.Binding
@@ -58,6 +59,7 @@ func NewKeyMap(kb config.KeybindingsConfig) KeyMap {
 		Palette:        key.NewBinding(key.WithKeys(kb.Palette), key.WithHelp(kb.Palette, "palette")),
 		Help:           key.NewBinding(key.WithKeys(kb.Help), key.WithHelp(kb.Help, "help")),
 		TmuxHelp:       key.NewBinding(key.WithKeys(kb.TmuxHelp), key.WithHelp(kb.TmuxHelp, "tmux shortcuts")),
+		Settings:       key.NewBinding(key.WithKeys(kb.Settings), key.WithHelp(kb.Settings, "settings")),
 		Quit:           key.NewBinding(key.WithKeys(kb.Quit), key.WithHelp(kb.Quit, "quit")),
 		QuitKill:       key.NewBinding(key.WithKeys(kb.QuitKill), key.WithHelp(kb.QuitKill, "quit+kill")),
 		Confirm:        key.NewBinding(key.WithKeys("y", "enter"), key.WithHelp("y/enter", "confirm")),

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -3,6 +3,7 @@ package tui
 import (
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/lucascaro/hive/internal/config"
 	"github.com/lucascaro/hive/internal/state"
 )
 
@@ -94,6 +95,11 @@ type AgentInstalledMsg struct{ AgentType string }
 // Sessions holds the tmux session names (e.g. "hive-abc12345") to kill.
 type CleanOrphansMsg struct {
 	Sessions []string
+}
+
+// ConfigSavedMsg is sent after config changes are successfully written to disk.
+type ConfigSavedMsg struct {
+	Config config.Config
 }
 
 // Ensure tea.Msg interface satisfaction (compile-time checks).


### PR DESCRIPTION
## Summary

Adds a full-screen interactive settings overlay to the TUI, letting users view and edit all configuration options in context.

## Features

- **Open with `S`** from the main view (shown in statusbar hints and help overlay)
- **All config fields** displayed with descriptions, grouped into categories: General, Team Defaults, Hooks, Keybindings
- **Inline editing** — strings/ints open a text input; booleans and selects toggle/cycle with `enter`/`space`
- **Safe saves** — pressing `s` shows an inline confirmation footer before writing to disk
- **Discard protection** — first `esc` with unsaved changes shows a warning; second `esc` discards; `● unsaved` indicator always visible when dirty
- **Scrollable** — list auto-scrolls to keep cursor visible
- Saves to `~/.config/hive/config.json`

## Changes

| File | Change |
|------|--------|
| `internal/tui/components/settings.go` | New full-screen settings overlay component |
| `internal/config/config.go` | Added `Settings` field to `KeybindingsConfig` |
| `internal/config/defaults.go` | Default keybinding `S` for settings |
| `internal/tui/keys.go` | Added `Settings key.Binding` |
| `internal/tui/messages.go` | Added `ConfigSavedMsg` |
| `internal/tui/app.go` | Integrated settings view: routing, rendering, save handler |
| `internal/tui/components/statusbar.go` | Added `S:settings` hint |

## Testing

All existing tests pass (`go test ./...`).