### PR TITLE
feat: custom command sessions with auto-cleanup

### DIFF
--- a/internal/mux/interface.go
+++ b/internal/mux/interface.go
@@ -56,6 +56,8 @@ type Backend interface {
 	CapturePaneRaw(target string, lines int) (string, error)
 	// GetCurrentCommand returns the name of the foreground process in the pane.
 	GetCurrentCommand(target string) (string, error)
+	// IsPaneDead reports whether the pane's process has exited.
+	IsPaneDead(target string) bool
 
 	// Attach takes over the current terminal and connects it to the window
 	// at target, allowing the user to interact with the running process.
@@ -174,6 +176,9 @@ func CapturePaneRaw(target string, lines int) (string, error) {
 func GetCurrentCommand(target string) (string, error) {
 	return active.GetCurrentCommand(target)
 }
+
+// IsPaneDead reports whether the pane's process has exited.
+func IsPaneDead(target string) bool { return active.IsPaneDead(target) }
 
 // Attach connects the current terminal to the window at target.
 func Attach(target string) error { return active.Attach(target) }

--- a/internal/mux/native/backend_unix.go
+++ b/internal/mux/native/backend_unix.go
@@ -124,6 +124,8 @@ func (b *Backend) GetCurrentCommand(_ string) (string, error) {
 	return "", nil
 }
 
+func (b *Backend) IsPaneDead(_ string) bool { return false }
+
 func (b *Backend) Attach(target string) error {
 	return clientAttach(b.client, target)
 }

--- a/internal/mux/native/backend_windows.go
+++ b/internal/mux/native/backend_windows.go
@@ -44,6 +44,7 @@ func (b *Backend) ListWindows(_ string) ([]mux.WindowInfo, error)         { retu
 func (b *Backend) CapturePane(_ string, _ int) (string, error)            { return "", errNotSupported }
 func (b *Backend) CapturePaneRaw(_ string, _ int) (string, error)         { return "", errNotSupported }
 func (b *Backend) GetCurrentCommand(_ string) (string, error)             { return "", errNotSupported }
+func (b *Backend) IsPaneDead(_ string) bool                                { return false }
 func (b *Backend) Attach(_ string) error                                   { return errNotSupported }
 func (b *Backend) DetachKey() string                                       { return "" }
 func (b *Backend) SupportsPopup() bool                                     { return false }

--- a/internal/mux/tmux/backend.go
+++ b/internal/mux/tmux/backend.go
@@ -65,6 +65,8 @@ func (b *Backend) GetCurrentCommand(target string) (string, error) {
 	return tmux.GetCurrentCommand(target)
 }
 
+func (b *Backend) IsPaneDead(target string) bool { return tmux.IsPaneDead(target) }
+
 // DetachKey returns the tmux detach key description.
 func (b *Backend) DetachKey() string { return "Ctrl+B D" }
 

--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -27,6 +27,12 @@ func CapturePaneRaw(target string, lines int) (string, error) {
 	return Exec(args...)
 }
 
+// IsPaneDead reports whether the pane's process has exited.
+func IsPaneDead(target string) bool {
+	out, err := Exec("display-message", "-p", "-t", target, "#{pane_dead}")
+	return err == nil && out == "1"
+}
+
 // GetCurrentCommand returns the name of the foreground process running in the pane.
 func GetCurrentCommand(target string) (string, error) {
 	return Exec("display-message", "-p", "-t", target, "#{pane_current_command}")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -68,6 +68,8 @@ type Model struct {
 	pendingWorktree          bool   // true when the next session should use a worktree
 	pendingWorktreeAgentType string // agent type selected for worktree session
 	pendingWorktreeAgentCmd  []string
+	// Custom command session creation
+	pendingCustomCmd []string // custom command parsed from user input
 	// Attach hint overlay
 	showAttachHint bool
 	pendingAttach  *SessionAttachMsg
@@ -468,6 +470,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.inputMode == "new-session" {
 			agentTypeStr := string(msg.AgentType)
+			// Custom command: prompt user for the command to run.
+			if msg.AgentType == state.AgentCustom {
+				m.inputMode = "custom-command"
+				m.nameInput.Placeholder = "command (empty = default shell)"
+				m.nameInput.Reset()
+				blinkCmd := m.nameInput.Focus()
+				return m, blinkCmd
+			}
 			profile := m.cfg.Agents[agentTypeStr]
 			agentBin := agentTypeStr
 			if len(profile.Cmd) > 0 {
@@ -648,6 +658,9 @@ func (m Model) View() string {
 	}
 	if m.inputMode == "project-dir-confirm" {
 		return m.overlayView(m.dirConfirmView())
+	}
+	if m.inputMode == "custom-command" {
+		return m.overlayView(m.nameInputView("Custom Command", "Command to run:", "enter: create  esc: cancel"))
 	}
 	if m.inputMode == "worktree-branch" {
 		return m.overlayView(m.nameInputView("New Worktree Session", "Branch name:", "enter: create  esc: cancel"))
@@ -863,6 +876,14 @@ func (m *Model) buildKeyHandlers() []KeyHandler {
 			focused: func() bool { return m.inputMode == "project-dir-confirm" },
 			handle: func(msg tea.KeyMsg) tea.Cmd {
 				result, cmd := m.handleDirConfirm(msg)
+				*m = result.(Model)
+				return cmd
+			},
+		},
+		componentHandler{
+			focused: func() bool { return m.inputMode == "custom-command" },
+			handle: func(msg tea.KeyMsg) tea.Cmd {
+				result, cmd := m.handleCustomCommandInput(msg)
 				*m = result.(Model)
 				return cmd
 			},
@@ -1519,6 +1540,52 @@ func (m Model) handleWorktreeBranchInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.pendingWorktree = false
 		m.pendingWorktreeAgentType = ""
 		m.pendingWorktreeAgentCmd = nil
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.nameInput, cmd = m.nameInput.Update(msg)
+	return m, cmd
+}
+
+// --- Custom command input ---
+
+func defaultShell() string {
+	if sh := os.Getenv("SHELL"); sh != "" {
+		return sh
+	}
+	return "/bin/sh"
+}
+
+func (m Model) handleCustomCommandInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		raw := strings.TrimSpace(m.nameInput.Value())
+		m.nameInput.Blur()
+		m.inputMode = ""
+
+		var agentCmd []string
+		if raw == "" {
+			agentCmd = []string{defaultShell()}
+		} else {
+			agentCmd = strings.Fields(raw)
+		}
+
+		if m.pendingWorktree {
+			// Chain to worktree branch input.
+			m.pendingWorktreeAgentType = "custom"
+			m.pendingWorktreeAgentCmd = agentCmd
+			m.inputMode = "worktree-branch"
+			m.nameInput.Placeholder = "branch-name"
+			m.nameInput.Reset()
+			m.nameInput.SetValue(git.RandomBranchName())
+			blinkCmd := m.nameInput.Focus()
+			return m, blinkCmd
+		}
+		return m, m.createSession(m.pendingProjectID, "custom", agentCmd)
+	case "esc":
+		m.nameInput.Blur()
+		m.inputMode = ""
+		m.pendingWorktree = false
 		return m, nil
 	}
 	var cmd tea.Cmd

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1565,7 +1565,7 @@ func (m Model) handleCustomCommandInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if raw == "" {
 			agentCmd = []string{defaultShell()}
 		} else {
-			agentCmd = strings.Fields(raw)
+			agentCmd = []string{raw}
 		}
 
 		if m.pendingWorktree {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -68,8 +68,6 @@ type Model struct {
 	pendingWorktree          bool   // true when the next session should use a worktree
 	pendingWorktreeAgentType string // agent type selected for worktree session
 	pendingWorktreeAgentCmd  []string
-	// Custom command session creation
-	pendingCustomCmd []string // custom command parsed from user input
 	// Attach hint overlay
 	showAttachHint bool
 	pendingAttach  *SessionAttachMsg

--- a/internal/tui/components/preview.go
+++ b/internal/tui/components/preview.go
@@ -218,6 +218,12 @@ func PollPreview(sessionID, tmuxSession string, tmuxWindow int, interval time.Du
 			previewLog.Printf("PollPreview: CapturePane(%s) error: %v gen=%d", target, err, gen)
 			return PreviewUpdatedMsg{SessionID: sessionID, Content: "", Generation: gen}
 		}
+		// Pane process exited but window still exists (e.g. remain-on-exit).
+		// Treat as gone so hive cleans up the session.
+		if mux.IsPaneDead(target) {
+			previewLog.Printf("PollPreview: pane dead session=%s target=%s gen=%d", sessionID, target, gen)
+			return SessionWindowGoneMsg{SessionID: sessionID}
+		}
 		previewLog.Printf("PollPreview: session=%s contentLen=%d gen=%d", sessionID, len(content), gen)
 		return PreviewUpdatedMsg{SessionID: sessionID, Content: content, Generation: gen}
 	})


### PR DESCRIPTION
## Summary
- **Custom command prompt**: Selecting "Custom command" from the agent picker now prompts for the command to run instead of trying to install a binary named "custom". Empty input launches `$SHELL` (or `/bin/sh`).
- **Worktree support**: Custom commands chain correctly into the worktree branch input flow.
- **Dead pane cleanup**: Detect exited pane processes via `#{pane_dead}` during preview polling, so sessions are automatically removed when the command exits — even if `remain-on-exit` keeps the tmux window alive.

## Test plan
- [ ] Select "Custom command", type a command (e.g. `htop`) → session runs it
- [ ] Select "Custom command", press Enter with empty input → default shell opens
- [ ] Exit the custom command/shell → session is removed from sidebar
- [ ] Worktree + custom command → prompts for command, then branch name
- [ ] Verify existing agent types (claude, codex, etc.) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)