### PR TITLE
feat: grid view arrow keys wrap between rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Grid view arrow keys wrap between rows**: pressing right on the last cell of a row now moves to the first cell of the next row, and left on the first cell wraps to the last cell of the previous row (#53).
+
 ## [0.5.0] — 2026-04-09
 
 ### Added

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,7 +7,7 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| 1 | #53 | Grid view: arrow keys should wrap between rows | PLAN | S |
+| 1 | #53 | Grid view: arrow keys should wrap between rows | IMPLEMENT | S |
 | 2 | #36 | Add missing tests | RESEARCH | L |
 | 3 | #34 | Terminal bell does not produce audible sound | RESEARCH | S |
 | 4 | #55 | Reorder sessions via keyboard | RESEARCH | M |

--- a/features/active/053-grid-view-arrow-keys-wrap-between-rows.md
+++ b/features/active/053-grid-view-arrow-keys-wrap-between-rows.md
@@ -1,7 +1,7 @@
 # Feature: Grid view: arrow keys should wrap between rows
 
 - **GitHub Issue:** #53
-- **Stage:** PLAN
+- **Stage:** IMPLEMENT
 - **Type:** enhancement
 - **Complexity:** S
 - **Priority:** P3
@@ -40,19 +40,21 @@ Single-file fix. The grid cursor is a flat integer index into a sessions slice. 
 
 ## Plan
 
-<Filled during PLAN stage.>
+Single-file logic change plus new tests. The cursor is a flat index; we add `else` clauses to the left/right branches so they cross row boundaries instead of clamping.
 
 ### Files to Change
-1. `path/to/file.go` — <what and why>
+1. `internal/tui/components/gridview.go:140-152` — Modify left/right `case` branches: if at row edge and an adjacent row exists, wrap cursor to it instead of clamping.
+2. `internal/tui/components/gridview_test.go` — Add table-driven unit tests for cursor movement: wrap right end-of-row → next row, wrap left start-of-row → prev row, no-wrap at index 0 and index n-1, partial last row, normal intra-row movement.
 
 ### Test Strategy
-- <how to verify>
+- Table-driven tests in `gridview_test.go` exercising all wrapping and non-wrapping scenarios
+- Run `go test ./internal/tui/components/...` to verify
 
 ### Risks
-- <what could go wrong>
+- Low risk. Two small `else` clauses in existing branches. Partial last row is safe since wrapping always lands on a valid index.
 
 ## Implementation Notes
 
-<Filled during IMPLEMENT stage.>
+No deviations from plan. Added `else` clauses to both left and right key branches in `GridView.Update()`. Added 8 table-driven test cases covering normal movement, wrapping, and boundary clamping with both vim keys and arrow keys.
 
 - **PR:** —

--- a/features/active/053-grid-view-arrow-keys-wrap-between-rows.md
+++ b/features/active/053-grid-view-arrow-keys-wrap-between-rows.md
@@ -57,4 +57,4 @@ Single-file logic change plus new tests. The cursor is a flat index; we add `els
 
 No deviations from plan. Added `else` clauses to both left and right key branches in `GridView.Update()`. Added 8 table-driven test cases covering normal movement, wrapping, and boundary clamping with both vim keys and arrow keys.
 
-- **PR:** —
+- **PR:** #60

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -141,6 +141,8 @@ func (gv *GridView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 		rowStart := (gv.Cursor / cols) * cols
 		if gv.Cursor > rowStart {
 			gv.Cursor--
+		} else if gv.Cursor > 0 {
+			gv.Cursor-- // wrap to last cell of previous row
 		}
 	case "right", "l", "d":
 		rowEnd := (gv.Cursor/cols)*cols + cols - 1
@@ -149,6 +151,8 @@ func (gv *GridView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 		if gv.Cursor < rowEnd {
 			gv.Cursor++
+		} else if gv.Cursor < n-1 {
+			gv.Cursor++ // wrap to first cell of next row
 		}
 	case "up", "k", "w":
 		if gv.Cursor >= cols {

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lucascaro/hive/internal/state"
 )
 
@@ -304,6 +305,59 @@ func TestGridView_SyncCursor(t *testing.T) {
 // arbitrary ANSI escape sequences and control characters; lipgloss does not
 // sanitize, so this function is the only thing standing between agent output
 // and the visible UI.
+// TestGridView_CursorWrap tests horizontal arrow-key wrapping between rows.
+// Uses 5 sessions at 160×50 which yields a 3×2 grid (row0=[0,1,2], row1=[3,4]).
+func TestGridView_CursorWrap(t *testing.T) {
+	sessions := make([]*state.Session, 5)
+	for i := range sessions {
+		sessions[i] = &state.Session{
+			ID: "s" + string(rune('1'+i)), Title: "sess",
+			AgentType: state.AgentClaude, Status: state.StatusRunning,
+		}
+	}
+
+	makeGV := func(cursor int) *GridView {
+		gv := &GridView{Active: true, Width: 160, Height: 50}
+		gv.Show(sessions, state.GridRestoreProject)
+		gv.Cursor = cursor
+		return gv
+	}
+
+	key := func(s string) tea.KeyMsg {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+
+	tests := []struct {
+		name      string
+		cursor    int
+		key       tea.KeyMsg
+		wantCursor int
+	}{
+		// Normal movement within a row
+		{"right within row", 0, key("l"), 1},
+		{"left within row", 1, key("h"), 0},
+		// Wrapping across rows
+		{"right wraps to next row", 2, key("l"), 3},
+		{"left wraps to prev row", 3, key("h"), 2},
+		// No wrap at boundaries
+		{"right at last session stays", 4, key("l"), 4},
+		{"left at index 0 stays", 0, key("h"), 0},
+		// Arrow keys work too
+		{"arrow right wraps", 2, tea.KeyMsg{Type: tea.KeyRight}, 3},
+		{"arrow left wraps", 3, tea.KeyMsg{Type: tea.KeyLeft}, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gv := makeGV(tc.cursor)
+			gv.Update(tc.key)
+			if gv.Cursor != tc.wantCursor {
+				t.Errorf("Cursor = %d, want %d", gv.Cursor, tc.wantCursor)
+			}
+		})
+	}
+}
+
 func TestSanitizePaneTitle(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -300,11 +300,6 @@ func TestGridView_SyncCursor(t *testing.T) {
 	})
 }
 
-// TestSanitizePaneTitle covers the sanitizer used to scrub untrusted OSC 0/2
-// payloads before rendering them inside grid cells.  Pane titles can contain
-// arbitrary ANSI escape sequences and control characters; lipgloss does not
-// sanitize, so this function is the only thing standing between agent output
-// and the visible UI.
 // TestGridView_CursorWrap tests horizontal arrow-key wrapping between rows.
 // Uses 5 sessions at 160×50 which yields a 3×2 grid (row0=[0,1,2], row1=[3,4]).
 func TestGridView_CursorWrap(t *testing.T) {
@@ -345,6 +340,8 @@ func TestGridView_CursorWrap(t *testing.T) {
 		// Arrow keys work too
 		{"arrow right wraps", 2, tea.KeyMsg{Type: tea.KeyRight}, 3},
 		{"arrow left wraps", 3, tea.KeyMsg{Type: tea.KeyLeft}, 2},
+		// "d" alias for right
+		{"d key wraps to next row", 2, key("d"), 3},
 	}
 
 	for _, tc := range tests {
@@ -358,6 +355,60 @@ func TestGridView_CursorWrap(t *testing.T) {
 	}
 }
 
+// TestGridView_CursorWrap_SingleColumn verifies wrapping in a 1-column grid.
+// With 1 column each cell is both first and last in its row, so left/right
+// should wrap to the adjacent row (since each row has exactly one cell).
+func TestGridView_CursorWrap_SingleColumn(t *testing.T) {
+	// 2 sessions at 40×50 → gridColumns returns 1 (too narrow for 2 cols).
+	sessions := []*state.Session{
+		{ID: "s1", Title: "a", AgentType: state.AgentClaude, Status: state.StatusRunning},
+		{ID: "s2", Title: "b", AgentType: state.AgentClaude, Status: state.StatusRunning},
+	}
+	makeGV := func(cursor int) *GridView {
+		gv := &GridView{Active: true, Width: 40, Height: 50}
+		gv.Show(sessions, state.GridRestoreProject)
+		gv.Cursor = cursor
+		return gv
+	}
+	key := func(s string) tea.KeyMsg {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+
+	t.Run("right wraps to next row", func(t *testing.T) {
+		gv := makeGV(0)
+		gv.Update(key("l"))
+		if gv.Cursor != 1 {
+			t.Errorf("Cursor = %d, want 1", gv.Cursor)
+		}
+	})
+	t.Run("left wraps to prev row", func(t *testing.T) {
+		gv := makeGV(1)
+		gv.Update(key("h"))
+		if gv.Cursor != 0 {
+			t.Errorf("Cursor = %d, want 0", gv.Cursor)
+		}
+	})
+	t.Run("right at last stays", func(t *testing.T) {
+		gv := makeGV(1)
+		gv.Update(key("l"))
+		if gv.Cursor != 1 {
+			t.Errorf("Cursor = %d, want 1", gv.Cursor)
+		}
+	})
+	t.Run("left at first stays", func(t *testing.T) {
+		gv := makeGV(0)
+		gv.Update(key("h"))
+		if gv.Cursor != 0 {
+			t.Errorf("Cursor = %d, want 0", gv.Cursor)
+		}
+	})
+}
+
+// TestSanitizePaneTitle covers the sanitizer used to scrub untrusted OSC 0/2
+// payloads before rendering them inside grid cells.  Pane titles can contain
+// arbitrary ANSI escape sequences and control characters; lipgloss does not
+// sanitize, so this function is the only thing standing between agent output
+// and the visible UI.
 func TestSanitizePaneTitle(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary
- Right-arrow on the last cell of a grid row now wraps to the first cell of the next row
- Left-arrow on the first cell wraps to the last cell of the previous row
- Boundary cells (index 0 and last session) stay put — no infinite wrapping

Fixes #53

## Test plan
- [x] 8 table-driven unit tests covering normal movement, wrapping, boundary clamping, vim keys, and arrow keys
- [x] `go test ./...` passes
- [ ] Manual: open grid with multiple rows, verify right-arrow wraps at row end and left-arrow wraps at row start

🤖 Generated with [Claude Code](https://claude.com/claude-code)