### PR TITLE
fix: prevent tests from touching real ~/.config/hive

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -25,15 +26,19 @@ import (
 	"github.com/lucascaro/hive/internal/tui/styles"
 )
 
-var debugLog *log.Logger
+var (
+	debugLog     = log.New(os.Stderr, "[hive] ", log.Ltime)
+	debugLogOnce sync.Once
+)
 
-func init() {
-	f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		debugLog = log.New(os.Stderr, "[hive] ", log.Ltime)
-		return
-	}
-	debugLog = log.New(f, "[hive] ", log.Ltime|log.Lmicroseconds)
+func initDebugLog() {
+	debugLogOnce.Do(func() {
+		f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return
+		}
+		debugLog = log.New(f, "[hive] ", log.Ltime|log.Lmicroseconds)
+	})
 }
 
 // Model is the root Bubble Tea model.
@@ -89,6 +94,10 @@ func (m Model) LastAttach() *SessionAttachMsg { return m.attachPending }
 
 // New creates the root model.
 func New(cfg config.Config, appState state.AppState) Model {
+	initDebugLog()
+	components.InitSidebarLog()
+	components.InitStatusLog()
+	components.InitPreviewLog()
 	km := NewKeyMap(cfg.Keybindings)
 	ni := textinput.New()
 	ni.CharLimit = 256

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +12,22 @@ import (
 	"github.com/lucascaro/hive/internal/state"
 	"github.com/lucascaro/hive/internal/tui/components"
 )
+
+// TestMain sets HIVE_CONFIG_DIR to a temporary directory so that no test in this
+// package (including helpers like New() that stat config.StatePath()) ever
+// resolves against the real ~/.config/hive.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "hive-tui-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cannot create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	os.Setenv("HIVE_CONFIG_DIR", dir)
+	os.MkdirAll(dir, 0o755)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 func testModelWithSessions() Model {
 	cfg := config.DefaultConfig()

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -22,8 +22,11 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "cannot create temp dir: %v\n", err)
 		os.Exit(1)
 	}
-	os.Setenv("HIVE_CONFIG_DIR", dir)
-	os.MkdirAll(dir, 0o755)
+	if err := os.Setenv("HIVE_CONFIG_DIR", dir); err != nil {
+		fmt.Fprintf(os.Stderr, "cannot set HIVE_CONFIG_DIR: %v\n", err)
+		os.RemoveAll(dir)
+		os.Exit(1)
+	}
 	code := m.Run()
 	os.RemoveAll(dir)
 	os.Exit(code)

--- a/internal/tui/components/preview.go
+++ b/internal/tui/components/preview.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/bubbles/viewport"
@@ -169,15 +170,21 @@ func runeDisplayWidth(r rune) int {
 	}
 }
 
-var previewLog *log.Logger
+var (
+	previewLog     = log.New(os.Stderr, "[preview] ", log.Ltime)
+	previewLogOnce sync.Once
+)
 
-func init() {
-	f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		previewLog = log.New(os.Stderr, "[preview] ", log.Ltime)
-		return
-	}
-	previewLog = log.New(f, "[preview] ", log.Ltime|log.Lmicroseconds)
+// InitPreviewLog upgrades the preview logger from stderr to the hive log file.
+// Called once from tui.New() so the log path is resolved after env overrides.
+func InitPreviewLog() {
+	previewLogOnce.Do(func() {
+		f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return
+		}
+		previewLog = log.New(f, "[preview] ", log.Ltime|log.Lmicroseconds)
+	})
 }
 
 // PreviewUpdatedMsg is sent when capture-pane returns new content.

--- a/internal/tui/components/sidebar.go
+++ b/internal/tui/components/sidebar.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/lucascaro/hive/internal/config"
@@ -12,15 +13,21 @@ import (
 	"github.com/lucascaro/hive/internal/tui/styles"
 )
 
-var sidebarLog *log.Logger
+var (
+	sidebarLog     = log.New(os.Stderr, "[sidebar] ", log.Ltime)
+	sidebarLogOnce sync.Once
+)
 
