### PR TITLE
feat(settings): show modal confirmation dialog when saving settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bell badge in grid view**: sessions with an unacknowledged bell now show a blinking `♪` badge replacing the status dot in the grid cell header, consistent with the existing sidebar indicator (#85).
 
 ### Changed
+- **Settings save confirmation dialog**: saving settings (`s`) now opens a modal confirmation dialog instead of the inline status-bar prompt, making the action more visible and consistent with other destructive-action dialogs (#93).
 - **Grid fills empty space**: when sessions don't evenly fill the grid layout, the last row now expands to use the remaining screen height instead of leaving a blank cell at the bottom (#89).
 
 ### Fixed

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -55,3 +55,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | #88 | Fix empty preview when session has insufficient text | — | — |
 | #78 | Persist user preferences — Startup View setting | — | — |
 | #89 | Extend grid cells to fill empty space in grid view | — | — |
+| #93 | Show confirmation dialog when saving settings | — | — |

--- a/features/completed/093-show-confirmation-dialog-when-saving-settings.md
+++ b/features/completed/093-show-confirmation-dialog-when-saving-settings.md
@@ -1,0 +1,102 @@
+# Feature: Show confirmation dialog when saving settings
+
+- **GitHub Issue:** #93
+- **Stage:** DONE
+- **Type:** enhancement
+- **Complexity:** S
+- **Priority:** P3
+- **Branch:** —
+
+## Description
+
+When saving settings in the settings view, the current confirmation feedback is shown in the status bar, which is easy to miss and not prominent enough. Users may not notice whether their settings were saved or not.
+
+The save confirmation should instead appear as a modal dialog, making it immediately clear that the action completed successfully. This improves discoverability and gives the save action the visual weight it deserves as a potentially impactful operation.
+
+## Research
+
+The current save flow lives entirely in the settings component. When the user presses `s` while dirty, `pendingSave = true`; the footer then shows "Save to [path]? y/enter: confirm  any other key: cancel". The next keypress either sends `SettingsSaveRequestMsg` or clears the flag.
+
+The existing `ViewConfirm` / `Confirm` dialog infrastructure is fully built and used for kill-session, kill-project, etc. It works via `ConfirmActionMsg` → push `ViewConfirm` → `ConfirmedMsg{Action}` → `handleConfirmedAction(action)`.
+
+### Relevant Code
+- `internal/tui/components/settings.go:69` — `pendingSave bool` field; lines 201-213 handle the inline confirmation; lines 369-381 render it in the footer
+- `internal/tui/components/confirm.go` — `Confirm` struct with `Message`, `Action`; renders a rounded-border modal dialog with y/n hints
+- `internal/tui/viewstack.go:15` — `ViewConfirm` ID; line 104 syncs `appState.ShowConfirm`
+- `internal/tui/handle_system.go:104` — `handleConfirmAction` sets up confirm and pushes `ViewConfirm`; line 113 `handleConfirmed` dispatches to `handleConfirmedAction`
+- `internal/tui/operations.go:436` — `handleConfirmedAction(action string)` dispatches on string prefix; add "save-settings" here
+- `internal/tui/app.go:41` — `Model` struct; has `confirm components.Confirm` and `pendingWorktree*` pattern to follow for storing config pending save
+- `internal/tui/app.go:322` — `Update` switch; add case for `components.SettingsSaveConfirmMsg`
+- `internal/tui/messages.go:102` — `ConfirmActionMsg` and `ConfirmedMsg` types
+
+### Constraints / Dependencies
+- `components` package must not import `tui` package (circular import); a new message type `SettingsSaveConfirmMsg` defined in `components` will carry the pending config to the app layer
+- `handleCancelled` already pops the top view (ViewConfirm) cleanly, leaving ViewSettings intact — no changes needed there
+
+## Plan
+
+Replace the inline `pendingSave` status-bar prompt in `SettingsView` with the existing `ViewConfirm` modal dialog system. Settings emits a new message type on save; the app stores the pending config and pushes `ViewConfirm`; confirm dispatches `SettingsSaveRequestMsg`.
+
+### Files to Change
+
+1. `internal/tui/components/settings.go`
+   - Add `SettingsSaveConfirmMsg{Config config.Config}` type (and `var _ tea.Msg` compile-check)
+   - Remove `pendingSave bool` from `SettingsView` struct
+   - Remove `sv.pendingSave = false` from `Open()` and `Close()`
+   - Remove `IsPendingSave() bool` method
+   - Remove the `if sv.pendingSave { ... }` block in `Update()` (lines 201–213)
+   - Change `case "s":` handler (line 238): instead of `sv.pendingSave = true`, return `func() tea.Msg { return SettingsSaveConfirmMsg{Config: sv.cfg} }`; don't call `sv.Close()` here
+   - Remove `pendingSave` branch from `View()` footer (lines 369–374)
+
+2. `internal/tui/app.go`
+   - Add `pendingSaveConfig config.Config` field to `Model` struct (next to other `pending*` fields)
+   - Add `case components.SettingsSaveConfirmMsg:` in `Update()` switch → `m.handleSettingsSaveConfirm(msg)`
+
+3. `internal/tui/handle_system.go`
+   - Add `handleSettingsSaveConfirm(msg components.SettingsSaveConfirmMsg)`:
+     - Store `m.pendingSaveConfig = msg.Config`
+     - Set `m.appState.ConfirmMsg` and `m.appState.ConfirmAction = "save-settings"`
+     - Set `m.confirm.Message = fmt.Sprintf("Save settings to %s?", config.ConfigPath())` and `m.confirm.Action = "save-settings"`
+     - Call `m.PushView(ViewConfirm)`
+
+4. `internal/tui/operations.go` — `handleConfirmedAction`
+   - Add at the top: `if action == "save-settings" { cfg := m.pendingSaveConfig; return func() tea.Msg { return components.SettingsSaveRequestMsg{Config: cfg} } }`
+
+5. `internal/tui/components/settings_test.go`
+   - Update `TestSettingsView_PendingSaveConfirm`: pressing 's' while dirty should emit `SettingsSaveConfirmMsg`, not `SettingsSaveRequestMsg`
+   - Update/remove `TestSettingsView_SaveCancelledByOtherKey`: cancel is now handled by ViewConfirm, not settings
+   - Update/remove `TestSettingsView_SwitchTab_BlockedWhilePendingSave`: behavior moved to ViewConfirm layer
+
+6. `internal/tui/flow_settings_test.go`
+   - `TestFlow_Settings_SaveStillWorks`: replace `IsPendingSave()` check with `TopView() == ViewConfirm` check; add `ExecCmdChain` after 's' to push dialog; press 'y', then `ExecCmdChain` chain
+   - `TestFlow_Settings_SaveError_PopsViewAndShowsError`: same pattern
+
+7. `internal/tui/flow_bell_test.go`
+   - `TestFlow_BellSoundInSettings`: adjust save-flow assertion to match new two-step dispatch
+
+8. `CHANGELOG.md` — add `[Unreleased]` entry under `Changed`
+
+### Test Strategy
+
+- `TestSettingsView_SaveEmitsConfirmMsg` (new/renamed in `settings_test.go`) — pressing 's' while dirty returns `SettingsSaveConfirmMsg` with correct config
+- `TestFlow_Settings_SaveStillWorks` (updated) — full flow: 's' → ExecCmd → ViewConfirm on stack; 'y' → ExecCmdChain → settings closed, ViewMain
+- `TestFlow_Settings_SaveCancelStillWorks` (new in `flow_settings_test.go`) — 's' → ExecCmd → ViewConfirm; 'n' → ViewSettings still on top
+- `TestFlow_Settings_SaveError_PopsViewAndShowsError` (updated) — same setup, save fails → ViewMain, LastError set
+- `TestFlow_BellSoundInSettings` (updated) — verify new two-step dispatch carries config through
+
+### Risks
+
+- Existing tests deeply tied to `pendingSave` state — must update carefully
+- `handleCancelled` resets unrelated fields (`pendingWorktree`, etc.) — no issue, those are orthogonal
+- If user presses 's' again while confirm is already shown — ViewConfirm is already on stack; settings key won't be reached (keys route to top view only)
+
+## Implementation Notes
+
+- Removed `pendingSave bool` from `SettingsView` entirely; no `IsPendingSave()` method remains
+- `SettingsSaveConfirmMsg{Config}` defined in `components` to avoid circular import with `tui`
+- `pendingSaveConfig config.Config` added to `Model` to hold staged config while dialog is open
+- `handleConfirmedAction("save-settings")` retrieves config from `m.pendingSaveConfig` — no encoding in action string needed
+- Cancelling the dialog (n/esc) pops `ViewConfirm` via `handleConfirm`, leaving `ViewSettings` intact — no special handling needed
+- 7 test functions updated across 3 test files; 2 new tests added (`TestFlow_Settings_SaveCancel`, `TestSettingsView_SStillActiveAfterSPress`)
+
+- **PR:** —

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -60,6 +60,7 @@ type Model struct {
 	pendingProjectName string // name entered in step 1 of project creation
 	pendingProjectID   string
 	pendingAgentType   string // agent type awaiting install confirmation
+	pendingSaveConfig  config.Config // config staged for save while confirm dialog is open
 	// Worktree session creation
 	pendingWorktree          bool   // true when the next session should use a worktree
 	pendingWorktreeAgentType string // agent type selected for worktree session
@@ -319,6 +320,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleDirPicked(msg)
 	case components.DirPickerCancelMsg:
 		return m.handleDirPickerCancel()
+	case components.SettingsSaveConfirmMsg:
+		return m.handleSettingsSaveConfirm(msg)
 	case ConfirmActionMsg:
 		return m.handleConfirmAction(msg)
 	case ConfirmedMsg:

--- a/internal/tui/components/settings.go
+++ b/internal/tui/components/settings.go
@@ -19,6 +19,14 @@ type SettingsSaveRequestMsg struct {
 	Config config.Config
 }
 
+// SettingsSaveConfirmMsg is sent when the user requests to save settings,
+// triggering a confirmation dialog at the app level.
+type SettingsSaveConfirmMsg struct {
+	Config config.Config
+}
+
+var _ tea.Msg = SettingsSaveConfirmMsg{}
+
 // SettingsClosedMsg is sent when the settings screen is closed.
 type SettingsClosedMsg struct{}
 
@@ -66,7 +74,6 @@ type SettingsView struct {
 	editInput      textinput.Model
 	editErr        string
 	pendingDiscard bool
-	pendingSave    bool
 }
 
 // NewSettingsView creates a SettingsView.
@@ -86,7 +93,6 @@ func (sv *SettingsView) Open(cfg config.Config) {
 	sv.editing = false
 	sv.editErr = ""
 	sv.pendingDiscard = false
-	sv.pendingSave = false
 	sv.tabs = buildSettingTabs()
 	sv.activeTab = 0
 	sv.tabCursors = make([]int, len(sv.tabs))
@@ -99,7 +105,6 @@ func (sv *SettingsView) Close() {
 	sv.editing = false
 	sv.editInput.Blur()
 	sv.pendingDiscard = false
-	sv.pendingSave = false
 	sv.dirty = false
 }
 
@@ -133,9 +138,6 @@ func (sv *SettingsView) SelectedFieldLabel() string {
 	}
 	return f.label
 }
-
-// IsPendingSave reports whether the save-confirmation prompt is active.
-func (sv *SettingsView) IsPendingSave() bool { return sv.pendingSave }
 
 func (sv *SettingsView) currentFields() []*settingField {
 	if len(sv.tabs) == 0 {
@@ -198,20 +200,6 @@ func (sv *SettingsView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 		return sv.handleEditKey(msg)
 	}
 
-	// Handle pending save confirmation inline (no app-level overlay needed).
-	if sv.pendingSave {
-		switch msg.String() {
-		case "y", "enter":
-			sv.pendingSave = false
-			cfg := sv.cfg
-			sv.Close()
-			return func() tea.Msg { return SettingsSaveRequestMsg{Config: cfg} }, true
-		default:
-			sv.pendingSave = false
-		}
-		return nil, true
-	}
-
 	// Any key other than esc clears the pending-discard warning.
 	if msg.String() != "esc" {
 		sv.pendingDiscard = false
@@ -235,8 +223,8 @@ func (sv *SettingsView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 			sv.Close()
 			return func() tea.Msg { return SettingsClosedMsg{} }, true
 		}
-		sv.pendingSave = true
-		return nil, true
+		cfg := sv.cfg
+		return func() tea.Msg { return SettingsSaveConfirmMsg{Config: cfg} }, true
 
 	case "left", "h":
 		if sv.activeTab > 0 {
@@ -366,13 +354,7 @@ func (sv *SettingsView) View() string {
 
 	// Footer hints — build content then truncate before styling.
 	var footerParts []string
-	if sv.pendingSave {
-		footerParts = []string{
-			lipgloss.NewStyle().Foreground(styles.ColorWarning).Bold(true).Render("Save to " + config.ConfigPath() + "?"),
-			styles.HelpKeyStyle.Render("y/enter") + ":" + styles.HelpDescStyle.Render("confirm"),
-			styles.HelpKeyStyle.Render("any other key") + ":" + styles.HelpDescStyle.Render("cancel"),
-		}
-	} else if sv.pendingDiscard {
+	if sv.pendingDiscard {
 		footerParts = []string{
 			styles.ErrorStyle.Render("Unsaved changes! Press"),
 			styles.HelpKeyStyle.Render("esc"),

--- a/internal/tui/components/settings.go
+++ b/internal/tui/components/settings.go
@@ -25,8 +25,6 @@ type SettingsSaveConfirmMsg struct {
 	Config config.Config
 }
 
-var _ tea.Msg = SettingsSaveConfirmMsg{}
-
 // SettingsClosedMsg is sent when the settings screen is closed.
 type SettingsClosedMsg struct{}
 

--- a/internal/tui/components/settings_test.go
+++ b/internal/tui/components/settings_test.go
@@ -307,46 +307,37 @@ func TestSettingsView_SaveFlow(t *testing.T) {
 	// Make dirty
 	sv.Update(keyType(tea.KeyEnter)) // toggle theme
 
-	// Press s → pending save
-	sv.Update(keyPress("s"))
-	if !sv.pendingSave {
-		t.Error("expected pendingSave=true")
-	}
-
-	// Confirm with y
-	cmd, consumed := sv.Update(keyPress("y"))
+	// Press s → should emit SettingsSaveConfirmMsg (dialog handled at app level)
+	cmd, consumed := sv.Update(keyPress("s"))
 	if !consumed {
 		t.Error("expected consumed=true")
 	}
-	if sv.Active {
-		t.Error("expected Active=false after save confirm")
-	}
 	if cmd == nil {
-		t.Fatal("expected non-nil cmd")
+		t.Fatal("expected non-nil cmd from 's' press")
+	}
+	if !sv.Active {
+		t.Error("expected settings to remain active (close happens after confirm)")
 	}
 	msg := cmd()
-	save, ok := msg.(SettingsSaveRequestMsg)
+	confirm, ok := msg.(SettingsSaveConfirmMsg)
 	if !ok {
-		t.Fatalf("expected SettingsSaveRequestMsg, got %T", msg)
+		t.Fatalf("expected SettingsSaveConfirmMsg, got %T", msg)
 	}
-	if save.Config.Theme != "light" {
-		t.Errorf("expected saved theme=light, got %s", save.Config.Theme)
+	if confirm.Config.Theme != "light" {
+		t.Errorf("confirm msg Config.Theme = %q, want \"light\"", confirm.Config.Theme)
 	}
 }
 
-func TestSettingsView_SaveCancelledByOtherKey(t *testing.T) {
+func TestSettingsView_SStillActiveAfterSPress(t *testing.T) {
 	sv := NewSettingsView()
 	sv.Open(testConfig())
 
 	sv.Update(keyType(tea.KeyEnter)) // make dirty
-	sv.Update(keyPress("s"))         // pending save
+	sv.Update(keyPress("s"))         // request save → emits SettingsSaveConfirmMsg
 
-	sv.Update(keyPress("n")) // cancel save
-	if sv.pendingSave {
-		t.Error("expected pendingSave=false after cancel")
-	}
+	// Settings should still be active — cancel/confirm are handled by the dialog
 	if !sv.Active {
-		t.Error("expected still active after save cancel")
+		t.Error("expected settings still active after 's' (dialog not yet confirmed)")
 	}
 }
 
@@ -373,22 +364,22 @@ func TestSettingsView_SaveConfirmedWithEnter(t *testing.T) {
 	sv.Open(testConfig())
 
 	sv.Update(keyType(tea.KeyEnter)) // toggle theme → dirty
-	sv.Update(keyPress("s"))         // pending save
 
-	// Confirm with enter (source also accepts "y")
-	cmd, consumed := sv.Update(keyType(tea.KeyEnter))
+	// Press s — the confirmation dialog is now at the app level (ViewConfirm).
+	// Settings emits SettingsSaveConfirmMsg and stays active.
+	cmd, consumed := sv.Update(keyPress("s"))
 	if !consumed {
 		t.Error("expected consumed=true")
 	}
-	if sv.Active {
-		t.Error("expected Active=false after enter-confirm")
+	if !sv.Active {
+		t.Error("expected Active=true after 's' (dialog is at app level)")
 	}
 	if cmd == nil {
-		t.Fatal("expected non-nil cmd")
+		t.Fatal("expected non-nil cmd from 's'")
 	}
 	msg := cmd()
-	if _, ok := msg.(SettingsSaveRequestMsg); !ok {
-		t.Fatalf("expected SettingsSaveRequestMsg, got %T", msg)
+	if _, ok := msg.(SettingsSaveConfirmMsg); !ok {
+		t.Fatalf("expected SettingsSaveConfirmMsg, got %T", msg)
 	}
 }
 
@@ -595,21 +586,20 @@ func TestSettingsView_SwitchTab_BlockedWhileEditing(t *testing.T) {
 	}
 }
 
-func TestSettingsView_SwitchTab_BlockedWhilePendingSave(t *testing.T) {
+func TestSettingsView_TabSwitchAfterSPress(t *testing.T) {
 	sv := NewSettingsView()
 	sv.Open(testConfig())
 
 	sv.Update(keyType(tea.KeyEnter)) // toggle theme → dirty
-	sv.Update(keyPress("s"))         // pendingSave
-	if !sv.pendingSave {
-		t.Fatal("precondition: pendingSave=true")
-	}
+	sv.Update(keyPress("s"))         // emits SettingsSaveConfirmMsg; settings stays active
 
 	startTab := sv.activeTab
-	// "l" isn't y/enter — it cancels pending save but must NOT switch tabs.
+	// After 's', settings is still active and keys work normally again
+	// (the confirm dialog is at the app layer, not here).
 	sv.Update(keyPress("l"))
-	if sv.activeTab != startTab {
-		t.Errorf("activeTab changed while pendingSave: got %d, want %d", sv.activeTab, startTab)
+	// Tab should switch since there is no pendingSave lock here anymore.
+	if sv.activeTab == startTab && len(sv.tabs) > 1 {
+		t.Errorf("expected tab to switch after 'l', still at %d", sv.activeTab)
 	}
 }
 

--- a/internal/tui/components/settings_test.go
+++ b/internal/tui/components/settings_test.go
@@ -593,12 +593,15 @@ func TestSettingsView_TabSwitchAfterSPress(t *testing.T) {
 	sv.Update(keyType(tea.KeyEnter)) // toggle theme → dirty
 	sv.Update(keyPress("s"))         // emits SettingsSaveConfirmMsg; settings stays active
 
+	if len(sv.tabs) < 2 {
+		t.Skip("need multiple tabs to test switch")
+	}
 	startTab := sv.activeTab
 	// After 's', settings is still active and keys work normally again
 	// (the confirm dialog is at the app layer, not here).
 	sv.Update(keyPress("l"))
 	// Tab should switch since there is no pendingSave lock here anymore.
-	if sv.activeTab == startTab && len(sv.tabs) > 1 {
+	if sv.activeTab == startTab {
 		t.Errorf("expected tab to switch after 'l', still at %d", sv.activeTab)
 	}
 }

--- a/internal/tui/flow_bell_test.go
+++ b/internal/tui/flow_bell_test.go
@@ -72,16 +72,26 @@ func TestFlow_BellSoundInSettings(t *testing.T) {
 		t.Errorf("BellSound after one Enter = %q, want %q", got, audio.BellBee)
 	}
 
-	// Save flow: 's' then 'y'.
-	f.SendKey("s")
-	cmd := f.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-	if cmd == nil {
-		t.Fatal("save confirm should emit a SettingsSaveRequestMsg cmd")
+	// Save flow: 's' → confirm dialog → 'y' → SettingsSaveRequestMsg.
+	cmd := f.SendKey("s") // emits SettingsSaveConfirmMsg
+	f.ExecCmdChain(cmd)   // pushes ViewConfirm
+
+	// 'y' triggers handleConfirm → ConfirmedMsg → handleConfirmedAction("save-settings")
+	// → SettingsSaveRequestMsg.
+	confirmCmd := f.SendKey("y")
+	if confirmCmd == nil {
+		t.Fatal("'y' on confirm dialog should emit a cmd")
 	}
-	msg := cmd()
-	save, ok := msg.(components.SettingsSaveRequestMsg)
+	// confirmCmd returns ConfirmedMsg; run it through Update to get SettingsSaveRequestMsg cmd.
+	confirmedMsg := confirmCmd()
+	saveCmd := f.Send(confirmedMsg)
+	if saveCmd == nil {
+		t.Fatal("ConfirmedMsg should emit a SettingsSaveRequestMsg cmd")
+	}
+	saveMsg := saveCmd()
+	save, ok := saveMsg.(components.SettingsSaveRequestMsg)
 	if !ok {
-		t.Fatalf("save cmd produced %T, want SettingsSaveRequestMsg", msg)
+		t.Fatalf("save cmd produced %T, want SettingsSaveRequestMsg", saveMsg)
 	}
 	if save.Config.BellSound != audio.BellBee {
 		t.Errorf("saved Config.BellSound = %q, want %q", save.Config.BellSound, audio.BellBee)

--- a/internal/tui/flow_settings_test.go
+++ b/internal/tui/flow_settings_test.go
@@ -118,12 +118,14 @@ func TestFlow_Settings_SaveStillWorks(t *testing.T) {
 	if !f.model.settings.IsDirty() {
 		t.Fatal("precondition: expected dirty")
 	}
-	f.SendKey("s") // pending save
-	if !f.model.settings.IsPendingSave() {
-		t.Fatal("precondition: expected pendingSave=true")
+	cmd := f.SendKey("s") // emits SettingsSaveConfirmMsg
+	f.ExecCmdChain(cmd)   // processes msg → pushes ViewConfirm
+
+	if got := f.model.TopView(); got != ViewConfirm {
+		t.Fatalf("expected ViewConfirm after 's', got %v", got)
 	}
-	cmd := f.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")}) // confirm
-	f.ExecCmdChain(cmd)                                                // run save + ConfigSavedMsg
+	cmd = f.SendKey("y") // confirm → ConfirmedMsg → SettingsSaveRequestMsg
+	f.ExecCmdChain(cmd)  // run save + ConfigSavedMsg
 
 	if f.model.settings.Active {
 		t.Error("expected settings closed after save confirm")
@@ -148,9 +150,11 @@ func TestFlow_Settings_SaveError_PopsViewAndShowsError(t *testing.T) {
 	if !f.model.settings.IsDirty() {
 		t.Fatal("precondition: expected dirty")
 	}
-	f.SendKey("s")
-	if !f.model.settings.IsPendingSave() {
-		t.Fatal("precondition: expected pendingSave=true")
+	cmd := f.SendKey("s") // emits SettingsSaveConfirmMsg
+	f.ExecCmdChain(cmd)   // pushes ViewConfirm
+
+	if got := f.model.TopView(); got != ViewConfirm {
+		t.Fatalf("expected ViewConfirm after 's', got %v", got)
 	}
 
 	// Make the config dir read-only so config.Save fails atomically.
@@ -160,7 +164,7 @@ func TestFlow_Settings_SaveError_PopsViewAndShowsError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(cfgDir, 0o700) })
 
-	cmd := f.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	cmd = f.SendKey("y") // confirm → SettingsSaveRequestMsg → save fails
 	f.ExecCmdChain(cmd)
 
 	if got := f.model.TopView(); got != ViewMain {
@@ -171,6 +175,36 @@ func TestFlow_Settings_SaveError_PopsViewAndShowsError(t *testing.T) {
 	}
 	if strings.TrimSpace(f.View()) == "" {
 		t.Error("expected non-empty render after save error, got blank")
+	}
+}
+
+func TestFlow_Settings_SaveCancel(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	openSettings(t, f)
+	f.SendSpecialKey(tea.KeyEnter) // toggle Theme → dirty
+	if !f.model.settings.IsDirty() {
+		t.Fatal("precondition: expected dirty")
+	}
+	cmd := f.SendKey("s") // emits SettingsSaveConfirmMsg
+	f.ExecCmdChain(cmd)   // pushes ViewConfirm
+
+	if got := f.model.TopView(); got != ViewConfirm {
+		t.Fatalf("expected ViewConfirm after 's', got %v", got)
+	}
+
+	// Cancel the dialog
+	f.SendKey("n")
+
+	if got := f.model.TopView(); got != ViewSettings {
+		t.Errorf("expected ViewSettings after cancel, got %v", got)
+	}
+	if !f.model.settings.Active {
+		t.Error("expected settings still active after cancel")
+	}
+	if !f.model.settings.IsDirty() {
+		t.Error("expected settings still dirty after cancel")
 	}
 }
 

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -2,7 +2,9 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -79,6 +81,7 @@ func (m Model) handleSettingsClosed() (tea.Model, tea.Cmd) {
 
 func (m Model) handleConfigSaved() (tea.Model, tea.Cmd) {
 	m.appState.LastError = "" // clear any previous error
+	m.pendingSaveConfig = config.Config{}
 	if m.TopView() == ViewSettings {
 		m.settings.Close()
 		m.PopView()
@@ -103,7 +106,13 @@ func (m Model) handleQuitAndKill() (tea.Model, tea.Cmd) {
 
 func (m Model) handleSettingsSaveConfirm(msg components.SettingsSaveConfirmMsg) (tea.Model, tea.Cmd) {
 	m.pendingSaveConfig = msg.Config
-	confirmMsg := fmt.Sprintf("Save settings to %s?", config.ConfigPath())
+	path := config.ConfigPath()
+	if home, err := os.UserHomeDir(); err == nil {
+		if rel, err := filepath.Rel(home, path); err == nil && !strings.HasPrefix(rel, "..") {
+			path = "~" + string(filepath.Separator) + rel
+		}
+	}
+	confirmMsg := fmt.Sprintf("Save settings to %s?", path)
 	m.appState.ConfirmMsg = confirmMsg
 	m.appState.ConfirmAction = "save-settings"
 	m.confirm.Message = confirmMsg

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -101,6 +101,17 @@ func (m Model) handleQuitAndKill() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
+func (m Model) handleSettingsSaveConfirm(msg components.SettingsSaveConfirmMsg) (tea.Model, tea.Cmd) {
+	m.pendingSaveConfig = msg.Config
+	confirmMsg := fmt.Sprintf("Save settings to %s?", config.ConfigPath())
+	m.appState.ConfirmMsg = confirmMsg
+	m.appState.ConfirmAction = "save-settings"
+	m.confirm.Message = confirmMsg
+	m.confirm.Action = "save-settings"
+	m.PushView(ViewConfirm)
+	return m, nil
+}
+
 func (m Model) handleConfirmAction(msg ConfirmActionMsg) (tea.Model, tea.Cmd) {
 	m.appState.ConfirmMsg = msg.Message
 	m.appState.ConfirmAction = msg.Action

--- a/internal/tui/operations.go
+++ b/internal/tui/operations.go
@@ -434,6 +434,10 @@ func (m *Model) killAllSessions() {
 }
 
 func (m Model) handleConfirmedAction(action string) tea.Cmd {
+	if action == "save-settings" {
+		cfg := m.pendingSaveConfig
+		return func() tea.Msg { return components.SettingsSaveRequestMsg{Config: cfg} }
+	}
 	if strings.HasPrefix(action, "kill-session:") {
 		sessionID := strings.TrimPrefix(action, "kill-session:")
 		return m.killSession(sessionID)


### PR DESCRIPTION
## Summary

- Replaces the inline status-bar save confirmation (`pendingSave` flag + footer prompt) with the existing `ViewConfirm` modal dialog system
- Pressing `s` in settings now opens a prominent, centered confirmation dialog — consistent with kill-session and other destructive-action dialogs
- Cancelling (`n`/`esc`) dismisses the dialog and leaves settings open with unsaved changes intact

## How it works

1. Settings emits `SettingsSaveConfirmMsg{Config}` when `s` is pressed (dirty state)
2. App stores the pending config and pushes `ViewConfirm` on top of `ViewSettings`
3. Confirming (`y`/`enter`) dispatches `SettingsSaveRequestMsg` via the existing `handleConfirmedAction("save-settings")` path
4. Cancelling pops `ViewConfirm`, returning to the settings view

## Test plan

- [x] `TestFlow_Settings_SaveStillWorks` — full save flow: `s` → confirm dialog → `y` → settings closed, main view
- [x] `TestFlow_Settings_SaveCancel` (new) — `s` → confirm dialog → `n` → settings still open and dirty
- [x] `TestFlow_Settings_SaveError_PopsViewAndShowsError` — save failure surfaces in status bar
- [x] `TestFlow_BellSoundInSettings` — correct config propagates through new two-step dispatch
- [x] `TestSettingsView_SaveFlow` — component-level: `s` emits `SettingsSaveConfirmMsg` with correct config
- [x] `go test ./...` — all tests pass

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)