### PR TITLE
test: add missing tests for state, mux, and protocol packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- **Test coverage for state, mux, and protocol packages**: added tests for `FindSession`, `FindProject`, `FindTeam`, `FindSessionByTmux`, `AllSessions`, `SessionLabel`, `RecordAgentUsage`, `WindowName`, `Target`, and the native mux protocol wire format (#36).
-
 ### Changed
 - **Grid view arrow keys wrap between rows**: pressing right on the last cell of a row now moves to the first cell of the next row, and left on the first cell wraps to the last cell of the previous row (#53).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Test coverage for state, mux, and protocol packages**: added tests for `FindSession`, `FindProject`, `FindTeam`, `FindSessionByTmux`, `AllSessions`, `SessionLabel`, `RecordAgentUsage`, `WindowName`, `Target`, and the native mux protocol wire format (#36).
+
 ### Changed
 - **Grid view arrow keys wrap between rows**: pressing right on the last cell of a row now moves to the first cell of the next row, and left on the first cell wraps to the last cell of the previous row (#53).
 

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,7 +7,7 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| 1 | #36 | Add missing tests | RESEARCH | L |
+| 1 | #36 | Add missing tests | IMPLEMENT | L |
 | 2 | #34 | Terminal bell does not produce audible sound | RESEARCH | S |
 | 3 | #55 | Reorder sessions via keyboard | RESEARCH | M |
 | 4 | #54 | Per-session color for grid cells | RESEARCH | S |

--- a/features/active/036-add-missing-tests.md
+++ b/features/active/036-add-missing-tests.md
@@ -142,4 +142,4 @@ No deviations from plan. Many state functions (`NextSessionAfterRemoval`, `Sessi
 
 PRs 2 and 3 (TUI components, config/hooks I/O) remain for follow-up.
 
-- **PR:** —
+- **PR:** #61 (PR 1 of 3)

--- a/features/active/036-add-missing-tests.md
+++ b/features/active/036-add-missing-tests.md
@@ -1,7 +1,7 @@
 # Feature: Add missing tests
 
 - **GitHub Issue:** #36
-- **Stage:** RESEARCH
+- **Stage:** IMPLEMENT
 - **Type:** enhancement
 - **Complexity:** L
 - **Priority:** P3
@@ -16,29 +16,130 @@ Improve test coverage by adding missing tests across the codebase.
 
 ## Research
 
-<Filled during RESEARCH stage.>
+### Summary
 
-### Relevant Code
-- `path/to/file.go` — <why it matters>
+22 files have tests, 37 do not. Coverage is strongest in `state`, `config`, `escape`, `git`, and `tui/components` (rendering). Major gaps are in the `tmux` CLI wrappers, `mux/native` daemon, `tui` event handlers, `cmd/` startup, and 4 untested TUI components.
+
+Many untested files are thin wrappers around external tools (tmux CLI, PTY I/O, OS calls) or event handlers tightly coupled to the Bubble Tea runtime — these are hard to unit-test without significant refactoring or integration harnesses. The highest-value targets are **pure logic functions** that can be tested in isolation.
+
+### High-Value Test Targets (pure logic, no I/O mocking)
+
+1. **`internal/state/store.go`** — `NextSessionAfterRemoval()` (line 222): complex focus-fallback logic after session deletion. `SessionLabel()` (line 421): display formatting. `RecordAgentUsage()` (line 352): usage tracking. `FindSession/FindProject/FindTeam/FindSessionByTmux` (lines 375-418): lookup functions.
+2. **`internal/mux/interface.go`** — `WindowName()` (line 114): window naming with truncation. `Target()` (line 127): target string building.
+3. **`internal/mux/native/protocol.go`** — `writeMsg()`/`readMsg()` (lines 45-77): binary message encoding/decoding. Testable with in-memory buffers.
+4. **`internal/tui/components/orphanpicker.go`** — `Update()` (line 39): multi-select toggle/select-all logic. Testable via direct `Update()` calls.
+5. **`internal/tui/components/recoverypicker.go`** — `Update()` (line 70): multi-select + agent-type cycling. `agentTypeIndex()` (line 59).
+6. **`internal/tui/components/teambuilder.go`** — `Update()` (line 92): multi-step wizard navigation. `advance()`: step progression.
+7. **`internal/tui/components/settings.go`** — Field editing and validation logic (300+ lines). Complex but self-contained.
+8. **`internal/config/load.go`** — `Ensure()` (line 32), `Save()` (line 82), `writeAtomic()` (line 91): directory creation and atomic writes. Testable with `t.TempDir()`.
+9. **`internal/hooks/runner.go`** — `Run()` (line 18), `findScripts()` (line 35): hook discovery and execution. Partially testable with temp dirs.
+
+### Medium-Value Targets (need some mocking or setup)
+
+10. **`internal/tui/handle_keys.go`** — `handleKey()`, `handleGridKey()`, `handleGlobalKey()`: key dispatch logic. Testable via the existing flow-test pattern (`tui/flow_test.go`).
+11. **`internal/tui/handle_session.go`** — Session lifecycle handlers. Could be tested via flow tests.
+12. **`internal/tmux/capture.go`** — `GetPaneTitles()` (line 45): parses tmux list-windows output into a map. Testable if the tmux exec is injectable.
+13. **`internal/tmux/window.go`** — `ListWindows()` (line 62): parses window list output.
+
+### Low-Value / Hard to Test
+
+- `cmd/` startup commands — tightly coupled to OS, tmux, config files
+- `mux/native/daemon.go`, `pane.go`, `client.go` — need Unix sockets, PTYs
+- `mux/tmux/backend.go` — thin wrapper around tmux CLI
+- `internal/tmux/client.go`, `session.go`, `window.go` — thin wrappers around `exec.Command`
+- `tui/handle_preview.go`, `handle_system.go` — timer/watcher-coupled handlers
+- `messages.go`, `events.go`, `views.go` — pure type definitions, no logic
 
 ### Constraints / Dependencies
-- <anything blocking or complicating this>
+
+1. **Tests must not read/write real config or state files** (per issue description and feedback memory). Use `t.TempDir()` for file-based tests.
+2. **No tmux dependency in tests.** The `internal/tmux/` package wraps `exec.Command("tmux", ...)` — unit testing requires either refactoring to inject the executor or limiting tests to output-parsing functions.
+3. **Bubble Tea coupling.** Many `tui/handle_*.go` functions are methods on `tui.Model` and depend on its full state. The existing flow-test pattern (`flow_test.go`) is the way to test these, but adding flow tests is more complex than unit tests.
+4. **This is L-complexity.** Should be broken into phases/PRs rather than one massive PR. Recommend grouping by package or by value tier.
 
 ## Plan
 
-<Filled during PLAN stage.>
+Break into 3 PRs by package group, highest-value first. Each PR is self-contained and independently mergeable.
 
-### Files to Change
-1. `path/to/file.go` — <what and why>
+### PR 1: State + Mux pure logic tests
+
+**Files to Change:**
+1. `internal/state/store_test.go` — Add tests for:
+   - `NextSessionAfterRemoval()`: next-in-group, prev-in-group, cross-group fallback, only session, session-not-found, team vs standalone
+   - `SessionLabel()`: orchestrator star prefix, non-orchestrator, various agent types
+   - `RecordAgentUsage()`: nil map init, first usage, repeated usage, multiple agent types
+   - `FindSession()`: standalone session, team session, not found, empty state
+   - `FindProject()`: found, not found, empty list
+   - `FindTeam()`: found in first/last project, not found
+   - `FindSessionByTmux()`: match both fields, match only one (miss), not found
+   - `AllSessions()`: empty, standalone only, team only, mixed ordering
+2. `internal/mux/interface_test.go` — New file. Add tests for:
+   - `WindowName()`: truncation at 8/12 chars, exact boundary, shorter names, empty fields
+   - `Target()`: standard formatting, window index 0, empty session
+3. `internal/mux/native/protocol_test.go` — New file. Add tests for:
+   - `writeMsg()`/`readMsg()` roundtrip with valid data
+   - `readMsg()` rejects messages > 4 MiB
+   - `readMsg()` handles malformed JSON, short header reads, zero-length messages
+   - `writeMsg()` handles marshal errors (e.g., channels)
+
+### PR 2: Untested TUI components
+
+**Files to Change:**
+4. `internal/tui/components/orphanpicker_test.go` — New file. Tests for:
+   - Cursor navigation (up/down bounds)
+   - Space toggle on/off
+   - Toggle-all (none→all, all→none, partial→all)
+   - Enter returns selected sessions; Esc returns nil
+5. `internal/tui/components/recoverypicker_test.go` — New file. Tests for:
+   - Cursor navigation bounds
+   - Left/right agent-type cycling with wrap-around
+   - `agentTypeIndex()` for known types and unknown (defaults to custom)
+   - Agent type stays synced with `sessions[].DetectedAgentType`
+   - Enter returns selected with correct agent types
+6. `internal/tui/components/teambuilder_test.go` — New file. Tests for:
+   - Empty name rejected (no advance)
+   - Worker count parsing: "abc"→2, "0"→1, "11"→10, "5"→5
+   - Step progression: name→goal→orchestrator→workerCount→workDir→confirm
+   - Esc hides at any step without emitting TeamBuiltMsg
+7. `internal/tui/components/settings_test.go` — New file. Tests for:
+   - Bool toggle (true↔false)
+   - Select field cycling with wrap
+   - Int validation: PreviewRefreshMs boundaries (49 rejected, 50 ok, 30000 ok, 30001 rejected)
+   - String validation: empty keybinding rejected, empty hooks dir rejected
+   - Dirty tracking: only set after successful edit, not on validation failure
+   - Esc flow: first esc sets pendingDiscard, second esc closes
+   - Save flow: s sets pendingSave, y/enter confirms
+
+### PR 3: Config/hooks I/O tests
+
+**Files to Change:**
+8. `internal/config/load_test.go` — Add tests for:
+   - `Ensure()`: creates dirs, idempotent on re-run (uses `t.TempDir()`)
+   - `Save()`: writes valid indented JSON, file permissions 0o600
+   - `writeAtomic()`: temp file removed on success, target file created
+9. `internal/hooks/runner_test.go` — Add tests for:
+   - `findScripts()`: flat file found, `.d/` dir entries sorted, non-executable skipped, dirs skipped, both flat + `.d/` combined
+   - `Run()`: no scripts → nil, one script succeeds, one script fails → error collected
+   - (Uses `t.TempDir()` with executable shell scripts)
 
 ### Test Strategy
-- <how to verify>
+- All tests run via `go test ./...`
+- No real config/state files — `t.TempDir()` for all file I/O
+- No tmux dependency — protocol tests use `bytes.Buffer`
+- Component tests use direct `Update()` calls, matching existing patterns
+- Each PR must pass `go build ./...`, `go vet ./...`, `go test ./...`
 
 ### Risks
-- <what could go wrong>
+- **Settings field count**: the settings component has ~30 fields with individual set/get functions. Testing all validation paths is thorough but verbose. Focus on one representative per field kind (bool, select, int, string) rather than exhaustive coverage.
+- **TeamBuilder agent picker integration**: testing the full orchestrator→worker flow requires simulating `AgentPickedMsg` messages, which is doable but requires careful state setup.
+- **Config path coupling**: `Ensure()` and `Save()` use `Dir()`/`ConfigPath()` which resolve to `~/.config/hive`. Tests must either override these or test `writeAtomic()` directly with explicit paths. Check if `Dir()` respects `XDG_CONFIG_HOME` for redirection to temp dir.
+- **Hooks timeout**: `runScript()` has a hardcoded 5s timeout. Skip timeout tests to avoid slow test suite; focus on `findScripts()` and error collection.
 
 ## Implementation Notes
 
-<Filled during IMPLEMENT stage.>
+### PR 1: State + Mux pure logic tests
+No deviations from plan. Many state functions (`NextSessionAfterRemoval`, `SessionLabel`, `RecordAgentUsage`, `AllSessions`) already had partial test coverage — added the remaining `FindX` and `FindSessionByTmux` tests plus additional edge cases. Created new test files for `mux/interface_test.go` (8 test cases for `WindowName` + `Target`) and `mux/native/protocol_test.go` (12 test cases for wire format, size validation, error handling).
+
+PRs 2 and 3 (TUI components, config/hooks I/O) remain for follow-up.
 
 - **PR:** —

--- a/internal/mux/interface_test.go
+++ b/internal/mux/interface_test.go
@@ -1,0 +1,52 @@
+package mux
+
+import "testing"
+
+func TestWindowName(t *testing.T) {
+	tests := []struct {
+		name        string
+		project     string
+		agentType   string
+		title       string
+		want        string
+	}{
+		{"short names", "proj", "claude", "sess", "proj-claude-sess"},
+		{"project truncated at 8", "longproject", "claude", "sess", "longproj-claude-sess"},
+		{"project exactly 8", "12345678", "claude", "sess", "12345678-claude-sess"},
+		{"title truncated at 12", "p", "claude", "a-very-long-title", "p-claude-a-very-long-"},
+		{"title exactly 12", "p", "claude", "123456789012", "p-claude-123456789012"},
+		{"empty fields", "", "", "", "--"},
+		{"empty project", "", "claude", "s", "-claude-s"},
+		{"empty title", "p", "claude", "", "p-claude-"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WindowName(tc.project, tc.agentType, tc.title)
+			if got != tc.want {
+				t.Errorf("WindowName(%q, %q, %q) = %q, want %q",
+					tc.project, tc.agentType, tc.title, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		session string
+		window  int
+		want    string
+	}{
+		{"standard", "hive-sessions", 3, "hive-sessions:3"},
+		{"window zero", "hive-sessions", 0, "hive-sessions:0"},
+		{"empty session", "", 5, ":5"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Target(tc.session, tc.window)
+			if got != tc.want {
+				t.Errorf("Target(%q, %d) = %q, want %q", tc.session, tc.window, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mux/native/protocol_test.go
+++ b/internal/mux/native/protocol_test.go
@@ -1,0 +1,157 @@
+package muxnative
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWriteReadMsg_Roundtrip(t *testing.T) {
+	req := Request{Op: "capture", Target: "hive-sessions:3", Lines: 50}
+	var buf bytes.Buffer
+	if err := writeMsg(&buf, req); err != nil {
+		t.Fatalf("writeMsg: %v", err)
+	}
+	var got Request
+	if err := readMsg(&buf, &got); err != nil {
+		t.Fatalf("readMsg: %v", err)
+	}
+	if got.Op != "capture" || got.Target != "hive-sessions:3" || got.Lines != 50 {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func TestWriteReadMsg_Response(t *testing.T) {
+	resp := Response{OK: true, Content: "hello world", Int: 42}
+	var buf bytes.Buffer
+	if err := writeMsg(&buf, resp); err != nil {
+		t.Fatalf("writeMsg: %v", err)
+	}
+	var got Response
+	if err := readMsg(&buf, &got); err != nil {
+		t.Fatalf("readMsg: %v", err)
+	}
+	if !got.OK || got.Content != "hello world" || got.Int != 42 {
+		t.Errorf("roundtrip mismatch: %+v", got)
+	}
+}
+
+func TestWriteMsg_HeaderFormat(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeMsg(&buf, "test"); err != nil {
+		t.Fatalf("writeMsg: %v", err)
+	}
+	data := buf.Bytes()
+	if len(data) < 4 {
+		t.Fatalf("output too short: %d bytes", len(data))
+	}
+	msgLen := binary.BigEndian.Uint32(data[:4])
+	if int(msgLen) != len(data)-4 {
+		t.Errorf("header says %d bytes, body is %d bytes", msgLen, len(data)-4)
+	}
+}
+
+func TestReadMsg_TooLarge(t *testing.T) {
+	var buf bytes.Buffer
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], maxMsgSize+1)
+	buf.Write(hdr[:])
+	var got Response
+	err := readMsg(&buf, &got)
+	if err == nil {
+		t.Fatal("readMsg should reject oversized message")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error = %q, want 'too large'", err)
+	}
+}
+
+func TestReadMsg_ExactlyMaxSize(t *testing.T) {
+	// Header claims exactly maxMsgSize — should not be rejected by size check.
+	// Will fail on ReadFull (not enough data), but that's a different error.
+	var buf bytes.Buffer
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], maxMsgSize)
+	buf.Write(hdr[:])
+	var got Response
+	err := readMsg(&buf, &got)
+	if err == nil {
+		t.Fatal("expected error (not enough data)")
+	}
+	if strings.Contains(err.Error(), "too large") {
+		t.Error("maxMsgSize should be accepted, not rejected as too large")
+	}
+}
+
+func TestReadMsg_EmptyReader(t *testing.T) {
+	var got Response
+	err := readMsg(bytes.NewReader(nil), &got)
+	if err == nil {
+		t.Fatal("readMsg should fail on empty reader")
+	}
+}
+
+func TestReadMsg_ShortHeader(t *testing.T) {
+	var got Response
+	err := readMsg(bytes.NewReader([]byte{0, 0}), &got)
+	if err == nil {
+		t.Fatal("readMsg should fail on short header")
+	}
+}
+
+func TestReadMsg_MalformedJSON(t *testing.T) {
+	body := []byte("not json")
+	var buf bytes.Buffer
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
+	buf.Write(hdr[:])
+	buf.Write(body)
+	var got Response
+	err := readMsg(&buf, &got)
+	if err == nil {
+		t.Fatal("readMsg should fail on malformed JSON")
+	}
+}
+
+func TestReadMsg_ZeroLength(t *testing.T) {
+	var buf bytes.Buffer
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], 0)
+	buf.Write(hdr[:])
+	var got Response
+	err := readMsg(&buf, &got)
+	if err == nil {
+		t.Fatal("readMsg should fail on zero-length message (empty JSON)")
+	}
+}
+
+func TestWriteMsg_MarshalError(t *testing.T) {
+	// Channels are not JSON-serializable.
+	ch := make(chan int)
+	err := writeMsg(io.Discard, ch)
+	if err == nil {
+		t.Fatal("writeMsg should fail on non-serializable type")
+	}
+}
+
+func TestErrResp(t *testing.T) {
+	r := errResp("something broke")
+	if r.OK {
+		t.Error("errResp should not be OK")
+	}
+	if r.Error != "something broke" {
+		t.Errorf("Error = %q, want %q", r.Error, "something broke")
+	}
+}
+
+func TestOkResp(t *testing.T) {
+	r := okResp()
+	if !r.OK {
+		t.Error("okResp should be OK")
+	}
+	if r.Error != "" {
+		t.Errorf("Error = %q, want empty", r.Error)
+	}
+}

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -499,3 +499,248 @@ func TestSessionLabel_OrchestratorHasStar(t *testing.T) {
 		t.Errorf("SessionLabel for orchestrator = %q, want ★ prefix", label)
 	}
 }
+
+func TestSessionLabel_ContainsAgentType(t *testing.T) {
+	sess := &Session{Title: "test", AgentType: AgentCodex, TeamRole: RoleStandalone}
+	label := SessionLabel(sess)
+	if !strings.Contains(label, "[codex]") {
+		t.Errorf("SessionLabel = %q, want to contain [codex]", label)
+	}
+}
+
+func TestSessionLabel_WorkerNoStar(t *testing.T) {
+	sess := &Session{Title: "worker", AgentType: AgentClaude, TeamRole: RoleWorker}
+	label := SessionLabel(sess)
+	if strings.HasPrefix(label, "★") {
+		t.Errorf("SessionLabel for worker = %q, should not start with ★", label)
+	}
+}
+
+// --- FindSession ---
+
+func TestFindSession_Standalone(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, sess := CreateSession(s, p.ID, "s1", AgentClaude, nil, "", "hive-abc", 0)
+	found := FindSession(s, sess.ID)
+	if found == nil {
+		t.Fatal("FindSession returned nil, want session")
+	}
+	if found.ID != sess.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, sess.ID)
+	}
+}
+
+func TestFindSession_InTeam(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, team := CreateTeam(s, p.ID, "team", "", "")
+	s, sess := AddTeamSession(s, p.ID, team.ID, RoleWorker, "w", AgentClaude, nil, "", "hive-abc", 0)
+	found := FindSession(s, sess.ID)
+	if found == nil {
+		t.Fatal("FindSession returned nil for team session")
+	}
+	if found.ID != sess.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, sess.ID)
+	}
+}
+
+func TestFindSession_NotFound(t *testing.T) {
+	s := emptyState()
+	if FindSession(s, "nonexistent") != nil {
+		t.Error("FindSession should return nil for unknown ID")
+	}
+}
+
+func TestFindSession_EmptyState(t *testing.T) {
+	s := &AppState{}
+	if FindSession(s, "any") != nil {
+		t.Error("FindSession should return nil on empty state")
+	}
+}
+
+// --- FindProject ---
+
+func TestFindProject_Found(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "proj", "", "", "")
+	found := FindProject(s, p.ID)
+	if found == nil {
+		t.Fatal("FindProject returned nil")
+	}
+	if found.Name != "proj" {
+		t.Errorf("found.Name = %q, want %q", found.Name, "proj")
+	}
+}
+
+func TestFindProject_NotFound(t *testing.T) {
+	s := emptyState()
+	s, _ = CreateProject(s, "proj", "", "", "")
+	if FindProject(s, "nonexistent") != nil {
+		t.Error("FindProject should return nil for unknown ID")
+	}
+}
+
+func TestFindProject_EmptyState(t *testing.T) {
+	s := emptyState()
+	if FindProject(s, "any") != nil {
+		t.Error("FindProject should return nil on empty state")
+	}
+}
+
+// --- FindTeam ---
+
+func TestFindTeam_Found(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, team := CreateTeam(s, p.ID, "my-team", "", "")
+	found := FindTeam(s, team.ID)
+	if found == nil {
+		t.Fatal("FindTeam returned nil")
+	}
+	if found.Name != "my-team" {
+		t.Errorf("found.Name = %q, want %q", found.Name, "my-team")
+	}
+}
+
+func TestFindTeam_NotFound(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, _ = CreateTeam(s, p.ID, "team", "", "")
+	if FindTeam(s, "nonexistent") != nil {
+		t.Error("FindTeam should return nil for unknown ID")
+	}
+}
+
+func TestFindTeam_EmptyState(t *testing.T) {
+	s := emptyState()
+	if FindTeam(s, "any") != nil {
+		t.Error("FindTeam should return nil on empty state")
+	}
+}
+
+func TestFindTeam_MultipleProjects(t *testing.T) {
+	s := emptyState()
+	s, p1 := CreateProject(s, "p1", "", "", "")
+	s, _ = CreateTeam(s, p1.ID, "team-a", "", "")
+	s, p2 := CreateProject(s, "p2", "", "", "")
+	s, teamB := CreateTeam(s, p2.ID, "team-b", "", "")
+	found := FindTeam(s, teamB.ID)
+	if found == nil {
+		t.Fatal("FindTeam returned nil for team in second project")
+	}
+	if found.Name != "team-b" {
+		t.Errorf("found.Name = %q, want %q", found.Name, "team-b")
+	}
+}
+
+// --- FindSessionByTmux ---
+
+func TestFindSessionByTmux_Found(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, sess := CreateSession(s, p.ID, "s1", AgentClaude, nil, "", "hive-abc", 3)
+	found := FindSessionByTmux(s, "hive-abc", 3)
+	if found == nil {
+		t.Fatal("FindSessionByTmux returned nil")
+	}
+	if found.ID != sess.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, sess.ID)
+	}
+}
+
+func TestFindSessionByTmux_WrongWindow(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, _ = CreateSession(s, p.ID, "s1", AgentClaude, nil, "", "hive-abc", 3)
+	if FindSessionByTmux(s, "hive-abc", 99) != nil {
+		t.Error("FindSessionByTmux should return nil when window doesn't match")
+	}
+}
+
+func TestFindSessionByTmux_WrongSession(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, _ = CreateSession(s, p.ID, "s1", AgentClaude, nil, "", "hive-abc", 3)
+	if FindSessionByTmux(s, "hive-xyz", 3) != nil {
+		t.Error("FindSessionByTmux should return nil when session doesn't match")
+	}
+}
+
+func TestFindSessionByTmux_InTeam(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, team := CreateTeam(s, p.ID, "team", "", "")
+	s, sess := AddTeamSession(s, p.ID, team.ID, RoleWorker, "w", AgentClaude, nil, "", "hive-abc", 5)
+	found := FindSessionByTmux(s, "hive-abc", 5)
+	if found == nil {
+		t.Fatal("FindSessionByTmux returned nil for team session")
+	}
+	if found.ID != sess.ID {
+		t.Errorf("found.ID = %q, want %q", found.ID, sess.ID)
+	}
+}
+
+func TestFindSessionByTmux_NotFound(t *testing.T) {
+	s := emptyState()
+	if FindSessionByTmux(s, "hive-abc", 0) != nil {
+		t.Error("FindSessionByTmux should return nil on empty state")
+	}
+}
+
+// --- AllSessions (additional) ---
+
+func TestAllSessions_EmptyState(t *testing.T) {
+	s := emptyState()
+	all := AllSessions(s)
+	if len(all) != 0 {
+		t.Errorf("AllSessions on empty state: len = %d, want 0", len(all))
+	}
+}
+
+func TestAllSessions_StandaloneOnly(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, _ = CreateSession(s, p.ID, "s1", AgentClaude, nil, "", "hive-abc", 0)
+	s, _ = CreateSession(s, p.ID, "s2", AgentClaude, nil, "", "hive-abc", 1)
+	all := AllSessions(s)
+	if len(all) != 2 {
+		t.Errorf("AllSessions len = %d, want 2", len(all))
+	}
+}
+
+func TestAllSessions_TeamOnly(t *testing.T) {
+	s := emptyState()
+	s, p := CreateProject(s, "p", "", "", "")
+	s, team := CreateTeam(s, p.ID, "team", "", "")
+	s, _ = AddTeamSession(s, p.ID, team.ID, RoleOrchestrator, "o", AgentClaude, nil, "", "hive-abc", 0)
+	s, _ = AddTeamSession(s, p.ID, team.ID, RoleWorker, "w", AgentClaude, nil, "", "hive-abc", 1)
+	all := AllSessions(s)
+	if len(all) != 2 {
+		t.Errorf("AllSessions len = %d, want 2", len(all))
+	}
+}
+
+// --- RecordAgentUsage (additional) ---
+
+func TestRecordAgentUsage_MultipleAgents(t *testing.T) {
+	s := emptyState()
+	RecordAgentUsage(s, "claude")
+	RecordAgentUsage(s, "codex")
+	RecordAgentUsage(s, "claude")
+	if s.AgentUsage["claude"].Count != 2 {
+		t.Errorf("claude Count = %d, want 2", s.AgentUsage["claude"].Count)
+	}
+	if s.AgentUsage["codex"].Count != 1 {
+		t.Errorf("codex Count = %d, want 1", s.AgentUsage["codex"].Count)
+	}
+}
+
+func TestRecordAgentUsage_SetsLastUsed(t *testing.T) {
+	s := emptyState()
+	RecordAgentUsage(s, "claude")
+	rec := s.AgentUsage["claude"]
+	if rec.LastUsed.IsZero() {
+		t.Error("LastUsed should not be zero")
+	}
+}


### PR DESCRIPTION
## Summary
PR 1 of 3 for #36. Adds 40+ test cases across three packages:

- **internal/state**: `FindSession`, `FindProject`, `FindTeam`, `FindSessionByTmux` (found/not-found/empty-state/team), plus additional `AllSessions`, `SessionLabel`, and `RecordAgentUsage` edge cases
- **internal/mux**: `WindowName` truncation at 8/12 char boundaries, `Target` formatting (new file)
- **internal/mux/native**: protocol `writeMsg`/`readMsg` roundtrip, 4 MiB size validation, malformed JSON, short headers, marshal errors, `errResp`/`okResp` helpers (new file)

Relates to #36

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes — all 40+ new tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)