### PR TITLE
fix: re-enable mouse after tmux attach/detach cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subdirectories; press `esc` to clear the filter.
 
 ### Fixed
+- **Mouse clicks broken after detach**: returning from an attached tmux session no
+  longer disables mouse support in the TUI. The bubbletea `RestoreTerminal()` path
+  does not re-enable mouse after `ExecProcess`; the fix explicitly re-enables mouse
+  cell motion when the attach completes.
 - **Stale preview after detach**: returning from an attached session no longer briefly
   shows outdated preview content from a different session. The preview pane clears
   immediately and shows a placeholder until fresh content arrives.

--- a/features/active/013-fix-mouse-support.md
+++ b/features/active/013-fix-mouse-support.md
@@ -76,4 +76,4 @@ Re-enable mouse cell motion after `tea.ExecProcess` returns by batching `tea.Ena
 - Test uses `fmt.Sprintf("%T")` to check for unexported `tea.enableMouseCellMotionMsg` in the batch, since bubbletea doesn't export the msg type
 - All checks pass: `go build`, `go vet`, `go test ./...`
 
-- **PR:** —
+- **PR:** #24

--- a/features/active/013-fix-mouse-support.md
+++ b/features/active/013-fix-mouse-support.md
@@ -1,7 +1,7 @@
 # Feature: Fix mouse support
 
 - **GitHub Issue:** #13
-- **Stage:** RESEARCH
+- **Stage:** IMPLEMENT
 - **Type:** enhancement
 - **Complexity:** S
 - **Priority:** P2
@@ -13,29 +13,67 @@ Enable clicking on previews to attach to that session. Mouse interactions should
 
 ## Research
 
-<Filled during RESEARCH stage.>
+### Key Finding: Mouse Breaks After First Attach/Detach Cycle
+
+The TUI has comprehensive mouse handling code, but **mouse stops working after attaching to a session and detaching back**. This is a bubbletea `RestoreTerminal()` bug.
+
+**Root cause chain:**
+1. User attaches to a session → `doAttach()` → `tea.ExecProcess()` (app.go:2761)
+2. bubbletea calls `ReleaseTerminal()` → `restoreTerminalState()` → **`p.disableMouse()`** (bubbletea tty.go:45)
+3. User detaches → `ExecProcess` callback fires → bubbletea calls `RestoreTerminal()` (bubbletea tea.go:885)
+4. `RestoreTerminal()` re-enables alt screen, bracketed paste, focus reporting — but **never re-enables mouse**
+5. Mouse is now dead for the rest of the session
+
+**Fix:** In the `AttachDoneMsg` handler (app.go:334), return `tea.EnableMouseCellMotion` to re-enable mouse after each attach/detach cycle.
+
+**Native backend is unaffected:** It uses `tea.Quit` + restart loop (`cmd/start.go:99-104`), creating a fresh `tea.NewProgram` with `WithMouseCellMotion()` each time.
+
+### Mouse Handling (Already Implemented)
+
+| Interaction | Location | Effect |
+|-------------|----------|--------|
+| Left-click | Sidebar session | Select session + load preview |
+| Left-click | Preview pane | Attach to active session |
+| Left-click | Grid cell | Select + attach session |
+| Wheel scroll | Sidebar | Navigate sessions |
+| Wheel scroll | Preview | Scroll output ±3 lines |
+| Left-click | Project/Team row | Toggle collapse/expand |
 
 ### Relevant Code
-- `path/to/file.go` — <why it matters>
+- `cmd/start.go:101-104` — `tea.NewProgram` with `tea.WithMouseCellMotion()` enables mouse on startup
+- `internal/tui/app.go:334-342` — `AttachDoneMsg` handler — **missing mouse re-enable** (the fix goes here)
+- `internal/tui/app.go:2761` — `tea.ExecProcess` call in `doAttach()` — triggers the ReleaseTerminal/RestoreTerminal cycle
+- `internal/tui/app.go:607-608` — `tea.MouseMsg` case routes to `handleMouse()`
+- `internal/tui/app.go:1311-1410` — `handleMouse()` — main mouse event router
+- `internal/tui/app.go:1412-1447` — `handleSidebarClick()` — sidebar click processing
+- `internal/tui/components/gridview.go:328-358` — `CellAt()` — grid click detection
+- `internal/tui/components/sidebar.go:184-196` — `ItemAtRow()` — sidebar row mapping
+- `internal/tui/layout.go:12-42` — `computeLayout()` — sidebar/preview width split
 
 ### Constraints / Dependencies
-- <anything blocking or complicating this>
+- **bubbletea bug:** `RestoreTerminal()` (tea.go:885-917) does not re-enable mouse, though it restores alt screen, bracketed paste, and focus reporting. This is a known gap — mouse state (`withMouseCellMotion`) is checked at startup (tea.go:664) but not in `RestoreTerminal`.
+- **Separate from #12:** Issue #12 enables mouse *inside* tmux sessions (for scrolling agent output). This issue is about the TUI's own mouse handling breaking after attach.
+- **Only affects tmux backend:** The native backend restarts the entire `tea.Program`, getting a fresh mouse init each time.
 
 ## Plan
 
-<Filled during PLAN stage.>
+Re-enable mouse cell motion after `tea.ExecProcess` returns by batching `tea.EnableMouseCellMotion` into the `AttachDoneMsg` handler's return command.
 
 ### Files to Change
-1. `path/to/file.go` — <what and why>
+1. `internal/tui/app.go` — In the `AttachDoneMsg` handler (line ~334), change the return to batch `tea.EnableMouseCellMotion` alongside `m.schedulePollPreview()`. Before: `return m, m.schedulePollPreview()`. After: `return m, tea.Batch(tea.EnableMouseCellMotion, m.schedulePollPreview())`.
+2. `CHANGELOG.md` — Add entry under `[Unreleased] > Fixed`: "Fix mouse clicks not working after detaching from a session"
 
 ### Test Strategy
-- <how to verify>
+- Add a test in `internal/tui/app_test.go` that sends `AttachDoneMsg{}` to the model and asserts the returned `tea.Cmd` produces an `enableMouseCellMotionMsg` (verify via `tea.BatchMsg` inspection, matching existing test patterns in `flow_test.go`)
+- Manual: start hive, attach to a session, detach, verify sidebar clicks and preview clicks still work
 
 ### Risks
-- <what could go wrong>
+- `tea.EnableMouseCellMotion` is a `func() tea.Msg` (a `tea.Cmd`), not a `tea.Msg`. Must be passed as a cmd to `tea.Batch`, not called directly. Low risk — same pattern used elsewhere in bubbletea apps.
 
 ## Implementation Notes
 
-<Filled during IMPLEMENT stage.>
+- No deviations from plan — single-line fix in `AttachDoneMsg` handler, wrapping return cmd with `tea.Batch(tea.EnableMouseCellMotion, m.schedulePollPreview())`
+- Test uses `fmt.Sprintf("%T")` to check for unexported `tea.enableMouseCellMotionMsg` in the batch, since bubbletea doesn't export the msg type
+- All checks pass: `go build`, `go vet`, `go test ./...`
 
 - **PR:** —

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -339,7 +339,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.previewPollGen++
 		m.appState.PreviewContent = ""
 		m.preview.SetContent("")
-		return m, m.schedulePollPreview()
+		return m, tea.Batch(tea.EnableMouseCellMotion, m.schedulePollPreview())
 
 	case SessionDetachedMsg:
 		m.previewPollGen++ // returning from native attach; start fresh poll chain

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -496,6 +496,38 @@ func TestAttachDoneMsg_ClearsPreview(t *testing.T) {
 	}
 }
 
+func TestAttachDoneMsg_ReenablesMouseCellMotion(t *testing.T) {
+	// After returning from a tmux attach, mouse cell motion must be re-enabled
+	// because bubbletea's RestoreTerminal() does not restore mouse state.
+	m := testModelWithSessions()
+
+	_, cmd := m.Update(AttachDoneMsg{})
+	if cmd == nil {
+		t.Fatal("AttachDoneMsg returned nil cmd, want batch with EnableMouseCellMotion")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("AttachDoneMsg cmd returned %T, want tea.BatchMsg", msg)
+	}
+
+	// Look for enableMouseCellMotionMsg in the batch.
+	found := false
+	for _, c := range batch {
+		if c == nil {
+			continue
+		}
+		m := c()
+		if fmt.Sprintf("%T", m) == "tea.enableMouseCellMotionMsg" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("AttachDoneMsg batch does not contain EnableMouseCellMotion cmd")
+	}
+}
+
 func TestSessionDetachedMsg_ClearsPreview(t *testing.T) {
 	// When returning from a native backend attach, stale preview content must
 	// be cleared so the user sees a placeholder until fresh content arrives.


### PR DESCRIPTION
## Summary
- **Root cause:** bubbletea's `RestoreTerminal()` does not re-enable mouse after `ExecProcess` returns — `ReleaseTerminal()` calls `disableMouse()` but `RestoreTerminal()` never calls the corresponding enable
- **Fix:** Batch `tea.EnableMouseCellMotion` into the `AttachDoneMsg` handler so mouse is restored every time the user detaches from a tmux session
- **Test:** Added `TestAttachDoneMsg_ReenablesMouseCellMotion` verifying the batch includes the mouse re-enable command

Fixes #13

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: start hive, attach to a session, detach, verify sidebar clicks and preview clicks still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)