-func init() {
-	f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		sidebarLog = log.New(os.Stderr, "[sidebar] ", log.Ltime)
-		return
-	}
-	sidebarLog = log.New(f, "[sidebar] ", log.Ltime|log.Lmicroseconds)
+// InitSidebarLog upgrades the sidebar logger from stderr to the hive log file.
+// Called once from tui.New() so the log path is resolved after env overrides.
+func InitSidebarLog() {
+	sidebarLogOnce.Do(func() {
+		f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return
+		}
+		sidebarLog = log.New(f, "[sidebar] ", log.Ltime|log.Lmicroseconds)
+	})
 }
 
 // ItemKind identifies the type of a sidebar row.

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
@@ -13,15 +14,21 @@ import (
 	"github.com/lucascaro/hive/internal/tui/styles"
 )
 
-var statusLog *log.Logger
+var (
+	statusLog     = log.New(os.Stderr, "[status] ", log.Ltime)
+	statusLogOnce sync.Once
+)
 
-func init() {
-	f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
-	if err != nil {
-		statusLog = log.New(os.Stderr, "[status] ", log.Ltime)
-		return
-	}
-	statusLog = log.New(f, "[status] ", log.Ltime|log.Lmicroseconds)
+// InitStatusLog upgrades the status logger from stderr to the hive log file.
+// Called once from tui.New() so the log path is resolved after env overrides.
+func InitStatusLog() {
+	statusLogOnce.Do(func() {
+		f, err := os.OpenFile(config.LogPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return
+		}
+		statusLog = log.New(f, "[status] ", log.Ltime|log.Lmicroseconds)
+	})
 }
 
 // StatusBar renders the two-line status bar at the bottom.

--- a/internal/tui/persist.go
+++ b/internal/tui/persist.go
@@ -61,7 +61,11 @@ func saveState(appState *state.AppState) (time.Time, error) {
 		}
 	}()
 
-	data, err := json.MarshalIndent(appState.Projects, "", "  ")
+	projects := appState.Projects
+	if projects == nil {
+		projects = []*state.Project{}
+	}
+	data, err := json.MarshalIndent(projects, "", "  ")
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/internal/tui/persist_test.go
+++ b/internal/tui/persist_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -219,8 +220,9 @@ func TestSaveState_NilProjectsWritesEmptyArray(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read state file: %v", err)
 	}
-	if string(data) != "[]" {
-		t.Errorf("state file content = %q, want %q", string(data), "[]")
+	got := strings.TrimSpace(string(data))
+	if got != "[]" {
+		t.Errorf("state file content = %q, want %q", got, "[]")
 	}
 }
 

--- a/internal/tui/persist_test.go
+++ b/internal/tui/persist_test.go
@@ -205,6 +205,25 @@ func TestSaveState_ConcurrentWritesNoCorruption(t *testing.T) {
 	}
 }
 
+func TestSaveState_NilProjectsWritesEmptyArray(t *testing.T) {
+	tmp := t.TempDir()
+	setHomePersist(t, tmp)
+	ensureConfigDir(t)
+
+	appState := &state.AppState{Projects: nil}
+	if _, err := saveState(appState); err != nil {
+		t.Fatalf("saveState() error: %v", err)
+	}
+
+	data, err := os.ReadFile(config.StatePath())
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	if string(data) != "[]" {
+		t.Errorf("state file content = %q, want %q", string(data), "[]")
+	}
+}
+
 func TestSaveUsage_EmptyMapNoOp(t *testing.T) {
 	tmp := t.TempDir()
 	setHomePersist(t, tmp)


### PR DESCRIPTION
## Summary
- Add nil guard in `saveState()` so nil `Projects` writes `[]` instead of `"null"`, preventing cascading state corruption
- Replace eager `init()` loggers in 4 files with lazy `sync.Once` initialization — avoids creating/opening `~/.config/hive/hive.log` at package load time before tests can override `HIVE_CONFIG_DIR`
- Add `TestMain` in the `tui` package that sets `HIVE_CONFIG_DIR` to a temp dir, ensuring `New()` and other runtime code never resolves against the real config dir during tests

## Test plan
- [x] All existing tests pass (`go test ./... -count=1`)
- [x] New test `TestSaveState_NilProjectsWritesEmptyArray` verifies the nil guard
- [ ] Run tests and verify `~/.config/hive/state.json` mtime is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)