### PR TITLE
feat: terminal bell forwarding and session bell indicator

### DIFF
--- a/internal/escape/parser.go
+++ b/internal/escape/parser.go
@@ -1,9 +1,22 @@
 package escape
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // oscTitleRE matches OSC 2 window title sequences: ESC ] 2 ; <title> BEL
 var oscTitleRE = regexp.MustCompile(`\x1b\]2;([^\x07\x1b]*)\x07`)
+
+// oscSeqRE matches any OSC sequence (used to strip them before bell detection).
+var oscSeqRE = regexp.MustCompile(`\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)`)
+
+// DetectBell reports whether raw pane output contains a standalone BEL character
+// (i.e. one that is not the terminator of an OSC sequence).
+func DetectBell(raw string) bool {
+	stripped := oscSeqRE.ReplaceAllString(raw, "")
+	return strings.ContainsRune(stripped, '\x07')
+}
 
 // nullMarkerRE matches the custom null-byte marker: \x00HIVE_TITLE:{title}\x00
 var nullMarkerRE = regexp.MustCompile(`\x00HIVE_TITLE:([^\x00]+)\x00`)

--- a/internal/escape/watcher.go
+++ b/internal/escape/watcher.go
@@ -35,19 +35,24 @@ func WatchTitles(sessionTargets map[string]string, interval time.Duration) tea.C
 // StatusesDetectedMsg carries fresh status readings and updated content snapshots
 // for all polled sessions.
 type StatusesDetectedMsg struct {
-	Statuses map[string]state.SessionStatus // sessionID → detected status
-	Contents map[string]string              // sessionID → captured pane content (for next diff)
+	Statuses    map[string]state.SessionStatus // sessionID → detected status
+	Contents    map[string]string              // sessionID → captured pane content (for next diff)
+	RawContents map[string]string              // sessionID → raw pane output (for bell detection bookkeeping)
+	Bells       map[string]bool               // sessionID → true if a new bell was detected
 }
 
 // WatchStatuses returns a tea.Cmd that captures pane content for all active sessions
 // and derives running/idle status by comparing against prevContents.
 // A session whose content changed since prevContents is StatusRunning; one whose
 // content is unchanged is StatusIdle. prevContents maps sessionID → last content.
+// prevRawContents maps sessionID → last raw output (used for bell detection).
 // sessionTargets maps sessionID → "tmuxSession:windowIdx".
