### PR TITLE
fix: key isolation for modals via focus-based dispatch

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -578,6 +578,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseMsg:
 		return m.handleMouse(msg)
 	}
+
+	// Forward non-key, non-handled messages to active modals that need
+	// internal ticks (e.g. cursor blink, filter debounce in charmbracelet/list).
+	if m.dirPicker.Active {
+		m.dirPicker.Update(msg)
+	}
+
 	return m, nil
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -199,20 +199,6 @@ func (m Model) Init() tea.Cmd {
 
 // Update handles all messages.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// While the directory picker is active, let it handle non-resize messages
-	// before the main update switch. Window size messages still need to be
-	// processed here so the app's dimensions and layout stay in sync.
-	// Only short-circuit when the picker actually consumes the message so that
-	// background messages (preview polls, title/status watchers) continue to run.
-	if m.dirPicker.Active {
-		if _, ok := msg.(tea.WindowSizeMsg); !ok {
-			cmd, consumed := m.dirPicker.Update(msg)
-			if consumed {
-				return m, cmd
-			}
-		}
-	}
-
 	switch msg := msg.(type) {
 	// --- Window resize ---
 	case tea.WindowSizeMsg:
@@ -740,96 +726,190 @@ func (m Model) View() string {
 
 // --- Key handler ---
 
-// handleKey handles keyboard events.
+// handleKey handles keyboard events. It uses a priority-ordered list of
+// KeyHandler adapters: the first focused handler exclusively receives the key
+// event, preventing leakage to lower-priority handlers or global bindings.
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	// Settings screen consumes all keys while active.
-	if m.settings.Active {
-		cmd, _ := m.settings.Update(msg)
+	// ctrl+c always quits, regardless of focus.
+	if msg.String() == "ctrl+c" {
+		return m, tea.Quit
+	}
+
+	if cmd, handled := dispatchKey(m.buildKeyHandlers(), msg); handled {
 		return m, cmd
 	}
-	// Grid overview consumes all keys while active.
-	if m.gridView.Active {
-		m.gridView.Width = m.appState.TermWidth
-		m.gridView.Height = m.appState.TermHeight
-		switch msg.String() {
-		case "G":
-			// Switch to all-projects view without closing.
-			prevID := ""
-			if s := m.gridView.Selected(); s != nil {
-				prevID = s.ID
-			}
-			m.gridView.Show(m.gridSessions(state.GridRestoreAll), state.GridRestoreAll)
-			m.gridView.SetProjectNames(m.gridProjectNames())
-			m.gridView.SyncCursor(prevID)
-			return m, m.scheduleGridPoll()
-		case "x":
-			if sess := m.gridView.Selected(); sess != nil {
-				m.gridView.Hide()
-				s := sess
-				return m, func() tea.Msg {
-					return ConfirmActionMsg{
-						Message: fmt.Sprintf("Kill session %q?", s.Title),
-						Action:  "kill-session:" + s.ID,
-					}
+
+	return m.handleGlobalKey(msg)
+}
+
+// buildKeyHandlers returns KeyHandler adapters in priority order. The first
+// handler whose Focused() returns true wins exclusive key input. Adding a new
+// modal is as simple as adding an entry here.
+func (m *Model) buildKeyHandlers() []KeyHandler {
+	return []KeyHandler{
+		// Full-screen overlays
+		componentHandler{
+			focused: func() bool { return m.settings.Active },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				cmd, _ := m.settings.Update(msg)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.gridView.Active },
+			handle:  func(msg tea.KeyMsg) tea.Cmd { return m.handleGridKey(msg) },
+		},
+
+		// Help overlays — esc closes, everything else is swallowed.
+		componentHandler{
+			focused: func() bool { return m.appState.ShowHelp || m.appState.ShowTmuxHelp },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				if msg.String() == "esc" {
+					m.appState.ShowHelp = false
+					m.appState.ShowTmuxHelp = false
+				}
+				return nil
+			},
+		},
+
+		// Modal dialogs and pickers
+		componentHandler{
+			focused: func() bool { return m.showAttachHint },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleAttachHint(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.appState.ShowConfirm },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleConfirm(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.recoveryPicker.Active },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				updated, cmd := m.recoveryPicker.Update(msg)
+				m.recoveryPicker = updated
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.orphanPicker.Active },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				updated, cmd := m.orphanPicker.Update(msg)
+				m.orphanPicker = updated
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.agentPicker.Active },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				cmd, _ := m.agentPicker.Update(msg)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.teamBuilder.Active },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				return m.teamBuilder.Update(msg)
+			},
+		},
+
+		// Inline editors and text inputs
+		componentHandler{
+			focused: func() bool { return m.appState.EditingTitle },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleTitleEdit(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.inputMode == "project-name" },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleNameInput(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.dirPicker.Active },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				cmd, _ := m.dirPicker.Update(msg)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.inputMode == "project-dir-confirm" },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleDirConfirm(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.inputMode == "worktree-branch" },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleWorktreeBranchInput(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.appState.FilterActive },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleFilter(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+	}
+}
+
+// handleGridKey handles keys when the grid overview is active.
+func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
+	m.gridView.Width = m.appState.TermWidth
+	m.gridView.Height = m.appState.TermHeight
+	switch msg.String() {
+	case "G":
+		prevID := ""
+		if s := m.gridView.Selected(); s != nil {
+			prevID = s.ID
+		}
+		m.gridView.Show(m.gridSessions(state.GridRestoreAll), state.GridRestoreAll)
+		m.gridView.SetProjectNames(m.gridProjectNames())
+		m.gridView.SyncCursor(prevID)
+		return m.scheduleGridPoll()
+	case "x":
+		if sess := m.gridView.Selected(); sess != nil {
+			m.gridView.Hide()
+			s := sess
+			return func() tea.Msg {
+				return ConfirmActionMsg{
+					Message: fmt.Sprintf("Kill session %q?", s.Title),
+					Action:  "kill-session:" + s.ID,
 				}
 			}
-		case "r":
-			if sess := m.gridView.Selected(); sess != nil {
-				m.gridView.Hide()
-				m.sidebar.SyncActiveSession(sess.ID)
-				m.appState.ActiveSessionID = sess.ID
-				return m, m.startRename()
-			}
 		}
-		cmd, _ := m.gridView.Update(msg)
-		return m, cmd
+	case "r":
+		if sess := m.gridView.Selected(); sess != nil {
+			m.gridView.Hide()
+			m.sidebar.SyncActiveSession(sess.ID)
+			m.appState.ActiveSessionID = sess.ID
+			return m.startRename()
+		}
 	}
-	// Route to active sub-component first.
-	if m.appState.EditingTitle {
-		return m.handleTitleEdit(msg)
-	}
-	if m.recoveryPicker.Active {
-		updated, cmd := m.recoveryPicker.Update(msg)
-		m.recoveryPicker = updated
-		return m, cmd
-	}
-	if m.orphanPicker.Active {
-		updated, cmd := m.orphanPicker.Update(msg)
-		m.orphanPicker = updated
-		return m, cmd
-	}
-	if m.agentPicker.Active {
-		cmd, _ := m.agentPicker.Update(msg)
-		return m, cmd
-	}
-	if m.teamBuilder.Active {
-		cmd := m.teamBuilder.Update(msg)
-		return m, cmd
-	}
-	if m.inputMode == "project-name" {
-		return m.handleNameInput(msg)
-	}
-	if m.inputMode == "project-dir-confirm" {
-		return m.handleDirConfirm(msg)
-	}
-	if m.inputMode == "worktree-branch" {
-		return m.handleWorktreeBranchInput(msg)
-	}
-	if m.appState.FilterActive {
-		return m.handleFilter(msg)
-	}
-	if m.showAttachHint {
-		return m.handleAttachHint(msg)
-	}
-	if m.appState.ShowConfirm {
-		return m.handleConfirm(msg)
-	}
+	cmd, _ := m.gridView.Update(msg)
+	return cmd
+}
 
-	// Global keys
+// handleGlobalKey handles keys when no overlay or modal has focus.
+func (m Model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
-	case msg.String() == "ctrl+c":
-		return m, tea.Quit
-
 	case key.Matches(msg, m.keys.Quit):
 		return m, tea.Quit
 
@@ -857,11 +937,6 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.appState.ShowHelp = false
 		return m, nil
 
-	case msg.String() == "esc" && (m.appState.ShowHelp || m.appState.ShowTmuxHelp):
-		m.appState.ShowHelp = false
-		m.appState.ShowTmuxHelp = false
-		return m, nil
-
 	case key.Matches(msg, m.keys.FocusToggle):
 		if m.appState.FocusedPane == state.PaneSidebar {
 			m.appState.FocusedPane = state.PanePreview
@@ -876,8 +951,6 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case key.Matches(msg, m.keys.GridOverview):
-		// g shows only current project; G (handled above in the active-grid block,
-		// or via msg.String()=="G" below) shows all.
 		sessions := m.gridSessions(state.GridRestoreProject)
 		m.gridView.Show(sessions, state.GridRestoreProject)
 		m.gridView.SetProjectNames(m.gridProjectNames())

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -608,3 +608,119 @@ func TestDirPicker_BackgroundMessages_NotDroppedWhileActive(t *testing.T) {
 			updated.appState.PreviewContent, "background update")
 	}
 }
+
+// --- Key isolation tests ---
+
+func TestHandleKey_DirPickerActive_BlocksGlobalKeys(t *testing.T) {
+	m := testModelWithSessions()
+	m.dirPicker.Active = true
+
+	// Press "/" which is the Filter key — should NOT activate global filter.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	updated := result.(Model)
+
+	if updated.appState.FilterActive {
+		t.Error("FilterActive=true while DirPicker is open — key leaked to global bindings")
+	}
+}
+
+func TestHandleKey_DirPickerActive_BlocksQuit(t *testing.T) {
+	m := testModelWithSessions()
+	m.dirPicker.Active = true
+
+	// Press "q" which is the Quit key — should NOT quit.
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+	// tea.Quit returns a special command; if cmd is non-nil and produces
+	// a QuitMsg, the key leaked.
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(tea.QuitMsg); ok {
+			t.Error("quit key fired while DirPicker is open — key leaked to global bindings")
+		}
+	}
+}
+
+func TestHandleKey_AgentPickerActive_BlocksGlobalKeys(t *testing.T) {
+	m := testModelWithSessions()
+	m.agentPicker.Show(components.DefaultAgentItems)
+
+	// Press "/" (Filter key) — should not activate global filter.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	updated := result.(Model)
+
+	if updated.appState.FilterActive {
+		t.Error("FilterActive=true while AgentPicker is open — key leaked to global bindings")
+	}
+}
+
+func TestHandleKey_FilterActive_BlocksGlobalKeys(t *testing.T) {
+	m := testModelWithSessions()
+	m.appState.FilterActive = true
+
+	// Press "n" which is the NewProject key — should add to filter, not open new project.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	updated := result.(Model)
+
+	if updated.inputMode == "project-name" {
+		t.Error("NewProject triggered while filter is active — key leaked to global bindings")
+	}
+	if updated.appState.FilterQuery != "n" {
+		t.Errorf("FilterQuery=%q, want %q", updated.appState.FilterQuery, "n")
+	}
+}
+
+func TestHandleKey_NoOverlay_GlobalKeysWork(t *testing.T) {
+	m := testModelWithSessions()
+
+	// Press "/" to activate filter — should work when no overlay is active.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	updated := result.(Model)
+
+	if !updated.appState.FilterActive {
+		t.Error("FilterActive=false after pressing / with no overlay — global keys broken")
+	}
+}
+
+func TestHandleKey_SettingsActive_BlocksAll(t *testing.T) {
+	m := testModelWithSessions()
+	m.settings.Active = true
+
+	// Press "n" (NewProject) — should be swallowed by settings.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	updated := result.(Model)
+
+	if updated.inputMode == "project-name" {
+		t.Error("NewProject triggered while Settings is open — key leaked to global bindings")
+	}
+}
+
+func TestHandleKey_ConfirmActive_BlocksAll(t *testing.T) {
+	m := testModelWithSessions()
+	m.appState.ShowConfirm = true
+	m.appState.ConfirmAction = "test-action"
+	m.confirm.Message = "Are you sure?"
+
+	// Press "n" (NewProject key) — should be handled by confirm (treated as cancel/no-op).
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	updated := result.(Model)
+
+	if updated.inputMode == "project-name" {
+		t.Error("NewProject triggered while Confirm is open — key leaked to global bindings")
+	}
+}
+
+func TestHandleKey_CtrlC_AlwaysQuits(t *testing.T) {
+	m := testModelWithSessions()
+	m.dirPicker.Active = true
+
+	// ctrl+c should always quit, even with an overlay active.
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Fatal("ctrl+c should return a quit command")
+	}
+	msg := cmd()
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		t.Fatalf("ctrl+c cmd returned %T, want tea.QuitMsg", msg)
+	}
+}

