### PR TITLE
fix(settings): pop ViewSettings from stack after save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Grid mode toggle preserves selection**: pressing `g` while in the all-projects grid (or `G` while in a single-project grid) now keeps the currently-selected session and its project, instead of resetting to a different project's first session (#80).
-- **Settings save no longer blanks the screen**: confirming a settings save (`s` → `y`) now returns to the main view instead of leaving a black, unresponsive screen. The `ViewSettings` layer was being left on the view stack after the component deactivated itself, so `View()` rendered an empty string (#84).
+- **Settings save no longer blanks the screen**: confirming a settings save (`s` → `y`) now returns to the main view instead of leaving a black, unresponsive screen. The `ViewSettings` layer was being left on the view stack after the component deactivated itself, so `View()` rendered an empty string. The failure path (save error, e.g. read-only config dir) also pops the view now so the error surfaces in the statusbar instead of a black screen (#84).
 
 ## [0.8.0] — 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Grid mode toggle preserves selection**: pressing `g` while in the all-projects grid (or `G` while in a single-project grid) now keeps the currently-selected session and its project, instead of resetting to a different project's first session (#80).
+- **Settings save no longer blanks the screen**: confirming a settings save (`s` → `y`) now returns to the main view instead of leaving a black, unresponsive screen. The `ViewSettings` layer was being left on the view stack after the component deactivated itself, so `View()` rendered an empty string (#84).
 
 ## [0.8.0] — 2026-04-12
 

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,7 +7,8 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| P1 | #79 | Consolidate hotkey definitions and display between sidebar and grid modes | RESEARCH | M |
+| P1 | #85 | Terminal bell only sounds in sidebar view, not when attached to session | RESEARCH | M |
+| P2 | #79 | Consolidate hotkey definitions and display between sidebar and grid modes | RESEARCH | M |
 | — | #78 | Persist user preferences (e.g. start in grid mode) | TRIAGE | — |
 
 ## Rejected
@@ -51,3 +52,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | #76 | Organize settings into tabbed categories | #81 | 2026-04-12 |
 | #80 | Preserve selected project and session when toggling between grid views (g/G) | — | 2026-04-12 |
 | #75 | Add custom terminal bell sounds with settings option | #83 | 2026-04-12 |
+| #84 | Fix black screen after saving config with no way to continue | — | 2026-04-12 |

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -52,4 +52,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | #76 | Organize settings into tabbed categories | #81 | 2026-04-12 |
 | #80 | Preserve selected project and session when toggling between grid views (g/G) | — | 2026-04-12 |
 | #75 | Add custom terminal bell sounds with settings option | #83 | 2026-04-12 |
-| #84 | Fix black screen after saving config with no way to continue | — | 2026-04-12 |
+| #84 | Fix black screen after saving config with no way to continue | #86 | 2026-04-12 |

--- a/features/active/085-terminal-bell-only-sounds-in-sidebar-view.md
+++ b/features/active/085-terminal-bell-only-sounds-in-sidebar-view.md
@@ -1,0 +1,45 @@
+# Feature: Terminal bell only sounds in sidebar view, not when attached to session
+
+- **GitHub Issue:** #85
+- **Stage:** RESEARCH
+- **Type:** bug
+- **Complexity:** M
+- **Priority:** P2
+- **Branch:** —
+
+## Description
+
+The alarm/terminal bell only sounds when the user is out of a session (appears to be sidebar view only). When attached to a session, bell events from the running agent do not produce audio.
+
+Expected: bell events should sound regardless of which view the user is in — sidebar, grid, or attached to a session.
+
+## Research
+
+<Filled during RESEARCH stage.>
+
+### Relevant Code
+- `internal/audio/bell.go` — bell audio playback
+- `internal/escape/watcher.go` — bell detection via escape sequences
+- `internal/tmux/capture.go` — tmux pane capture path
+
+### Constraints / Dependencies
+- <anything blocking or complicating this>
+
+## Plan
+
+<Filled during PLAN stage.>
+
+### Files to Change
+1. `path/to/file.go` — <what and why>
+
+### Test Strategy
+- <how to verify>
+
+### Risks
+- <what could go wrong>
+
+## Implementation Notes
+
+<Filled during IMPLEMENT stage.>
+
+- **PR:** —

--- a/features/completed/084-fix-black-screen-after-saving-config.md
+++ b/features/completed/084-fix-black-screen-after-saving-config.md
@@ -1,0 +1,65 @@
+# Feature: Fix black screen after saving config with no way to continue
+
+- **GitHub Issue:** #84
+- **Stage:** DONE
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P1
+- **Branch:** —
+
+## Description
+
+After saving changes in the config/settings screen, the UI goes to a black screen with no visible content and no way to continue or return to the main view. The user is stuck and must kill the process.
+
+Expected: after saving config, the UI should return to the previous screen (or main view) with a confirmation, and all keybindings should remain functional.
+
+## Research
+
+**Root cause:** After save, the settings component is marked `Active=false` but `ViewSettings` is never popped from the view stack. The app's `View()` dispatches to `m.settings.View()`, which returns `""` because `sv.Active == false` — producing a black screen.
+
+**Code path:**
+1. `internal/tui/components/settings.go:207-208` — on "y" confirm, `sv.Close()` sets `Active=false` and returns `SettingsSaveRequestMsg`.
+2. `internal/tui/handle_system.go:56-65` — `handleSettingsSaveRequest()` saves config, returns `ConfigSavedMsg`. Does **not** pop the view.
+3. `internal/tui/handle_system.go:74-76` — `handleConfigSaved()` clears errors and returns `nil`. Also does not pop.
+4. `internal/tui/app.go:353-357` — `View()` sees `TopView() == ViewSettings`, calls `m.settings.View()` → empty string (inactive).
+
+**Viewstack behavior** (`internal/tui/viewstack.go:46-62`): `PopView()` is safe — removes top if len > 1, else returns `ViewMain`. `ViewMain` is always the bottom entry (`app.go:154`).
+
+**Test gap:** `internal/tui/flow_settings_test.go:120` (`TestFlow_Settings_SaveStillWorks`) checks `settings.Active` but does not assert view stack state — which is why this regression slipped through.
+
+### Relevant Code
+- `internal/tui/components/settings.go:207` — `Close()` on save confirm
+- `internal/tui/handle_system.go:56-76` — save request & config-saved handlers (missing `PopView()`)
+- `internal/tui/app.go:353-357` — view dispatch on `ViewSettings`
+- `internal/tui/viewstack.go:46-62` — `PopView`/`TopView` semantics
+- `internal/tui/flow_settings_test.go:120` — existing test needs stack assertion
+
+### Constraints / Dependencies
+- None. Fix is local to `handle_system.go` + test update.
+
+## Plan
+
+**Fix:** in `handleConfigSaved()`, pop `ViewSettings` from the stack after save succeeds. Keeping the pop in `handleConfigSaved` (not `handleSettingsSaveRequest`) means on save-error the settings view stays open so the user sees the error.
+
+### Files to Change
+1. `internal/tui/handle_system.go:74-77` — `handleConfigSaved()`: guard `if m.TopView() == ViewSettings`, call `m.settings.Close()` and `m.PopView()` before returning. Mirrors `handleSettingsClosed` (lines 68-72).
+2. `internal/tui/flow_settings_test.go:105-123` — `TestFlow_Settings_SaveStillWorks`: add assertion `f.model.TopView() == ViewMain` and a main-view render check after save confirm.
+3. `internal/tui/flow_settings_test.go` — new test `TestFlow_Settings_SaveError_KeepsSettingsOpen`: induce a save error, assert `TopView() == ViewSettings` remains.
+
+### Test Strategy
+- Updated flow test `TestFlow_Settings_SaveStillWorks`: `TopView() == ViewMain` + non-empty render after save.
+- New flow test `TestFlow_Settings_SaveError_KeepsSettingsOpen`: settings stays on stack on error.
+- Unit test `TestHandleConfigSaved_PopsView` in `handle_system_test.go` (new or existing): directly invoke `handleConfigSaved()` with `ViewSettings` pushed, assert popped and `LastError` cleared.
+
+### Risks
+- `handleConfigSaved` dispatched when settings not on top (external config reload) — guard with `TopView() == ViewSettings` check.
+- Inducing save error in flow test may need filesystem manipulation — verify existing test patterns.
+
+## Implementation Notes
+
+- Added `TopView() == ViewSettings` guard + `m.settings.Close()` + `m.PopView()` in `handleConfigSaved` (internal/tui/handle_system.go:74).
+- Updated `TestFlow_Settings_SaveStillWorks` to use `ExecCmdChain` so the SettingsSaveRequestMsg → ConfigSavedMsg chain actually runs, and added assertions for `TopView() == ViewMain` and non-empty render. Existing test silently hid the bug because it never executed the returned cmd.
+- Added unit tests in `internal/tui/handle_system_test.go` covering the pop-on-settings-top and noop-when-not-on-top cases.
+- Skipped the planned `SaveError_KeepsSettingsOpen` flow test: inducing a real `config.Save` failure requires filesystem manipulation on a per-test basis. The unit tests cover both TopView branches; the save-error path is pre-existing behavior (settings component also renders blank when Active=false after `sv.Close()` at components/settings.go:207). Surfacing save errors visibly is a separate issue worth filing.
+
+- **PR:** —

--- a/features/completed/084-fix-black-screen-after-saving-config.md
+++ b/features/completed/084-fix-black-screen-after-saving-config.md
@@ -60,6 +60,6 @@ Expected: after saving config, the UI should return to the previous screen (or m
 - Added `TopView() == ViewSettings` guard + `m.settings.Close()` + `m.PopView()` in `handleConfigSaved` (internal/tui/handle_system.go:74).
 - Updated `TestFlow_Settings_SaveStillWorks` to use `ExecCmdChain` so the SettingsSaveRequestMsg → ConfigSavedMsg chain actually runs, and added assertions for `TopView() == ViewMain` and non-empty render. Existing test silently hid the bug because it never executed the returned cmd.
 - Added unit tests in `internal/tui/handle_system_test.go` covering the pop-on-settings-top and noop-when-not-on-top cases.
-- Skipped the planned `SaveError_KeepsSettingsOpen` flow test: inducing a real `config.Save` failure requires filesystem manipulation on a per-test basis. The unit tests cover both TopView branches; the save-error path is pre-existing behavior (settings component also renders blank when Active=false after `sv.Close()` at components/settings.go:207). Surfacing save errors visibly is a separate issue worth filing.
+- Review (gstack-review) caught that the failure path of `handleSettingsSaveRequest` had the same black-screen bug — component already self-closed but view stack wasn't popped on error, so `LastError` was set but hidden. Fixed by also popping in the error branch. Added `TestFlow_Settings_SaveError_PopsViewAndShowsError` which chmods the config dir read-only to induce a real `config.Save` failure and asserts `TopView=ViewMain` + non-empty `LastError`.
 
-- **PR:** —
+- **PR:** #86

--- a/internal/tui/flow_settings_test.go
+++ b/internal/tui/flow_settings_test.go
@@ -1,10 +1,14 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/lucascaro/hive/internal/config"
 )
 
 // openSettings pushes the Settings view via the configured keybinding ("S").
@@ -127,5 +131,40 @@ func TestFlow_Settings_SaveStillWorks(t *testing.T) {
 	}
 	if strings.TrimSpace(f.View()) == "" {
 		t.Error("expected non-empty main view render after save, got blank")
+	}
+}
+
+func TestFlow_Settings_SaveError_PopsViewAndShowsError(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	openSettings(t, f)
+	f.SendSpecialKey(tea.KeyEnter) // toggle Theme → dirty
+	if !f.model.settings.IsDirty() {
+		t.Fatal("precondition: expected dirty")
+	}
+	f.SendKey("s")
+	if !f.model.settings.IsPendingSave() {
+		t.Fatal("precondition: expected pendingSave=true")
+	}
+
+	// Make the config dir read-only so config.Save fails atomically.
+	cfgDir := filepath.Dir(config.ConfigPath())
+	if err := os.Chmod(cfgDir, 0o500); err != nil {
+		t.Fatalf("chmod config dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cfgDir, 0o700) })
+
+	cmd := f.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	f.ExecCmdChain(cmd)
+
+	if got := f.model.TopView(); got != ViewMain {
+		t.Errorf("TopView after save error = %v, want ViewMain (so statusbar renders)", got)
+	}
+	if f.model.appState.LastError == "" {
+		t.Error("LastError should be set after save failure")
+	}
+	if strings.TrimSpace(f.View()) == "" {
+		t.Error("expected non-empty render after save error, got blank")
 	}
 }

--- a/internal/tui/flow_settings_test.go
+++ b/internal/tui/flow_settings_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -115,9 +116,16 @@ func TestFlow_Settings_SaveStillWorks(t *testing.T) {
 	if !f.model.settings.IsPendingSave() {
 		t.Fatal("precondition: expected pendingSave=true")
 	}
-	f.SendKey("y") // confirm
+	cmd := f.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")}) // confirm
+	f.ExecCmdChain(cmd)                                                // run save + ConfigSavedMsg
 
 	if f.model.settings.Active {
 		t.Error("expected settings closed after save confirm")
+	}
+	if got := f.model.TopView(); got != ViewMain {
+		t.Errorf("expected TopView=ViewMain after save, got %v", got)
+	}
+	if strings.TrimSpace(f.View()) == "" {
+		t.Error("expected non-empty main view render after save, got blank")
 	}
 }

--- a/internal/tui/flow_settings_test.go
+++ b/internal/tui/flow_settings_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -135,6 +136,9 @@ func TestFlow_Settings_SaveStillWorks(t *testing.T) {
 }
 
 func TestFlow_Settings_SaveError_PopsViewAndShowsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod directory perms don't block writes on Windows")
+	}
 	m, mock := testFlowModel(t)
 	f := newFlowRunner(t, m, mock)
 

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -56,6 +56,12 @@ func (m Model) handleStateWatch(msg stateWatchMsg) (tea.Model, tea.Cmd) {
 func (m Model) handleSettingsSaveRequest(msg components.SettingsSaveRequestMsg) (tea.Model, tea.Cmd) {
 	newCfg := msg.Config
 	if err := config.Save(newCfg); err != nil {
+		// Pop the (already-deactivated) settings view so the main statusbar
+		// can surface the error — otherwise the user sees a black screen.
+		if m.TopView() == ViewSettings {
+			m.settings.Close()
+			m.PopView()
+		}
 		return m, func() tea.Msg {
 			return ErrorMsg{Err: fmt.Errorf("save settings: %w", err)}
 		}

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -73,6 +73,10 @@ func (m Model) handleSettingsClosed() (tea.Model, tea.Cmd) {
 
 func (m Model) handleConfigSaved() (tea.Model, tea.Cmd) {
 	m.appState.LastError = "" // clear any previous error
+	if m.TopView() == ViewSettings {
+		m.settings.Close()
+		m.PopView()
+	}
 	return m, nil
 }
 

--- a/internal/tui/handle_system_test.go
+++ b/internal/tui/handle_system_test.go
@@ -5,8 +5,7 @@ import (
 )
 
 func TestHandleConfigSaved_PopsSettingsView(t *testing.T) {
-	m, mock := testFlowModel(t)
-	_ = mock
+	m, _ := testFlowModel(t)
 	m.appState.LastError = "prior error"
 	m.PushView(ViewSettings)
 
@@ -27,8 +26,7 @@ func TestHandleConfigSaved_PopsSettingsView(t *testing.T) {
 }
 
 func TestHandleConfigSaved_NoopWhenSettingsNotOnTop(t *testing.T) {
-	m, mock := testFlowModel(t)
-	_ = mock
+	m, _ := testFlowModel(t)
 	m.appState.LastError = "prior error"
 	// Stack stays at ViewMain; e.g. config reloaded externally.
 

--- a/internal/tui/handle_system_test.go
+++ b/internal/tui/handle_system_test.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestHandleConfigSaved_PopsSettingsView(t *testing.T) {
+	m, mock := testFlowModel(t)
+	_ = mock
+	m.appState.LastError = "prior error"
+	m.PushView(ViewSettings)
+
+	result, cmd := m.handleConfigSaved()
+	m = result.(Model)
+	if cmd != nil {
+		t.Errorf("expected nil cmd, got %v", cmd)
+	}
+	if got := m.TopView(); got != ViewMain {
+		t.Errorf("TopView = %v, want ViewMain", got)
+	}
+	if m.settings.Active {
+		t.Error("settings.Active = true, want false after save")
+	}
+	if m.appState.LastError != "" {
+		t.Errorf("LastError = %q, want empty", m.appState.LastError)
+	}
+}
+
+func TestHandleConfigSaved_NoopWhenSettingsNotOnTop(t *testing.T) {
+	m, mock := testFlowModel(t)
+	_ = mock
+	m.appState.LastError = "prior error"
+	// Stack stays at ViewMain; e.g. config reloaded externally.
+
+	result, _ := m.handleConfigSaved()
+	m = result.(Model)
+	if got := m.TopView(); got != ViewMain {
+		t.Errorf("TopView = %v, want ViewMain", got)
+	}
+	if m.appState.LastError != "" {
+		t.Errorf("LastError = %q, want empty", m.appState.LastError)
+	}
+}


### PR DESCRIPTION
## Summary
- Confirming a settings save (`s` → `y`) left `ViewSettings` on the view stack while the component deactivated itself, so `View()` dispatched to `settings.View()` which returned `""` — a black, unresponsive screen.
- `handleConfigSaved` now closes settings and pops `ViewSettings` when it is on top of the stack.
- Fixed `TestFlow_Settings_SaveStillWorks` to execute the save cmd chain (it was silently hiding the bug) and added unit tests for the handler.

Fixes #84

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Manual: open settings, toggle a field, `s` → `y`, verify main view returns with no black screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)