### PR TITLE
feat: single hive-sessions tmux session with descriptive window names

### DIFF
--- a/internal/mux/doc.go
+++ b/internal/mux/doc.go
@@ -18,9 +18,9 @@
 //
 // Sessions and windows are addressed by string targets:
 //
-//	session  = mux.SessionName(projectID)   // "hive-{projectID[:8]}"
-//	window   = mux.WindowName(sessionID)    // sessionID[:8]
-//	target   = mux.Target(session, index)   // "session:index"
+//	session  = mux.SessionName(projectID)              // always "hive-sessions"
+//	window   = mux.WindowName(projName, agent, title)  // "{proj[:8]}-{agent}-{title[:12]}"
+//	target   = mux.Target(session, index)              // "hive-sessions:index"
 //
 // # Thread safety
 //

--- a/internal/mux/interface.go
+++ b/internal/mux/interface.go
@@ -5,7 +5,13 @@ package mux
 
 import "fmt"
 
-const shortIDLen = 8
+const (
+	projMaxLen  = 8
+	titleMaxLen = 12
+
+	// HiveSession is the single shared tmux session used for all hive windows.
+	HiveSession = "hive-sessions"
+)
 
 // WindowInfo holds information about a window within a session.
 type WindowInfo struct {
@@ -72,21 +78,24 @@ func SetBackend(b Backend) {
 
 // ---- Utility functions (backend-independent) --------------------------------
 
-// SessionName returns the session name for a project.
-func SessionName(projectID string) string {
-	short := projectID
-	if len(short) > shortIDLen {
-		short = short[:shortIDLen]
-	}
-	return fmt.Sprintf("hive-%s", short)
-}
+// SessionName returns the shared tmux session name. All hive windows live in
+// one session so they are easy to find and recover. The projectID argument is
+// ignored; it is kept for call-site compatibility.
+func SessionName(_ string) string { return HiveSession }
 
-// WindowName returns the window name for a session.
-func WindowName(sessionID string) string {
-	if len(sessionID) > shortIDLen {
-		return sessionID[:shortIDLen]
+// WindowName returns a descriptive window name encoding the project, agent
+// type, and session title so windows are identifiable in `tmux list-windows`.
+// Format: {project[:8]}-{agentType}-{title[:12]}
+func WindowName(projectName, agentType, sessionTitle string) string {
+	proj := projectName
+	if len(proj) > projMaxLen {
+		proj = proj[:projMaxLen]
 	}
-	return sessionID
+	title := sessionTitle
+	if len(title) > titleMaxLen {
+		title = title[:titleMaxLen]
+	}
+	return fmt.Sprintf("%s-%s-%s", proj, agentType, title)
 }
 
 // Target returns the target string "session:window" used to address a pane.

--- a/internal/tmux/names.go
+++ b/internal/tmux/names.go
@@ -3,7 +3,6 @@ package tmux
 import "fmt"
 
 const (
-	shortIDLen  = 8
 	projMaxLen  = 8
 	titleMaxLen = 12
 

--- a/internal/tmux/names.go
+++ b/internal/tmux/names.go
@@ -2,23 +2,31 @@ package tmux
 
 import "fmt"
 
-const shortIDLen = 8
+const (
+	shortIDLen  = 8
+	projMaxLen  = 8
+	titleMaxLen = 12
 
-// SessionName returns the tmux session name for a project.
-func SessionName(projectID string) string {
-	short := projectID
-	if len(short) > shortIDLen {
-		short = short[:shortIDLen]
-	}
-	return fmt.Sprintf("hive-%s", short)
-}
+	// HiveSession is the single shared tmux session used for all hive windows.
+	HiveSession = "hive-sessions"
+)
 
-// WindowName returns the tmux window name for a session.
-func WindowName(sessionID string) string {
-	if len(sessionID) > shortIDLen {
-		return sessionID[:shortIDLen]
+// SessionName returns the shared tmux session name. The projectID argument is
+// ignored; all hive windows live in one session for easy identification and recovery.
+func SessionName(_ string) string { return HiveSession }
+
+// WindowName returns a descriptive window name encoding the project, agent
+// type, and session title. Format: {project[:8]}-{agentType}-{title[:12]}
+func WindowName(projectName, agentType, sessionTitle string) string {
+	proj := projectName
+	if len(proj) > projMaxLen {
+		proj = proj[:projMaxLen]
 	}
-	return sessionID
+	title := sessionTitle
+	if len(title) > titleMaxLen {
+		title = title[:titleMaxLen]
+	}
+	return fmt.Sprintf("%s-%s-%s", proj, agentType, title)
 }
 
 // Target returns the tmux target string "session:window".

--- a/internal/tmux/names_test.go
+++ b/internal/tmux/names_test.go
@@ -35,47 +35,43 @@ func TestWindowName(t *testing.T) {
 		projectName string
 		agentType   string
 		title       string
-		wantPrefix  string
-		wantContain string
+		want        string
 	}{
 		{
 			name:        "short names",
 			projectName: "myproj",
 			agentType:   "claude",
 			title:       "main",
-			wantPrefix:  "myproj-claude-main",
+			want:        "myproj-claude-main",
 		},
 		{
 			name:        "long project truncated",
 			projectName: "very-long-project-name",
 			agentType:   "codex",
 			title:       "feature",
-			wantPrefix:  "very-lon-codex-feature",
+			want:        "very-lon-codex-feature",
 		},
 		{
 			name:        "long title truncated",
 			projectName: "proj",
 			agentType:   "gemini",
 			title:       "a-very-long-feature-branch-name",
-			wantPrefix:  "proj-gemini-a-very-long-",
+			want:        "proj-gemini-a-very-long-",
 		},
 		{
 			name:        "team worker",
 			projectName: "api",
 			agentType:   "claude",
 			title:       "worker-1",
-			wantPrefix:  "api-claude-worker-1",
+			want:        "api-claude-worker-1",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := WindowName(tc.projectName, tc.agentType, tc.title)
-			if !strings.HasPrefix(got, tc.wantPrefix) {
-				t.Errorf("WindowName(%q, %q, %q) = %q, want prefix %q", tc.projectName, tc.agentType, tc.title, got, tc.wantPrefix)
-			}
-			if !strings.Contains(got, tc.agentType) {
-				t.Errorf("WindowName(%q, %q, %q) = %q, want agent type in name", tc.projectName, tc.agentType, tc.title, got)
+			if got != tc.want {
+				t.Errorf("WindowName(%q, %q, %q) = %q, want %q", tc.projectName, tc.agentType, tc.title, got, tc.want)
 			}
 		})
 	}

--- a/internal/tmux/names_test.go
+++ b/internal/tmux/names_test.go
@@ -9,35 +9,18 @@ func TestSessionName(t *testing.T) {
 	cases := []struct {
 		name      string
 		projectID string
-		want      string
 	}{
-		{
-			name:      "short id not truncated",
-			projectID: "abc",
-			want:      "hive-abc",
-		},
-		{
-			name:      "exactly 8 chars",
-			projectID: "12345678",
-			want:      "hive-12345678",
-		},
-		{
-			name:      "longer than 8 chars gets truncated",
-			projectID: "123456789abcdef",
-			want:      "hive-12345678",
-		},
-		{
-			name:      "empty id",
-			projectID: "",
-			want:      "hive-",
-		},
+		{name: "short id", projectID: "abc"},
+		{name: "exactly 8 chars", projectID: "12345678"},
+		{name: "longer than 8 chars", projectID: "123456789abcdef"},
+		{name: "empty id", projectID: ""},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := SessionName(tc.projectID)
-			if got != tc.want {
-				t.Errorf("SessionName(%q) = %q, want %q", tc.projectID, got, tc.want)
+			if got != HiveSession {
+				t.Errorf("SessionName(%q) = %q, want %q", tc.projectID, got, HiveSession)
 			}
 			if !strings.HasPrefix(got, "hive-") {
 				t.Errorf("SessionName(%q) = %q, want hive- prefix", tc.projectID, got)
@@ -48,37 +31,51 @@ func TestSessionName(t *testing.T) {
 
 func TestWindowName(t *testing.T) {
 	cases := []struct {
-		name      string
-		sessionID string
-		want      string
+		name        string
+		projectName string
+		agentType   string
+		title       string
+		wantPrefix  string
+		wantContain string
 	}{
 		{
-			name:      "short id not truncated",
-			sessionID: "abc",
-			want:      "abc",
+			name:        "short names",
+			projectName: "myproj",
+			agentType:   "claude",
+			title:       "main",
+			wantPrefix:  "myproj-claude-main",
 		},
 		{
-			name:      "exactly 8 chars",
-			sessionID: "12345678",
-			want:      "12345678",
+			name:        "long project truncated",
+			projectName: "very-long-project-name",
+			agentType:   "codex",
+			title:       "feature",
+			wantPrefix:  "very-lon-codex-feature",
 		},
 		{
-			name:      "longer than 8 chars gets truncated",
-			sessionID: "123456789abcdef",
-			want:      "12345678",
+			name:        "long title truncated",
+			projectName: "proj",
+			agentType:   "gemini",
+			title:       "a-very-long-feature-branch-name",
+			wantPrefix:  "proj-gemini-a-very-long-",
 		},
 		{
-			name:      "empty id",
-			sessionID: "",
-			want:      "",
+			name:        "team worker",
+			projectName: "api",
+			agentType:   "claude",
+			title:       "worker-1",
+			wantPrefix:  "api-claude-worker-1",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := WindowName(tc.sessionID)
-			if got != tc.want {
-				t.Errorf("WindowName(%q) = %q, want %q", tc.sessionID, got, tc.want)
+			got := WindowName(tc.projectName, tc.agentType, tc.title)
+			if !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Errorf("WindowName(%q, %q, %q) = %q, want prefix %q", tc.projectName, tc.agentType, tc.title, got, tc.wantPrefix)
+			}
+			if !strings.Contains(got, tc.agentType) {
+				t.Errorf("WindowName(%q, %q, %q) = %q, want agent type in name", tc.projectName, tc.agentType, tc.title, got)
 			}
 		})
 	}
@@ -93,15 +90,15 @@ func TestTarget(t *testing.T) {
 	}{
 		{
 			name:        "basic target",
-			tmuxSession: "hive-abc",
+			tmuxSession: "hive-sessions",
 			windowIdx:   0,
-			want:        "hive-abc:0",
+			want:        "hive-sessions:0",
 		},
 		{
 			name:        "window index 5",
-			tmuxSession: "hive-proj",
+			tmuxSession: "hive-sessions",
 			windowIdx:   5,
-			want:        "hive-proj:5",
+			want:        "hive-sessions:5",
 		},
 		{
 			name:        "empty session",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -273,11 +273,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case SessionTitleChangedMsg:
 		m.appState = *state.UpdateSessionTitle(&m.appState, msg.SessionID, msg.Title, msg.Source)
-		// Rename tmux window too
+		// Rename tmux window keeping the structured {proj}-{agent}-{title} format.
 		sess := m.appState.ActiveSession()
 		if sess != nil {
+			projName := ""
+			if proj := m.appState.ActiveProject(); proj != nil {
+				projName = proj.Name
+			}
 			target := mux.Target(sess.TmuxSession, sess.TmuxWindow)
-			_ = mux.RenameWindow(target, msg.Title)
+			_ = mux.RenameWindow(target, mux.WindowName(projName, string(sess.AgentType), msg.Title))
 			m.fireHook(state.HookEvent{
 				Name:         state.EventSessionTitleChange,
 				SessionID:    sess.ID,
@@ -1805,8 +1809,12 @@ func (m *Model) killProject(projectID string) tea.Cmd {
 					_ = mux.KillWindow(target)
 				}
 			}
-			// Kill session if still around.
-			_ = mux.KillSession(mux.SessionName(projectID))
+			// Kill per-project session if it's not the shared container.
+			// Old persisted sessions may still reference a per-project tmux
+			// session name; the shared HiveSession must never be killed here.
+			if sess := mux.SessionName(projectID); sess != mux.HiveSession {
+				_ = mux.KillSession(sess)
+			}
 			m.fireHook(state.HookEvent{
 				Name:      state.EventProjectKill,
 				ProjectID: p.ID, ProjectName: p.Name,

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1514,14 +1514,14 @@ func (m *Model) spawnWorktreeSession(proj *state.Project, agentTypeStr string, a
 	var windowIdx int
 	var err error
 	if !mux.SessionExists(muxSess) {
-		winName := mux.WindowName(sessionTitle)
+		winName := mux.WindowName(proj.Name, agentTypeStr, sessionTitle)
 		if err = mux.CreateSession(muxSess, winName, worktreePath, agentCmd); err != nil {
 			_ = git.RemoveWorktree(gitRoot, worktreePath)
 			return func() tea.Msg { return ErrorMsg{Err: err} }
 		}
 		windowIdx = 0
 	} else {
-		winName := mux.WindowName(sessionTitle)
+		winName := mux.WindowName(proj.Name, agentTypeStr, sessionTitle)
 		windowIdx, err = mux.CreateWindow(muxSess, winName, worktreePath, agentCmd)
 		if err != nil {
 			_ = git.RemoveWorktree(gitRoot, worktreePath)
@@ -1589,13 +1589,13 @@ func (m *Model) createSession(projectID, agentTypeStr string, agentCmd []string)
 	var windowIdx int
 	var err error
 	if !mux.SessionExists(muxSess) {
-		winName := mux.WindowName(sessionTitle)
+		winName := mux.WindowName(proj.Name, agentTypeStr, sessionTitle)
 		if err = mux.CreateSession(muxSess, winName, workDir, agentCmd); err != nil {
 			return func() tea.Msg { return ErrorMsg{Err: err} }
 		}
 		windowIdx = 0
 	} else {
-		winName := mux.WindowName(sessionTitle)
+		winName := mux.WindowName(proj.Name, agentTypeStr, sessionTitle)
 		windowIdx, err = mux.CreateWindow(muxSess, winName, workDir, agentCmd)
 		if err != nil {
 			return func() tea.Msg { return ErrorMsg{Err: err} }
@@ -1668,13 +1668,13 @@ func (m *Model) addTeamSession(proj *state.Project, team *state.Team, role state
 	var windowIdx int
 	var err error
 	if !mux.SessionExists(muxSess) {
-		winName := mux.WindowName(title)
+		winName := mux.WindowName(proj.Name, string(agentType), title)
 		if err = mux.CreateSession(muxSess, winName, workDir, agentCmd); err != nil {
 			return func() tea.Msg { return ErrorMsg{Err: err} }
 		}
 		windowIdx = 0
 	} else {
-		winName := mux.WindowName(title)
+		winName := mux.WindowName(proj.Name, string(agentType), title)
 		windowIdx, err = mux.CreateWindow(muxSess, winName, workDir, agentCmd)
 		if err != nil {
 			return func() tea.Msg { return ErrorMsg{Err: err} }


### PR DESCRIPTION
## Summary

- All agent windows now live in one shared `hive-sessions` tmux session instead of one per project
- Window names encode project, agent type, and session title: `{proj[:8]}-{agent}-{title[:12]}`
- `SessionName()` returns the constant `"hive-sessions"` regardless of project ID (signature kept for call-site compatibility)
- `WindowName()` updated to a 3-arg signature: `(projectName, agentType, sessionTitle string)`

This makes `tmux list-windows -t hive-sessions` immediately useful — you can see at a glance which project and agent each window belongs to, and recover sessions manually without hive running.

**Example window names:** `myproj-claude-feat-login`, `api-codex-worker-1`, `backend-gemini-orchest`

**Migration:** Existing persisted sessions store their old per-project tmux session name and continue to work during reconcile. New sessions created after this change use `hive-sessions`.

## Test plan

- [x] `go build ./...` — clean build
- [x] `go test ./internal/tmux/... ./internal/mux/...` — all tests pass
- [ ] Launch hive, create sessions in multiple projects with different agent types
- [ ] Run `tmux list-windows -t hive-sessions` and verify window names include project, agent, and title
- [ ] Kill and restart hive; verify sessions reconcile correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)