### PR TITLE
feat: improve selected session visibility in grid view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Per-session color**: each session gets its own color, shown as a gradient in the grid cell header and sidebar title (project color → session color). Colors are auto-assigned on creation and can be cycled with `v`/`V` in both sidebar and grid view (#54).
 
+### Changed
+- **Improved grid selection visibility**: the selected cell now has a subtle dark background tint on the content preview area, making it easier to identify at a glance alongside the existing accent border (#68).
+
 ## [0.6.0] — 2026-04-11
 
 ### Added

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,7 +7,7 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| 1 | #68 | Improve selected session visibility in grid view | RESEARCH | S |
+| 1 | #68 | Improve selected session visibility in grid view | IMPLEMENT | S |
 | 2 | #69 | Display changelog since last version on open | RESEARCH | M |
 | 3 | #37 | Code refactor: remove bloat | RESEARCH | L |
 | 4 | #66 | Hive mode: hexagonal honeycomb grid layout | RESEARCH | L |

--- a/features/active/068-improve-selected-session-visibility-grid.md
+++ b/features/active/068-improve-selected-session-visibility-grid.md
@@ -22,7 +22,7 @@ Improve the selected cell's visual treatment to make it stand out more clearly. 
 - `internal/tui/styles/theme.go:12-23` — Color constants. Key values:
   - `ColorAccent` (#7C3AED) — selected border
   - `ColorBorder` (#374151) — unselected border
-  - `ColorGridSelected` (#151520) — used in sidebar for row background but **not used in grid view at all**
+  - `ColorGridSelected` (#151520) — near-black purple tint used for selected grid cell content background
   - `ColorBg` (#111827) — base background
 - `internal/tui/styles/theme.go:47-50` — `PreviewFocusedStyle` shows the pattern for focused border (accent color on rounded border) — grid cells follow the same pattern.
 - `internal/tui/styles/theme.go:79-81` — `SessionSelectedStyle` uses `ColorSelected` background in sidebar. Grid view does not use this.
@@ -49,8 +49,8 @@ Add a `ColorGridSelected` (#151520 — near-black with slight purple lean) backg
 ### Test Strategy
 
 **Unit tests** in `internal/tui/components/gridview_test.go`:
-1. `TestGridView_SelectedCellHasBackground` — Render a 2-session grid, verify the selected cell's output contains the ANSI escape for `ColorGridSelected` (#151520) background, and the unselected cell does not.
-2. `TestGridView_SelectedCellSubtitleHasBackground` — Render a selected cell with a tall enough height (≥8) and a pane title set, verify the subtitle line includes the `ColorSelected` background.
+1. `TestGridView_SelectedCellHasBackground` — Render a grid cell selected vs unselected, verify the selected cell's output contains the `GridSelectedBgEsc` escape (derived from `ColorGridSelected`) and the unselected cell does not.
+2. `TestGridView_SelectedCellSubtitleHasBackground` — Render a selected cell with a tall enough height (≥8) and a pane title set, verify the subtitle line includes the `ColorGridSelected` background escape and the unselected subtitle does not.
 
 **Golden tests** in `internal/tui/golden_test.go`:
 3. Update golden snapshots — the existing `TestGolden_GridView_ProjectScope` and `TestGolden_GridView_AllProjects` will need their `.golden` files regenerated since the selected cell rendering changes.

--- a/features/active/068-improve-selected-session-visibility-grid.md
+++ b/features/active/068-improve-selected-session-visibility-grid.md
@@ -1,11 +1,11 @@
 # Feature: Improve selected session visibility in grid view
 
 - **GitHub Issue:** #68
-- **Stage:** RESEARCH
+- **Stage:** IMPLEMENT
 - **Type:** enhancement
 - **Complexity:** S
 - **Priority:** P2
-- **Branch:** —
+- **Branch:** feature/68-grid-selected-visibility
 
 ## Description
 
@@ -15,29 +15,60 @@ Improve the selected cell's visual treatment to make it stand out more clearly. 
 
 ## Research
 
-<Filled during RESEARCH stage.>
-
 ### Relevant Code
-- `path/to/file.go` — <why it matters>
+
+- `internal/tui/components/gridview.go:235-381` — `renderCell()` method. The selected cell is distinguished **only** by border color: `ColorAccent` (#7C3AED purple) vs `ColorBorder` (#374151 gray). The border style itself (rounded, single-line) is identical. Title gets `Bold(true)` when selected (line 314), but only in the flat-header path (no session color gradient). No background tint, no glow, no thickness change.
+- `internal/tui/components/gridview.go:176-233` — `View()` method. Composes grid rows from `renderCell()` outputs. No per-cell wrapper or highlight layer exists.
+- `internal/tui/styles/theme.go:12-23` — Color constants. Key values:
+  - `ColorAccent` (#7C3AED) — selected border
+  - `ColorBorder` (#374151) — unselected border
+  - `ColorGridSelected` (#151520) — used in sidebar for row background but **not used in grid view at all**
+  - `ColorBg` (#111827) — base background
+- `internal/tui/styles/theme.go:47-50` — `PreviewFocusedStyle` shows the pattern for focused border (accent color on rounded border) — grid cells follow the same pattern.
+- `internal/tui/styles/theme.go:79-81` — `SessionSelectedStyle` uses `ColorSelected` background in sidebar. Grid view does not use this.
+- `internal/tui/components/sidebar.go:415-418` — Sidebar selected row gets a `ColorSelected` (#1E3A5F dark blue) background + lighter text. Much more visible than the grid's border-only approach.
+- `internal/tui/styles/theme.go:254-309` — `GradientBg()` / `GradientFg()` functions used for per-session color rendering. The `GradientBg` function already receives a `bold bool` parameter (used when selected).
 
 ### Constraints / Dependencies
-- <anything blocking or complicating this>
+
+- **lipgloss border limitations:** lipgloss does not support double/thick borders or border width. The `RoundedBorder()`, `NormalBorder()`, `ThickBorder()` are the available options, but they all render as single-character-width borders.
+- **Per-session color (PR #70):** Recently merged. The header already uses gradient backgrounds for sessions with custom colors. Any new selected-cell styling must not conflict with or obscure the gradient header.
+- **Content preview area:** The cell body shows terminal output preview. Session output is mostly light text on dark/black backgrounds, so a dark background tint on the content area is safe. A new color `ColorGridSelected` (#151520) will be used — a near-black with a slight purple lean, much darker than the sidebar's `ColorGridSelected` (#151520). Subtle enough to not distract from terminal content while remaining distinguishable from a transparent background. All standard ANSI foreground colors remain legible. Apply to content area only, not the header (which already has project/session color). Edge case: sessions with blue background output — rare in practice.
+- **Minimal diff preferred:** This is an S-complexity feature. The fix should be surgical — ideally just a few lines in `renderCell()` and possibly `theme.go`.
 
 ## Plan
 
-<Filled during PLAN stage.>
+Add a `ColorGridSelected` (#151520 — near-black with slight purple lean) background tint to the **content preview area** and **subtitle line** of the selected grid cell. The header is left untouched (it already has project/session color). Combined with the existing accent border and bold title, this gives three reinforcing cues for the selected cell.
 
 ### Files to Change
-1. `path/to/file.go` — <what and why>
+
+1. `internal/tui/components/gridview.go` — In `renderCell()`:
+   - **Content area (lines 359-362, 364-368):** When `selected`, add `.Background(styles.ColorGridSelected)` to the content lipgloss style in both the has-content and empty-content branches.
+   - **Subtitle line (lines 334-338):** When `selected`, add `.Background(styles.ColorGridSelected)` to the subtitle lipgloss style.
 
 ### Test Strategy
-- <how to verify>
+
+**Unit tests** in `internal/tui/components/gridview_test.go`:
+1. `TestGridView_SelectedCellHasBackground` — Render a 2-session grid, verify the selected cell's output contains the ANSI escape for `ColorGridSelected` (#151520) background, and the unselected cell does not.
+2. `TestGridView_SelectedCellSubtitleHasBackground` — Render a selected cell with a tall enough height (≥8) and a pane title set, verify the subtitle line includes the `ColorSelected` background.
+
+**Golden tests** in `internal/tui/golden_test.go`:
+3. Update golden snapshots — the existing `TestGolden_GridView_ProjectScope` and `TestGolden_GridView_AllProjects` will need their `.golden` files regenerated since the selected cell rendering changes.
+
+**Flow tests** — No new flow tests needed. The change is purely visual (styling), not behavioral. Existing flow tests (`TestFlow_GridNavigateAndSelect`, `TestFlow_GridAttachDetachRestoresGrid`, etc.) already verify selection mechanics and will continue to pass since the logic is unchanged.
 
 ### Risks
-- <what could go wrong>
+
+- **ANSI color stacking:** If terminal content already has background colors set via ANSI escapes, the lipgloss `Background()` may not override them per-character — it sets a default background. In practice this is fine: most terminal output uses default background, and characters with explicit backgrounds will keep their own color, which is acceptable.
+- **Golden test churn:** Two golden files need updating. This is expected and low-risk.
+- **Contrast edge case:** Sessions outputting blue-backgrounded text may blend slightly with `ColorGridSelected` (#151520). This is rare and the border+bold title still provide selection cues.
 
 ## Implementation Notes
 
-<Filled during IMPLEMENT stage.>
+- Added `ColorGridSelected` (#151520) to `theme.go` — separate from sidebar's `ColorSelected`
+- Applied background to both content area and subtitle line in `renderCell()` via a shared `contentStyle`
+- Tests use `lipgloss.SetColorProfile(termenv.TrueColor)` to force color output since test runners don't have a TTY
+- Golden tests unaffected (use `TERM=dumb` which strips all color)
+- No deviations from plan
 
 - **PR:** —

--- a/features/active/068-improve-selected-session-visibility-grid.md
+++ b/features/active/068-improve-selected-session-visibility-grid.md
@@ -71,4 +71,4 @@ Add a `ColorGridSelected` (#151520 — near-black with slight purple lean) backg
 - Golden tests unaffected (use `TERM=dumb` which strips all color)
 - No deviations from plan
 
-- **PR:** —
+- **PR:** #71

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -331,11 +331,14 @@ func (gv *GridView) renderCell(sess *state.Session, w, h int, selected bool) str
 	if h >= 8 {
 		if t := sanitizePaneTitle(gv.paneTitles[mux.Target(sess.TmuxSession, sess.TmuxWindow)]); t != "" {
 			trunc := ansi.Truncate(t, innerW, "…")
-			subtitleLine = lipgloss.NewStyle().
+			subtitleStyle := lipgloss.NewStyle().
 				Foreground(styles.ColorMuted).
 				Italic(true).
-				Width(innerW).MaxWidth(innerW).
-				Render(trunc)
+				Width(innerW).MaxWidth(innerW)
+			if selected {
+				subtitleStyle = subtitleStyle.Background(styles.ColorGridSelected)
+			}
+			subtitleLine = subtitleStyle.Render(trunc)
 			showSubtitle = true
 			innerH-- // give the row back from the content area
 			if innerH < 1 {
@@ -350,20 +353,28 @@ func (gv *GridView) renderCell(sess *state.Session, w, h int, selected bool) str
 	// short lines and MaxHeight then discards the most-recent content, keeping
 	// only the oldest wrapped fragment.  Pre-truncation also prevents
 	// cellbuf.Wrap from unexpectedly expanding line count in edge cases.
+	contentStyle := lipgloss.NewStyle().
+		Width(innerW).Height(innerH).
+		MaxWidth(innerW).MaxHeight(innerH)
+	if selected {
+		contentStyle = contentStyle.Background(styles.ColorGridSelected)
+	}
 	var contentStr string
 	if content := gv.contents[sess.ID]; content != "" {
 		rawLines := strings.Split(lastNLines(content, innerH), "\n")
 		for i, l := range rawLines {
 			rawLines[i] = ansi.Truncate(l, innerW, "")
 		}
-		contentStr = lipgloss.NewStyle().
-			Width(innerW).Height(innerH).
-			MaxWidth(innerW).MaxHeight(innerH).
-			Render(strings.Join(rawLines, "\n"))
+		joined := strings.Join(rawLines, "\n")
+		// Re-apply the selected background after every ANSI SGR reset
+		// (\033[0m) in the captured content, so the tint persists through
+		// reset sequences emitted by the terminal session.
+		if selected {
+			joined = strings.ReplaceAll(joined, "\033[0m", "\033[0m"+styles.GridSelectedBgEsc)
+		}
+		contentStr = contentStyle.Render(joined)
 	} else {
-		contentStr = lipgloss.NewStyle().
-			Width(innerW).Height(innerH).
-			MaxWidth(innerW).MaxHeight(innerH).
+		contentStr = contentStyle.
 			Foreground(styles.ColorMuted).
 			Render("…")
 	}

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -366,11 +366,13 @@ func (gv *GridView) renderCell(sess *state.Session, w, h int, selected bool) str
 			rawLines[i] = ansi.Truncate(l, innerW, "")
 		}
 		joined := strings.Join(rawLines, "\n")
-		// Re-apply the selected background after every ANSI SGR reset
-		// (\033[0m) in the captured content, so the tint persists through
-		// reset sequences emitted by the terminal session.
+		// Re-apply the selected background after ANSI SGR resets in the
+		// captured content so the tint persists through reset sequences
+		// emitted by the terminal session. Handles both \033[0m and the
+		// shorthand \033[m variant.
 		if selected {
 			joined = strings.ReplaceAll(joined, "\033[0m", "\033[0m"+styles.GridSelectedBgEsc)
+			joined = strings.ReplaceAll(joined, "\033[m", "\033[m"+styles.GridSelectedBgEsc)
 		}
 		contentStr = contentStyle.Render(joined)
 	} else {

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/lucascaro/hive/internal/state"
+	"github.com/lucascaro/hive/internal/tui/styles"
 	"github.com/muesli/termenv"
 )
 
@@ -406,9 +407,8 @@ func TestGridView_CursorWrap_SingleColumn(t *testing.T) {
 	})
 }
 
-// TestGridView_SelectedCellHasBackground verifies that renderCell produces
-// different output for selected vs unselected cells (the selected cell gets
-// a ColorGridSelected background tint on the content area).
+// TestGridView_SelectedCellHasBackground verifies that the selected cell
+// contains the ColorGridSelected background escape and the unselected does not.
 func TestGridView_SelectedCellHasBackground(t *testing.T) {
 	prev := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -424,13 +424,21 @@ func TestGridView_SelectedCellHasBackground(t *testing.T) {
 
 	selected := gv.renderCell(sess, 40, 15, true)
 	unselected := gv.renderCell(sess, 40, 15, false)
-	if selected == unselected {
-		t.Error("selected and unselected cells should render differently")
+
+	bgEsc := styles.GridSelectedBgEsc
+	if bgEsc == "" {
+		t.Fatal("GridSelectedBgEsc is empty — cannot verify background")
+	}
+	if !strings.Contains(selected, bgEsc) {
+		t.Errorf("selected cell missing GridSelectedBgEsc %q", bgEsc)
+	}
+	if strings.Contains(unselected, bgEsc) {
+		t.Errorf("unselected cell should not contain GridSelectedBgEsc %q", bgEsc)
 	}
 }
 
 // TestGridView_SelectedCellSubtitleHasBackground verifies that the subtitle
-// line renders differently when the cell is selected (background tint applied).
+// line in the selected cell contains the ColorGridSelected background escape.
 func TestGridView_SelectedCellSubtitleHasBackground(t *testing.T) {
 	prev := lipgloss.ColorProfile()
 	lipgloss.SetColorProfile(termenv.TrueColor)
@@ -447,14 +455,31 @@ func TestGridView_SelectedCellSubtitleHasBackground(t *testing.T) {
 
 	selected := gv.renderCell(sess, 40, 15, true)
 	unselected := gv.renderCell(sess, 40, 15, false)
-	if !strings.Contains(selected, "Working on task") {
-		t.Error("subtitle text missing from selected cell")
+
+	findSubtitleLine := func(rendered string) string {
+		for _, line := range strings.Split(rendered, "\n") {
+			if strings.Contains(line, "Working on task") {
+				return line
+			}
+		}
+		return ""
 	}
-	if !strings.Contains(unselected, "Working on task") {
-		t.Error("subtitle text missing from unselected cell")
+
+	selSub := findSubtitleLine(selected)
+	unselSub := findSubtitleLine(unselected)
+	if selSub == "" {
+		t.Fatal("subtitle text missing from selected cell")
 	}
-	if selected == unselected {
-		t.Error("selected and unselected cells with subtitle should render differently")
+	if unselSub == "" {
+		t.Fatal("subtitle text missing from unselected cell")
+	}
+
+	bgEsc := styles.GridSelectedBgEsc
+	if !strings.Contains(selSub, bgEsc) {
+		t.Errorf("selected subtitle missing GridSelectedBgEsc %q: %q", bgEsc, selSub)
+	}
+	if strings.Contains(unselSub, bgEsc) {
+		t.Errorf("unselected subtitle should not contain GridSelectedBgEsc %q: %q", bgEsc, unselSub)
 	}
 }
 

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/lucascaro/hive/internal/state"
+	"github.com/muesli/termenv"
 )
 
 func TestGridViewView_ShowsStatusLegend(t *testing.T) {
@@ -402,6 +404,58 @@ func TestGridView_CursorWrap_SingleColumn(t *testing.T) {
 			t.Errorf("Cursor = %d, want 0", gv.Cursor)
 		}
 	})
+}
+
+// TestGridView_SelectedCellHasBackground verifies that renderCell produces
+// different output for selected vs unselected cells (the selected cell gets
+// a ColorGridSelected background tint on the content area).
+func TestGridView_SelectedCellHasBackground(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prev)
+	sess := &state.Session{
+		ID: "s1", ProjectID: "p1", Title: "test-sess",
+		AgentType: state.AgentClaude, Status: state.StatusRunning,
+	}
+	gv := &GridView{Active: true, Width: 80, Height: 20}
+	gv.Show([]*state.Session{sess}, state.GridRestoreProject)
+	gv.SetProjectColors(map[string]string{"p1": "#7C3AED"})
+	gv.SetContents(map[string]string{"s1": "hello world"})
+
+	selected := gv.renderCell(sess, 40, 15, true)
+	unselected := gv.renderCell(sess, 40, 15, false)
+	if selected == unselected {
+		t.Error("selected and unselected cells should render differently")
+	}
+}
+
+// TestGridView_SelectedCellSubtitleHasBackground verifies that the subtitle
+// line renders differently when the cell is selected (background tint applied).
+func TestGridView_SelectedCellSubtitleHasBackground(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prev)
+	sess := &state.Session{
+		ID: "s1", ProjectID: "p1", Title: "test",
+		AgentType: state.AgentClaude, Status: state.StatusRunning,
+		TmuxSession: "sess", TmuxWindow: 0,
+	}
+	gv := &GridView{Active: true, Width: 80, Height: 30}
+	gv.Show([]*state.Session{sess}, state.GridRestoreProject)
+	gv.SetProjectColors(map[string]string{"p1": "#7C3AED"})
+	gv.SetPaneTitles(map[string]string{"sess:0": "Working on task"})
+
+	selected := gv.renderCell(sess, 40, 15, true)
+	unselected := gv.renderCell(sess, 40, 15, false)
+	if !strings.Contains(selected, "Working on task") {
+		t.Error("subtitle text missing from selected cell")
+	}
+	if !strings.Contains(unselected, "Working on task") {
+		t.Error("subtitle text missing from unselected cell")
+	}
+	if selected == unselected {
+		t.Error("selected and unselected cells with subtitle should render differently")
+	}
 }
 
 // TestSanitizePaneTitle covers the sanitizer used to scrub untrusted OSC 0/2

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -19,8 +19,12 @@ var (
 	ColorText     = lipgloss.Color("#F9FAFB")
 	ColorSubtext  = lipgloss.Color("#9CA3AF")
 	ColorBorder   = lipgloss.Color("#374151")
-	ColorSelected = lipgloss.Color("#1E3A5F")
-	ColorBg       = lipgloss.Color("#111827")
+	ColorSelected     = lipgloss.Color("#1E3A5F")
+	ColorGridSelected = lipgloss.Color("#151520") // near-black purple tint for grid cell selection
+	// GridSelectedBgEsc is the raw ANSI escape to re-apply ColorGridSelected
+	// background after SGR resets in captured terminal content.
+	GridSelectedBgEsc = "\033[48;2;21;21;32m"
+	ColorBg           = lipgloss.Color("#111827")
 
 	// Agent type colors
 	AgentColors = map[string]lipgloss.Color{

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -19,9 +19,9 @@ var (
 	ColorText     = lipgloss.Color("#F9FAFB")
 	ColorSubtext  = lipgloss.Color("#9CA3AF")
 	ColorBorder   = lipgloss.Color("#374151")
-	ColorSelected     = lipgloss.Color("#1E3A5F")
+	ColorSelected = lipgloss.Color("#1E3A5F")
 	ColorGridSelected = lipgloss.Color("#151520") // near-black purple tint for grid cell selection
-	ColorBg           = lipgloss.Color("#111827")
+	ColorBg       = lipgloss.Color("#111827")
 )
 
 // GridSelectedBgEsc is the raw ANSI escape to re-apply ColorGridSelected

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -21,10 +21,21 @@ var (
 	ColorBorder   = lipgloss.Color("#374151")
 	ColorSelected     = lipgloss.Color("#1E3A5F")
 	ColorGridSelected = lipgloss.Color("#151520") // near-black purple tint for grid cell selection
-	// GridSelectedBgEsc is the raw ANSI escape to re-apply ColorGridSelected
-	// background after SGR resets in captured terminal content.
-	GridSelectedBgEsc = "\033[48;2;21;21;32m"
 	ColorBg           = lipgloss.Color("#111827")
+)
+
+// GridSelectedBgEsc is the raw ANSI escape to re-apply ColorGridSelected
+// background after SGR resets in captured terminal content.
+// Derived from ColorGridSelected so the two can never diverge.
+var GridSelectedBgEsc = func() string {
+	r, g, b, ok := parseHexRGB(string(ColorGridSelected))
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("\033[48;2;%d;%d;%dm", r, g, b)
+}()
+
+var (
 
 	// Agent type colors
 	AgentColors = map[string]lipgloss.Color{


### PR DESCRIPTION
## Summary
- Adds a subtle dark background tint (`ColorGridSelected` #151520) to the content preview and subtitle areas of the selected grid cell
- Patches ANSI SGR resets in captured terminal content to re-apply the background, so the tint persists through colored output
- Adds `TestGridView_SelectedCellHasBackground` and `TestGridView_SelectedCellSubtitleHasBackground` unit tests

Fixes #68

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing + 2 new tests)
- [ ] Visual QA: open grid view with multiple sessions, verify selected cell has visible background tint
- [ ] Visual QA: verify tint persists on lines with colored terminal output (ANSI resets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)