### PR TITLE
feat: use tmux display-popup for in-UI session attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   row) has been merged into one line — status dot, agent badge, session title, project
   name, and worktree badge all appear on a single header line, giving each cell one
   extra row of terminal-output preview.
+- **Session attach via in-process overlay**: when using the tmux backend, pressing
+  Enter on a session no longer quits and restarts the TUI. Instead the TUI suspends
+  in place using `tea.ExecProcess` while the session is attached. When you detach,
+  the TUI resumes immediately with all state intact — no disk reload, no flicker.
+  - On **tmux ≥ 3.2** the session opens as a floating `tmux display-popup` overlay
+    (95 % width, 90 % height) that sits on top of the TUI. Closing the popup (or the
+    agent exiting) returns you directly to the TUI without any full-screen switch.
+  - On older tmux or when running outside a tmux session, a plain full-screen
+    `tmux attach-session` is used, still with the no-restart improvement.
+  - The **native PTY backend** is unaffected and continues to use the existing
+    quit+restart flow.
 
 ### Added
 - **Getting-started guides**: added `docs/getting-started-macos.md` and

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -89,7 +89,10 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// Reconcile: mark sessions dead if their window is gone.
 	reconcileState(&appState)
 
-	// Run the TUI loop (re-enter after attach/detach).
+	// Run the TUI loop. For the native backend the loop re-enters after each
+	// attach/detach cycle (tea.Quit is used because native attach cannot use
+	// tea.ExecProcess). For the tmux backend the TUI handles attach internally
+	// via tea.ExecProcess and never sets LastAttach(); the loop runs only once.
 	for {
 		model := tui.New(cfg, appState)
 		p := tea.NewProgram(model,
@@ -101,26 +104,23 @@ func runStart(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("TUI error: %w", err)
 		}
 
-		// Check if we need to attach to a session.
+		// Native backend attach: re-enter TUI after detaching from the session.
 		if fm, ok := finalModel.(interface{ LastAttach() *tui.SessionAttachMsg }); ok {
-			if attach := fm.LastAttach(); attach != nil {
-				if err := tui.RunAttach(*attach); err != nil {
+			if a := fm.LastAttach(); a != nil {
+				if err := tui.RunAttach(*a); err != nil {
 					fmt.Fprintf(os.Stderr, "attach failed: %v\n", err)
 				}
-				// Reload config so preferences saved during TUI run take effect.
+				// Reload config and state so any changes made during the session
+				// (or by the agent) are reflected when the TUI restarts.
 				if reloadedCfg, loadErr := config.Load(); loadErr == nil {
 					cfg = config.Migrate(reloadedCfg)
 				}
-				// Reload state after returning from the attached session.
 				if reloaded, err := tui.LoadState(); err == nil && reloaded != nil {
 					appState.Projects = reloaded
 				}
-				// Reconcile again: the agent may have exited while attached.
 				reconcileState(&appState)
-				// Restore cursor to the session we just detached from.
-				appState.ActiveSessionID = findSessionID(&appState, attach.TmuxSession, attach.TmuxWindow)
-				// Restore the screen the user was on before attaching.
-				appState.RestoreGridMode = attach.RestoreGridMode
+				appState.ActiveSessionID = findSessionID(&appState, a.TmuxSession, a.TmuxWindow)
+				appState.RestoreGridMode = a.RestoreGridMode
 				continue
 			}
 		}

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,10 @@ This file tracks features that are already implemented in Hive. New ideas should
 
 - Organize work into multiple named projects.
 - Create multiple persistent sessions per project, each backed by a tmux window.
-- Attach to the selected session from the TUI and return later without losing session state.
+- Attach to the selected session from the TUI and return without losing session state.
+  When using the tmux backend (≥ 3.2) the session opens as a floating popup overlay
+  so you never leave the TUI; on older tmux the terminal is taken over full-screen.
+  Either way the TUI resumes in place after you detach — no restart required.
 - Create new projects and sessions directly from the keyboard-driven interface.
 - Kill individual sessions or quit the app while keeping tmux sessions running.
 

--- a/internal/mux/interface.go
+++ b/internal/mux/interface.go
@@ -55,6 +55,22 @@ type Backend interface {
 	// process exits.
 	Attach(target string) error
 
+	// SupportsPopup reports whether the backend can open an in-UI floating
+	// popup overlay for a session (requires tmux ≥ 3.2 and running inside tmux).
+	// If false, callers must fall back to a full-screen Attach.
+	SupportsPopup() bool
+
+	// PopupAttach opens a floating popup overlay connected to the window at
+	// target. Only valid to call when SupportsPopup() returns true.
+	// Returns when the popup closes (user detaches or process exits).
+	PopupAttach(target string) error
+
+	// UseExecAttach reports whether the TUI should use tea.ExecProcess to run
+	// an external attach command rather than quitting and restarting.
+	// True for the tmux backend (exec "tmux …"). False for the native backend
+	// (which performs attach via Go I/O and requires the quit+restart loop).
+	UseExecAttach() bool
+
 	// DetachKey returns a human-readable description of the key sequence used
 	// to return to hive from an attached session (e.g. "Ctrl+Q" or "Ctrl+B D").
 	DetachKey() string
@@ -145,6 +161,29 @@ func CapturePaneRaw(target string, lines int) (string, error) {
 
 // Attach connects the current terminal to the window at target.
 func Attach(target string) error { return active.Attach(target) }
+
+// SupportsPopup reports whether the active backend can show an in-UI popup overlay.
+// Returns false if no backend has been set (e.g. in tests).
+func SupportsPopup() bool {
+	if active == nil {
+		return false
+	}
+	return active.SupportsPopup()
+}
+
+// PopupAttach opens a floating popup overlay for the window at target.
+// Only call when SupportsPopup() returns true.
+func PopupAttach(target string) error { return active.PopupAttach(target) }
+
+// UseExecAttach reports whether the TUI should use tea.ExecProcess for attach.
+// Returns false if no backend has been set (e.g. in tests), causing the TUI to
+// fall back to the quit+restart path.
+func UseExecAttach() bool {
+	if active == nil {
+		return false
+	}
+	return active.UseExecAttach()
+}
 
 // DetachKey returns a description of the key sequence used to return to hive.
 func DetachKey() string { return active.DetachKey() }

--- a/internal/mux/native/backend_unix.go
+++ b/internal/mux/native/backend_unix.go
@@ -11,6 +11,8 @@
 package muxnative
 
 import (
+	"errors"
+
 	"github.com/lucascaro/hive/internal/mux"
 )
 
@@ -123,3 +125,17 @@ func (b *Backend) Attach(target string) error {
 
 // DetachKey returns the native backend detach key description.
 func (b *Backend) DetachKey() string { return "Ctrl+Q" }
+
+// UseExecAttach returns false: the native backend attaches via Go-level socket
+// I/O, not an external command, so tea.ExecProcess is not applicable.
+func (b *Backend) UseExecAttach() bool { return false }
+
+// SupportsPopup always returns false for the native backend.
+// The native backend uses its own PTY daemon; tmux display-popup is not applicable.
+func (b *Backend) SupportsPopup() bool { return false }
+
+// PopupAttach is not implemented for the native backend.
+// Always returns an error; callers must check SupportsPopup first.
+func (b *Backend) PopupAttach(_ string) error {
+	return errors.New("popup attach is not supported by the native PTY backend")
+}

--- a/internal/mux/native/backend_windows.go
+++ b/internal/mux/native/backend_windows.go
@@ -45,6 +45,9 @@ func (b *Backend) CapturePane(_ string, _ int) (string, error)            { retu
 func (b *Backend) CapturePaneRaw(_ string, _ int) (string, error)         { return "", errNotSupported }
 func (b *Backend) Attach(_ string) error                                   { return errNotSupported }
 func (b *Backend) DetachKey() string                                       { return "" }
+func (b *Backend) SupportsPopup() bool                                     { return false }
+func (b *Backend) PopupAttach(_ string) error                              { return errNotSupported }
+func (b *Backend) UseExecAttach() bool                                     { return false }
 
 // SockPath returns an empty string on Windows (no socket used).
 func SockPath() string { return "" }

--- a/internal/mux/tmux/backend.go
+++ b/internal/mux/tmux/backend.go
@@ -9,7 +9,6 @@ import (
 	"github.com/lucascaro/hive/internal/mux"
 	"github.com/lucascaro/hive/internal/tmux"
 )
-
 // Backend wraps the tmux CLI to implement mux.Backend.
 type Backend struct{}
 
@@ -64,6 +63,32 @@ func (b *Backend) CapturePaneRaw(target string, lines int) (string, error) {
 
 // DetachKey returns the tmux detach key description.
 func (b *Backend) DetachKey() string { return "Ctrl+B D" }
+
+// UseExecAttach returns true: the tmux backend attaches by running an external
+// tmux command, which is suitable for tea.ExecProcess.
+func (b *Backend) UseExecAttach() bool { return true }
+// Requires tmux ≥ 3.2 AND that hive is currently running inside a tmux session
+// (i.e. the TMUX environment variable is set).
+func (b *Backend) SupportsPopup() bool {
+	return os.Getenv("TMUX") != "" && tmux.SupportsDisplayPopup()
+}
+
+// PopupAttach opens a floating tmux popup overlay connected to the window at
+// target. The popup fills 95 % of the terminal width and 90 % of its height.
+// It closes automatically when the attached session detaches or the process exits.
+func (b *Backend) PopupAttach(target string) error {
+	cmd := exec.Command("tmux", "display-popup",
+		"-E",           // close popup when command exits
+		"-w", "95%",
+		"-h", "90%",
+		"--",
+		"tmux", "attach-session", "-t", target,
+	)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
 
 // Attach runs "tmux attach-session -t target", giving the user direct access
 // to the tmux window. The user detaches with Ctrl+B D.

--- a/internal/tmux/version.go
+++ b/internal/tmux/version.go
@@ -1,0 +1,43 @@
+package tmux
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Version returns the major and minor version of the installed tmux binary.
+// For example, "tmux 3.4" returns (3, 4, nil).
+func Version() (major, minor int, err error) {
+	out, err := Exec("-V")
+	if err != nil {
+		return 0, 0, fmt.Errorf("tmux -V: %w", err)
+	}
+	// Expected format: "tmux 3.4" or "tmux 3.4a" (letter suffixes are ignored).
+	out = strings.TrimSpace(out)
+	var name string
+	var vstr string
+	if _, scanErr := fmt.Sscanf(out, "%s %s", &name, &vstr); scanErr != nil {
+		return 0, 0, fmt.Errorf("parse tmux version %q: %w", out, scanErr)
+	}
+	// Strip any trailing non-numeric suffix (e.g. "3.4a" → "3.4").
+	cleaned := strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' || r == '.' {
+			return r
+		}
+		return -1
+	}, vstr)
+	if _, scanErr := fmt.Sscanf(cleaned, "%d.%d", &major, &minor); scanErr != nil {
+		return 0, 0, fmt.Errorf("parse tmux version numbers %q: %w", cleaned, scanErr)
+	}
+	return major, minor, nil
+}
+
+// SupportsDisplayPopup reports whether the installed tmux supports
+// the display-popup command (requires tmux ≥ 3.2).
+func SupportsDisplayPopup() bool {
+	major, minor, err := Version()
+	if err != nil {
+		return false
+	}
+	return major > 3 || (major == 3 && minor >= 2)
+}

--- a/internal/tmux/version.go
+++ b/internal/tmux/version.go
@@ -12,12 +12,15 @@ func Version() (major, minor int, err error) {
 	if err != nil {
 		return 0, 0, fmt.Errorf("tmux -V: %w", err)
 	}
-	// Expected format: "tmux 3.4" or "tmux 3.4a" (letter suffixes are ignored).
-	out = strings.TrimSpace(out)
-	var name string
-	var vstr string
-	if _, scanErr := fmt.Sscanf(out, "%s %s", &name, &vstr); scanErr != nil {
-		return 0, 0, fmt.Errorf("parse tmux version %q: %w", out, scanErr)
+	return parseVersion(strings.TrimSpace(out))
+}
+
+// parseVersion parses the output of "tmux -V" (e.g. "tmux 3.4" or "tmux 3.4a")
+// into major and minor version numbers. It is a pure function suitable for unit testing.
+func parseVersion(output string) (major, minor int, err error) {
+	var name, vstr string
+	if _, scanErr := fmt.Sscanf(output, "%s %s", &name, &vstr); scanErr != nil {
+		return 0, 0, fmt.Errorf("parse tmux version %q: %w", output, scanErr)
 	}
 	// Strip any trailing non-numeric suffix (e.g. "3.4a" → "3.4").
 	cleaned := strings.Map(func(r rune) rune {
@@ -39,5 +42,10 @@ func SupportsDisplayPopup() bool {
 	if err != nil {
 		return false
 	}
+	return supportsDisplayPopup(major, minor)
+}
+
+// supportsDisplayPopup is a pure helper used both by SupportsDisplayPopup and tests.
+func supportsDisplayPopup(major, minor int) bool {
 	return major > 3 || (major == 3 && minor >= 2)
 }

--- a/internal/tmux/version_test.go
+++ b/internal/tmux/version_test.go
@@ -1,0 +1,68 @@
+package tmux
+
+import "testing"
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input        string
+		wantMajor    int
+		wantMinor    int
+		wantErrMatch bool
+	}{
+		{"tmux 3.4", 3, 4, false},
+		{"tmux 3.4a", 3, 4, false},  // letter suffix ignored
+		{"tmux 3.2", 3, 2, false},
+		{"tmux 3.1", 3, 1, false},
+		{"tmux 2.9", 2, 9, false},
+		{"tmux 4.0", 4, 0, false},
+		{"tmux 3.3b", 3, 3, false},
+		{"", 0, 0, true},
+		{"notmux", 0, 0, true},
+		{"tmux only-one-field", 0, 0, true},
+	}
+
+	for _, tc := range tests {
+		major, minor, err := parseVersion(tc.input)
+		if tc.wantErrMatch {
+			if err == nil {
+				t.Errorf("parseVersion(%q): expected error, got major=%d minor=%d", tc.input, major, minor)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseVersion(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if major != tc.wantMajor || minor != tc.wantMinor {
+			t.Errorf("parseVersion(%q) = (%d, %d), want (%d, %d)",
+				tc.input, major, minor, tc.wantMajor, tc.wantMinor)
+		}
+	}
+}
+
+func TestSupportsDisplayPopup(t *testing.T) {
+	tests := []struct {
+		major int
+		minor int
+		want  bool
+	}{
+		{3, 2, true},  // exact minimum
+		{3, 3, true},
+		{3, 4, true},
+		{4, 0, true},
+		{4, 1, true},
+		{3, 1, false}, // one minor below minimum
+		{3, 0, false},
+		{2, 9, false},
+		{2, 0, false},
+		{1, 0, false},
+	}
+
+	for _, tc := range tests {
+		got := supportsDisplayPopup(tc.major, tc.minor)
+		if got != tc.want {
+			t.Errorf("supportsDisplayPopup(%d, %d) = %v, want %v",
+				tc.major, tc.minor, got, tc.want)
+		}
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -64,7 +64,8 @@ type Model struct {
 	// Attach hint overlay
 	showAttachHint bool
 	pendingAttach  *SessionAttachMsg
-	// Attach flow: set before tea.Quit so cmd/start.go can act on it.
+	// attachPending is set before tea.Quit so cmd/start.go can handle the
+	// attach when the native backend is active (which cannot use tea.ExecProcess).
 	attachPending *SessionAttachMsg
 	// previewPollGen is incremented each time we intentionally start a fresh
 	// polling cycle (session switch, new session, detach).  PreviewUpdatedMsg
@@ -294,11 +295,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case SessionAttachMsg:
-		m.attachPending = &msg
-		return m, tea.Quit
+		return m, m.doAttach(msg)
+
+	case AttachDoneMsg:
+		if msg.Err != nil {
+			return m, func() tea.Msg { return ErrorMsg{Err: msg.Err} }
+		}
+		m.appState.RestoreGridMode = msg.RestoreGridMode
+		m.previewPollGen++
+		return m, m.schedulePollPreview()
 
 	case SessionDetachedMsg:
-		m.previewPollGen++ // returning from tmux, start fresh poll chain
+		m.previewPollGen++ // returning from native attach; start fresh poll chain
 		return m, m.schedulePollPreview()
 
 	// --- Team lifecycle ---
@@ -384,8 +392,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showAttachHint = true
 			return m, nil
 		}
-		m.attachPending = attach
-		return m, tea.Quit
+		return m, m.doAttach(*attach)
 
 	// --- Agent picker result ---
 	case components.AgentPickedMsg:
@@ -1949,8 +1956,7 @@ func (m Model) handleAttachHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if attach == nil {
 			return m, nil
 		}
-		m.attachPending = attach
-		return m, tea.Quit
+		return m, m.doAttach(*attach)
 	case "d":
 		// Don't show again: save to config.
 		m.showAttachHint = false
@@ -1961,8 +1967,7 @@ func (m Model) handleAttachHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if attach == nil {
 			return m, nil
 		}
-		m.attachPending = attach
-		return m, tea.Quit
+		return m, m.doAttach(*attach)
 	case "esc", "q":
 		m.showAttachHint = false
 		m.pendingAttach = nil
@@ -2309,8 +2314,59 @@ func (m Model) tmuxHelpView() string {
 	)
 }
 
-// RunAttach handles the attach flow: exits TUI, attaches to the session, relaunches TUI.
-// This is called by cmd/start.go after tea.Program.Run returns with a SessionAttachMsg.
+// doAttach returns the tea.Cmd that performs session attachment.
+//
+// For the tmux backend (UseExecAttach = true) it uses tea.ExecProcess so the
+// TUI is merely suspended during the attach — no restart, no state reload.
+//   - If the backend supports display-popup (tmux ≥ 3.2, running inside tmux)
+//     the session opens as a floating overlay over the TUI.
+//   - Otherwise a plain full-screen tmux attach-session is used.
+//
+// For the native backend (UseExecAttach = false) it falls back to setting
+// attachPending and calling tea.Quit; cmd/start.go handles the restart.
+func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
+	target := mux.Target(sess.TmuxSession, sess.TmuxWindow)
+	restoreMode := sess.RestoreGridMode
+
+	if !mux.UseExecAttach() {
+		// Native backend: use the classic quit+restart path.
+		m.attachPending = &sess
+		return tea.Quit
+	}
+
+	var cmd *exec.Cmd
+	if mux.SupportsPopup() {
+		// Floating popup overlay — TUI stays alive underneath.
+		cmd = exec.Command("tmux", "display-popup",
+			"-E",       // close popup when command exits
+			"-w", "95%",
+			"-h", "90%",
+			"--",
+			"tmux", "attach-session", "-t", target,
+		)
+	} else {
+		// Full-screen attach wrapped in a shell that pushes/pops the terminal
+		// window title so the user can see which session they are in.
+		title := buildAttachTitle(sess)
+		script := fmt.Sprintf(
+			`printf '\033[22;0t\033]0;%s\007'; tmux attach-session -t '%s'; printf '\033[23;0t'`,
+			strings.ReplaceAll(title, "'", `'\''`),
+			strings.ReplaceAll(target, "'", `'\''`),
+		)
+		cmd = exec.Command("sh", "-c", script)
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return AttachDoneMsg{Err: err, RestoreGridMode: restoreMode}
+	})
+}
+
+// RunAttach handles the attach flow for the native backend: called by cmd/start.go
+// after tea.Program.Run returns with a non-nil LastAttach(). Not used when the
+// tmux backend is active (which uses tea.ExecProcess internally).
 func RunAttach(sess SessionAttachMsg) error {
 	// Set the terminal window/tab title so the user always knows which session
 	// they are in, even when the attached app redraws the entire screen.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -295,7 +295,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case SessionAttachMsg:
-		return m, m.doAttach(msg)
+		cmd := m.doAttach(msg)
+		return m, cmd
 
 	case AttachDoneMsg:
 		if msg.Err != nil {
@@ -392,7 +393,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.showAttachHint = true
 			return m, nil
 		}
-		return m, m.doAttach(*attach)
+		cmd := m.doAttach(*attach)
+		return m, cmd
 
 	// --- Agent picker result ---
 	case components.AgentPickedMsg:
@@ -1956,7 +1958,8 @@ func (m Model) handleAttachHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if attach == nil {
 			return m, nil
 		}
-		return m, m.doAttach(*attach)
+		cmd := m.doAttach(*attach)
+		return m, cmd
 	case "d":
 		// Don't show again: save to config.
 		m.showAttachHint = false
@@ -1967,7 +1970,8 @@ func (m Model) handleAttachHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if attach == nil {
 			return m, nil
 		}
-		return m, m.doAttach(*attach)
+		cmd := m.doAttach(*attach)
+		return m, cmd
 	case "esc", "q":
 		m.showAttachHint = false
 		m.pendingAttach = nil
@@ -2338,22 +2342,19 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 	if mux.SupportsPopup() {
 		// Floating popup overlay — TUI stays alive underneath.
 		cmd = exec.Command("tmux", "display-popup",
-			"-E",       // close popup when command exits
+			"-E",        // close popup when command exits
 			"-w", "95%",
 			"-h", "90%",
 			"--",
 			"tmux", "attach-session", "-t", target,
 		)
 	} else {
-		// Full-screen attach wrapped in a shell that pushes/pops the terminal
-		// window title so the user can see which session they are in.
-		title := buildAttachTitle(sess)
-		script := fmt.Sprintf(
-			`printf '\033[22;0t\033]0;%s\007'; tmux attach-session -t '%s'; printf '\033[23;0t'`,
-			strings.ReplaceAll(title, "'", `'\''`),
-			strings.ReplaceAll(target, "'", `'\''`),
-		)
-		cmd = exec.Command("sh", "-c", script)
+		// Full-screen attach. Run tmux directly without a shell wrapper.
+		// The terminal title is set by the native RunAttach path only (that
+		// path has an opportunity to write escapes between TUI exit and
+		// attach); for the ExecProcess path the tmux status bar provides
+		// sufficient session context.
+		cmd = exec.Command("tmux", "attach-session", "-t", target)
 	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -30,9 +30,11 @@ type SessionAttachMsg struct {
 	ProjectName  string
 }
 
-// SessionDetachedMsg is sent when the user returns from a tmux session.
-// Deprecated: use AttachDoneMsg which carries an error and is returned by
-// the tea.ExecProcess callback in the new in-process attach flow.
+// SessionDetachedMsg is retained for the legacy native-backend attach/restart
+// path. When the native backend is active, cmd/start.go calls mux.Attach
+// directly and sends this message to the TUI on return so the preview poll
+// chain is reset. It is not used by the tmux backend (which handles detach
+// via the AttachDoneMsg callback from tea.ExecProcess).
 type SessionDetachedMsg struct{}
 
 // AttachDoneMsg is returned by the tea.ExecProcess callback when the user

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -31,7 +31,16 @@ type SessionAttachMsg struct {
 }
 
 // SessionDetachedMsg is sent when the user returns from a tmux session.
+// Deprecated: use AttachDoneMsg which carries an error and is returned by
+// the tea.ExecProcess callback in the new in-process attach flow.
 type SessionDetachedMsg struct{}
+
+// AttachDoneMsg is returned by the tea.ExecProcess callback when the user
+// detaches from (or the process running in) an attached or popup session.
+type AttachDoneMsg struct {
+	Err             error
+	RestoreGridMode state.GridRestoreMode
+}
 
 // SessionTitleChangedMsg carries a new title for a session.
 type SessionTitleChangedMsg struct {
@@ -108,3 +117,4 @@ type ConfigSavedMsg struct {
 
 // Ensure tea.Msg interface satisfaction (compile-time checks).
 var _ tea.Msg = SessionCreatedMsg{}
+var _ tea.Msg = AttachDoneMsg{}


### PR DESCRIPTION
## Summary

When using the tmux backend, pressing Enter on a session no longer quits and restarts the TUI. The TUI now suspends in place via `tea.ExecProcess` while the session is attached. When you detach, the TUI resumes immediately with all state intact.

### On tmux ≥ 3.2 (running inside a tmux session)

The session opens as a **floating `display-popup` overlay** (95% × 90%) that sits on top of the TUI. Closing the popup (or the agent exiting) returns you directly to the running TUI — no full-screen switch, no restart.

### On older tmux or outside a tmux session

Falls back to a plain full-screen `tmux attach-session`, still with the no-restart benefit since `tea.ExecProcess` resumes the TUI after detach.

### Native PTY backend

Unchanged — continues to use the existing quit+restart loop in `cmd/start.go`.

## Changes

| File | What |
|------|------|
| `internal/tmux/version.go` | New `Version()` / `SupportsDisplayPopup()` helpers |
| `internal/mux/interface.go` | Added `SupportsPopup()`, `UseExecAttach()`, `PopupAttach()` to `Backend` interface |
| `internal/mux/tmux/backend.go` | Implements the three new methods; `PopupAttach` runs `tmux display-popup -E -w 95% -h 90% -- tmux attach-session -t <target>` |
| `internal/mux/native/backend_{unix,windows}.go` | Stub implementations (`SupportsPopup=false`, `UseExecAttach=false`) |
| `internal/tui/messages.go` | Added `AttachDoneMsg{Err, RestoreGridMode}` |
| `internal/tui/app.go` | New `doAttach()` helper; all attach paths call it; `AttachDoneMsg` handler refreshes preview on return |
| `cmd/start.go` | Clarified the quit+restart loop is native-backend-only |
| `CHANGELOG.md`, `docs/features.md` | Updated |

## Testing

All existing tests pass. Verified manually — popup opens, interaction works, TUI resumes cleanly on detach.