-func WatchStatuses(sessionTargets map[string]string, prevContents map[string]string, interval time.Duration) tea.Cmd {
+func WatchStatuses(sessionTargets map[string]string, prevContents map[string]string, prevRawContents map[string]string, interval time.Duration) tea.Cmd {
 	return tea.Tick(interval, func(_ time.Time) tea.Msg {
 		statuses := make(map[string]state.SessionStatus, len(sessionTargets))
 		contents := make(map[string]string, len(sessionTargets))
+		rawContents := make(map[string]string, len(sessionTargets))
+		bells := make(map[string]bool)
 		for sessionID, target := range sessionTargets {
 			content, err := mux.CapturePane(target, 50)
 			if err != nil {
@@ -59,7 +64,14 @@ func WatchStatuses(sessionTargets map[string]string, prevContents map[string]str
 			} else {
 				statuses[sessionID] = state.StatusIdle
 			}
+			raw, err := mux.CapturePaneRaw(target, 50)
+			if err == nil {
+				rawContents[sessionID] = raw
+				if raw != prevRawContents[sessionID] && DetectBell(raw) {
+					bells[sessionID] = true
+				}
+			}
 		}
-		return StatusesDetectedMsg{Statuses: statuses, Contents: contents}
+		return StatusesDetectedMsg{Statuses: statuses, Contents: contents, RawContents: rawContents, Bells: bells}
 	})
 }

--- a/internal/state/model.go
+++ b/internal/state/model.go
@@ -126,6 +126,7 @@ type Session struct {
 	CreatedAt      time.Time         `json:"created_at"`
 	LastActiveAt   time.Time         `json:"last_active_at"`
 	Meta           map[string]string `json:"meta,omitempty"`
+	BellPending    bool              `json:"-"` // transient: unacknowledged bell from this session
 }
 
 // AppState is the single source of truth for the TUI.

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -147,6 +147,15 @@ func UpdateSessionTitle(state *AppState, sessionID, title string, src TitleSourc
 	return state
 }
 
+// SetSessionBell sets or clears the BellPending flag on a session.
+func SetSessionBell(state *AppState, sessionID string, pending bool) *AppState {
+	sess := findSession(state, sessionID)
+	if sess != nil {
+		sess.BellPending = pending
+	}
+	return state
+}
+
 // UpdateSessionStatus updates the status of a session.
 func UpdateSessionStatus(state *AppState, sessionID string, status SessionStatus) *AppState {
 	sess := findSession(state, sessionID)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -75,6 +75,9 @@ type Model struct {
 	// contentSnapshots holds the last captured pane content for each session,
 	// used by the status watcher to detect activity via content diffing.
 	contentSnapshots map[string]string
+	// rawSnapshots holds the last raw pane output for each session,
+	// used by the status watcher to detect new bell characters.
+	rawSnapshots map[string]string
 }
 
 // LastAttach returns the pending attach request after the TUI exits, or nil.
@@ -99,6 +102,7 @@ func New(cfg config.Config, appState state.AppState) Model {
 		orphanPicker:     components.NewOrphanPicker(appState.OrphanSessions),
 		nameInput:        ni,
 		contentSnapshots: make(map[string]string),
+		rawSnapshots:     make(map[string]string),
 	}
 	// Clear the transient field now that the picker owns the list.
 	m.appState.OrphanSessions = nil
@@ -234,6 +238,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		for sessionID, content := range msg.Contents {
 			m.contentSnapshots[sessionID] = content
 		}
+		for sessionID, raw := range msg.RawContents {
+			m.rawSnapshots[sessionID] = raw
+		}
 		// If the status watcher captured new content for the active session, update
 		// the preview immediately rather than waiting for the next PollPreview tick.
 		if content, ok := msg.Contents[m.appState.ActiveSessionID]; ok {
@@ -248,10 +255,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				changed = true
 			}
 		}
+		var bellCmds []tea.Cmd
+		for sessionID, hasBell := range msg.Bells {
+			if hasBell {
+				m.appState = *state.SetSessionBell(&m.appState, sessionID, true)
+				changed = true
+				bellCmds = append(bellCmds, soundBellCmd())
+			}
+		}
 		if changed {
 			m.sidebar.Rebuild(&m.appState)
 		}
-		return m, m.scheduleWatchStatuses()
+		return m, tea.Batch(append(bellCmds, m.scheduleWatchStatuses())...)
 
 	// --- Session lifecycle ---
 	case SessionCreatedMsg:
@@ -1875,6 +1890,8 @@ func (m *Model) syncActiveFromSidebar() {
 		cached := m.contentSnapshots[sel.SessionID]
 		m.appState.PreviewContent = cached
 		m.preview.SetContent(cached)
+		// Clear any pending bell notification for the session now being viewed.
+		m.appState = *state.SetSessionBell(&m.appState, sel.SessionID, false)
 	}
 	if sel.ProjectID != "" {
 		m.appState.ActiveProjectID = sel.ProjectID
@@ -2141,6 +2158,14 @@ func (m *Model) scheduleWatchTitles() tea.Cmd {
 	return escape.WatchTitles(targets, interval)
 }
 
+// soundBellCmd returns a command that writes the BEL character to the host terminal.
+func soundBellCmd() tea.Cmd {
+	return func() tea.Msg {
+		fmt.Fprint(os.Stdout, "\a")
+		return nil
+	}
+}
+
 func (m *Model) scheduleWatchStatuses() tea.Cmd {
 	targets := make(map[string]string)
 	for _, sess := range state.AllSessions(&m.appState) {
@@ -2152,7 +2177,7 @@ func (m *Model) scheduleWatchStatuses() tea.Cmd {
 		return nil
 	}
 	interval := time.Duration(m.cfg.PreviewRefreshMs*2) * time.Millisecond
-	return escape.WatchStatuses(targets, m.contentSnapshots, interval)
+	return escape.WatchStatuses(targets, m.contentSnapshots, m.rawSnapshots, interval)
 }
 
 // --- View helpers ---

--- a/internal/tui/components/sidebar.go
+++ b/internal/tui/components/sidebar.go
@@ -48,6 +48,7 @@ type SidebarItem struct {
 	ProjectNum     int    // 1-based number for projects (0 = not a project)
 	IsWorktree     bool   // true if the session runs in a git worktree
 	WorktreeBranch string // branch name for worktree sessions
+	Bell           bool   // true if session has an unacknowledged bell
 }
 
 // Sidebar manages the project/team/session tree.
@@ -113,6 +114,7 @@ func (s *Sidebar) Rebuild(appState *state.AppState) {
 					TeamRole:       string(sess.TeamRole),
 					IsWorktree:     sess.WorktreePath != "",
 					WorktreeBranch: sess.WorktreeBranch,
+					Bell:           sess.BellPending,
 				})
 			}
 		}
@@ -132,6 +134,7 @@ func (s *Sidebar) Rebuild(appState *state.AppState) {
 				TeamRole:       string(state.RoleStandalone),
 				IsWorktree:     sess.WorktreePath != "",
 				WorktreeBranch: sess.WorktreeBranch,
+				Bell:           sess.BellPending,
 			})
 		}
 	}
