### PR TITLE
refactor: replace view flag cascade with view stack

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,11 +41,17 @@ The Bubble Tea root model (`app.go`) wires together all components. The UI
 follows the Elm architecture: messages flow in, the model updates, and `View()`
 renders the current state.
 
+View navigation uses a **view stack** (`viewstack.go`): `PushView()` to open a
+dialog/overlay, `PopView()` to close it and return to whatever was underneath.
+`View()` and key dispatch both use `TopView()` to determine which view is active.
+This replaces the earlier priority-ordered boolean flag cascade.
+
 Key components:
 
 | File | Responsibility |
 |------|---------------|
 | `app.go` | Root model — update loop, message routing |
+| `viewstack.go` | View stack: ViewID enum, push/pop/top/has, legacy flag sync |
 | `keys.go` | Key map, loaded from config |
 | `messages.go` | All `tea.Msg` types used across the app |
 | `layout.go` | Terminal size tracking and pane sizing |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **View stack replaces flag-based view dispatch**: the TUI now uses a view
+  stack (`PushView`/`PopView`) instead of scattered boolean flags to track
+  which overlay is active. This fixes dialogs opened from grid view (rename,
+  kill, new session) incorrectly returning to the main view instead of back
+  to the grid (#46).
+
 ### Added
 - **Create directories in dir picker**: press `n` or `+` in the directory picker
   to create a new subdirectory without leaving hive (#45).

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -39,6 +39,8 @@
 | `G` | Open grid view for all projects |
 | `←`/`→`/`↑`/`↓` or `h`/`l`/`k`/`j` | Navigate grid cells |
 | `Enter` / `a` | Attach to selected session |
+| `t` | New session in the selected session's project |
+| `W` | New worktree session in the selected session's project |
 | `x` | Kill selected session (with confirmation) |
 | `r` | Rename selected session |
 | `G` | Switch to all-projects view (while grid is open) |

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -9,13 +9,14 @@ See `features/templates/FEATURE.md` for the feature file template.
 |---|-------|-------|-------|------------|
 | 1 | #38 | Session status does not detect "Waiting for input" state | RESEARCH | M |
 | 2 | #39 | Remove window list from title bar and add more text colors | RESEARCH | S |
-| 3 | #41 | Simplify detach shortcut to a single key combo | RESEARCH | S |
-| 4 | #36 | Add missing tests | RESEARCH | L |
-| 5 | #34 | Terminal bell does not produce audible sound | RESEARCH | S |
-| 6 | #46 | Rework dialog system to use a view stack | RESEARCH | M |
-| 7 | #48 | Allow creating new sessions from grid view | IMPLEMENT | S |
-| 8 | #40 | Ability to reorder sessions within a project | RESEARCH | L |
-| 9 | #37 | Code refactor: remove bloat | RESEARCH | L |
+| 3 | #49 | Bug: Renaming projects doesn't update the project name | RESEARCH | S |
+| 4 | #41 | Simplify detach shortcut to a single key combo | RESEARCH | S |
+| 5 | #36 | Add missing tests | RESEARCH | L |
+| 6 | #34 | Terminal bell does not produce audible sound | RESEARCH | S |
+| 7 | #46 | Rework dialog system to use a view stack | IMPLEMENT | M |
+| 8 | #48 | Allow creating new sessions from grid view | IMPLEMENT | S |
+| 9 | #40 | Ability to reorder sessions within a project | RESEARCH | L |
+| 10 | #37 | Code refactor: remove bloat | RESEARCH | L |
 
 ## Completed
 

--- a/features/active/046-rework-dialog-system-view-stack.md
+++ b/features/active/046-rework-dialog-system-view-stack.md
@@ -1,7 +1,7 @@
 # Feature: Rework dialog system to use a view stack
 
 - **GitHub Issue:** #46
-- **Stage:** RESEARCH
+- **Stage:** IMPLEMENT
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** P3
@@ -21,29 +21,146 @@ This would fix the rename-in-grid-view bug and prevent similar navigation issues
 
 ## Research
 
-<Filled during RESEARCH stage.>
+### Current Architecture
+
+The app has **no centralized view/mode tracking**. Instead, it uses a priority-ordered cascade of boolean flags and `Active` fields to determine what's shown. The `View()` method checks each overlay in priority order and renders the first active one.
+
+**View state is distributed across:**
+- `AppState` flags: `ShowHelp`, `ShowTmuxHelp`, `ShowConfirm`, `EditingTitle`, `FilterActive` — in `internal/state/model.go:143-182`
+- Component `Active` fields: `gridView.Active`, `settings.Active`, `agentPicker.Active`, `teamBuilder.Active`, `dirPicker.Active`, `recoveryPicker.Active`, `orphanPicker.Active` — in `internal/tui/app.go:39-84`
+- `inputMode` string: `"project-name"`, `"project-dir-confirm"`, `"custom-command"`, `"worktree-branch"`, `"new-session"` — in `internal/tui/app.go:56`
+
+**Key handlers use the same priority cascade** (`buildKeyHandlers()` at `handle_keys.go:35-166`): the first handler whose `Focused()` returns true gets exclusive key input.
+
+**View rendering** (`app.go:296-355`) checks overlays in the same order: settings > grid > help > attach hint > confirm > pickers > inputs > rename > main layout.
+
+### The Bug: Grid → Rename → Returns to Main
+
+When pressing `r` in grid view (`handle_keys.go:193-199`):
+1. `m.gridView.Hide()` — grid is closed immediately
+2. `m.startRename()` — rename dialog opens
+3. When rename completes (`handle_input.go:175-199`), it just sets `EditingTitle = false`
+4. Since `gridView.Active` is already false, the main sidebar/preview view is shown
+
+The same pattern affects `x` (kill) from grid (`handle_keys.go:182-192`) — grid is hidden before the confirm dialog opens. After confirmation, the user lands on the main view instead of returning to the grid.
 
 ### Relevant Code
-- `path/to/file.go` — <why it matters>
+
+- `internal/tui/app.go:296-355` — `View()` method: priority-ordered view cascade, the core rendering logic that would need to respect a view stack
+- `internal/tui/app.go:39-84` — `Model` struct: holds all component references and overlay state
+- `internal/tui/app.go:156-167` — `restoreGrid()`: existing pattern for restoring grid view after detach (uses `RestoreGridMode` flag)
+- `internal/tui/handle_keys.go:35-166` — `buildKeyHandlers()`: priority-ordered key handler dispatch
+- `internal/tui/handle_keys.go:168-245` — `handleGridKey()`: grid key handling, contains the rename/kill bug
+- `internal/tui/handle_input.go:15-24` — `startRename()`: opens rename dialog
+- `internal/tui/handle_input.go:175-199` — `handleTitleEdit()`: closes rename dialog, no grid restoration
+- `internal/tui/handle_system.go:90-101` — `handleCancelled()`: blanket cancel that clears all overlay flags
+- `internal/state/model.go:143-182` — `AppState`: all overlay boolean flags
+- `internal/state/model.go:64-79` — `Pane` and `GridRestoreMode` constants
+- `internal/tui/components/gridview.go:46-71` — `GridView` struct with `Show()`/`Hide()`
+- `internal/tui/views.go:33-48` — `renameDialogView()` rendering
+
+### Existing "Restore" Pattern
+
+The app already has a limited restore mechanism for the grid-after-detach case:
+- `AppState.RestoreGridMode` stores which grid mode was active when attaching
+- `restoreGrid()` (`app.go:156-167`) re-opens the grid on detach
+- This is a single-level "remember one previous state" pattern, not a stack
 
 ### Constraints / Dependencies
-- <anything blocking or complicating this>
+
+- **Rendering is priority-based, not stack-based**: The `View()` method uses if/else-if. A view stack would need to coexist with or replace this cascade.
+- **Key handling mirrors View()**: `buildKeyHandlers()` returns handlers in the same priority order. Both systems need to stay in sync.
+- **`handleCancelled()` is a blanket reset**: It clears all overlay flags at once. A stack-based system would just pop the top.
+- **Multiple overlay types**: Some are full-screen (grid, settings), some are overlays on the main view (rename, confirm, pickers). The stack needs to handle both.
+- **Grid state is expensive**: Grid view tracks sessions, preview data, cursor position. Hiding and re-showing loses cursor state unless preserved.
+- **`inputMode` is a mini-state-machine**: The project creation flow uses `inputMode` transitions (`"project-name"` → dir picker → `"project-dir-confirm"`). This is already a form of navigation sequence that could be modeled as stack pushes.
+- **No dependency on external features**: This is a self-contained UI refactor.
 
 ## Plan
 
-<Filled during PLAN stage.>
+### Approach: View Stack
+
+Introduce a `viewStack []ViewID` on Model as the **single source of truth** for which view is displayed. Push to open, pop to close. `View()` and key handling inspect the stack top — no more priority cascade of boolean flags.
+
+**ViewID** is a string enum identifying each view layer:
+- Base: `ViewMain` (always at stack bottom, never popped)
+- Full-screen: `ViewSettings`, `ViewGrid`
+- Overlays: `ViewHelp`, `ViewTmuxHelp`, `ViewAttachHint`, `ViewConfirm`, `ViewRecovery`, `ViewOrphan`, `ViewAgentPicker`, `ViewTeamBuilder`, `ViewRename`, `ViewProjectName`, `ViewDirPicker`, `ViewDirConfirm`, `ViewCustomCmd`, `ViewWorktreeBranch`
+
+**Stack operations** on Model:
+- `PushView(id)` — push a view on top
+- `PopView() ViewID` — remove and return top (never pops below ViewMain)
+- `TopView() ViewID` — peek at the top
+- `HasView(id) bool` — is this view anywhere in the stack (e.g., "is grid underneath?")
+
+**Why this is better than reordering:**
+- Single source of truth instead of ~15 scattered flags
+- Open/close is symmetric push/pop — no per-dialog "return to" logic
+- Nesting works naturally (grid → rename → confirm = 3 stack entries)
+- Future dialogs just need a ViewID constant, no cascade insertion
+- `handleCancelled()` becomes `PopView()` instead of blanket flag reset
+- Impossible to forget restoring the previous view
+
+### Transition strategy
+
+The stack replaces the dispatch logic (View() and key routing). Component structs still live as fields on Model and keep their internal state (grid cursor, picker items, etc.). Component `Active` fields and AppState overlay flags (`ShowHelp`, `ShowConfirm`, `EditingTitle`, etc.) are **kept in sync** with the stack during this PR — they're set on push, cleared on pop. This avoids breaking any component code that reads its own Active field internally. A future cleanup PR can remove the redundant flags.
 
 ### Files to Change
-1. `path/to/file.go` — <what and why>
+
+1. **`internal/tui/viewstack.go` (NEW)** — Define `ViewID` type, all constants, and stack methods on Model: `PushView`, `PopView`, `TopView`, `HasView`, `ReplaceTop` (for inputMode transitions like project-name → dir-picker). Include a `refreshGrid()` helper that refreshes the grid session list when it's in the stack (extracted from the pattern at `handle_session.go:19-24`).
+
+2. **`internal/tui/app.go`** — Add `viewStack []ViewID` field to Model struct (~line 39). In `New()` (~line 90), initialize stack with `[]ViewID{ViewMain}`. In `restoreGrid()` (~line 156), push `ViewGrid` onto stack instead of just calling `gridView.Show()`. **Rewrite `View()` method** (~lines 296-355): replace the if/else-if cascade with a `switch m.TopView()` that dispatches to the correct renderer. Each case calls the same rendering function as today (e.g., `ViewRename` → `m.overlayView(m.renameDialogView())`).
+
+3. **`internal/tui/handle_keys.go`** — **Rewrite `buildKeyHandlers()`** (~lines 35-166): replace the priority-ordered `[]KeyHandler` slice with a single `switch m.TopView()` dispatch. Each case calls the corresponding handler function. This eliminates the `componentHandler` wrapper and `focused()` callbacks entirely. **Modify `handleGridKey()`** (~lines 182-199): for `"r"` and `"x"`, replace `m.gridView.Hide()` with `m.PushView(ViewRename)` / `m.PushView(ViewConfirm)` (the grid stays in the stack underneath). For `"t"` and `"W"` (~lines 200-227), add `m.PushView(ViewAgentPicker)`. **Modify `handleGlobalKey()`**: for keys that open overlays (`"?"` → help, `"S"` → settings, `"g"`/`"G"` → grid, `"r"` → rename, `"/"` → filter, etc.), replace flag-setting with `PushView()`.
+
+4. **`internal/tui/handle_input.go`** — In `startRename()` (~line 15): replace `m.appState.EditingTitle = true` with `m.PushView(ViewRename)` (which also sets EditingTitle for compat). In `handleTitleEdit()` (~line 175): replace `m.appState.EditingTitle = false` with `m.PopView()` (which clears EditingTitle). If `m.HasView(ViewGrid)`, call `refreshGrid()`. In `handleNameInput()` (~line 60): replace `m.inputMode = ""` / `m.dirPicker.Show()` transitions with `m.ReplaceTop(ViewDirPicker)`. In `handleDirConfirm()`, `handleCustomCommandInput()`, `handleWorktreeBranchInput()`: replace `m.inputMode = ""` with `m.PopView()`. For chained transitions (custom-command → worktree-branch), use `m.ReplaceTop(ViewWorktreeBranch)`.
+
+5. **`internal/tui/handle_system.go`** — Rewrite `handleCancelled()` (~line 90): replace blanket flag reset with `m.PopView()`. The pop clears the appropriate flag for the popped view. Keep component cleanup (titleEditor.Stop(), agentPicker.Hide(), nameInput.Blur()) triggered by checking what was popped. Rewrite `handleConfirmed()` (~line 84): after the confirmed action, `m.PopView()` the confirm view. If grid is in the stack, call `refreshGrid()`.
+
+6. **`internal/tui/handle_session.go`** — In `handleSessionKilled()` (~line 30): add sidebar rebuild and `refreshGrid()` call (currently missing). In `handleSessionTitleChanged()` (~line 36): add `refreshGrid()` call after `commitState()`. In `handleSessionCreated()` (~line 12): replace `m.gridView.Active` check with `m.HasView(ViewGrid)`.
+
+7. **`internal/tui/handle_project.go`** — In `handleDirPicked()` (~line 25): replace `m.dirPicker.Active = false` / `m.inputMode = "project-dir-confirm"` with stack operations (`PopView` or `ReplaceTop`). In `handleDirPickerCancel()` (~line 47): replace manual flag manipulation with `m.ReplaceTop(ViewProjectName)`.
+
+8. **`internal/tui/viewstack_test.go` (NEW)** — Unit tests for the view stack.
 
 ### Test Strategy
-- <how to verify>
+
+- **Unit tests** (`internal/tui/viewstack_test.go`):
+  - `PushView`/`PopView` basics: push several views, pop returns them in LIFO order, can't pop below ViewMain
+  - `TopView` returns the top view, `HasView` checks the full stack
+  - `ReplaceTop` swaps the top without affecting views below
+  - Scenario: push ViewGrid, push ViewRename, pop → top is ViewGrid
+  - Scenario: push ViewGrid, push ViewConfirm, pop → top is ViewGrid
+  - Scenario: push ViewGrid, push ViewAgentPicker, pop → top is ViewGrid
+- **Integration-style tests** (same file or separate):
+  - Simulate: grid active → press `r` → verify stack is `[Main, Grid, Rename]`
+  - Simulate: rename done (enter/esc) → verify stack is `[Main, Grid]`
+  - Simulate: grid active → press `x` → verify stack is `[Main, Grid, Confirm]`
+  - Simulate: confirm done → verify stack is `[Main, Grid]` and session killed
+- **Manual testing scenarios:**
+  - Grid → rename (`r`) → confirm → verify grid shown with updated title
+  - Grid → rename (`r`) ��� cancel (`esc`) → verify grid shown
+  - Grid → kill (`x`) → confirm → verify grid shown without killed session
+  - Grid → new session (`t`) → pick agent → verify session created, grid refreshed
+  - All main-view overlay flows unchanged (rename, confirm, help, settings, project creation wizard)
+  - Project creation wizard: new project (`n`) → name → dir picker → confirm → verify project created
 
 ### Risks
-- <what could go wrong>
+
+- **Sync drift**: Component `Active` fields and AppState flags are kept in sync with the stack during this PR. If a code path sets a flag without going through push/pop, the stack and flags will diverge. Mitigation: audit all flag-setting code during implementation; add a debug assertion that validates stack-flag consistency.
+- **Multi-step flows**: The project creation wizard (name → dir picker → dir confirm) and worktree flow (agent picker → custom command → branch name) chain several views. These need `ReplaceTop()` for lateral transitions and `PushView()` for nested ones. Getting this wrong would break the wizard. Mitigation: test each step of each wizard flow.
+- **handleCancelled() scope**: The current blanket reset clears everything. With the stack, `PopView()` only removes the top layer. If multiple overlays were somehow pushed (shouldn't happen normally), a single cancel only pops one. This is actually correct behavior, but differs from the current "nuclear reset". Mitigation: verify no flow depends on the blanket reset clearing more than the active overlay.
+- **Grid refresh after state changes**: Grid is now underneath overlays in the stack. After state-changing operations (kill, rename, create), the grid's session list may be stale. Mitigation: `refreshGrid()` helper called whenever state changes and grid is in the stack.
 
 ## Implementation Notes
 
-<Filled during IMPLEMENT stage.>
+- **Branch:** `feature/46-view-stack`
+- Implemented the full view stack approach as planned.
+- Legacy flags (`ShowHelp`, `ShowConfirm`, `EditingTitle`, `gridView.Active`, etc.) are kept in sync via `syncLegacyFlags()` during push/pop. This avoids breaking component code that reads its own Active field internally.
+- `inputMode = "new-session"` was kept as a semantic flag (not a ViewID) because it tracks purpose, not a visible view. The visible view in that flow is `ViewAgentPicker`.
+- The `focus.go` file (KeyHandler interface, componentHandler, dispatchKey) is no longer used in production code but kept for its standalone tests. Could be removed in a future cleanup.
+- `handleGridKey` now detects when the grid component internally closes itself (esc/q/enter) by checking `!m.gridView.Active` after calling `gridView.Update()`, and pops the stack accordingly.
+- Startup overlays (recoveryPicker, orphanPicker) that initialize with `Active = true` are pushed onto the stack in `New()`.
+- Grid refresh helper (`refreshGrid()`) added and called from session handlers to keep grid data fresh when it's underneath a dialog.
 
 - **PR:** —

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -81,6 +81,9 @@ type Model struct {
 	// recent write or reload.  The background watcher compares against this to
 	// detect writes made by other hive instances.
 	stateLastKnownMtime time.Time
+	// viewStack tracks the active view layers. ViewMain is always at the bottom.
+	// Push to open a view, pop to close it. TopView() drives View() and key dispatch.
+	viewStack []ViewID
 }
 
 // LastAttach returns the pending attach request after the TUI exits, or nil.
@@ -120,6 +123,7 @@ func New(cfg config.Config, appState state.AppState) Model {
 		recoveryPicker:      components.NewRecoveryPicker(appState.RecoverableSessions),
 		nameInput:           ni,
 		contentSnapshots:    make(map[string]string),
+		viewStack:           []ViewID{ViewMain},
 	}
 	// Clear the transient fields now that the pickers own their lists.
 	m.appState.OrphanSessions = nil
@@ -145,6 +149,13 @@ func New(cfg config.Config, appState state.AppState) Model {
 		m.sidebar.SyncActiveSession(m.appState.ActiveSessionID)
 		debugLog.Printf("synced cursor to existing active session %s", m.appState.ActiveSessionID)
 	}
+	// Push startup overlays onto the view stack if they were activated by constructors.
+	if m.recoveryPicker.Active {
+		m.PushView(ViewRecovery)
+	}
+	if m.orphanPicker.Active {
+		m.PushView(ViewOrphan)
+	}
 	// Restore the grid view if the user detached from a grid-initiated session.
 	m.restoreGrid()
 	debugLog.Printf("New() done: ActiveSessionID=%q, %d projects, %d sidebar items",
@@ -164,6 +175,7 @@ func (m *Model) restoreGrid() {
 	m.gridView.SetProjectNames(m.gridProjectNames())
 	m.gridView.SetContents(m.gridContentsFromSnapshots(sessions))
 	m.gridView.SyncCursor(m.appState.ActiveSessionID)
+	m.PushView(ViewGrid)
 }
 
 // expandForActiveSession un-collapses any parent project or team that contains
@@ -200,7 +212,7 @@ func (m Model) Init() tea.Cmd {
 		m.scheduleWatchStatuses(),
 		scheduleWatchState(m.stateLastKnownMtime),
 	}
-	if m.gridView.Active {
+	if m.HasView(ViewGrid) {
 		cmds = append(cmds, m.scheduleGridPoll())
 	}
 	return tea.Batch(cmds...)
@@ -285,73 +297,58 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Forward non-key, non-handled messages to active modals that need
 	// internal ticks (e.g. cursor blink, filter debounce in charmbracelet/list).
-	if m.dirPicker.Active {
+	if m.HasView(ViewDirPicker) {
 		m.dirPicker.Update(msg)
 	}
 
 	return m, nil
 }
 
-// View renders the full UI.
+// View renders the full UI based on the top of the view stack.
 func (m Model) View() string {
-	// Settings screen fills the full terminal.
-	if m.settings.Active {
+	switch m.TopView() {
+	case ViewSettings:
 		m.settings.Width = m.appState.TermWidth
 		m.settings.Height = m.appState.TermHeight
 		return m.settings.View()
-	}
-	// Grid overview fills the full terminal.
-	if m.gridView.Active {
+	case ViewGrid:
 		m.gridView.Width = m.appState.TermWidth
 		m.gridView.Height = m.appState.TermHeight
 		return m.gridView.View()
-	}
-	// Show overlays first.
-	if m.appState.ShowHelp {
+	case ViewHelp:
 		return m.helpView()
-	}
-	if m.appState.ShowTmuxHelp {
+	case ViewTmuxHelp:
 		return m.tmuxHelpView()
-	}
-	if m.showAttachHint {
+	case ViewAttachHint:
 		return m.overlayView(m.attachHintView())
-	}
-	if m.appState.ShowConfirm {
+	case ViewConfirm:
 		return m.overlayView(m.confirm.View())
-	}
-	if m.recoveryPicker.Active {
+	case ViewRecovery:
 		m.recoveryPicker.Width = m.appState.TermWidth
 		m.recoveryPicker.Height = m.appState.TermHeight
 		return m.overlayView(m.recoveryPicker.View())
-	}
-	if m.orphanPicker.Active {
+	case ViewOrphan:
 		m.orphanPicker.Width = m.appState.TermWidth
 		m.orphanPicker.Height = m.appState.TermHeight
 		return m.overlayView(m.orphanPicker.View())
-	}
-	if m.agentPicker.Active {
+	case ViewAgentPicker:
 		return m.overlayView(m.agentPicker.View())
-	}
-	if m.teamBuilder.Active {
+	case ViewTeamBuilder:
 		return m.overlayView(m.teamBuilder.View())
-	}
-	if m.inputMode == "project-name" {
+	case ViewProjectName:
 		return m.overlayView(m.nameInputView("New Project (1/2)", "Project name:", "enter: next  esc: cancel"))
-	}
-	if m.dirPicker.Active {
+	case ViewDirPicker:
 		return m.overlayView(m.dirPicker.View())
-	}
-	if m.inputMode == "project-dir-confirm" {
+	case ViewDirConfirm:
 		return m.overlayView(m.dirConfirmView())
-	}
-	if m.inputMode == "custom-command" {
+	case ViewCustomCmd:
 		return m.overlayView(m.nameInputView("Custom Command", "Command to run:", "enter: create  esc: cancel"))
-	}
-	if m.inputMode == "worktree-branch" {
+	case ViewWorktreeBranch:
 		return m.overlayView(m.nameInputView("New Worktree Session", "Branch name:", "enter: create  esc: cancel"))
-	}
-	if m.appState.EditingTitle {
+	case ViewRename:
 		return m.overlayView(m.renameDialogView())
+	case ViewFilter:
+		// Filter is an inline mode — fall through to main layout rendering.
 	}
 
 	sw, pw, ch := computeLayout(m.appState.TermWidth, m.appState.TermHeight)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -618,7 +618,7 @@ func TestNewProject_PressN_OpensDirPickerAfterName(t *testing.T) {
 func TestDirPickedMsg_ExistingDir_CreatesProject(t *testing.T) {
 	m := testModelWithSessions()
 	m.pendingProjectName = "myproject"
-	m.dirPicker.Active = true
+	m.PushView(ViewDirPicker)
 
 	dir := t.TempDir()
 	result, cmd := m.Update(components.DirPickedMsg{Dir: dir})
@@ -639,7 +639,7 @@ func TestDirPickedMsg_ExistingDir_CreatesProject(t *testing.T) {
 func TestDirPickedMsg_NonExistentDir_AsksConfirmation(t *testing.T) {
 	m := testModelWithSessions()
 	m.pendingProjectName = "myproject"
-	m.dirPicker.Active = true
+	m.PushView(ViewDirPicker)
 
 	nonexistent := t.TempDir() + "/does-not-exist"
 	result, _ := m.Update(components.DirPickedMsg{Dir: nonexistent})
@@ -653,7 +653,7 @@ func TestDirPickedMsg_NonExistentDir_AsksConfirmation(t *testing.T) {
 func TestDirPickerCancelMsg_ReturnsToNameStep(t *testing.T) {
 	m := testModelWithSessions()
 	m.pendingProjectName = "myproject"
-	m.dirPicker.Active = true
+	m.PushView(ViewDirPicker)
 
 	result, _ := m.Update(components.DirPickerCancelMsg{})
 	updated := result.(Model)
@@ -672,7 +672,7 @@ func TestDirPickerCancelMsg_ReturnsToNameStep(t *testing.T) {
 
 func TestDirPicker_BackgroundMessages_NotDroppedWhileActive(t *testing.T) {
 	m := testModelWithSessions()
-	m.dirPicker.Active = true
+	m.PushView(ViewDirPicker)
 
 	// A preview update should still be processed while the picker is open.
 	m.previewPollGen = 1
@@ -695,7 +695,7 @@ func TestDirPicker_BackgroundMessages_NotDroppedWhileActive(t *testing.T) {
 
 func TestHandleKey_DirPickerActive_BlocksGlobalKeys(t *testing.T) {
 	m := testModelWithSessions()
-	m.dirPicker.Active = true
+	m.PushView(ViewDirPicker)
 
 	// Press "/" which is the Filter key — should NOT activate global filter.
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
@@ -708,7 +708,7 @@ func TestHandleKey_DirPickerActive_BlocksGlobalKeys(t *testing.T) {
 
 func TestHandleKey_DirPickerActive_BlocksQuit(t *testing.T) {
 	m := testModelWithSessions()
-	m.dirPicker.Active = true
+	m.PushView(ViewDirPicker)
 
 	// Press "q" which is the Quit key — should NOT quit.
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
@@ -726,6 +726,7 @@ func TestHandleKey_DirPickerActive_BlocksQuit(t *testing.T) {
 func TestHandleKey_AgentPickerActive_BlocksGlobalKeys(t *testing.T) {
 	m := testModelWithSessions()
 	m.agentPicker.Show(components.DefaultAgentItems)
+	m.PushView(ViewAgentPicker)
 
 	// Press "/" (Filter key) — should not activate global filter.
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
@@ -738,7 +739,7 @@ func TestHandleKey_AgentPickerActive_BlocksGlobalKeys(t *testing.T) {
 
 func TestHandleKey_FilterActive_BlocksGlobalKeys(t *testing.T) {
 	m := testModelWithSessions()
-	m.appState.FilterActive = true
+	m.PushView(ViewFilter)
 
 	// Press "n" which is the NewProject key — should add to filter, not open new project.
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
@@ -766,7 +767,7 @@ func TestHandleKey_NoOverlay_GlobalKeysWork(t *testing.T) {
 
 func TestHandleKey_SettingsActive_BlocksAll(t *testing.T) {
 	m := testModelWithSessions()
-	m.settings.Active = true
+	m.PushView(ViewSettings)
 
 	// Press "n" (NewProject) — should be swallowed by settings.
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
@@ -779,9 +780,9 @@ func TestHandleKey_SettingsActive_BlocksAll(t *testing.T) {
 
 func TestHandleKey_ConfirmActive_BlocksAll(t *testing.T) {
 	m := testModelWithSessions()
-	m.appState.ShowConfirm = true
 	m.appState.ConfirmAction = "test-action"
 	m.confirm.Message = "Are you sure?"
+	m.PushView(ViewConfirm)
 
 	// Press "n" (NewProject key) — should be handled by confirm (treated as cancel/no-op).
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
@@ -794,7 +795,7 @@ func TestHandleKey_ConfirmActive_BlocksAll(t *testing.T) {
 
 func TestHandleKey_CtrlC_AlwaysQuits(t *testing.T) {
 	m := testModelWithSessions()
-	m.dirPicker.Active = true
+	m.PushView(ViewDirPicker)
 
 	// ctrl+c should always quit, even with an overlay active.
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})

--- a/internal/tui/components/dirpicker.go
+++ b/internal/tui/components/dirpicker.go
@@ -163,7 +163,7 @@ func (dp *DirPicker) Update(msg tea.Msg) (tea.Cmd, bool) {
 				return nil, true
 			case tea.KeyEnter:
 				name := strings.TrimSpace(dp.createInput.Value())
-				if name == "" || strings.Contains(name, string(filepath.Separator)) {
+				if name == "" || strings.ContainsAny(name, `/\`) {
 					return nil, true
 				}
 				newDir := filepath.Join(dp.currentDir, name)

--- a/internal/tui/components/dirpicker_test.go
+++ b/internal/tui/components/dirpicker_test.go
@@ -290,7 +290,7 @@ func TestDirPicker_CreateModeRejectsPathSeparator(t *testing.T) {
 	dp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 
 	// Type a name containing a path separator.
-	for _, r := range "../../evil" {
+	for _, r := range ".." + string(filepath.Separator) + "evil" {
 		dp.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 	}
 
@@ -306,9 +306,10 @@ func TestDirPicker_CreateModeRejectsPathSeparator(t *testing.T) {
 
 func TestDirPicker_CreateModeShowsError(t *testing.T) {
 	dp := NewDirPicker()
-	// Point at a non-existent base directory so MkdirAll fails.
+	// Point at a path nested under a file (not a directory) so MkdirAll fails.
+	// os.DevNull is /dev/null on Unix and NUL on Windows — both are files.
 	dp.Active = true
-	dp.currentDir = "/dev/null/impossible"
+	dp.currentDir = filepath.Join(os.DevNull, "impossible")
 
 	dp.creating = true
 	dp.createInput.Focus()

--- a/internal/tui/golden_test.go
+++ b/internal/tui/golden_test.go
@@ -59,6 +59,7 @@ func TestGolden_GridView_ProjectScope(t *testing.T) {
 	m.gridView.SetProjectNames(m.gridProjectNames())
 	m.gridView.Width = 120
 	m.gridView.Height = 40
+	m.PushView(ViewGrid)
 	golden.RequireEqual(t, m.View())
 }
 
@@ -73,6 +74,7 @@ func TestGolden_GridView_AllProjects(t *testing.T) {
 	m.gridView.SetProjectNames(m.gridProjectNames())
 	m.gridView.Width = 120
 	m.gridView.Height = 40
+	m.PushView(ViewGrid)
 	golden.RequireEqual(t, m.View())
 }
 
@@ -94,7 +96,7 @@ func TestGolden_FilterActive(t *testing.T) {
 	appState.FilterActive = true
 	appState.FilterQuery = "sess"
 	m := goldenModel(t, appState)
-	m.appState.FilterActive = true
+	m.PushView(ViewFilter)
 	m.appState.FilterQuery = "sess"
 	m.sidebar.FilterQuery = "sess"
 	m.sidebar.Rebuild(&m.appState)
@@ -106,7 +108,7 @@ func TestGolden_HelpOverlay(t *testing.T) {
 	appState.TermWidth = 120
 	appState.TermHeight = 40
 	m := goldenModel(t, appState)
-	m.appState.ShowHelp = true
+	m.PushView(ViewHelp)
 	golden.RequireEqual(t, m.View())
 }
 
@@ -115,11 +117,11 @@ func TestGolden_ConfirmDialog(t *testing.T) {
 	appState.TermWidth = 120
 	appState.TermHeight = 40
 	m := goldenModel(t, appState)
-	m.appState.ShowConfirm = true
 	m.appState.ConfirmMsg = "Kill session \"session-1\"?"
 	m.appState.ConfirmAction = "kill-session:sess-1"
 	m.confirm.Message = "Kill session \"session-1\"?"
 	m.confirm.Action = "kill-session:sess-1"
+	m.PushView(ViewConfirm)
 	golden.RequireEqual(t, m.View())
 }
 

--- a/internal/tui/handle_input.go
+++ b/internal/tui/handle_input.go
@@ -18,8 +18,8 @@ func (m *Model) startRename() tea.Cmd {
 		return nil
 	}
 	current := sel.Label
-	m.appState.EditingTitle = true
 	m.titleEditor.Start(sel.SessionID, sel.TeamID, current)
+	m.PushView(ViewRename)
 	return m.titleEditor.Update(nil)
 }
 
@@ -33,7 +33,7 @@ func defaultShell() string {
 func (m Model) handleFilter(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc", "enter":
-		m.appState.FilterActive = false
+		m.PopView()
 		if msg.String() == "esc" {
 			m.appState.FilterQuery = ""
 			m.sidebar.FilterQuery = ""
@@ -64,18 +64,16 @@ func (m Model) handleNameInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if val == "" {
 			return m, nil
 		}
-		if m.inputMode == "project-name" {
-			// Step 1 done: open the interactive directory picker.
-			m.pendingProjectName = val
-			m.inputMode = ""
-			m.nameInput.Blur()
-			cwd, _ := os.Getwd()
-			m.dirPicker.Show(cwd)
-			return m, nil
-		}
+		// Step 1 done: open the interactive directory picker.
+		m.pendingProjectName = val
+		m.nameInput.Blur()
+		cwd, _ := os.Getwd()
+		m.dirPicker.Show(cwd)
+		m.ReplaceTop(ViewDirPicker)
+		return m, nil
 	case "esc":
 		m.nameInput.Blur()
-		m.inputMode = ""
+		m.PopView()
 		m.pendingProjectName = ""
 		return m, nil
 	}
@@ -89,19 +87,19 @@ func (m Model) handleDirConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y", "Y", "enter":
 		dir := strings.TrimSpace(m.nameInput.Value())
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			m.inputMode = ""
+			m.PopView()
 			m.pendingProjectName = ""
 			return m, func() tea.Msg { return ErrorMsg{Err: fmt.Errorf("create directory: %w", err)} }
 		}
-		m.inputMode = ""
+		m.PopView()
 		cmd := m.createProject(m.pendingProjectName, dir)
 		m.pendingProjectName = ""
 		return m, cmd
 	case "n", "N", "esc":
 		// Return to directory picker so user can choose a different path.
-		m.inputMode = ""
 		dir := strings.TrimSpace(m.nameInput.Value())
 		m.dirPicker.Show(dir)
+		m.ReplaceTop(ViewDirPicker)
 		return m, nil
 	}
 	return m, nil
@@ -115,7 +113,7 @@ func (m Model) handleWorktreeBranchInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.nameInput.Blur()
-		m.inputMode = ""
+		m.PopView()
 		agentType := m.pendingWorktreeAgentType
 		agentCmd := m.pendingWorktreeAgentCmd
 		m.pendingWorktreeAgentType = ""
@@ -124,7 +122,7 @@ func (m Model) handleWorktreeBranchInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.createSessionWithWorktree(m.pendingProjectID, agentType, agentCmd, branch)
 	case "esc":
 		m.nameInput.Blur()
-		m.inputMode = ""
+		m.PopView()
 		m.pendingWorktree = false
 		m.pendingWorktreeAgentType = ""
 		m.pendingWorktreeAgentCmd = nil
@@ -140,7 +138,6 @@ func (m Model) handleCustomCommandInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		raw := strings.TrimSpace(m.nameInput.Value())
 		m.nameInput.Blur()
-		m.inputMode = ""
 
 		var agentCmd []string
 		if raw == "" {
@@ -153,17 +150,18 @@ func (m Model) handleCustomCommandInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			// Chain to worktree branch input.
 			m.pendingWorktreeAgentType = "custom"
 			m.pendingWorktreeAgentCmd = agentCmd
-			m.inputMode = "worktree-branch"
 			m.nameInput.Placeholder = "branch-name"
 			m.nameInput.Reset()
 			m.nameInput.SetValue(git.RandomBranchName())
+			m.ReplaceTop(ViewWorktreeBranch)
 			blinkCmd := m.nameInput.Focus()
 			return m, blinkCmd
 		}
+		m.PopView()
 		return m, m.createSession(m.pendingProjectID, "custom", agentCmd)
 	case "esc":
 		m.nameInput.Blur()
-		m.inputMode = ""
+		m.PopView()
 		m.pendingWorktree = false
 		return m, nil
 	}
@@ -178,7 +176,7 @@ func (m Model) handleTitleEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		newTitle := m.titleEditor.Value()
 		sessionID := m.titleEditor.SessionID
 		m.titleEditor.Stop()
-		m.appState.EditingTitle = false
+		m.PopView()
 		if newTitle != "" && sessionID != "" {
 			return m, func() tea.Msg {
 				return SessionTitleChangedMsg{
@@ -191,7 +189,7 @@ func (m Model) handleTitleEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "esc":
 		m.titleEditor.Stop()
-		m.appState.EditingTitle = false
+		m.PopView()
 		return m, nil
 	}
 	cmd := m.titleEditor.Update(msg)
@@ -201,12 +199,12 @@ func (m Model) handleTitleEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) handleConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if key.Matches(msg, m.keys.Confirm) {
 		action := m.appState.ConfirmAction
-		m.appState.ShowConfirm = false
+		m.PopView()
 		m.confirm.Message = ""
 		return m, func() tea.Msg { return ConfirmedMsg{Action: action} }
 	}
 	if key.Matches(msg, m.keys.Cancel) {
-		m.appState.ShowConfirm = false
+		m.PopView()
 		m.confirm.Message = ""
 		return m, nil
 	}

--- a/internal/tui/handle_keys.go
+++ b/internal/tui/handle_keys.go
@@ -13,156 +13,61 @@ import (
 	"github.com/lucascaro/hive/internal/tui/components"
 )
 
-// handleKey handles keyboard events. It uses a priority-ordered list of
-// KeyHandler adapters: the first focused handler exclusively receives the key
-// event, preventing leakage to lower-priority handlers or global bindings.
+// handleKey dispatches keyboard events based on the view stack top.
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// ctrl+c always quits, regardless of focus.
 	if msg.String() == "ctrl+c" {
 		return m, tea.Quit
 	}
 
-	if cmd, handled := dispatchKey(m.buildKeyHandlers(), msg); handled {
+	switch m.TopView() {
+	case ViewSettings:
+		cmd, _ := m.settings.Update(msg)
 		return m, cmd
+	case ViewGrid:
+		cmd := m.handleGridKey(msg)
+		return m, cmd
+	case ViewHelp, ViewTmuxHelp:
+		if msg.String() == "esc" {
+			m.PopView()
+		}
+		return m, nil
+	case ViewAttachHint:
+		return m.handleAttachHint(msg)
+	case ViewConfirm:
+		return m.handleConfirm(msg)
+	case ViewRecovery:
+		updated, cmd := m.recoveryPicker.Update(msg)
+		m.recoveryPicker = updated
+		return m, cmd
+	case ViewOrphan:
+		updated, cmd := m.orphanPicker.Update(msg)
+		m.orphanPicker = updated
+		return m, cmd
+	case ViewAgentPicker:
+		cmd, _ := m.agentPicker.Update(msg)
+		return m, cmd
+	case ViewTeamBuilder:
+		cmd := m.teamBuilder.Update(msg)
+		return m, cmd
+	case ViewRename:
+		return m.handleTitleEdit(msg)
+	case ViewProjectName:
+		return m.handleNameInput(msg)
+	case ViewDirPicker:
+		cmd, _ := m.dirPicker.Update(msg)
+		return m, cmd
+	case ViewDirConfirm:
+		return m.handleDirConfirm(msg)
+	case ViewCustomCmd:
+		return m.handleCustomCommandInput(msg)
+	case ViewWorktreeBranch:
+		return m.handleWorktreeBranchInput(msg)
+	case ViewFilter:
+		return m.handleFilter(msg)
 	}
 
 	return m.handleGlobalKey(msg)
-}
-
-// buildKeyHandlers returns KeyHandler adapters in priority order. The first
-// handler whose Focused() returns true wins exclusive key input. Adding a new
-// modal is as simple as adding an entry here.
-func (m *Model) buildKeyHandlers() []KeyHandler {
-	return []KeyHandler{
-		// Full-screen overlays
-		componentHandler{
-			focused: func() bool { return m.settings.Active },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				cmd, _ := m.settings.Update(msg)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.gridView.Active },
-			handle:  func(msg tea.KeyMsg) tea.Cmd { return m.handleGridKey(msg) },
-		},
-
-		// Help overlays — esc closes, everything else is swallowed.
-		componentHandler{
-			focused: func() bool { return m.appState.ShowHelp || m.appState.ShowTmuxHelp },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				if msg.String() == "esc" {
-					m.appState.ShowHelp = false
-					m.appState.ShowTmuxHelp = false
-				}
-				return nil
-			},
-		},
-
-		// Modal dialogs and pickers
-		componentHandler{
-			focused: func() bool { return m.showAttachHint },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleAttachHint(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.appState.ShowConfirm },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleConfirm(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.recoveryPicker.Active },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				updated, cmd := m.recoveryPicker.Update(msg)
-				m.recoveryPicker = updated
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.orphanPicker.Active },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				updated, cmd := m.orphanPicker.Update(msg)
-				m.orphanPicker = updated
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.agentPicker.Active },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				cmd, _ := m.agentPicker.Update(msg)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.teamBuilder.Active },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				return m.teamBuilder.Update(msg)
-			},
-		},
-
-		// Inline editors and text inputs
-		componentHandler{
-			focused: func() bool { return m.appState.EditingTitle },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleTitleEdit(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.inputMode == "project-name" },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleNameInput(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.dirPicker.Active },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				cmd, _ := m.dirPicker.Update(msg)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.inputMode == "project-dir-confirm" },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleDirConfirm(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.inputMode == "custom-command" },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleCustomCommandInput(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.inputMode == "worktree-branch" },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleWorktreeBranchInput(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-		componentHandler{
-			focused: func() bool { return m.appState.FilterActive },
-			handle: func(msg tea.KeyMsg) tea.Cmd {
-				result, cmd := m.handleFilter(msg)
-				*m = result.(Model)
-				return cmd
-			},
-		},
-	}
 }
 
 // handleGridKey handles keys when the grid overview is active.
@@ -181,8 +86,8 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 		return m.scheduleGridPoll()
 	case "x":
 		if sess := m.gridView.Selected(); sess != nil {
-			m.gridView.Hide()
 			s := sess
+			// Grid stays in the stack; confirm dialog is pushed on top.
 			return func() tea.Msg {
 				return ConfirmActionMsg{
 					Message: fmt.Sprintf("Kill session %q?", s.Title),
@@ -192,9 +97,9 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 		}
 	case "r":
 		if sess := m.gridView.Selected(); sess != nil {
-			m.gridView.Hide()
 			m.sidebar.SyncActiveSession(sess.ID)
 			m.appState.ActiveSessionID = sess.ID
+			// Grid stays in the stack; rename dialog is pushed on top.
 			return m.startRename()
 		}
 	case "t":
@@ -203,6 +108,7 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 			m.pendingWorktree = false
 			m.inputMode = "new-session"
 			m.agentPicker.Show(m.sortedAgentItems())
+			m.PushView(ViewAgentPicker)
 			return nil
 		}
 	case "W":
@@ -223,13 +129,17 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 			m.pendingWorktree = true
 			m.inputMode = "new-session"
 			m.agentPicker.Show(m.sortedAgentItems())
+			m.PushView(ViewAgentPicker)
 			return nil
 		}
 	}
-	wasActive := m.gridView.Active
 	prevSel := m.gridView.Selected()
 	cmd, _ := m.gridView.Update(msg)
-	if wasActive && !m.gridView.Active && prevSel != nil {
+	// gridView.Update may set Active=false (esc/q/enter). Detect that and
+	// pop the grid from the stack, syncing state to the selected session.
+	if !m.gridView.Active && prevSel != nil {
+		// Grid closed itself — pop it from the stack.
+		m.PopView()
 		m.appState.ActiveSessionID = prevSel.ID
 		if prevSel.ProjectID != "" {
 			m.appState.ActiveProjectID = prevSel.ProjectID
@@ -259,19 +169,18 @@ func (m Model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case key.Matches(msg, m.keys.Help):
-		m.appState.ShowHelp = !m.appState.ShowHelp
-		m.appState.ShowTmuxHelp = false
+		m.PushView(ViewHelp)
 		return m, nil
 
 	case key.Matches(msg, m.keys.Settings):
 		m.settings.Width = m.appState.TermWidth
 		m.settings.Height = m.appState.TermHeight
 		m.settings.Open(m.cfg)
+		m.PushView(ViewSettings)
 		return m, nil
 
 	case key.Matches(msg, m.keys.TmuxHelp):
-		m.appState.ShowTmuxHelp = !m.appState.ShowTmuxHelp
-		m.appState.ShowHelp = false
+		m.PushView(ViewTmuxHelp)
 		return m, nil
 
 	case key.Matches(msg, m.keys.FocusToggle):
@@ -283,27 +192,22 @@ func (m Model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case key.Matches(msg, m.keys.Filter):
-		m.appState.FilterActive = true
 		m.appState.FilterQuery = ""
+		m.PushView(ViewFilter)
 		return m, nil
 
 	case key.Matches(msg, m.keys.GridOverview):
-		sessions := m.gridSessions(state.GridRestoreProject)
-		m.gridView.Show(sessions, state.GridRestoreProject)
-		m.gridView.SetProjectNames(m.gridProjectNames())
-		m.gridView.SyncCursor(m.appState.ActiveSessionID)
+		m.openGrid(state.GridRestoreProject)
 		return m, m.scheduleGridPoll()
 
 	case msg.String() == "G":
-		m.gridView.Show(m.gridSessions(state.GridRestoreAll), state.GridRestoreAll)
-		m.gridView.SetProjectNames(m.gridProjectNames())
-		m.gridView.SyncCursor(m.appState.ActiveSessionID)
+		m.openGrid(state.GridRestoreAll)
 		return m, m.scheduleGridPoll()
 
 	case key.Matches(msg, m.keys.NewProject):
-		m.inputMode = "project-name"
 		m.nameInput.Placeholder = "my-project"
 		m.nameInput.Reset()
+		m.PushView(ViewProjectName)
 		blinkCmd := m.nameInput.Focus()
 		return m, blinkCmd
 
@@ -320,6 +224,7 @@ func (m Model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.pendingWorktree = false
 		m.inputMode = "new-session"
 		m.agentPicker.Show(m.sortedAgentItems())
+		m.PushView(ViewAgentPicker)
 		return m, nil
 
 	case key.Matches(msg, m.keys.NewWorktreeSession):
@@ -348,6 +253,7 @@ func (m Model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.pendingWorktree = true
 		m.inputMode = "new-session"
 		m.agentPicker.Show(m.sortedAgentItems())
+		m.PushView(ViewAgentPicker)
 		return m, nil
 
 	case key.Matches(msg, m.keys.NewTeam):
@@ -364,6 +270,7 @@ func (m Model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.teamBuilder.Start(workDir)
 		m.pendingProjectID = sel.ProjectID
+		m.PushView(ViewTeamBuilder)
 		return m, nil
 
 	case key.Matches(msg, m.keys.Attach):
@@ -371,7 +278,7 @@ func (m Model) handleGlobalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			attach := m.pendingAttachDetails()
 			if attach != nil {
 				m.pendingAttach = attach
-				m.showAttachHint = true
+				m.PushView(ViewAttachHint)
 				return m, nil
 			}
 		}
@@ -556,12 +463,12 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Settings screen: ignore mouse (keyboard-only).
-	if m.settings.Active {
+	if m.TopView() == ViewSettings {
 		return m, nil
 	}
 
 	// Grid view: cell selection and attach.
-	if m.gridView.Active {
+	if m.TopView() == ViewGrid {
 		m.gridView.Width = m.appState.TermWidth
 		m.gridView.Height = m.appState.TermHeight
 		switch msg.Button {
@@ -570,7 +477,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				m.gridView.Cursor = idx
 				// Clicking a grid cell activates (attaches) that session.
 				if sess := m.gridView.Selected(); sess != nil {
-					m.gridView.Hide()
+					m.PopView() // pops ViewGrid
 					s := sess
 					return m, func() tea.Msg {
 						return components.GridSessionSelectedMsg{
@@ -589,10 +496,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 
 	// Ignore mouse when any modal overlay is active.
-	if m.appState.ShowHelp || m.appState.ShowTmuxHelp || m.appState.ShowConfirm ||
-		m.showAttachHint || m.recoveryPicker.Active || m.orphanPicker.Active || m.agentPicker.Active ||
-		m.teamBuilder.Active || m.appState.EditingTitle ||
-		m.inputMode != "" || m.dirPicker.Active {
+	if m.TopView() != ViewMain && m.TopView() != ViewFilter {
 		return m, nil
 	}
 
@@ -609,7 +513,7 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			attach := m.pendingAttachDetails()
 			if attach != nil {
 				m.pendingAttach = attach
-				m.showAttachHint = true
+				m.PushView(ViewAttachHint)
 				return m, nil
 			}
 		}
@@ -689,7 +593,7 @@ func (m Model) handleSidebarClick(y int) (tea.Model, tea.Cmd) {
 func (m Model) handleAttachHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "enter", "y", " ":
-		m.showAttachHint = false
+		m.PopView()
 		attach := m.pendingAttach
 		m.pendingAttach = nil
 		if attach == nil {
@@ -699,7 +603,7 @@ func (m Model) handleAttachHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	case "d":
 		// Don't show again: save to config.
-		m.showAttachHint = false
+		m.PopView()
 		m.cfg.HideAttachHint = true
 		_ = config.Save(m.cfg)
 		attach := m.pendingAttach
@@ -710,7 +614,7 @@ func (m Model) handleAttachHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		cmd := m.doAttach(*attach)
 		return m, cmd
 	case "esc", "q":
-		m.showAttachHint = false
+		m.PopView()
 		m.pendingAttach = nil
 	}
 	return m, nil

--- a/internal/tui/handle_preview.go
+++ b/internal/tui/handle_preview.go
@@ -31,7 +31,7 @@ func (m Model) handlePreviewUpdated(msg components.PreviewUpdatedMsg) (tea.Model
 
 func (m Model) handleGridPreviewsUpdated(msg components.GridPreviewsUpdatedMsg) (tea.Model, tea.Cmd) {
 	m.gridView.SetContents(msg.Contents)
-	if m.gridView.Active {
+	if m.HasView(ViewGrid) {
 		return m, m.scheduleGridPoll()
 	}
 	return m, nil
@@ -71,7 +71,7 @@ func (m Model) handleGridSessionSelected(msg components.GridSessionSelectedMsg) 
 	}
 	if !m.cfg.HideAttachHint {
 		m.pendingAttach = attach
-		m.showAttachHint = true
+		m.PushView(ViewAttachHint)
 		return m, nil
 	}
 	cmd := m.doAttach(*attach)

--- a/internal/tui/handle_project.go
+++ b/internal/tui/handle_project.go
@@ -23,32 +23,30 @@ func (m Model) handleProjectKilled(msg ProjectKilledMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleDirPicked(msg components.DirPickedMsg) (tea.Model, tea.Cmd) {
-	m.dirPicker.Active = false
 	dir := msg.Dir
 	if _, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {
 			// Directory doesn't exist — ask for confirmation before creating.
 			m.nameInput.SetValue(dir)
-			m.inputMode = "project-dir-confirm"
+			m.ReplaceTop(ViewDirConfirm)
 			return m, nil
 		}
 		// Unexpected error (e.g. permission denied) — surface it and abort.
-		m.inputMode = ""
+		m.PopView()
 		return m, func() tea.Msg {
 			return ErrorMsg{Err: fmt.Errorf("check directory: %w", err)}
 		}
 	}
 	name := m.pendingProjectName
 	m.pendingProjectName = ""
-	m.inputMode = ""
+	m.PopView()
 	return m, m.createProject(name, dir)
 }
 
 func (m Model) handleDirPickerCancel() (tea.Model, tea.Cmd) {
-	m.dirPicker.Active = false
 	// Return to the project name step.
-	m.inputMode = "project-name"
 	m.nameInput.Reset()
 	m.nameInput.SetValue(m.pendingProjectName)
+	m.ReplaceTop(ViewProjectName)
 	return m, m.nameInput.Focus()
 }

--- a/internal/tui/handle_session.go
+++ b/internal/tui/handle_session.go
@@ -16,12 +16,7 @@ func (m Model) handleSessionCreated(msg SessionCreatedMsg) (tea.Model, tea.Cmd) 
 	m.preview.SetContent("")
 	m.sidebar.Rebuild(&m.appState)
 	m.sidebar.SyncActiveSession(msg.Session.ID)
-	if m.gridView.Active {
-		prevID := msg.Session.ID
-		m.gridView.Show(m.gridSessions(m.gridView.Mode), m.gridView.Mode)
-		m.gridView.SetProjectNames(m.gridProjectNames())
-		m.gridView.SyncCursor(prevID)
-	}
+	m.refreshGrid()
 	m.persist()
 	m.previewPollGen++ // new session, start fresh poll chain
 	return m, m.schedulePollPreview()
@@ -29,6 +24,8 @@ func (m Model) handleSessionCreated(msg SessionCreatedMsg) (tea.Model, tea.Cmd) 
 
 func (m Model) handleSessionKilled(msg SessionKilledMsg) (tea.Model, tea.Cmd) {
 	m.appState = *state.RemoveSession(&m.appState, msg.SessionID)
+	m.sidebar.Rebuild(&m.appState)
+	m.refreshGrid()
 	m.commitState()
 	return m, nil
 }
@@ -55,6 +52,7 @@ func (m Model) handleSessionTitleChanged(msg SessionTitleChangedMsg) (tea.Model,
 			WorkDir:      sess.WorkDir,
 		})
 	}
+	m.refreshGrid()
 	m.commitState()
 	return m, nil
 }
@@ -76,7 +74,7 @@ func (m Model) handleAttachDone(msg AttachDoneMsg) (tea.Model, tea.Cmd) {
 	m.appState.PreviewContent = ""
 	m.preview.SetContent("")
 	cmds := []tea.Cmd{tea.EnableMouseCellMotion, m.schedulePollPreview()}
-	if m.gridView.Active {
+	if m.HasView(ViewGrid) {
 		cmds = append(cmds, m.scheduleGridPoll())
 	}
 	return m, tea.Batch(cmds...)

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -129,6 +129,7 @@ func (m Model) handleAgentPicked(msg components.AgentPickedMsg) (tea.Model, tea.
 	if _, err := exec.LookPath(agentBin); err != nil {
 		// Binary not found — prompt to install.
 		m.pendingAgentType = agentTypeStr
+		m.inputMode = ""
 		m.PopView() // pop agent picker before confirm is pushed via message
 		installInfo := ""
 		if len(profile.InstallCmd) > 0 {
@@ -152,6 +153,7 @@ func (m Model) handleAgentPicked(msg components.AgentPickedMsg) (tea.Model, tea.
 		blinkCmd := m.nameInput.Focus()
 		return m, blinkCmd
 	}
+	m.inputMode = ""
 	m.PopView() // pop agent picker
 	cmd := m.createSession(m.pendingProjectID, agentTypeStr, profile.Cmd)
 	return m, cmd

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -49,6 +49,7 @@ func (m Model) handleSettingsSaveRequest(msg components.SettingsSaveRequestMsg) 
 
 func (m Model) handleSettingsClosed() (tea.Model, tea.Cmd) {
 	m.settings.Close()
+	m.PopView()
 	return m, nil
 }
 
@@ -73,28 +74,36 @@ func (m Model) handleQuitAndKill() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleConfirmAction(msg ConfirmActionMsg) (tea.Model, tea.Cmd) {
-	m.appState.ShowConfirm = true
 	m.appState.ConfirmMsg = msg.Message
 	m.appState.ConfirmAction = msg.Action
 	m.confirm.Message = msg.Message
 	m.confirm.Action = msg.Action
+	m.PushView(ViewConfirm)
 	return m, nil
 }
 
 func (m Model) handleConfirmed(msg ConfirmedMsg) (tea.Model, tea.Cmd) {
-	m.appState.ShowConfirm = false
 	m.confirm.Message = ""
 	return m, m.handleConfirmedAction(msg.Action)
 }
 
 func (m Model) handleCancelled() (tea.Model, tea.Cmd) {
-	m.appState.ShowConfirm = false
-	m.appState.EditingTitle = false
-	m.titleEditor.Stop()
-	m.agentPicker.Hide()
-	m.teamBuilder.Hide()
-	m.nameInput.Blur()
-	m.inputMode = ""
+	popped := m.PopView()
+	// Clean up component state for the popped view.
+	switch popped {
+	case ViewRename:
+		m.titleEditor.Stop()
+	case ViewAgentPicker:
+		m.agentPicker.Hide()
+	case ViewTeamBuilder:
+		m.teamBuilder.Hide()
+	case ViewProjectName, ViewCustomCmd, ViewWorktreeBranch:
+		m.nameInput.Blur()
+	case ViewDirPicker:
+		m.dirPicker.Active = false
+	case ViewDirConfirm:
+		m.nameInput.Blur()
+	}
 	m.pendingWorktree = false
 	m.pendingWorktreeAgentType = ""
 	m.pendingWorktreeAgentCmd = nil
@@ -103,54 +112,53 @@ func (m Model) handleCancelled() (tea.Model, tea.Cmd) {
 
 func (m Model) handleAgentPicked(msg components.AgentPickedMsg) (tea.Model, tea.Cmd) {
 	// Team builder owns agent selection while it is active.
-	if m.teamBuilder.Active {
+	if m.HasView(ViewTeamBuilder) {
 		cmd := m.teamBuilder.Update(msg)
 		return m, cmd
 	}
-	if m.inputMode == "new-session" {
-		agentTypeStr := string(msg.AgentType)
-		// Custom command: prompt user for the command to run.
-		if msg.AgentType == state.AgentCustom {
-			m.inputMode = "custom-command"
-			m.nameInput.Placeholder = "command (empty = default shell)"
-			m.nameInput.Reset()
-			blinkCmd := m.nameInput.Focus()
-			return m, blinkCmd
-		}
-		profile := m.cfg.Agents[agentTypeStr]
-		agentBin := agentTypeStr
-		if len(profile.Cmd) > 0 {
-			agentBin = profile.Cmd[0]
-		}
-		if _, err := exec.LookPath(agentBin); err != nil {
-			// Binary not found — prompt to install.
-			m.pendingAgentType = agentTypeStr
-			installInfo := ""
-			if len(profile.InstallCmd) > 0 {
-				installInfo = "\n\nInstall with: " + strings.Join(profile.InstallCmd, " ")
-			}
-			return m, func() tea.Msg {
-				return ConfirmActionMsg{
-					Message: fmt.Sprintf("%q not found in PATH.%s\n\nInstall now?", agentBin, installInfo),
-					Action:  "install-agent:" + agentTypeStr,
-				}
-			}
-		}
-		if m.pendingWorktree {
-			// Worktree flow: collect branch name next.
-			m.pendingWorktreeAgentType = agentTypeStr
-			m.pendingWorktreeAgentCmd = profile.Cmd
-			m.inputMode = "worktree-branch"
-			m.nameInput.Placeholder = "branch-name"
-			m.nameInput.Reset()
-			m.nameInput.SetValue(git.RandomBranchName())
-			blinkCmd := m.nameInput.Focus()
-			return m, blinkCmd
-		}
-		cmd := m.createSession(m.pendingProjectID, agentTypeStr, profile.Cmd)
-		return m, cmd
+	agentTypeStr := string(msg.AgentType)
+	// Custom command: prompt user for the command to run.
+	if msg.AgentType == state.AgentCustom {
+		m.nameInput.Placeholder = "command (empty = default shell)"
+		m.nameInput.Reset()
+		m.ReplaceTop(ViewCustomCmd)
+		blinkCmd := m.nameInput.Focus()
+		return m, blinkCmd
 	}
-	return m, nil
+	profile := m.cfg.Agents[agentTypeStr]
+	agentBin := agentTypeStr
+	if len(profile.Cmd) > 0 {
+		agentBin = profile.Cmd[0]
+	}
+	if _, err := exec.LookPath(agentBin); err != nil {
+		// Binary not found — prompt to install.
+		m.pendingAgentType = agentTypeStr
+		m.PopView() // pop agent picker before confirm is pushed via message
+		installInfo := ""
+		if len(profile.InstallCmd) > 0 {
+			installInfo = "\n\nInstall with: " + strings.Join(profile.InstallCmd, " ")
+		}
+		return m, func() tea.Msg {
+			return ConfirmActionMsg{
+				Message: fmt.Sprintf("%q not found in PATH.%s\n\nInstall now?", agentBin, installInfo),
+				Action:  "install-agent:" + agentTypeStr,
+			}
+		}
+	}
+	if m.pendingWorktree {
+		// Worktree flow: collect branch name next.
+		m.pendingWorktreeAgentType = agentTypeStr
+		m.pendingWorktreeAgentCmd = profile.Cmd
+		m.nameInput.Placeholder = "branch-name"
+		m.nameInput.Reset()
+		m.nameInput.SetValue(git.RandomBranchName())
+		m.ReplaceTop(ViewWorktreeBranch)
+		blinkCmd := m.nameInput.Focus()
+		return m, blinkCmd
+	}
+	m.PopView() // pop agent picker
+	cmd := m.createSession(m.pendingProjectID, agentTypeStr, profile.Cmd)
+	return m, cmd
 }
 
 func (m Model) handleAgentInstalled(msg AgentInstalledMsg) (tea.Model, tea.Cmd) {
@@ -162,6 +170,7 @@ func (m Model) handleAgentInstalled(msg AgentInstalledMsg) (tea.Model, tea.Cmd) 
 }
 
 func (m Model) handleRecoveryPickerDone(msg components.RecoveryPickerDoneMsg) (tea.Model, tea.Cmd) {
+	m.PopView()
 	if len(msg.Selected) > 0 {
 		m.recoverSessions(msg.Selected)
 	}
@@ -169,6 +178,7 @@ func (m Model) handleRecoveryPickerDone(msg components.RecoveryPickerDoneMsg) (t
 }
 
 func (m Model) handleOrphanPickerDone(msg components.OrphanPickerDoneMsg) (tea.Model, tea.Cmd) {
+	m.PopView()
 	for _, name := range msg.Selected {
 		_ = mux.KillSession(name)
 	}

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -97,11 +97,7 @@ func (m Model) handleCancelled() (tea.Model, tea.Cmd) {
 		m.agentPicker.Hide()
 	case ViewTeamBuilder:
 		m.teamBuilder.Hide()
-	case ViewProjectName, ViewCustomCmd, ViewWorktreeBranch:
-		m.nameInput.Blur()
-	case ViewDirPicker:
-		m.dirPicker.Active = false
-	case ViewDirConfirm:
+	case ViewProjectName, ViewCustomCmd, ViewWorktreeBranch, ViewDirConfirm:
 		m.nameInput.Blur()
 	}
 	m.pendingWorktree = false

--- a/internal/tui/handle_team.go
+++ b/internal/tui/handle_team.go
@@ -20,6 +20,7 @@ func (m Model) handleTeamKilled(msg TeamKilledMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleTeamBuilt(msg components.TeamBuiltMsg) (tea.Model, tea.Cmd) {
+	m.PopView() // pop team builder
 	cmd := m.createTeam(msg.Spec)
 	return m, cmd
 }

--- a/internal/tui/viewstack.go
+++ b/internal/tui/viewstack.go
@@ -28,6 +28,14 @@ const (
 
 // PushView pushes a view onto the stack and syncs legacy flags.
 func (m *Model) PushView(id ViewID) {
+	if debugLog != nil {
+		for _, v := range m.viewStack {
+			if v == id {
+				debugLog.Printf("WARNING: PushView(%s) duplicates existing stack entry", id)
+				break
+			}
+		}
+	}
 	m.viewStack = append(m.viewStack, id)
 	m.syncLegacyFlags(id, true)
 }
@@ -155,15 +163,6 @@ func (m *Model) refreshGrid() {
 	m.gridView.SetProjectNames(m.gridProjectNames())
 	if prevID != "" {
 		m.gridView.SyncCursor(prevID)
-	}
-}
-
-// popViewTo pops views from the stack until the top is the target view
-// or the stack only has ViewMain. Used by flows that need to unwind
-// multiple views (e.g., completing a wizard from grid context).
-func (m *Model) popViewTo(target ViewID) {
-	for len(m.viewStack) > 1 && m.TopView() != target {
-		m.PopView()
 	}
 }
 

--- a/internal/tui/viewstack.go
+++ b/internal/tui/viewstack.go
@@ -1,0 +1,177 @@
+package tui
+
+import "github.com/lucascaro/hive/internal/state"
+
+// ViewID identifies a view layer in the view stack.
+type ViewID string
+
+const (
+	ViewMain           ViewID = "main"
+	ViewSettings       ViewID = "settings"
+	ViewGrid           ViewID = "grid"
+	ViewHelp           ViewID = "help"
+	ViewTmuxHelp       ViewID = "tmux-help"
+	ViewAttachHint     ViewID = "attach-hint"
+	ViewConfirm        ViewID = "confirm"
+	ViewRecovery       ViewID = "recovery"
+	ViewOrphan         ViewID = "orphan"
+	ViewAgentPicker    ViewID = "agent-picker"
+	ViewTeamBuilder    ViewID = "team-builder"
+	ViewRename         ViewID = "rename"
+	ViewProjectName    ViewID = "project-name"
+	ViewDirPicker      ViewID = "dir-picker"
+	ViewDirConfirm     ViewID = "dir-confirm"
+	ViewCustomCmd      ViewID = "custom-command"
+	ViewWorktreeBranch ViewID = "worktree-branch"
+	ViewFilter         ViewID = "filter"
+)
+
+// PushView pushes a view onto the stack and syncs legacy flags.
+func (m *Model) PushView(id ViewID) {
+	m.viewStack = append(m.viewStack, id)
+	m.syncLegacyFlags(id, true)
+}
+
+// PopView removes the top view from the stack, clears its legacy flags,
+// and returns the popped ViewID. Never pops below ViewMain.
+func (m *Model) PopView() ViewID {
+	if len(m.viewStack) <= 1 {
+		return ViewMain
+	}
+	top := m.viewStack[len(m.viewStack)-1]
+	m.viewStack = m.viewStack[:len(m.viewStack)-1]
+	m.syncLegacyFlags(top, false)
+	return top
+}
+
+// TopView returns the view at the top of the stack.
+func (m *Model) TopView() ViewID {
+	if len(m.viewStack) == 0 {
+		return ViewMain
+	}
+	return m.viewStack[len(m.viewStack)-1]
+}
+
+// HasView returns true if the given view is anywhere in the stack.
+func (m *Model) HasView(id ViewID) bool {
+	for _, v := range m.viewStack {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}
+
+// ReplaceTop replaces the top view with a new one, clearing the old
+// view's flags and setting the new view's flags. If the stack only
+// has ViewMain, it pushes instead.
+func (m *Model) ReplaceTop(id ViewID) {
+	if len(m.viewStack) <= 1 {
+		m.PushView(id)
+		return
+	}
+	old := m.viewStack[len(m.viewStack)-1]
+	m.syncLegacyFlags(old, false)
+	m.viewStack[len(m.viewStack)-1] = id
+	m.syncLegacyFlags(id, true)
+}
+
+// syncLegacyFlags sets or clears the legacy boolean flags and Active fields
+// to keep backward compat with component code that reads them directly.
+func (m *Model) syncLegacyFlags(id ViewID, active bool) {
+	switch id {
+	case ViewSettings:
+		m.settings.Active = active
+	case ViewGrid:
+		// Grid data (sessions, cursor) is managed by Show/Hide; Active is
+		// the only field we need to sync here. The caller handles Show/Hide.
+		m.gridView.Active = active
+	case ViewHelp:
+		m.appState.ShowHelp = active
+	case ViewTmuxHelp:
+		m.appState.ShowTmuxHelp = active
+	case ViewAttachHint:
+		m.showAttachHint = active
+	case ViewConfirm:
+		m.appState.ShowConfirm = active
+	case ViewRecovery:
+		m.recoveryPicker.Active = active
+	case ViewOrphan:
+		m.orphanPicker.Active = active
+	case ViewAgentPicker:
+		m.agentPicker.Active = active
+		if !active {
+			m.agentPicker.Hide()
+		}
+	case ViewTeamBuilder:
+		m.teamBuilder.Active = active
+		if !active {
+			m.teamBuilder.Hide()
+		}
+	case ViewRename:
+		m.appState.EditingTitle = active
+	case ViewProjectName:
+		if active {
+			m.inputMode = "project-name"
+		} else {
+			m.inputMode = ""
+		}
+	case ViewDirPicker:
+		m.dirPicker.Active = active
+	case ViewDirConfirm:
+		if active {
+			m.inputMode = "project-dir-confirm"
+		} else {
+			m.inputMode = ""
+		}
+	case ViewCustomCmd:
+		if active {
+			m.inputMode = "custom-command"
+		} else {
+			m.inputMode = ""
+		}
+	case ViewWorktreeBranch:
+		if active {
+			m.inputMode = "worktree-branch"
+		} else {
+			m.inputMode = ""
+		}
+	case ViewFilter:
+		m.appState.FilterActive = active
+	}
+}
+
+// refreshGrid refreshes the grid's session list and project names if the
+// grid is in the view stack. Preserves cursor position.
+func (m *Model) refreshGrid() {
+	if !m.HasView(ViewGrid) {
+		return
+	}
+	prevID := ""
+	if s := m.gridView.Selected(); s != nil {
+		prevID = s.ID
+	}
+	m.gridView.Show(m.gridSessions(m.gridView.Mode), m.gridView.Mode)
+	m.gridView.SetProjectNames(m.gridProjectNames())
+	if prevID != "" {
+		m.gridView.SyncCursor(prevID)
+	}
+}
+
+// popViewTo pops views from the stack until the top is the target view
+// or the stack only has ViewMain. Used by flows that need to unwind
+// multiple views (e.g., completing a wizard from grid context).
+func (m *Model) popViewTo(target ViewID) {
+	for len(m.viewStack) > 1 && m.TopView() != target {
+		m.PopView()
+	}
+}
+
+// openGrid is a helper that pushes the grid view and sets up grid state.
+func (m *Model) openGrid(mode state.GridRestoreMode) {
+	sessions := m.gridSessions(mode)
+	m.gridView.Show(sessions, mode)
+	m.gridView.SetProjectNames(m.gridProjectNames())
+	m.gridView.SyncCursor(m.appState.ActiveSessionID)
+	m.PushView(ViewGrid)
+}

--- a/internal/tui/viewstack_test.go
+++ b/internal/tui/viewstack_test.go
@@ -1,0 +1,270 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/lucascaro/hive/internal/config"
+	"github.com/lucascaro/hive/internal/state"
+)
+
+func testModelForStack() Model {
+	cfg := config.DefaultConfig()
+	cfg.PreviewRefreshMs = 1
+	appState := state.AppState{
+		Projects: []*state.Project{{
+			ID:   "proj-1",
+			Name: "test",
+			Sessions: []*state.Session{{
+				ID:          "sess-1",
+				ProjectID:   "proj-1",
+				Title:       "session-1",
+				AgentType:   state.AgentClaude,
+				TmuxSession: "hive-test",
+				TmuxWindow:  0,
+				Status:      state.StatusRunning,
+			}},
+		}},
+		ActiveProjectID: "proj-1",
+		ActiveSessionID: "sess-1",
+		AgentUsage:      make(map[string]state.AgentUsageRecord),
+		TermWidth:       120,
+		TermHeight:      40,
+	}
+	return New(cfg, appState)
+}
+
+func TestPushView_AddsToStack(t *testing.T) {
+	m := testModelForStack()
+	if m.TopView() != ViewMain {
+		t.Fatalf("initial top = %q, want %q", m.TopView(), ViewMain)
+	}
+
+	m.PushView(ViewGrid)
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after push grid, top = %q, want %q", m.TopView(), ViewGrid)
+	}
+
+	m.PushView(ViewRename)
+	if m.TopView() != ViewRename {
+		t.Fatalf("after push rename, top = %q, want %q", m.TopView(), ViewRename)
+	}
+}
+
+func TestPopView_LIFO(t *testing.T) {
+	m := testModelForStack()
+	m.PushView(ViewGrid)
+	m.PushView(ViewRename)
+	m.PushView(ViewConfirm)
+
+	got := m.PopView()
+	if got != ViewConfirm {
+		t.Fatalf("first pop = %q, want %q", got, ViewConfirm)
+	}
+	got = m.PopView()
+	if got != ViewRename {
+		t.Fatalf("second pop = %q, want %q", got, ViewRename)
+	}
+	got = m.PopView()
+	if got != ViewGrid {
+		t.Fatalf("third pop = %q, want %q", got, ViewGrid)
+	}
+	if m.TopView() != ViewMain {
+		t.Fatalf("after popping all, top = %q, want %q", m.TopView(), ViewMain)
+	}
+}
+
+func TestPopView_NeverPopsBelowMain(t *testing.T) {
+	m := testModelForStack()
+	got := m.PopView()
+	if got != ViewMain {
+		t.Fatalf("pop on base stack = %q, want %q", got, ViewMain)
+	}
+	if m.TopView() != ViewMain {
+		t.Fatalf("top after over-pop = %q, want %q", m.TopView(), ViewMain)
+	}
+}
+
+func TestHasView(t *testing.T) {
+	m := testModelForStack()
+	m.PushView(ViewGrid)
+	m.PushView(ViewRename)
+
+	if !m.HasView(ViewMain) {
+		t.Error("HasView(ViewMain) should be true")
+	}
+	if !m.HasView(ViewGrid) {
+		t.Error("HasView(ViewGrid) should be true")
+	}
+	if !m.HasView(ViewRename) {
+		t.Error("HasView(ViewRename) should be true")
+	}
+	if m.HasView(ViewSettings) {
+		t.Error("HasView(ViewSettings) should be false")
+	}
+}
+
+func TestReplaceTop(t *testing.T) {
+	m := testModelForStack()
+	m.PushView(ViewGrid)
+	m.PushView(ViewAgentPicker)
+
+	m.ReplaceTop(ViewCustomCmd)
+
+	if m.TopView() != ViewCustomCmd {
+		t.Fatalf("after ReplaceTop, top = %q, want %q", m.TopView(), ViewCustomCmd)
+	}
+	if !m.HasView(ViewGrid) {
+		t.Error("grid should still be in stack after ReplaceTop")
+	}
+	if m.HasView(ViewAgentPicker) {
+		t.Error("agent picker should not be in stack after ReplaceTop")
+	}
+}
+
+func TestReplaceTop_OnBaseStack_PushesInstead(t *testing.T) {
+	m := testModelForStack()
+	m.ReplaceTop(ViewHelp)
+	if m.TopView() != ViewHelp {
+		t.Fatalf("ReplaceTop on base = %q, want %q", m.TopView(), ViewHelp)
+	}
+	if !m.HasView(ViewMain) {
+		t.Error("main should still be in stack")
+	}
+}
+
+func TestSyncLegacyFlags_PushSetsFlags(t *testing.T) {
+	m := testModelForStack()
+
+	m.PushView(ViewHelp)
+	if !m.appState.ShowHelp {
+		t.Error("ShowHelp should be true after pushing ViewHelp")
+	}
+
+	m.PopView()
+	if m.appState.ShowHelp {
+		t.Error("ShowHelp should be false after popping ViewHelp")
+	}
+}
+
+func TestSyncLegacyFlags_GridActive(t *testing.T) {
+	m := testModelForStack()
+	m.PushView(ViewGrid)
+	if !m.gridView.Active {
+		t.Error("gridView.Active should be true after pushing ViewGrid")
+	}
+	m.PopView()
+	if m.gridView.Active {
+		t.Error("gridView.Active should be false after popping ViewGrid")
+	}
+}
+
+func TestSyncLegacyFlags_Filter(t *testing.T) {
+	m := testModelForStack()
+	m.PushView(ViewFilter)
+	if !m.appState.FilterActive {
+		t.Error("FilterActive should be true after pushing ViewFilter")
+	}
+	m.PopView()
+	if m.appState.FilterActive {
+		t.Error("FilterActive should be false after popping ViewFilter")
+	}
+}
+
+// Scenario tests for the grid→dialog→back-to-grid flow.
+
+func TestScenario_GridRename_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	// Open grid, then push rename on top.
+	m.PushView(ViewGrid)
+	m.PushView(ViewRename)
+
+	if m.TopView() != ViewRename {
+		t.Fatalf("top = %q, want ViewRename", m.TopView())
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should be in stack under rename")
+	}
+
+	// Pop rename (user pressed esc or enter).
+	m.PopView()
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after pop, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestScenario_GridConfirm_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	m.PushView(ViewGrid)
+	m.PushView(ViewConfirm)
+
+	if m.TopView() != ViewConfirm {
+		t.Fatalf("top = %q, want ViewConfirm", m.TopView())
+	}
+
+	m.PopView()
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after pop, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestScenario_GridAgentPicker_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	m.PushView(ViewGrid)
+	m.PushView(ViewAgentPicker)
+
+	m.PopView()
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after pop, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestScenario_ProjectWizard_NameToDirToConfirm(t *testing.T) {
+	m := testModelForStack()
+
+	m.PushView(ViewProjectName)
+	if m.TopView() != ViewProjectName {
+		t.Fatal("top should be project-name")
+	}
+
+	// Step 1 → Step 2: replace with dir picker.
+	m.ReplaceTop(ViewDirPicker)
+	if m.TopView() != ViewDirPicker {
+		t.Fatal("top should be dir-picker")
+	}
+	if m.HasView(ViewProjectName) {
+		t.Error("project-name should not be in stack after ReplaceTop")
+	}
+
+	// Dir doesn't exist → replace with dir confirm.
+	m.ReplaceTop(ViewDirConfirm)
+	if m.TopView() != ViewDirConfirm {
+		t.Fatal("top should be dir-confirm")
+	}
+
+	// User confirms → pop.
+	m.PopView()
+	if m.TopView() != ViewMain {
+		t.Fatalf("after wizard done, top = %q, want ViewMain", m.TopView())
+	}
+}
+
+func TestRefreshGrid_NoopWhenGridNotInStack(t *testing.T) {
+	m := testModelForStack()
+	// Should not panic when grid is not in the stack.
+	m.refreshGrid()
+}
+
+func TestPopViewTo(t *testing.T) {
+	m := testModelForStack()
+	m.PushView(ViewGrid)
+	m.PushView(ViewAgentPicker)
+	m.PushView(ViewCustomCmd)
+
+	m.popViewTo(ViewGrid)
+	if m.TopView() != ViewGrid {
+		t.Fatalf("popViewTo(ViewGrid): top = %q, want ViewGrid", m.TopView())
+	}
+}

--- a/internal/tui/viewstack_test.go
+++ b/internal/tui/viewstack_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/lucascaro/hive/internal/config"
 	"github.com/lucascaro/hive/internal/state"
 )
@@ -257,14 +259,91 @@ func TestRefreshGrid_NoopWhenGridNotInStack(t *testing.T) {
 	m.refreshGrid()
 }
 
-func TestPopViewTo(t *testing.T) {
-	m := testModelForStack()
-	m.PushView(ViewGrid)
-	m.PushView(ViewAgentPicker)
-	m.PushView(ViewCustomCmd)
+// Integration tests that exercise the actual Update() pipeline.
 
-	m.popViewTo(ViewGrid)
+func TestIntegration_GridRename_Esc_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	// Open grid.
+	m.openGrid(state.GridRestoreProject)
+
 	if m.TopView() != ViewGrid {
-		t.Fatalf("popViewTo(ViewGrid): top = %q, want ViewGrid", m.TopView())
+		t.Fatalf("after opening grid, top = %q, want ViewGrid", m.TopView())
+	}
+
+	// Press "r" to rename from grid.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = result.(Model)
+
+	if m.TopView() != ViewRename {
+		t.Fatalf("after pressing r in grid, top = %q, want ViewRename", m.TopView())
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should still be in stack under rename")
+	}
+
+	// Press esc to cancel rename.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = result.(Model)
+
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after esc from rename, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestIntegration_GridKill_Cancel_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	// Open grid.
+	m.openGrid(state.GridRestoreProject)
+
+	// Press "x" to kill from grid.
+	result, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = result.(Model)
+
+	// The "x" handler returns a func that produces ConfirmActionMsg.
+	// Process it to push the confirm dialog.
+	if cmd != nil {
+		msg := cmd()
+		result, _ = m.Update(msg)
+		m = result.(Model)
+	}
+
+	if m.TopView() != ViewConfirm {
+		t.Fatalf("after x+confirm, top = %q, want ViewConfirm", m.TopView())
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should still be in stack under confirm")
+	}
+
+	// Press esc to cancel the confirm.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = result.(Model)
+
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after cancelling confirm, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestIntegration_GridRename_Enter_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	// Open grid.
+	m.openGrid(state.GridRestoreProject)
+
+	// Press "r" to rename from grid.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = result.(Model)
+
+	// Type a new title.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	m = result.(Model)
+
+	// Press enter to confirm rename.
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = result.(Model)
+
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after enter from rename, top = %q, want ViewGrid", m.TopView())
 	}
 }


### PR DESCRIPTION
## Summary

- Introduces a **view stack** (`PushView`/`PopView`/`TopView`/`HasView`) as the single source of truth for which view/overlay is displayed, replacing ~15 scattered boolean flags and a priority-ordered if/else cascade
- Rewrites `View()` and key dispatch as `switch m.TopView()` — cleaner, no ordering bugs
- **Fixes the grid→dialog→main bug**: rename (`r`), kill (`x`), new session (`t`/`W`) from grid view now correctly return to the grid instead of the main sidebar view
- Legacy component `Active` fields and `AppState` overlay flags are kept in sync via `syncLegacyFlags()` for backward compatibility

## Files changed

| File | What |
|------|------|
| `viewstack.go` (new) | ViewID enum, stack operations, `refreshGrid()` helper |
| `viewstack_test.go` (new) | 17 unit tests covering push/pop/LIFO/scenarios |
| `app.go` | `viewStack` field, rewritten `View()`, updated `New()`/`restoreGrid()` |
| `handle_keys.go` | Replaced `buildKeyHandlers()` cascade with `switch TopView()`, fixed `handleGridKey` |
| `handle_input.go` | All view transitions use push/pop/replace |
| `handle_system.go` | `handleCancelled()` → `PopView()`, `handleConfirmAction` → `PushView` |
| `handle_session.go` | Added `refreshGrid()` calls for session kill/title changes |
| `handle_project.go` | Dir picker flow uses stack operations |
| `handle_preview.go`, `handle_team.go` | Minor stack integration |

## Test plan

- [x] All existing tests pass (`go test ./...`, `go vet ./...`)
- [x] 17 new view stack unit tests (LIFO, HasView, ReplaceTop, scenario tests for grid→rename→back, grid→confirm→back, project wizard flow)
- [ ] Manual: grid → rename (`r`) → confirm → verify grid shown with updated title
- [ ] Manual: grid → rename (`r`) → cancel (`esc`) → verify grid shown
- [ ] Manual: grid → kill (`x`) → confirm → verify grid shown without killed session
- [ ] Manual: grid → new session (`t`) → pick agent → verify session created, grid refreshed
- [ ] Manual: all main-view overlay flows unchanged

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)