### PR TITLE
feat(settings): constrain panel max-width and center on wide terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`d` kill-session alias removed**: sessions are killed with `x` only; the `d` alias no longer works (#79).
 - **Consistent grid actions**: `?` (help), `S` (settings), `H` (tmux reference), and `q` (quit app) now work in grid view the same as in sidebar view. Previously `q` in the grid only closed the grid; it now quits the app. Use `Esc` or `g`/`G` to exit the grid without quitting (#79).
 - **Settings save confirmation dialog**: saving settings (`s`) now opens a modal confirmation dialog instead of the inline status-bar prompt, making the action more visible and consistent with other destructive-action dialogs (#93).
+- **Settings panel max-width**: settings panel now caps at 100 columns and is centered on wider terminals, making it easier to use without stretching across the full screen (#98).
 - **Grid fills empty space**: when sessions don't evenly fill the grid layout, the last row now expands to use the remaining screen height instead of leaving a blank cell at the bottom (#89).
 
 ### Fixed

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -57,3 +57,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | #79 | Consolidate hotkey definitions and display between sidebar and grid modes | — | — |
 | #93 | Show confirmation dialog when saving settings | — | — |
 | #94 | Play bell sound on selection and add volume control in settings | — | — |
+| #98 | Constrain settings panel max-width on wide screens | #99 | 2026-04-12 |

--- a/features/completed/098-constrain-settings-panel-max-width-on-wide.md
+++ b/features/completed/098-constrain-settings-panel-max-width-on-wide.md
@@ -1,0 +1,48 @@
+# Feature: Constrain settings panel max-width on wide screens
+
+- **GitHub Issue:** #98
+- **Stage:** DONE
+- **Type:** enhancement
+- **Complexity:** S
+- **Priority:** P1
+- **Branch:** —
+
+## Description
+
+The settings panel currently expands to fill the full terminal width on wide screens, making it harder to use — form fields stretch to extreme widths, reducing readability and ergonomics. The panel should have a sensible maximum width so it stays compact and usable regardless of terminal size. Content should be centered or left-anchored within the available space.
+
+## Research
+
+The settings panel uses its full `Width` field for every rendered element. Width is set to `TermWidth` before each render. A simple max-width cap with centering solves the problem with minimal code change.
+
+### Relevant Code
+- `internal/tui/components/settings.go:329` — `View()` computes `w := sv.Width` and uses it for all sub-elements (header, tab strip, body, footer). Capping `w` here and centering the final output in `sv.Width` is the complete fix.
+- `internal/tui/app.go:404` — sets `m.settings.Width = m.appState.TermWidth` immediately before calling `m.settings.View()`. No change needed here.
+
+### Constraints / Dependencies
+- None. The fix is entirely within `View()` in a single file. No state, no messages, no other components involved.
+
+## Plan
+
+Cap the rendered settings panel at a sensible max width and center it within the terminal.
+
+### Files to Change
+1. `internal/tui/components/settings.go` — In `View()`, save the full terminal width as `fullW := sv.Width`, then cap `w` at a new `maxSettingsWidth = 100` constant. After building the panel with `lipgloss.JoinVertical`, wrap the result with `lipgloss.Place(fullW, h, lipgloss.Center, lipgloss.Top, panel)` to center it horizontally on wide terminals.
+2. `CHANGELOG.md` — Add `[Unreleased]` entry: "Settings panel now has a maximum width and is centered on wide terminals."
+
+### Test Strategy
+- `internal/tui/components/settings_test.go` — Add `TestSettingsViewMaxWidth`: open a `SettingsView` with `Width=200, Height=40`, call `View()`, assert that `lipgloss.Width(view) == 200` (outer wrapper is full width) but that the visible panel content does not exceed `maxSettingsWidth + padding`.
+- Run `go test ./...` — all existing tests must pass.
+
+### Risks
+- `renderTabStrip` uses `w` for its full-width fill — works fine since `w` is still ≥ any real field width.
+- `lipgloss.Place` pads with spaces to fill `fullW`; this is the expected TUI behavior for centering and harmless for the outer terminal viewport.
+
+## Implementation Notes
+
+- Added `maxSettingsWidth = 100` const in `settings.go`.
+- In `View()`, saved `fullW := sv.Width` before capping `w`; used `lipgloss.Place(fullW, h, lipgloss.Center, lipgloss.Top, panel)` to center when `fullW > w`.
+- Added `TestSettingsViewMaxWidth` in `settings_test.go`: verifies outer line width equals `sv.Width` and trimmed content lines stay within `maxSettingsWidth`.
+- No deviations from the plan.
+
+- **PR:** #99

--- a/internal/tui/components/settings.go
+++ b/internal/tui/components/settings.go
@@ -320,16 +320,24 @@ func (sv *SettingsView) startEditing(f *settingField) {
 	sv.editInput.Focus()
 }
 
+// maxSettingsWidth is the maximum width the settings panel will occupy.
+// On wider terminals the panel is centered within the full terminal width.
+const maxSettingsWidth = 100
+
 // View renders the full-screen settings panel.
 func (sv *SettingsView) View() string {
 	if !sv.Active {
 		return ""
 	}
 
+	fullW := sv.Width
 	w := sv.Width
 	h := sv.Height
 	if w <= 0 {
 		w = 80
+	}
+	if w > maxSettingsWidth {
+		w = maxSettingsWidth
 	}
 	if h <= 0 {
 		h = 24
@@ -446,7 +454,11 @@ func (sv *SettingsView) View() string {
 		Padding(0, 2).
 		Render(strings.Join(visible, "\n"))
 
-	return lipgloss.JoinVertical(lipgloss.Left, header, tabStrip, body, footer)
+	panel := lipgloss.JoinVertical(lipgloss.Left, header, tabStrip, body, footer)
+	if fullW > w {
+		return lipgloss.Place(fullW, h, lipgloss.Center, lipgloss.Top, panel)
+	}
+	return panel
 }
 
 // tabActiveBg matches StatusBarStyle's background so the active tab reads

--- a/internal/tui/components/settings.go
+++ b/internal/tui/components/settings.go
@@ -330,6 +330,10 @@ func (sv *SettingsView) View() string {
 		return ""
 	}
 
+	// fullW is captured before the zero-guard so it always reflects the real
+	// terminal width. When sv.Width is 0 (invalid), fullW=0 and w is corrected
+	// to 80; fullW > w is false, so lipgloss.Place is skipped — the panel
+	// renders at the fallback width without centering, which is fine.
 	fullW := sv.Width
 	w := sv.Width
 	h := sv.Height

--- a/internal/tui/components/settings_test.go
+++ b/internal/tui/components/settings_test.go
@@ -1,10 +1,12 @@
 package components
 
 import (
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/lucascaro/hive/internal/audio"
 	"github.com/lucascaro/hive/internal/config"
@@ -719,6 +721,39 @@ func TestSettingsView_View_ShowsActiveTabContent(t *testing.T) {
 
 func contains(haystack, needle string) bool {
 	return len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0
+}
+
+func TestSettingsViewMaxWidth(t *testing.T) {
+	sv := NewSettingsView()
+	sv.Width = 200
+	sv.Height = 40
+	sv.Open(testConfig())
+
+	view := sv.View()
+	if view == "" {
+		t.Fatal("expected non-empty view")
+	}
+
+	// lipgloss.Place centers the panel within the full terminal width by adding
+	// spaces on each side. The outer line width should be the full terminal width.
+	firstLine := strings.SplitN(view, "\n", 2)[0]
+	outerW := lipgloss.Width(firstLine)
+	if outerW != 200 {
+		t.Errorf("outer width = %d, want 200", outerW)
+	}
+
+	// After trimming the centering whitespace, no panel content line should
+	// exceed maxSettingsWidth.
+	for i, line := range strings.Split(view, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		lw := ansi.StringWidth(trimmed)
+		if lw > maxSettingsWidth {
+			t.Errorf("line %d content width = %d, exceeds maxSettingsWidth %d", i, lw, maxSettingsWidth)
+		}
+	}
 }
 
 func indexOf(s, sub string) int {

--- a/internal/tui/components/settings_test.go
+++ b/internal/tui/components/settings_test.go
@@ -742,8 +742,10 @@ func TestSettingsViewMaxWidth(t *testing.T) {
 		t.Errorf("outer width = %d, want 200", outerW)
 	}
 
-	// After trimming the centering whitespace, no panel content line should
-	// exceed maxSettingsWidth.
+	// TrimSpace removes the space-padding that lipgloss.Place adds on each side
+	// to center the panel. ANSI escape sequences are not whitespace, so
+	// TrimSpace leaves them intact. ansi.StringWidth then measures only visible
+	// characters (ignoring escape sequences), giving the true content width.
 	for i, line := range strings.Split(view, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {


### PR DESCRIPTION
## Summary

- Settings panel now caps at 100 columns wide instead of expanding to fill the full terminal
- On wider terminals the panel is horizontally centered using `lipgloss.Place`
- Added `TestSettingsViewMaxWidth` to verify the constraint and centering

## Test plan

- [x] `go test ./...` passes
- [x] `TestSettingsViewMaxWidth` verifies outer width = terminal width and content ≤ 100 cols
- [ ] Manually resize terminal to >100 columns and open settings — panel should be centered and compact

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)