@@ -349,7 +352,11 @@ func (s *Sidebar) renderItem(item SidebarItem, selected, active bool, width int)
 		if item.IsWorktree && item.WorktreeBranch != "" {
 			worktreeBadge = " " + styles.MutedStyle.Render("⎇ "+item.WorktreeBranch)
 		}
-		label = fmt.Sprintf("%s%s %s %s%s", rolePrefix, dot, item.Label, badge, worktreeBadge)
+		bellBadge := ""
+		if item.Bell {
+			bellBadge = " " + styles.BellStyle.Render("!")
+		}
+		label = fmt.Sprintf("%s%s %s %s%s%s", rolePrefix, dot, item.Label, badge, worktreeBadge, bellBadge)
 		if active {
 			label += " ←"
 		}

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -93,6 +93,8 @@ var (
 	ErrorStyle = lipgloss.NewStyle().Foreground(ColorError)
 
 	MutedStyle = lipgloss.NewStyle().Foreground(ColorMuted)
+
+	BellStyle = lipgloss.NewStyle().Foreground(ColorWarning).Bold(true)
 )
 
 // AgentBadge returns a styled agent type badge.


### PR DESCRIPTION
## Summary

- Detect BEL (`\x07`) in raw pane output during the status polling cycle, distinguishing standalone bells from OSC sequence terminators
- Forward the bell to the host terminal so users hear it regardless of which session is active or focused
- Show a persistent bold orange `!` badge on sessions with an unacknowledged bell in the sidebar
- Clear the badge automatically when the user navigates to the session

## How it works

`WatchStatuses` now fetches raw pane output alongside stripped content. `DetectBell()` strips OSC sequences (which legitimately use `\x07` as a terminator) before checking for bare BEL characters. New bells trigger `soundBellCmd()` and set a transient `BellPending` flag on the session — `syncActiveFromSidebar` clears it on navigation.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/escape/...` passes
- [ ] Start hive, open a session, run `printf '\a'` → host terminal bell sounds and `!` badge appears on that session in the sidebar
- [ ] Navigate to the session → `!` badge clears
- [ ] With multiple sessions, ring bell in a non-active session → bell sounds, badge only on that session

🤖 Generated with [Claude Code](https://claude.ai/claude-code)