--- a/internal/tui/components/dirpicker.go
+++ b/internal/tui/components/dirpicker.go
@@ -169,7 +169,10 @@ func (dp *DirPicker) Update(msg tea.Msg) (tea.Cmd, bool) {
 
 	var cmd tea.Cmd
 	dp.list, cmd = dp.list.Update(msg)
-	return cmd, false
+	// When the picker is active, always consume key messages so they never
+	// leak to global bindings (e.g. while the list's built-in filter is open).
+	_, isKey := msg.(tea.KeyMsg)
+	return cmd, isKey
 }
 
 // View renders the picker as a styled modal overlay. Returns empty when inactive.

--- a/internal/tui/components/dirpicker_test.go
+++ b/internal/tui/components/dirpicker_test.go
@@ -1,0 +1,185 @@
+package components
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func testDirPicker(t *testing.T) DirPicker {
+	t.Helper()
+	dp := NewDirPicker()
+	dir := t.TempDir()
+	// Create a couple of sub-directories for navigation tests.
+	os.MkdirAll(filepath.Join(dir, "aaa"), 0755)
+	os.MkdirAll(filepath.Join(dir, "bbb"), 0755)
+	dp.Show(dir)
+	return dp
+}
+
+func TestDirPicker_ActiveConsumesAllKeyMsg(t *testing.T) {
+	dp := testDirPicker(t)
+
+	keys := []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune{'a'}},
+		{Type: tea.KeyRunes, Runes: []rune{'/'}},
+		{Type: tea.KeyRunes, Runes: []rune{'x'}},
+		{Type: tea.KeyUp},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyTab},
+	}
+
+	for _, k := range keys {
+		_, consumed := dp.Update(k)
+		if !consumed {
+			t.Errorf("key %q: consumed=false, want true", k.String())
+		}
+	}
+}
+
+func TestDirPicker_FilteringKeysConsumed(t *testing.T) {
+	dp := testDirPicker(t)
+
+	// Press "/" to start filtering.
+	dp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+
+	// Type characters while filtering.
+	chars := []rune{'a', 'b', 'c'}
+	for _, r := range chars {
+		_, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		if !consumed {
+			t.Errorf("filter char %q: consumed=false, want true", string(r))
+		}
+	}
+
+	// Esc to clear filter should also be consumed.
+	_, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if !consumed {
+		t.Error("esc during filter: consumed=false, want true")
+	}
+}
+
+func TestDirPicker_NonKeyMsgNotConsumed(t *testing.T) {
+	dp := testDirPicker(t)
+
+	// Window size messages should not be consumed.
+	_, consumed := dp.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if consumed {
+		t.Error("WindowSizeMsg: consumed=true, want false")
+	}
+}
+
+func TestDirPicker_InactiveDoesNotConsume(t *testing.T) {
+	dp := NewDirPicker()
+	// Not shown / not active.
+
+	_, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if consumed {
+		t.Error("inactive picker should not consume keys")
+	}
+}
+
+func TestDirPicker_EscCancels(t *testing.T) {
+	dp := testDirPicker(t)
+
+	cmd, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if !consumed {
+		t.Fatal("esc should be consumed")
+	}
+	if !dp.Active {
+		// The picker sets Active=false itself.
+	}
+	if cmd == nil {
+		t.Fatal("esc should return a cmd")
+	}
+	msg := cmd()
+	if _, ok := msg.(DirPickerCancelMsg); !ok {
+		t.Fatalf("esc cmd returned %T, want DirPickerCancelMsg", msg)
+	}
+}
+
+func TestDirPicker_DotConfirmsCurrentDir(t *testing.T) {
+	dp := testDirPicker(t)
+	origDir := dp.currentDir
+
+	cmd, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}})
+	if !consumed {
+		t.Fatal("dot should be consumed")
+	}
+	if cmd == nil {
+		t.Fatal("dot should return a cmd")
+	}
+	msg := cmd()
+	picked, ok := msg.(DirPickedMsg)
+	if !ok {
+		t.Fatalf("dot cmd returned %T, want DirPickedMsg", msg)
+	}
+	if picked.Dir != origDir {
+		t.Errorf("picked dir=%q, want %q", picked.Dir, origDir)
+	}
+}
+
+func TestDirPicker_EnterDescends(t *testing.T) {
+	dp := testDirPicker(t)
+	origDir := dp.currentDir
+
+	// The first item should be "aaa" (alphabetical).
+	cmd, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !consumed {
+		t.Fatal("enter should be consumed")
+	}
+	// No cmd returned for navigation.
+	_ = cmd
+
+	expected := filepath.Join(origDir, "aaa")
+	if dp.currentDir != expected {
+		t.Errorf("after enter: currentDir=%q, want %q", dp.currentDir, expected)
+	}
+}
+
+func TestDirPicker_BackspaceGoesUp(t *testing.T) {
+	dp := testDirPicker(t)
+	origDir := dp.currentDir
+
+	// Descend first.
+	dp.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Now go up with backspace.
+	_, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if !consumed {
+		t.Fatal("backspace should be consumed")
+	}
+	if dp.currentDir != origDir {
+		t.Errorf("after backspace: currentDir=%q, want %q", dp.currentDir, origDir)
+	}
+}
+
+func TestDirPicker_LeftArrowGoesUp(t *testing.T) {
+	dp := testDirPicker(t)
+	origDir := dp.currentDir
+
+	dp.Update(tea.KeyMsg{Type: tea.KeyEnter}) // descend
+	_, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if !consumed {
+		t.Fatal("left arrow should be consumed")
+	}
+	if dp.currentDir != origDir {
+		t.Errorf("after left: currentDir=%q, want %q", dp.currentDir, origDir)
+	}
+}
+
+func TestDirPicker_HKeyGoesUp(t *testing.T) {
+	dp := testDirPicker(t)
+	origDir := dp.currentDir
+
+	dp.Update(tea.KeyMsg{Type: tea.KeyEnter}) // descend
+	_, consumed := dp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if !consumed {
+		t.Fatal("h should be consumed")
+	}
+	if dp.currentDir != origDir {
+		t.Errorf("after h: currentDir=%q, want %q", dp.currentDir, origDir)
+	}
+}

