### PR TITLE
fix: restore grid previews after tmux detach

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -120,7 +120,7 @@ func runStart(_ *cobra.Command, _ []string) error {
 				// Restore cursor to the session we just detached from.
 				appState.ActiveSessionID = findSessionID(&appState, attach.TmuxSession, attach.TmuxWindow)
 				// Restore the screen the user was on before attaching.
-				appState.RestoreGridView = attach.FromGridView
+				appState.RestoreGridMode = attach.RestoreGridMode
 				continue
 			}
 		}

--- a/internal/state/model.go
+++ b/internal/state/model.go
@@ -66,6 +66,15 @@ const (
 	PanePreview
 )
 
+// GridRestoreMode identifies which grid scope should be restored after attach.
+type GridRestoreMode string
+
+const (
+	GridRestoreNone    GridRestoreMode = ""
+	GridRestoreProject GridRestoreMode = "project"
+	GridRestoreAll     GridRestoreMode = "all"
+)
+
 // Project groups related AI agent sessions.
 type Project struct {
 	ID             string            `json:"id"`
@@ -97,23 +106,23 @@ type Team struct {
 
 // Session maps 1:1 to a tmux window.
 type Session struct {
-	ID           string            `json:"id"`
-	ProjectID    string            `json:"project_id"`
-	TeamID       string            `json:"team_id,omitempty"`
-	TeamRole     TeamRole          `json:"team_role"`
-	Title        string            `json:"title"`
-	TmuxSession  string            `json:"tmux_session"`
-	TmuxWindow   int               `json:"tmux_window"`
-	Status       SessionStatus     `json:"status"`
-	TitleSource  TitleSource       `json:"title_source"`
-	AgentType    AgentType         `json:"agent_type"`
-	AgentCmd     []string          `json:"agent_cmd"`
+	ID             string            `json:"id"`
+	ProjectID      string            `json:"project_id"`
+	TeamID         string            `json:"team_id,omitempty"`
+	TeamRole       TeamRole          `json:"team_role"`
+	Title          string            `json:"title"`
+	TmuxSession    string            `json:"tmux_session"`
+	TmuxWindow     int               `json:"tmux_window"`
+	Status         SessionStatus     `json:"status"`
+	TitleSource    TitleSource       `json:"title_source"`
+	AgentType      AgentType         `json:"agent_type"`
+	AgentCmd       []string          `json:"agent_cmd"`
 	WorkDir        string            `json:"work_dir"`
 	WorktreePath   string            `json:"worktree_path,omitempty"`   // non-empty = session runs in a git worktree
 	WorktreeBranch string            `json:"worktree_branch,omitempty"` // branch name for the worktree
 	CreatedAt      time.Time         `json:"created_at"`
-	LastActiveAt time.Time         `json:"last_active_at"`
-	Meta         map[string]string `json:"meta,omitempty"`
+	LastActiveAt   time.Time         `json:"last_active_at"`
+	Meta           map[string]string `json:"meta,omitempty"`
 }
 
 // AppState is the single source of truth for the TUI.
@@ -131,20 +140,21 @@ type AppState struct {
 	TermHeight      int
 	LastError       string
 	// UI overlay states
-	ShowHelp        bool
-	ShowTmuxHelp    bool
-	ShowConfirm     bool
-	ConfirmMsg      string
-	ConfirmAction   string // opaque action identifier
-	FilterQuery     string
-	FilterActive    bool
+	ShowHelp      bool
+	ShowTmuxHelp  bool
+	ShowConfirm   bool
+	ConfirmMsg    string
+	ConfirmAction string // opaque action identifier
+	FilterQuery   string
+	FilterActive  bool
 	// Agent usage tracking (persisted separately in usage.json)
-	AgentUsage      map[string]AgentUsageRecord
+	AgentUsage map[string]AgentUsageRecord
 	// InstallingAgent holds the agent type currently being installed (empty = none).
 	InstallingAgent string
-	// RestoreGridView is transient: when true, New() opens the grid view on startup.
-	// Set by cmd/start.go after the user detaches from a grid-initiated session.
-	RestoreGridView bool
+	// RestoreGridMode is transient: when non-empty, New() opens the grid view on
+	// startup using the matching scope. Set by cmd/start.go after the user
+	// detaches from a grid-initiated session.
+	RestoreGridMode GridRestoreMode
 	// OrphanSessions is transient: when non-empty, the TUI shows an orphan-cleanup
 	// overlay on startup listing hive-* tmux sessions with no matching project.
 	// Set by cmd/start.go after reconcileState detects orphaned containers.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -38,31 +38,31 @@ func init() {
 
 // Model is the root Bubble Tea model.
 type Model struct {
-	cfg         config.Config
-	appState    state.AppState
-	keys        KeyMap
-	sidebar     components.Sidebar
-	preview     components.Preview
-	statusBar   components.StatusBar
-	titleEditor components.TitleEditor
-	agentPicker components.AgentPicker
-	teamBuilder components.TeamBuilder
-	confirm     components.Confirm
-	gridView    components.GridView
+	cfg          config.Config
+	appState     state.AppState
+	keys         KeyMap
+	sidebar      components.Sidebar
+	preview      components.Preview
+	statusBar    components.StatusBar
+	titleEditor  components.TitleEditor
+	agentPicker  components.AgentPicker
+	teamBuilder  components.TeamBuilder
+	confirm      components.Confirm
+	gridView     components.GridView
 	orphanPicker components.OrphanPicker
-	nameInput   textinput.Model // for project name / directory input
+	nameInput    textinput.Model // for project name / directory input
 	// UI sub-states
-	inputMode           string // "project-name", "project-dir", "new-session", "worktree-branch", ""
-	pendingProjectName  string // name entered in step 1 of project creation
-	pendingProjectID    string
-	pendingAgentType    string // agent type awaiting install confirmation
+	inputMode          string // "project-name", "project-dir", "new-session", "worktree-branch", ""
+	pendingProjectName string // name entered in step 1 of project creation
+	pendingProjectID   string
+	pendingAgentType   string // agent type awaiting install confirmation
 	// Worktree session creation
 	pendingWorktree          bool   // true when the next session should use a worktree
 	pendingWorktreeAgentType string // agent type selected for worktree session
 	pendingWorktreeAgentCmd  []string
 	// Attach hint overlay
-	showAttachHint  bool
-	pendingAttach   *SessionAttachMsg
+	showAttachHint bool
+	pendingAttach  *SessionAttachMsg
 	// Attach flow: set before tea.Quit so cmd/start.go can act on it.
 	attachPending *SessionAttachMsg
 	// previewPollGen is incremented each time we intentionally start a fresh
@@ -126,9 +126,12 @@ func New(cfg config.Config, appState state.AppState) Model {
 		debugLog.Printf("synced cursor to existing active session %s", m.appState.ActiveSessionID)
 	}
 	// Restore the grid view if the user detached from a grid-initiated session.
-	if m.appState.RestoreGridView {
-		m.appState.RestoreGridView = false
-		m.gridView.Show(m.liveSessions())
+	if m.appState.RestoreGridMode != state.GridRestoreNone {
+		mode := m.appState.RestoreGridMode
+		m.appState.RestoreGridMode = state.GridRestoreNone
+		sessions := m.gridSessions(mode)
+		m.gridView.Show(sessions, mode)
+		m.gridView.SetContents(m.gridContentsFromSnapshots(sessions))
 	}
 	debugLog.Printf("New() done: ActiveSessionID=%q, %d projects, %d sidebar items",
 		m.appState.ActiveSessionID, len(m.appState.Projects), len(m.sidebar.Items))
@@ -162,12 +165,16 @@ func expandForActiveSession(appState *state.AppState, sessionID string) {
 
 // Init returns the initial commands.
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(
+	cmds := []tea.Cmd{
 		tea.SetWindowTitle("hive"),
 		m.schedulePollPreview(),
 		m.scheduleWatchTitles(),
 		m.scheduleWatchStatuses(),
-	)
+	}
+	if m.gridView.Active {
+		cmds = append(cmds, m.scheduleGridPoll())
+	}
+	return tea.Batch(cmds...)
 }
 
 // Update handles all messages.
@@ -376,7 +383,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case components.GridSessionSelectedMsg:
-		attach := &SessionAttachMsg{TmuxSession: msg.TmuxSession, TmuxWindow: msg.TmuxWindow, FromGridView: true}
+		attach := &SessionAttachMsg{
+			TmuxSession:     msg.TmuxSession,
+			TmuxWindow:      msg.TmuxWindow,
+			RestoreGridMode: m.gridView.Mode,
+		}
 		if !m.cfg.HideAttachHint {
 			m.pendingAttach = attach
 			m.showAttachHint = true
@@ -605,8 +616,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "G":
 			// Switch to all-projects view without closing.
-			m.gridView.Show(m.liveSessions())
-			return m, nil
+			m.gridView.Show(m.gridSessions(state.GridRestoreAll), state.GridRestoreAll)
+			return m, m.scheduleGridPoll()
 		case "x":
 			if sess := m.gridView.Selected(); sess != nil {
 				m.gridView.Hide()
@@ -709,20 +720,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.GridOverview):
 		// g shows only current project; G (handled above in the active-grid block,
 		// or via msg.String()=="G" below) shows all.
-		var sessions []*state.Session
-		for _, sess := range m.liveSessions() {
-			if m.appState.ActiveProjectID == "" || sess.ProjectID == m.appState.ActiveProjectID {
-				sessions = append(sessions, sess)
-			}
-		}
-		if len(sessions) == 0 {
-			sessions = m.liveSessions()
-		}
-		m.gridView.Show(sessions)
+		sessions := m.gridSessions(state.GridRestoreProject)
+		m.gridView.Show(sessions, state.GridRestoreProject)
 		return m, m.scheduleGridPoll()
 
 	case msg.String() == "G":
-		m.gridView.Show(m.liveSessions())
+		m.gridView.Show(m.gridSessions(state.GridRestoreAll), state.GridRestoreAll)
 		return m, m.scheduleGridPoll()
 
 	case key.Matches(msg, m.keys.NewProject):
@@ -1384,16 +1387,16 @@ func (m *Model) createSession(projectID, agentTypeStr string, agentCmd []string)
 	m.persist()
 
 	m.fireHook(state.HookEvent{
-		Name:        state.EventSessionCreate,
-		ProjectID:   projectID,
-		ProjectName: proj.Name,
-		SessionID:   sess.ID,
+		Name:         state.EventSessionCreate,
+		ProjectID:    projectID,
+		ProjectName:  proj.Name,
+		SessionID:    sess.ID,
 		SessionTitle: sess.Title,
-		AgentType:   agentType,
-		AgentCmd:    agentCmd,
-		TmuxSession: muxSess,
-		TmuxWindow:  windowIdx,
-		WorkDir:     workDir,
+		AgentType:    agentType,
+		AgentCmd:     agentCmd,
+		TmuxSession:  muxSess,
+		TmuxWindow:   windowIdx,
+		WorkDir:      workDir,
 	})
 	return func() tea.Msg { return SessionCreatedMsg{Session: sess} }
 }
@@ -1460,19 +1463,19 @@ func (m *Model) addTeamSession(proj *state.Project, team *state.Team, role state
 	_, sess := state.AddTeamSession(&m.appState, proj.ID, team.ID, role, title, agentType, agentCmd, workDir, muxSess, windowIdx)
 	state.RecordAgentUsage(&m.appState, string(agentType))
 	m.fireHook(state.HookEvent{
-		Name:        state.EventTeamMemberAdd,
-		ProjectID:   proj.ID,
-		ProjectName: proj.Name,
-		SessionID:   sess.ID,
+		Name:         state.EventTeamMemberAdd,
+		ProjectID:    proj.ID,
+		ProjectName:  proj.Name,
+		SessionID:    sess.ID,
 		SessionTitle: title,
-		TeamID:      team.ID,
-		TeamName:    team.Name,
-		TeamRole:    role,
-		AgentType:   agentType,
-		AgentCmd:    agentCmd,
-		TmuxSession: muxSess,
-		TmuxWindow:  windowIdx,
-		WorkDir:     workDir,
+		TeamID:       team.ID,
+		TeamName:     team.Name,
+		TeamRole:     role,
+		AgentType:    agentType,
+		AgentCmd:     agentCmd,
+		TmuxSession:  muxSess,
+		TmuxWindow:   windowIdx,
+		WorkDir:      workDir,
 	})
 	return func() tea.Msg { return SessionCreatedMsg{Session: sess} }
 }
@@ -1487,16 +1490,20 @@ func (m *Model) attachActiveSession() tea.Cmd {
 		return nil
 	}
 	m.fireHook(state.HookEvent{
-		Name:        state.EventSessionAttach,
-		SessionID:   sess.ID,
+		Name:         state.EventSessionAttach,
+		SessionID:    sess.ID,
 		SessionTitle: sess.Title,
-		AgentType:   sess.AgentType,
-		TmuxSession: sess.TmuxSession,
-		TmuxWindow:  sess.TmuxWindow,
-		WorkDir:     sess.WorkDir,
+		AgentType:    sess.AgentType,
+		TmuxSession:  sess.TmuxSession,
+		TmuxWindow:   sess.TmuxWindow,
+		WorkDir:      sess.WorkDir,
 	})
 	return func() tea.Msg {
-		return SessionAttachMsg{TmuxSession: sess.TmuxSession, TmuxWindow: sess.TmuxWindow}
+		return SessionAttachMsg{
+			TmuxSession:     sess.TmuxSession,
+			TmuxWindow:      sess.TmuxWindow,
+			RestoreGridMode: state.GridRestoreNone,
+		}
 	}
 }
 
@@ -1698,7 +1705,11 @@ func (m *Model) pendingAttachDetails() *SessionAttachMsg {
 	if sess == nil {
 		return nil
 	}
-	return &SessionAttachMsg{TmuxSession: sess.TmuxSession, TmuxWindow: sess.TmuxWindow}
+	return &SessionAttachMsg{
+		TmuxSession:     sess.TmuxSession,
+		TmuxWindow:      sess.TmuxWindow,
+		RestoreGridMode: state.GridRestoreNone,
+	}
 }
 
 // handleAttachHint handles key input while the attach hint overlay is shown.
@@ -1789,8 +1800,41 @@ func (m *Model) liveSessions() []*state.Session {
 	return out
 }
 
+func (m *Model) gridSessions(mode state.GridRestoreMode) []*state.Session {
+	switch mode {
+	case state.GridRestoreAll:
+		return m.liveSessions()
+	case state.GridRestoreProject:
+		var sessions []*state.Session
+		for _, sess := range m.liveSessions() {
+			if m.appState.ActiveProjectID == "" || sess.ProjectID == m.appState.ActiveProjectID {
+				sessions = append(sessions, sess)
+			}
+		}
+		if len(sessions) == 0 {
+			return m.liveSessions()
+		}
+		return sessions
+	default:
+		return nil
+	}
+}
+
+func (m *Model) gridContentsFromSnapshots(sessions []*state.Session) map[string]string {
+	if len(sessions) == 0 {
+		return nil
+	}
+	contents := make(map[string]string, len(sessions))
+	for _, sess := range sessions {
+		if content := m.contentSnapshots[sess.ID]; content != "" {
+			contents[sess.ID] = content
+		}
+	}
+	return contents
+}
+
 func (m *Model) scheduleGridPoll() tea.Cmd {
-	sessions := m.liveSessions()
+	sessions := m.gridSessions(m.gridView.Mode)
 	if len(sessions) == 0 {
 		return nil
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lucascaro/hive/internal/config"
 	"github.com/lucascaro/hive/internal/escape"
 	"github.com/lucascaro/hive/internal/state"
@@ -16,8 +17,8 @@ func testModelWithSessions() Model {
 	appState := state.AppState{
 		Projects: []*state.Project{
 			{
-				ID:   "proj-1",
-				Name: "test-project",
+				ID:    "proj-1",
+				Name:  "test-project",
 				Teams: []*state.Team{},
 				Sessions: []*state.Session{
 					{
@@ -48,6 +49,50 @@ func testModelWithSessions() Model {
 	return New(cfg, appState)
 }
 
+func testAppStateWithTwoProjects() state.AppState {
+	return state.AppState{
+		ActiveProjectID: "proj-1",
+		ActiveSessionID: "sess-1",
+		Projects: []*state.Project{
+			{
+				ID:    "proj-1",
+				Name:  "test-project-1",
+				Teams: []*state.Team{},
+				Sessions: []*state.Session{
+					{
+						ID:          "sess-1",
+						ProjectID:   "proj-1",
+						Title:       "session-1",
+						TmuxSession: "hive-proj1234",
+						TmuxWindow:  0,
+						Status:      state.StatusRunning,
+						AgentType:   state.AgentClaude,
+						AgentCmd:    []string{"claude"},
+					},
+				},
+			},
+			{
+				ID:    "proj-2",
+				Name:  "test-project-2",
+				Teams: []*state.Team{},
+				Sessions: []*state.Session{
+					{
+						ID:          "sess-2",
+						ProjectID:   "proj-2",
+						Title:       "session-2",
+						TmuxSession: "hive-proj5678",
+						TmuxWindow:  0,
+						Status:      state.StatusRunning,
+						AgentType:   state.AgentCodex,
+						AgentCmd:    []string{"codex"},
+					},
+				},
+			},
+		},
+		AgentUsage: make(map[string]state.AgentUsageRecord),
+	}
+}
+
 func TestNewAutoSelectsFirstSession(t *testing.T) {
 	m := testModelWithSessions()
 
@@ -72,6 +117,66 @@ func TestNewAutoSelectsFirstSession_Empty(t *testing.T) {
 
 	if m.appState.ActiveSessionID != "" {
 		t.Fatalf("New() with no sessions should leave ActiveSessionID empty, got %q", m.appState.ActiveSessionID)
+	}
+}
+
+func TestNew_RestoresProjectGridMode(t *testing.T) {
+	cfg := config.DefaultConfig()
+	appState := testAppStateWithTwoProjects()
+	appState.RestoreGridMode = state.GridRestoreProject
+
+	m := New(cfg, appState)
+
+	if !m.gridView.Active {
+		t.Fatal("grid view should be active after restore")
+	}
+	if m.gridView.Mode != state.GridRestoreProject {
+		t.Fatalf("grid mode = %q, want %q", m.gridView.Mode, state.GridRestoreProject)
+	}
+	sessions := m.gridSessions(m.gridView.Mode)
+	if len(sessions) != 1 {
+		t.Fatalf("restored project grid should show 1 session, got %d", len(sessions))
+	}
+	if sessions[0].ProjectID != "proj-1" {
+		t.Fatalf("restored project grid session project = %q, want proj-1", sessions[0].ProjectID)
+	}
+}
+
+func TestNew_RestoresAllProjectsGridMode(t *testing.T) {
+	cfg := config.DefaultConfig()
+	appState := testAppStateWithTwoProjects()
+	appState.RestoreGridMode = state.GridRestoreAll
+
+	m := New(cfg, appState)
+
+	if !m.gridView.Active {
+		t.Fatal("grid view should be active after restore")
+	}
+	if m.gridView.Mode != state.GridRestoreAll {
+		t.Fatalf("grid mode = %q, want %q", m.gridView.Mode, state.GridRestoreAll)
+	}
+	if got := len(m.gridSessions(m.gridView.Mode)); got != 2 {
+		t.Fatalf("restored all-projects grid should show 2 sessions, got %d", got)
+	}
+}
+
+func TestInit_IncludesGridPollWhenGridRestored(t *testing.T) {
+	cfg := config.DefaultConfig()
+	appState := testAppStateWithTwoProjects()
+	appState.RestoreGridMode = state.GridRestoreProject
+
+	m := New(cfg, appState)
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("Init() should return a batch command")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("Init() msg type = %T, want tea.BatchMsg", msg)
+	}
+	if len(batch) != 5 {
+		t.Fatalf("Init() batch length = %d, want 5 including grid poll", len(batch))
 	}
 }
 
@@ -404,5 +509,47 @@ func TestStatusesDetectedMsg_IgnoresBackgroundPreview(t *testing.T) {
 
 	if updated.appState.PreviewContent != "active session output" {
 		t.Errorf("PreviewContent = %q, want active session content unchanged", updated.appState.PreviewContent)
+	}
+}
+
+func TestGridSessionSelectedMsg_PreservesProjectGridRestoreMode(t *testing.T) {
+	m := testModelWithSessions()
+	m.gridView.Show(m.gridSessions(state.GridRestoreProject), state.GridRestoreProject)
+
+	result, _ := m.Update(components.GridSessionSelectedMsg{
+		TmuxSession: "hive-proj1234",
+		TmuxWindow:  0,
+	})
+	updated := result.(Model)
+
+	if updated.pendingAttach == nil {
+		t.Fatal("pendingAttach should be set when attach hint is shown")
+	}
+	if updated.pendingAttach.RestoreGridMode != state.GridRestoreProject {
+		t.Fatalf("RestoreGridMode = %q, want %q", updated.pendingAttach.RestoreGridMode, state.GridRestoreProject)
+	}
+}
+
+func TestGridSessionSelectedMsg_PreservesAllProjectsGridRestoreMode(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.HideAttachHint = true
+	appState := testAppStateWithTwoProjects()
+	m := New(cfg, appState)
+	m.gridView.Show(m.gridSessions(state.GridRestoreAll), state.GridRestoreAll)
+
+	result, cmd := m.Update(components.GridSessionSelectedMsg{
+		TmuxSession: "hive-proj1234",
+		TmuxWindow:  0,
+	})
+	updated := result.(Model)
+
+	if cmd == nil {
+		t.Fatal("expected quit command when attach hint is disabled")
+	}
+	if updated.attachPending == nil {
+		t.Fatal("attachPending should be set")
+	}
+	if updated.attachPending.RestoreGridMode != state.GridRestoreAll {
+		t.Fatalf("RestoreGridMode = %q, want %q", updated.attachPending.RestoreGridMode, state.GridRestoreAll)
 	}
 }

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -8,8 +8,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/lucascaro/hive/internal/state"
 	"github.com/lucascaro/hive/internal/mux"
+	"github.com/lucascaro/hive/internal/state"
 	"github.com/lucascaro/hive/internal/tui/styles"
 )
 
@@ -48,13 +48,15 @@ type GridView struct {
 	Cursor   int
 	Width    int
 	Height   int
+	Mode     state.GridRestoreMode
 	sessions []*state.Session
 	contents map[string]string
 }
 
 // Show activates the grid with the given sessions.
-func (gv *GridView) Show(sessions []*state.Session) {
+func (gv *GridView) Show(sessions []*state.Session, mode state.GridRestoreMode) {
 	gv.Active = true
+	gv.Mode = mode
 	gv.sessions = sessions
 	if gv.Cursor >= len(sessions) {
 		gv.Cursor = 0
@@ -240,14 +242,14 @@ func (gv *GridView) renderCell(sess *state.Session, w, h int, selected bool) str
 //
 // Scoring (lower is better, evaluated for each candidate column count):
 //
-//	score = waste×5  +  |cols−rows|×2  +  ratioDiff
+//		score = waste×5  +  |cols−rows|×2  +  ratioDiff
 //
-//   • waste      — wasted cells (cols×rows − n); strongly penalised.
-//   • |cols−rows| — prefer grids whose shape is close to square
-//                   (e.g. 2×2 beats 4×1 for n=4, 3×3 beats 9×1 for n=9).
-//   • ratioDiff  — prefer cells whose char-unit aspect ratio (cellW/cellH)
-//                  is close to 2.5, which is visually square given that a
-//                  terminal glyph is roughly twice as tall as wide in pixels.
+//	  • waste      — wasted cells (cols×rows − n); strongly penalised.
+//	  • |cols−rows| — prefer grids whose shape is close to square
+//	                  (e.g. 2×2 beats 4×1 for n=4, 3×3 beats 9×1 for n=9).
+//	  • ratioDiff  — prefer cells whose char-unit aspect ratio (cellW/cellH)
+//	                 is close to 2.5, which is visually square given that a
+//	                 terminal glyph is roughly twice as tall as wide in pixels.
 //
 // Typical results (w=160, h=50):
 //

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -15,7 +15,7 @@ func TestGridViewView_ShowsStatusLegend(t *testing.T) {
 	}
 	gv.Show([]*state.Session{
 		{ID: "s1", Title: "alpha", AgentType: state.AgentClaude, Status: state.StatusRunning},
-	})
+	}, state.GridRestoreProject)
 
 	out := gv.View()
 	for _, want := range []string{"idle", "working", "waiting", "dead"} {
@@ -41,7 +41,7 @@ func TestGridView_ExactHeight(t *testing.T) {
 	}
 	for _, d := range dims {
 		gv := &GridView{Active: true, Width: d.w, Height: d.h}
-		gv.Show(sessions)
+		gv.Show(sessions, state.GridRestoreProject)
 		out := gv.View()
 		got := strings.Count(out, "\n") + 1
 		if got != d.h {
@@ -63,7 +63,7 @@ func TestGridView_ExactHeight_VariousCounts(t *testing.T) {
 	for n := 1; n <= 9; n++ {
 		for _, h := range []int{24, 30, 40, 50, 62} {
 			gv := &GridView{Active: true, Width: 160, Height: h}
-			gv.Show(allSessions[:n])
+			gv.Show(allSessions[:n], state.GridRestoreProject)
 			out := gv.View()
 			got := strings.Count(out, "\n") + 1
 			if got != h {
@@ -73,4 +73,3 @@ func TestGridView_ExactHeight_VariousCounts(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -20,9 +20,9 @@ type SessionKilledMsg struct {
 
 // SessionAttachMsg triggers attaching to a session (suspends TUI).
 type SessionAttachMsg struct {
-	TmuxSession  string
-	TmuxWindow   int
-	FromGridView bool // true when the user attached from the grid view
+	TmuxSession     string
+	TmuxWindow      int
+	RestoreGridMode state.GridRestoreMode
 }
 
 // SessionDetachedMsg is sent when the user returns from a tmux session.


### PR DESCRIPTION
## Summary
- restore the same grid scope after detaching from tmux instead of reopening a blank grid
- start grid preview polling during startup restore and preserve grid scope in attach metadata
- add regression tests for project/all grid restore and startup polling

## Testing
- GOCACHE=/tmp/go-build go test ./internal/tui/... ./internal/state/...
- GOCACHE=/tmp/go-build go test ./cmd/...