### PR TITLE
feat: tmux status bar with session info on attach

### DIFF
--- a/internal/mux/interface.go
+++ b/internal/mux/interface.go
@@ -70,8 +70,9 @@ type Backend interface {
 
 	// PopupAttach opens a floating popup overlay connected to the window at
 	// target. Only valid to call when SupportsPopup() returns true.
+	// If title is non-empty it is shown in the popup border.
 	// Returns when the popup closes (user detaches or process exits).
-	PopupAttach(target string) error
+	PopupAttach(target, title string) error
 
 	// UseExecAttach reports whether the TUI should use tea.ExecProcess to run
 	// an external attach command rather than quitting and restarting.
@@ -189,7 +190,7 @@ func SupportsPopup() bool {
 
 // PopupAttach opens a floating popup overlay for the window at target.
 // Only call when SupportsPopup() returns true.
-func PopupAttach(target string) error { return active.PopupAttach(target) }
+func PopupAttach(target, title string) error { return active.PopupAttach(target, title) }
 
 // UseExecAttach reports whether the TUI should use tea.ExecProcess for attach.
 // Returns false if no backend has been set (e.g. in tests), causing the TUI to

--- a/internal/mux/native/backend_unix.go
+++ b/internal/mux/native/backend_unix.go
@@ -141,6 +141,6 @@ func (b *Backend) SupportsPopup() bool { return false }
 
 // PopupAttach is not implemented for the native backend.
 // Always returns an error; callers must check SupportsPopup first.
-func (b *Backend) PopupAttach(_ string) error {
+func (b *Backend) PopupAttach(_, _ string) error {
 	return errors.New("popup attach is not supported by the native PTY backend")
 }

--- a/internal/mux/native/backend_windows.go
+++ b/internal/mux/native/backend_windows.go
@@ -47,7 +47,7 @@ func (b *Backend) GetCurrentCommand(_ string) (string, error)             { retu
 func (b *Backend) Attach(_ string) error                                   { return errNotSupported }
 func (b *Backend) DetachKey() string                                       { return "" }
 func (b *Backend) SupportsPopup() bool                                     { return false }
-func (b *Backend) PopupAttach(_ string) error                              { return errNotSupported }
+func (b *Backend) PopupAttach(_, _ string) error                           { return errNotSupported }
 func (b *Backend) UseExecAttach() bool                                     { return false }
 
 // SockPath returns an empty string on Windows (no socket used).

--- a/internal/mux/tmux/backend.go
+++ b/internal/mux/tmux/backend.go
@@ -79,15 +79,19 @@ func (b *Backend) SupportsPopup() bool {
 
 // PopupAttach opens a floating tmux popup overlay connected to the window at
 // target. The popup fills 95 % of the terminal width and 90 % of its height.
+// If title is non-empty it is displayed in the popup border via -T.
 // It closes automatically when the attached session detaches or the process exits.
-func (b *Backend) PopupAttach(target string) error {
-	cmd := exec.Command("tmux", "display-popup",
-		"-E",           // close popup when command exits
+func (b *Backend) PopupAttach(target, title string) error {
+	args := []string{"display-popup",
+		"-E", // close popup when command exits
 		"-w", "95%",
 		"-h", "90%",
-		"--",
-		"tmux", "attach-session", "-t", target,
-	)
+	}
+	if title != "" {
+		args = append(args, "-T", " "+title+" ")
+	}
+	args = append(args, "--", "tmux", "attach-session", "-t", target)
+	cmd := exec.Command("tmux", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2679,10 +2679,10 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 		return tea.Quit
 	}
 
-	// Full-screen attach with tmux status bars showing session info at top
-	// and key hints at bottom. The shell script saves/restores the original
-	// tmux status configuration around the attach.
-	header := buildPopupTitle(sess)
+	// Full-screen attach with a tmux top status bar: session info on the
+	// left, detach key hint on the right. The shell script saves/restores
+	// the original tmux status configuration around the attach.
+	header := buildSessionHeader(sess)
 	script := buildAttachScript(sess.TmuxSession, target, header, mux.DetachKey())
 	cmd := exec.Command("sh", "-c", script)
 	cmd.Stdin = os.Stdin
@@ -2731,11 +2731,14 @@ func buildAttachScript(tmuxSession, target, title, detachKey string) string {
 
 	var lines []string
 
-	// Save current status settings
+	// Save current status settings. We track both the value and whether the
+	// option had a session-level override (exit code) so we can distinguish
+	// "set to empty string" from "not set at all" during restore.
 	for _, opt := range statusBarOpts {
+		v := strings.ReplaceAll(opt, "-", "_")
 		lines = append(lines,
-			fmt.Sprintf("old_%s=$(tmux show-option -t %s -v %s 2>/dev/null)",
-				strings.ReplaceAll(opt, "-", "_"), s, opt))
+			fmt.Sprintf("old_%s=$(tmux show-option -t %s -v %s 2>/dev/null) && had_%s=1 || had_%s=0",
+				v, s, opt, v, v))
 	}
 
 	// Configure top status bar: session info on the left, detach hint on the right
@@ -2752,20 +2755,24 @@ func buildAttachScript(tmuxSession, target, title, detachKey string) string {
 	// Attach (blocks until user detaches)
 	lines = append(lines, "tmux attach-session -t "+t)
 
-	// Restore original settings; unset if the option had no session-level override
+	// Restore original settings; unset if the option had no session-level override.
+	// We use the had_* flag (not string emptiness) so intentionally-empty values
+	// like status-left '' are correctly restored.
 	for _, opt := range statusBarOpts {
-		varName := "old_" + strings.ReplaceAll(opt, "-", "_")
+		v := strings.ReplaceAll(opt, "-", "_")
 		lines = append(lines,
-			fmt.Sprintf(`if [ -n "$%s" ]; then tmux set-option -t %s %s "$%s"; else tmux set-option -u -t %s %s; fi`,
-				varName, s, opt, varName, s, opt))
+			fmt.Sprintf(`if [ "$had_%s" = 1 ]; then tmux set-option -t %s %s "$old_%s"; else tmux set-option -u -t %s %s; fi`,
+				v, s, opt, v, s, opt))
 	}
 
 	return strings.Join(lines, "\n")
 }
 
-// buildPopupTitle returns a plain-text title for the tmux popup border.
-// Format mirrors the grid cell header: status dot, agent badge, title, project, worktree.
-func buildPopupTitle(sess SessionAttachMsg) string {
+// buildSessionHeader returns a plain-text session summary used as the tmux
+// status-bar left content and popup border title. Format mirrors the grid cell
+// header: status dot, agent badge, title, project, worktree.
+// '#' is escaped to '##' so tmux does not interpret format sequences like #(cmd).
+func buildSessionHeader(sess SessionAttachMsg) string {
 	var dot string
 	switch string(sess.Status) {
 	case "running":
@@ -2778,13 +2785,17 @@ func buildPopupTitle(sess SessionAttachMsg) string {
 		dot = "○"
 	}
 
-	title := fmt.Sprintf("%s [%s] %s", dot, sess.AgentType, sess.SessionTitle)
+	// Escape '#' in user-controlled fields so tmux does not interpret
+	// format sequences like #(cmd) which would execute shell commands.
+	esc := func(s string) string { return strings.ReplaceAll(s, "#", "##") }
+
+	title := fmt.Sprintf("%s [%s] %s", dot, esc(string(sess.AgentType)), esc(sess.SessionTitle))
 	if sess.ProjectName != "" {
-		title += " · " + sess.ProjectName
+		title += " · " + esc(sess.ProjectName)
 	}
 	if sess.WorktreePath != "" {
 		if sess.WorktreeBranch != "" && sess.WorktreeBranch != sess.SessionTitle {
-			title += " ⎇ " + sess.WorktreeBranch
+			title += " ⎇ " + esc(sess.WorktreeBranch)
 		} else {
 			title += " ⎇"
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -438,10 +438,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var sessionTitle string
 		var agentType state.AgentType
 		var projectName string
+		var status state.SessionStatus
+		var worktreeBranch, worktreePath string
 		if s := m.sessionByTmux(msg.TmuxSession, msg.TmuxWindow); s != nil {
 			sessionTitle = s.Title
 			agentType = s.AgentType
 			projectName = m.projectNameByID(s.ProjectID)
+			status = s.Status
+			worktreeBranch = s.WorktreeBranch
+			worktreePath = s.WorktreePath
 		}
 		attach := &SessionAttachMsg{
 			TmuxSession:     msg.TmuxSession,
@@ -450,6 +455,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			SessionTitle:    sessionTitle,
 			AgentType:       agentType,
 			ProjectName:     projectName,
+			Status:          status,
+			WorktreeBranch:  worktreeBranch,
+			WorktreePath:    worktreePath,
 		}
 		if !m.cfg.HideAttachHint {
 			m.pendingAttach = attach
@@ -1906,6 +1914,9 @@ func (m *Model) attachActiveSession() tea.Cmd {
 			SessionTitle:    sess.Title,
 			AgentType:       sess.AgentType,
 			ProjectName:     m.projectNameByID(sess.ProjectID),
+			Status:          sess.Status,
+			WorktreeBranch:  sess.WorktreeBranch,
+			WorktreePath:    sess.WorktreePath,
 		}
 	}
 }
@@ -2119,6 +2130,9 @@ func (m *Model) pendingAttachDetails() *SessionAttachMsg {
 		SessionTitle:    sess.Title,
 		AgentType:       sess.AgentType,
 		ProjectName:     m.projectNameByID(sess.ProjectID),
+		Status:          sess.Status,
+		WorktreeBranch:  sess.WorktreeBranch,
+		WorktreePath:    sess.WorktreePath,
 	}
 }
 
@@ -2665,24 +2679,12 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 		return tea.Quit
 	}
 
-	var cmd *exec.Cmd
-	if mux.SupportsPopup() {
-		// Floating popup overlay — TUI stays alive underneath.
-		cmd = exec.Command("tmux", "display-popup",
-			"-E",        // close popup when command exits
-			"-w", "95%",
-			"-h", "90%",
-			"--",
-			"tmux", "attach-session", "-t", target,
-		)
-	} else {
-		// Full-screen attach. Run tmux directly without a shell wrapper.
-		// The terminal title is set by the native RunAttach path only (that
-		// path has an opportunity to write escapes between TUI exit and
-		// attach); for the ExecProcess path the tmux status bar provides
-		// sufficient session context.
-		cmd = exec.Command("tmux", "attach-session", "-t", target)
-	}
+	// Full-screen attach with tmux status bars showing session info at top
+	// and key hints at bottom. The shell script saves/restores the original
+	// tmux status configuration around the attach.
+	header := buildPopupTitle(sess)
+	script := buildAttachScript(sess.TmuxSession, target, header, mux.DetachKey())
+	cmd := exec.Command("sh", "-c", script)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -2706,6 +2708,88 @@ func RunAttach(sess SessionAttachMsg) error {
 
 	target := mux.Target(sess.TmuxSession, sess.TmuxWindow)
 	return mux.Attach(target)
+}
+
+// statusBarOpts lists the tmux session options we override for the attach status bar.
+var statusBarOpts = []string{
+	"status",
+	"status-position",
+	"status-style",
+	"status-left",
+	"status-right",
+	"status-left-length",
+	"status-right-length",
+}
+
+// buildAttachScript returns a shell script that configures a tmux top status bar
+// with session info and detach hint, attaches to the target, and restores the
+// original status bar settings on detach.
+func buildAttachScript(tmuxSession, target, title, detachKey string) string {
+	sq := func(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
+	s := sq(tmuxSession)
+	t := sq(target)
+
+	var lines []string
+
+	// Save current status settings
+	for _, opt := range statusBarOpts {
+		lines = append(lines,
+			fmt.Sprintf("old_%s=$(tmux show-option -t %s -v %s 2>/dev/null)",
+				strings.ReplaceAll(opt, "-", "_"), s, opt))
+	}
+
+	// Configure top status bar: session info on the left, detach hint on the right
+	lines = append(lines,
+		"tmux set-option -t "+s+" status on",
+		"tmux set-option -t "+s+" status-position top",
+		"tmux set-option -t "+s+" status-style 'bg=#1F2937,fg=#F9FAFB'",
+		"tmux set-option -t "+s+" status-left "+sq(" "+title+" "),
+		"tmux set-option -t "+s+" status-left-length 200",
+		"tmux set-option -t "+s+" status-right "+sq(" "+detachKey+": detach "),
+		"tmux set-option -t "+s+" status-right-length 40",
+	)
+
+	// Attach (blocks until user detaches)
+	lines = append(lines, "tmux attach-session -t "+t)
+
+	// Restore original settings; unset if the option had no session-level override
+	for _, opt := range statusBarOpts {
+		varName := "old_" + strings.ReplaceAll(opt, "-", "_")
+		lines = append(lines,
+			fmt.Sprintf(`if [ -n "$%s" ]; then tmux set-option -t %s %s "$%s"; else tmux set-option -u -t %s %s; fi`,
+				varName, s, opt, varName, s, opt))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// buildPopupTitle returns a plain-text title for the tmux popup border.
+// Format mirrors the grid cell header: status dot, agent badge, title, project, worktree.
+func buildPopupTitle(sess SessionAttachMsg) string {
+	var dot string
+	switch string(sess.Status) {
+	case "running":
+		dot = "●"
+	case "waiting":
+		dot = "◉"
+	case "dead":
+		dot = "✕"
+	default:
+		dot = "○"
+	}
+
+	title := fmt.Sprintf("%s [%s] %s", dot, sess.AgentType, sess.SessionTitle)
+	if sess.ProjectName != "" {
+		title += " · " + sess.ProjectName
+	}
+	if sess.WorktreePath != "" {
+		if sess.WorktreeBranch != "" && sess.WorktreeBranch != sess.SessionTitle {
+			title += " ⎇ " + sess.WorktreeBranch
+		} else {
+			title += " ⎇"
+		}
+	}
+	return title
 }
 
 // buildAttachTitle returns a terminal window title string for the attached session.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -744,3 +744,111 @@ func TestHandleKey_CtrlC_AlwaysQuits(t *testing.T) {
 		t.Fatalf("ctrl+c cmd returned %T, want tea.QuitMsg", msg)
 	}
 }
+
+func TestBuildPopupTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  SessionAttachMsg
+		want string
+	}{
+		{
+			name: "all fields",
+			msg: SessionAttachMsg{
+				SessionTitle:   "fix-bug",
+				AgentType:      "claude",
+				ProjectName:    "myproj",
+				Status:         "running",
+				WorktreePath:   "/tmp/wt",
+				WorktreeBranch: "feat-branch",
+			},
+			want: "● [claude] fix-bug · myproj ⎇ feat-branch",
+		},
+		{
+			name: "no project",
+			msg: SessionAttachMsg{
+				SessionTitle: "task1",
+				AgentType:    "codex",
+				Status:       "idle",
+			},
+			want: "○ [codex] task1",
+		},
+		{
+			name: "worktree branch matches title",
+			msg: SessionAttachMsg{
+				SessionTitle:   "feat-x",
+				AgentType:      "gemini",
+				ProjectName:    "proj",
+				Status:         "waiting",
+				WorktreePath:   "/tmp/wt",
+				WorktreeBranch: "feat-x",
+			},
+			want: "◉ [gemini] feat-x · proj ⎇",
+		},
+		{
+			name: "dead status no worktree",
+			msg: SessionAttachMsg{
+				SessionTitle: "done",
+				AgentType:    "aider",
+				ProjectName:  "p",
+				Status:       "dead",
+			},
+			want: "✕ [aider] done · p",
+		},
+		{
+			name: "worktree with empty branch",
+			msg: SessionAttachMsg{
+				SessionTitle: "s",
+				AgentType:    "claude",
+				Status:       "running",
+				WorktreePath: "/tmp/wt",
+			},
+			want: "● [claude] s ⎇",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPopupTitle(tt.msg)
+			if got != tt.want {
+				t.Errorf("buildPopupTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildAttachScript(t *testing.T) {
+	script := buildAttachScript("hive-sessions", "hive-sessions:3", "● [claude] my-task · myproj ⎇ feat", "Ctrl+B D")
+	if !strings.Contains(script, "status-position top") {
+		t.Error("script should set status-position top")
+	}
+	if !strings.Contains(script, "tmux attach-session -t 'hive-sessions:3'") {
+		t.Error("script should attach to the correct target")
+	}
+	if !strings.Contains(script, "● [claude] my-task · myproj ⎇ feat") {
+		t.Error("script should contain the title text")
+	}
+	if !strings.Contains(script, "Ctrl+B D: detach") {
+		t.Error("script should show detach key hint")
+	}
+	// Verify restore section exists
+	lines := strings.Split(script, "\n")
+	hasRestore := false
+	for _, l := range lines {
+		if strings.Contains(l, "set-option -u") {
+			hasRestore = true
+			break
+		}
+	}
+	if !hasRestore {
+		t.Error("script should restore status settings")
+	}
+}
+
+func TestBuildAttachScript_QuotesSingleQuotes(t *testing.T) {
+	script := buildAttachScript("hive's-sess", "hive's-sess:0", "it's a test", "Ctrl+B D")
+	if strings.Contains(script, "hive's-sess") {
+		t.Error("unescaped single quotes in session name")
+	}
+	if !strings.Contains(script, "tmux attach-session") {
+		t.Error("script should contain attach command")
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -745,7 +745,7 @@ func TestHandleKey_CtrlC_AlwaysQuits(t *testing.T) {
 	}
 }
 
-func TestBuildPopupTitle(t *testing.T) {
+func TestBuildSessionHeader(t *testing.T) {
 	tests := []struct {
 		name string
 		msg  SessionAttachMsg
@@ -807,9 +807,9 @@ func TestBuildPopupTitle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPopupTitle(tt.msg)
+			got := buildSessionHeader(tt.msg)
 			if got != tt.want {
-				t.Errorf("buildPopupTitle() = %q, want %q", got, tt.want)
+				t.Errorf("buildSessionHeader() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -829,17 +829,12 @@ func TestBuildAttachScript(t *testing.T) {
 	if !strings.Contains(script, "Ctrl+B D: detach") {
 		t.Error("script should show detach key hint")
 	}
-	// Verify restore section exists
-	lines := strings.Split(script, "\n")
-	hasRestore := false
-	for _, l := range lines {
-		if strings.Contains(l, "set-option -u") {
-			hasRestore = true
-			break
-		}
+	// Verify restore uses had_* flag (not string emptiness) for correctness
+	if !strings.Contains(script, `had_status" = 1`) {
+		t.Error("script should use had_* flag for restore decisions")
 	}
-	if !hasRestore {
-		t.Error("script should restore status settings")
+	if !strings.Contains(script, "set-option -u") {
+		t.Error("script should restore/unset status settings")
 	}
 }
 
@@ -850,5 +845,20 @@ func TestBuildAttachScript_QuotesSingleQuotes(t *testing.T) {
 	}
 	if !strings.Contains(script, "tmux attach-session") {
 		t.Error("script should contain attach command")
+	}
+}
+
+func TestBuildSessionHeader_EscapesHash(t *testing.T) {
+	got := buildSessionHeader(SessionAttachMsg{
+		SessionTitle: "fix #123",
+		AgentType:    "claude",
+		ProjectName:  "my#proj",
+		Status:       "running",
+	})
+	if strings.Contains(got, "fix #1") && !strings.Contains(got, "fix ##1") {
+		t.Errorf("expected '#' to be escaped to '##', got %q", got)
+	}
+	if strings.Contains(got, "my#p") && !strings.Contains(got, "my##p") {
+		t.Errorf("expected '#' in project name to be escaped, got %q", got)
 	}
 }

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -25,9 +25,12 @@ type SessionAttachMsg struct {
 	TmuxWindow      int
 	RestoreGridMode state.GridRestoreMode
 	// Display metadata used to set the terminal window title while attached.
-	SessionTitle string
-	AgentType    state.AgentType
-	ProjectName  string
+	SessionTitle   string
+	AgentType      state.AgentType
+	ProjectName    string
+	Status         state.SessionStatus
+	WorktreeBranch string
+	WorktreePath   string
 }
 
 // SessionDetachedMsg is retained for the legacy native-backend attach/restart


### PR DESCRIPTION
## Summary
- Show a tmux top status bar when attaching to a session, displaying: status dot (●/○/◉/✕), agent badge ([claude]), session title, project name, and worktree branch (⎇)
- Right side of status bar shows detach key hint (Ctrl+B D: detach)
- Original tmux status settings are saved before attach and restored on detach via a shell wrapper script
- Extends `SessionAttachMsg` with `Status`, `WorktreeBranch`, `WorktreePath` fields to carry the metadata through the attach flow
- Updates `PopupAttach` interface to accept a title parameter for future popup use

## Test plan
- [ ] `go build ./...` and `go test ./...` pass
- [ ] Run hive from a regular terminal (outside tmux), create a session, attach — verify the top status bar appears with correct session info
- [ ] Detach and verify the tmux status bar is restored to its original state
- [ ] Test with a worktree session to verify the ⎇ branch indicator appears
- [ ] Test with different agent types to verify the badge renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)