--- a/internal/tui/components/dirpicker_test.go
+++ b/internal/tui/components/dirpicker_test.go
@@ -13,8 +13,12 @@ func testDirPicker(t *testing.T) DirPicker {
 	dp := NewDirPicker()
 	dir := t.TempDir()
 	// Create a couple of sub-directories for navigation tests.
-	os.MkdirAll(filepath.Join(dir, "aaa"), 0755)
-	os.MkdirAll(filepath.Join(dir, "bbb"), 0755)
+	if err := os.MkdirAll(filepath.Join(dir, "aaa"), 0755); err != nil {
+		t.Fatalf("create test dir aaa: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "bbb"), 0755); err != nil {
+		t.Fatalf("create test dir bbb: %v", err)
+	}
 	dp.Show(dir)
 	return dp
 }
@@ -88,8 +92,8 @@ func TestDirPicker_EscCancels(t *testing.T) {
 	if !consumed {
 		t.Fatal("esc should be consumed")
 	}
-	if !dp.Active {
-		// The picker sets Active=false itself.
+	if dp.Active {
+		t.Fatal("esc should deactivate the picker")
 	}
 	if cmd == nil {
 		t.Fatal("esc should return a cmd")

--- a/internal/tui/focus.go
+++ b/internal/tui/focus.go
@@ -21,7 +21,7 @@ type componentHandler struct {
 	handle  func(tea.KeyMsg) tea.Cmd
 }
 
-func (c componentHandler) Focused() bool                  { return c.focused() }
+func (c componentHandler) Focused() bool                    { return c.focused() }
 func (c componentHandler) HandleKey(msg tea.KeyMsg) tea.Cmd { return c.handle(msg) }
 
 // dispatchKey walks handlers in priority order and routes msg to the first

--- a/internal/tui/focus.go
+++ b/internal/tui/focus.go
@@ -1,0 +1,37 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// KeyHandler is implemented by any component that can exclusively capture
+// keyboard input. When a KeyHandler reports itself as focused, all KeyMsg
+// events are routed to it — nothing leaks to lower-priority handlers or
+// global bindings.
+type KeyHandler interface {
+	// Focused returns true when this handler wants exclusive key input.
+	Focused() bool
+	// HandleKey processes a key event and returns a command.
+	HandleKey(msg tea.KeyMsg) tea.Cmd
+}
+
+// componentHandler is a lightweight adapter that turns a pair of closures into
+// a KeyHandler. This lets existing components participate in the focus dispatch
+// without changing their signatures.
+type componentHandler struct {
+	focused func() bool
+	handle  func(tea.KeyMsg) tea.Cmd
+}
+
+func (c componentHandler) Focused() bool                  { return c.focused() }
+func (c componentHandler) HandleKey(msg tea.KeyMsg) tea.Cmd { return c.handle(msg) }
+
+// dispatchKey walks handlers in priority order and routes msg to the first
+// focused handler. Returns the handler's command and true if a handler was
+// found, or (nil, false) if no handler is focused.
+func dispatchKey(handlers []KeyHandler, msg tea.KeyMsg) (tea.Cmd, bool) {
+	for _, h := range handlers {
+		if h.Focused() {
+			return h.HandleKey(msg), true
+		}
+	}
+	return nil, false
+}

--- a/internal/tui/focus_test.go
+++ b/internal/tui/focus_test.go
@@ -111,8 +111,9 @@ func TestDispatchKey_ReturnsHandlerCmd(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("cmd should not be nil")
 	}
-	if _, ok := cmd().(testMsg); !ok {
-		t.Fatalf("cmd returned %T, want testMsg", cmd())
+	result := cmd()
+	if _, ok := result.(testMsg); !ok {
+		t.Fatalf("cmd returned %T, want testMsg", result)
 	}
 }
 

--- a/internal/tui/focus_test.go
+++ b/internal/tui/focus_test.go
@@ -1,0 +1,129 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestDispatchKey_FirstFocusedHandlerWins(t *testing.T) {
+	captured := false
+	leaked := false
+
+	handlers := []KeyHandler{
+		componentHandler{
+			focused: func() bool { return true },
+			handle:  func(tea.KeyMsg) tea.Cmd { captured = true; return nil },
+		},
+		componentHandler{
+			focused: func() bool { return true },
+			handle:  func(tea.KeyMsg) tea.Cmd { leaked = true; return nil },
+		},
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+	_, handled := dispatchKey(handlers, msg)
+
+	if !handled {
+		t.Fatal("dispatchKey should report handled=true when a handler is focused")
+	}
+	if !captured {
+		t.Fatal("first focused handler should have received the key")
+	}
+	if leaked {
+		t.Fatal("second handler should NOT have received the key")
+	}
+}
+
+func TestDispatchKey_NoFocusedHandler(t *testing.T) {
+	called := false
+	handlers := []KeyHandler{
+		componentHandler{
+			focused: func() bool { return false },
+			handle:  func(tea.KeyMsg) tea.Cmd { called = true; return nil },
+		},
+		componentHandler{
+			focused: func() bool { return false },
+			handle:  func(tea.KeyMsg) tea.Cmd { called = true; return nil },
+		},
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}}
+	cmd, handled := dispatchKey(handlers, msg)
+
+	if handled {
+		t.Fatal("dispatchKey should report handled=false when no handler is focused")
+	}
+	if cmd != nil {
+		t.Fatal("cmd should be nil when no handler is focused")
+	}
+	if called {
+		t.Fatal("no handler should have been called")
+	}
+}
+
+func TestDispatchKey_SkipsUnfocusedHandler(t *testing.T) {
+	order := []int{}
+
+	handlers := []KeyHandler{
+		componentHandler{
+			focused: func() bool { return false },
+			handle:  func(tea.KeyMsg) tea.Cmd { order = append(order, 0); return nil },
+		},
+		componentHandler{
+			focused: func() bool { return true },
+			handle:  func(tea.KeyMsg) tea.Cmd { order = append(order, 1); return nil },
+		},
+		componentHandler{
+			focused: func() bool { return true },
+			handle:  func(tea.KeyMsg) tea.Cmd { order = append(order, 2); return nil },
+		},
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}}
+	_, handled := dispatchKey(handlers, msg)
+
+	if !handled {
+		t.Fatal("should be handled")
+	}
+	if len(order) != 1 || order[0] != 1 {
+		t.Fatalf("expected only handler[1] to fire, got %v", order)
+	}
+}
+
+func TestDispatchKey_ReturnsHandlerCmd(t *testing.T) {
+	type testMsg struct{}
+	handlers := []KeyHandler{
+		componentHandler{
+			focused: func() bool { return true },
+			handle: func(tea.KeyMsg) tea.Cmd {
+				return func() tea.Msg { return testMsg{} }
+			},
+		},
+	}
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	cmd, handled := dispatchKey(handlers, msg)
+
+	if !handled {
+		t.Fatal("should be handled")
+	}
+	if cmd == nil {
+		t.Fatal("cmd should not be nil")
+	}
+	if _, ok := cmd().(testMsg); !ok {
+		t.Fatalf("cmd returned %T, want testMsg", cmd())
+	}
+}
+
+func TestDispatchKey_EmptyHandlers(t *testing.T) {
+	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+	cmd, handled := dispatchKey(nil, msg)
+
+	if handled {
+		t.Fatal("should not be handled with nil handlers")
+	}
+	if cmd != nil {
+		t.Fatal("cmd should be nil")
+	}
+}


### PR DESCRIPTION
## Summary

- **Fixes DirPicker search key leakage**: keystrokes typed in the directory picker's filter were leaking to global bindings (e.g. `/` activating the main search)
- **Refactors key dispatch**: replaces the ~400-line `if`-chain in `handleKey()` with a `KeyHandler` interface and priority-ordered adapter list — first focused modal exclusively receives all keys
- **Adds comprehensive tests**: dispatcher unit tests, DirPicker key isolation tests, and integration tests verifying overlays block global bindings

## Key changes

| File | Change |
|------|--------|
| `focus.go` | New `KeyHandler` interface, `componentHandler` adapter, `dispatchKey()` helper |
| `app.go` | `buildKeyHandlers()` returns 15 adapters in priority order; `handleKey()` reduced to ~10 lines; extracted `handleGlobalKey()` and `handleGridKey()` |
| `dirpicker.go` | Always consume `KeyMsg` when active (was returning `consumed=false`) |
| `focus_test.go` | 5 tests: priority, isolation, passthrough, cmd forwarding, empty handlers |
| `dirpicker_test.go` | 10 tests: key consumption, filter isolation, navigation, cancel, confirm |
| `app_test.go` | 8 new integration tests: overlay key blocking for DirPicker, AgentPicker, Filter, Settings, Confirm; ctrl+c always quits |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 10 packages pass (0 failures)
- [ ] Manual: open app → new project → DirPicker → press `/` to search → type characters → verify they stay in DirPicker filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)