### PR TITLE
fix(preview): show actual content instead of blank rows in sidebar and grid

### DIFF
--- a/internal/tmux/capture.go
+++ b/internal/tmux/capture.go
@@ -5,10 +5,31 @@ import (
 	"strings"
 )
 
+// IsAlternateScreen reports whether the given pane is currently in alternate
+// screen mode (i.e. running a TUI application like Claude Code that switches
+// to the alternate screen buffer via \e[?1049h).
+func IsAlternateScreen(target string) bool {
+	out, err := Exec("display-message", "-p", "-t", target, "#{alternate_on}")
+	return err == nil && strings.TrimSpace(out) == "1"
+}
+
 // CapturePane returns the visible content of a tmux pane.
 // target is "session:window". lines specifies how many lines to capture (0 = visible only).
 // The -e flag preserves ANSI color codes; -J joins wrapped lines.
+//
+// When the pane is in alternate screen mode (e.g. running a TUI like Claude Code),
+// the alternate screen is captured instead of the normal screen buffer. The normal
+// screen buffer only holds content from before the TUI started (usually a shell
+// prompt), so it would appear nearly empty in the preview even though the session
+// has real content visible to the user.
 func CapturePane(target string, lines int) (string, error) {
+	if IsAlternateScreen(target) {
+		// Capture the alternate screen — the current visible TUI state.
+		// No -S flag: the alternate screen has no scrollback buffer; the entire
+		// visible screen is captured as-is.
+		return Exec("capture-pane", "-a", "-p", "-e", "-J", "-t", target)
+	}
+	// Normal screen: capture with scrollback for context.
 	args := []string{"capture-pane", "-p", "-e", "-J", "-t", target}
 	if lines > 0 {
 		args = append(args, "-S", fmt.Sprintf("-%d", lines))
@@ -18,7 +39,12 @@ func CapturePane(target string, lines int) (string, error) {
 
 // CapturePaneRaw returns pane content without stripping escape sequences
 // (used by the title watcher to detect OSC sequences).
+// Like CapturePane, it captures the alternate screen when the pane is in
+// alternate screen mode so the title watcher sees the current output.
 func CapturePaneRaw(target string, lines int) (string, error) {
+	if IsAlternateScreen(target) {
+		return Exec("capture-pane", "-a", "-p", "-J", "-t", target)
+	}
 	args := []string{"capture-pane", "-p", "-J", "-t", target}
 	if lines > 0 {
 		args = append(args, "-S", fmt.Sprintf("-%d", lines))

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -437,9 +437,12 @@ func TestSessionSwitch_PreviewShowsCachedContent(t *testing.T) {
 	}
 }
 
-func TestStatusesDetectedMsg_UpdatesActivePreview(t *testing.T) {
-	// When StatusesDetectedMsg carries content for the active session, the
-	// preview must be updated immediately without waiting for the next PollPreview tick.
+func TestStatusesDetectedMsg_UpdatesContentSnapshot(t *testing.T) {
+	// StatusesDetectedMsg updates the content snapshot (used by the grid and
+	// session-switch cache) but must NOT update the live preview.  The preview
+	// is only updated by PollPreview (PreviewUpdatedMsg), which captures 500
+	// lines of scrollback.  Mixing 50-line WatchStatuses content with 500-line
+	// PollPreview content alternately causes the scroll position to jump.
 	m := testModelWithSessions()
 
 	const freshContent = "fresh output from status watcher"
@@ -454,8 +457,13 @@ func TestStatusesDetectedMsg_UpdatesActivePreview(t *testing.T) {
 	result, _ := m.Update(msg)
 	updated := result.(Model)
 
-	if updated.appState.PreviewContent != freshContent {
-		t.Errorf("PreviewContent = %q after StatusesDetectedMsg, want %q", updated.appState.PreviewContent, freshContent)
+	// Content snapshot must be updated for grid/session-switching.
+	if got := updated.contentSnapshots["sess-1"]; got != freshContent {
+		t.Errorf("contentSnapshot[sess-1] = %q, want %q", got, freshContent)
+	}
+	// Preview must NOT be updated — PollPreview is the sole preview source.
+	if updated.appState.PreviewContent != "" {
+		t.Errorf("PreviewContent = %q after StatusesDetectedMsg, want empty (only PollPreview updates preview)", updated.appState.PreviewContent)
 	}
 }
 

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -422,7 +422,7 @@ func (gv *GridView) renderCell(sess *state.Session, w, h int, selected bool) str
 	}
 	var contentStr string
 	if content := gv.contents[sess.ID]; content != "" {
-		rawLines := strings.Split(lastNLines(content, innerH), "\n")
+		rawLines := strings.Split(lastNContentLines(content, innerH), "\n")
 		for i, l := range rawLines {
 			rawLines[i] = ansi.Truncate(l, innerW, "")
 		}
@@ -483,6 +483,30 @@ func lastNLines(s string, n int) string {
 		return s
 	}
 	return strings.Join(lines[len(lines)-n:], "\n")
+}
+
+// lastNContentLines returns the last n lines of s before any trailing blank
+// rows.  capture-pane pads the terminal height with empty rows below the
+// cursor; taking the raw last-n lines would show those blank rows instead of
+// real content.  This mirrors the sidebar's lastNonBlankIdx approach.
+func lastNContentLines(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	// Find the last line with visible text.
+	end := len(lines)
+	for end > 0 && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+	if end == 0 {
+		return ""
+	}
+	start := end - n
+	if start < 0 {
+		start = 0
+	}
+	return strings.Join(lines[start:end], "\n")
 }
 
 // MoveUp moves the grid cursor up by one row.

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -660,3 +660,75 @@ func TestGridView_CellAt_ExtendedCell(t *testing.T) {
 		}
 	}
 }
+
+func TestLastNContentLines(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		n     int
+		want  string
+	}{
+		{
+			name:  "n=0 returns empty",
+			input: "line1\nline2",
+			n:     0,
+			want:  "",
+		},
+		{
+			name:  "all blank returns empty",
+			input: "\n\n\n",
+			n:     3,
+			want:  "",
+		},
+		{
+			name:  "trailing blank rows stripped",
+			input: "line1\nline2\n\n\n",
+			n:     5,
+			want:  "line1\nline2",
+		},
+		{
+			name:  "last n lines before trailing blanks",
+			input: "a\nb\nc\nd\n\n\n",
+			n:     2,
+			want:  "c\nd",
+		},
+		{
+			name:  "fewer content lines than n returns all",
+			input: "only\n\n\n",
+			n:     10,
+			want:  "only",
+		},
+		{
+			name:  "no trailing blanks returns last n",
+			input: "x\ny\nz",
+			n:     2,
+			want:  "y\nz",
+		},
+		{
+			name:  "exactly n content lines returns all",
+			input: "a\nb\n\n",
+			n:     2,
+			want:  "a\nb",
+		},
+		{
+			name:  "single content line",
+			input: "hello\n\n\n",
+			n:     1,
+			want:  "hello",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			n:     5,
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lastNContentLines(tc.input, tc.n)
+			if got != tc.want {
+				t.Errorf("lastNContentLines(%q, %d) = %q; want %q", tc.input, tc.n, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/components/preview.go
+++ b/internal/tui/components/preview.go
@@ -240,8 +240,12 @@ type Preview struct {
 	Width   int
 	Height  int
 	Focused bool
-	vp         viewport.Model
-	hasContent bool
+	vp              viewport.Model
+	hasContent      bool
+	// lastNonBlankIdx is the index of the last line in the viewport content
+	// that contains visible text (after sanitization).  Stored so Resize can
+	// re-apply the same scroll position without re-scanning the content.
+	lastNonBlankIdx int
 }
 
 // ScrollUp scrolls the preview viewport up by n lines.
@@ -252,28 +256,40 @@ func (p *Preview) ScrollDown(n int) { p.vp.LineDown(n) }
 
 // Resize updates the preview dimensions and passes them to the internal viewport.
 // Must be called before the first View() call and whenever the terminal resizes.
-// Scrolls back to the bottom when content is present, because a height change
-// invalidates the previous YOffset.
+// Re-applies the last-content scroll position (invalidated by the height change).
 func (p *Preview) Resize(w, h int) {
 	p.Width = w
 	p.Height = h
 	p.vp.Width = w
 	p.vp.Height = h
 	if p.hasContent {
-		// Set style before GotoBottom so maxYOffset uses the correct frame size.
-		// Without this the zero-value style (no border) produces a YOffset that is
-		// off by borderVerticalFrameSize, hiding the last few lines of content.
-		// Guard against tiny viewports where the frame exceeds the height.
 		// Always update vp.Style — if a previously-set style is left in place
-		// on a now-tiny viewport, GotoBottom will compute maxYOffset using the
-		// old frame size and scroll past the end of the content.
+		// on a now-tiny viewport, scrollToLastContent will compute a wrong offset.
 		if p.vp.Height > styles.PreviewStyle.GetVerticalFrameSize() {
 			p.vp.Style = styles.PreviewStyle
 		} else {
 			p.vp.Style = lipgloss.Style{}
 		}
-		p.vp.GotoBottom()
+		p.scrollToLastContent()
 	}
+}
+
+// scrollToLastContent positions the viewport so that lastNonBlankIdx is the
+// last visible line.  This keeps the display stable across polls: the cursor
+// position in the tmux pane (and therefore the number of trailing blank rows
+// in capture-pane output) fluctuates, but as long as the last line of actual
+// content doesn't change, the scroll offset stays the same.
+func (p *Preview) scrollToLastContent() {
+	frameH := p.vp.Style.GetVerticalFrameSize()
+	innerH := p.vp.Height - frameH
+	if innerH < 1 {
+		innerH = 1
+	}
+	offset := p.lastNonBlankIdx - innerH + 1
+	if offset < 0 {
+		offset = 0
+	}
+	p.vp.SetYOffset(offset)
 }
 
 // SetContent sanitizes raw tmux capture-pane output and stores it in the
@@ -299,24 +315,51 @@ func (p *Preview) SetContent(content string) {
 		// overlong row wraps into extra physical lines, which pushes the total
 		// frame height over TermHeight and causes the terminal to scroll —
 		// the "screen corruption" seen when switching sessions.
+		lines := strings.Split(sanitized, "\n")
 		if innerW := p.Width - styles.PreviewStyle.GetHorizontalFrameSize(); innerW > 0 {
-			lines := strings.Split(sanitized, "\n")
 			for i, l := range lines {
 				lines[i] = xansi.Truncate(l, innerW, "")
 			}
-			sanitized = strings.Join(lines, "\n")
 		}
-		// Always update vp.Style before SetContent/GotoBottom so maxYOffset
-		// uses the correct frame size.  Leaving a previously-set style in place
-		// on a now-tiny viewport would compute a wrong YOffset.
+		sanitized = strings.Join(lines, "\n")
+
+		// Find the last line with visible text.  capture-pane pads the terminal
+		// height with blank rows below the cursor; GotoBottom() would scroll to
+		// those blank rows, making the preview appear almost empty.  Instead,
+		// store the index of the last non-blank line and use it for scrolling.
+		// We do NOT trim the content because the blank count fluctuates each poll
+		// (the cursor moves as output is written), which would cause the viewport
+		// to jump on every update.
+		//
+		// To prevent jumping from cursor oscillation (TUI apps move the cursor a
+		// few lines up/down as they redraw spinners and status lines), we apply a
+		// high-water-mark strategy: only advance lastNonBlankIdx forward, or reset
+		// it downward when it drops by more than resetThreshold lines (indicating a
+		// genuine clear/reset rather than normal cursor movement).
+		newLast := 0
+		for i := len(lines) - 1; i >= 0; i-- {
+			if strings.TrimSpace(lines[i]) != "" {
+				newLast = i
+				break
+			}
+		}
+		const resetThreshold = 50
+		if newLast >= p.lastNonBlankIdx || p.lastNonBlankIdx-newLast > resetThreshold {
+			p.lastNonBlankIdx = newLast
+		}
+		// else: small backward movement from cursor oscillation — keep current position
+
+		// Always update vp.Style before setting content/offset so the frame size
+		// used by scrollToLastContent is correct.
 		if p.vp.Height > styles.PreviewStyle.GetVerticalFrameSize() {
 			p.vp.Style = styles.PreviewStyle
 		} else {
 			p.vp.Style = lipgloss.Style{}
 		}
 		p.vp.SetContent(sanitized)
-		p.vp.GotoBottom()
+		p.scrollToLastContent()
 	} else {
+		p.lastNonBlankIdx = 0
 		p.vp.SetContent("")
 	}
 }

--- a/internal/tui/components/preview.go
+++ b/internal/tui/components/preview.go
@@ -246,10 +246,17 @@ type Preview struct {
 	// that contains visible text (after sanitization).  Stored so Resize can
 	// re-apply the same scroll position without re-scanning the content.
 	lastNonBlankIdx int
+	// userScrolled is set when the user manually scrolls up, and cleared when
+	// new content arrives via SetContent.  While true, Resize preserves the
+	// user's scroll position instead of snapping back to the last content line.
+	userScrolled bool
 }
 
 // ScrollUp scrolls the preview viewport up by n lines.
-func (p *Preview) ScrollUp(n int) { p.vp.LineUp(n) }
+func (p *Preview) ScrollUp(n int) {
+	p.vp.LineUp(n)
+	p.userScrolled = true
+}
 
 // ScrollDown scrolls the preview viewport down by n lines.
 func (p *Preview) ScrollDown(n int) { p.vp.LineDown(n) }
@@ -270,7 +277,11 @@ func (p *Preview) Resize(w, h int) {
 		} else {
 			p.vp.Style = lipgloss.Style{}
 		}
-		p.scrollToLastContent()
+		// Don't override the user's manual scroll position on resize — only
+		// snap to last content when the user hasn't scrolled up themselves.
+		if !p.userScrolled {
+			p.scrollToLastContent()
+		}
 	}
 }
 
@@ -357,9 +368,13 @@ func (p *Preview) SetContent(content string) {
 			p.vp.Style = lipgloss.Style{}
 		}
 		p.vp.SetContent(sanitized)
+		// New content arrived — release any manual scroll hold so the viewport
+		// snaps back to the last content line (showing the most recent output).
+		p.userScrolled = false
 		p.scrollToLastContent()
 	} else {
 		p.lastNonBlankIdx = 0
+		p.userScrolled = false
 		p.vp.SetContent("")
 	}
 }

--- a/internal/tui/components/preview_test.go
+++ b/internal/tui/components/preview_test.go
@@ -567,6 +567,114 @@ func TestPreviewView_EscapeOnlyContent_ShowsPlaceholder(t *testing.T) {
 }
 
 
+func TestPreviewSetContent_TrailingBlanksScrollToContent(t *testing.T) {
+	// capture-pane pads output with blank rows below the cursor.
+	// After SetContent the viewport should show the last real line, not blanks.
+	const h = 10
+	p := &Preview{}
+	p.Resize(80, h)
+
+	// 3 content lines followed by 20 blank rows (simulating capture-pane padding).
+	content := "line1\nline2\nline3" + strings.Repeat("\n", 20)
+	p.SetContent(content)
+
+	// The visible window starts at lastNonBlankIdx - (innerH-1).
+	// With lastNonBlankIdx=2 (0-indexed) and innerH=h-frameH,
+	// the offset should be ≤ 2 so that line3 is visible.
+	// We verify by checking that the rendered output contains the last content line.
+	out := p.View("sess-1")
+	if !strings.Contains(out, "line3") {
+		t.Errorf("preview should show last content line after SetContent with trailing blanks; got:\n%s", out)
+	}
+}
+
+func TestPreviewSetContent_HighWaterMark_SmallDrop(t *testing.T) {
+	// High-water-mark: a small backward movement in lastNonBlankIdx (e.g. from
+	// cursor oscillation in a TUI spinner) should NOT reset the position —
+	// it should stay at the previous high-water mark.
+	p := &Preview{}
+	p.Resize(80, 20)
+
+	// First update: 100 content lines.
+	first := strings.Repeat("content\n", 100)
+	p.SetContent(first)
+	high := p.lastNonBlankIdx // should be ~99
+
+	// Second update: slightly fewer content lines (cursor moved up 3).
+	second := strings.Repeat("content\n", 97) + strings.Repeat("\n", 3)
+	p.SetContent(second)
+
+	if p.lastNonBlankIdx != high {
+		t.Errorf("small backward movement: lastNonBlankIdx changed from %d to %d; high-water-mark should hold",
+			high, p.lastNonBlankIdx)
+	}
+}
+
+func TestPreviewSetContent_HighWaterMark_LargeDrop(t *testing.T) {
+	// High-water-mark: a large drop (> resetThreshold=50 lines) IS a genuine
+	// screen clear and must reset lastNonBlankIdx to the new position.
+	p := &Preview{}
+	p.Resize(80, 20)
+
+	// Start at 200 content lines.
+	first := strings.Repeat("content\n", 200)
+	p.SetContent(first)
+	high := p.lastNonBlankIdx
+
+	// After a screen clear: only 5 content lines.
+	second := strings.Repeat("fresh\n", 5) + strings.Repeat("\n", 195)
+	p.SetContent(second)
+
+	if p.lastNonBlankIdx >= high-50 {
+		t.Errorf("large drop: lastNonBlankIdx=%d should have reset far below high=%d",
+			p.lastNonBlankIdx, high)
+	}
+	if p.lastNonBlankIdx > 10 {
+		t.Errorf("large drop: lastNonBlankIdx=%d should be ~4 after reset", p.lastNonBlankIdx)
+	}
+}
+
+func TestPreviewSetContent_ClearsUserScrolled(t *testing.T) {
+	// After the user scrolls up, new content must reset userScrolled so the
+	// next resize re-applies scrollToLastContent.
+	p := &Preview{}
+	p.Resize(80, 20)
+	p.SetContent(strings.Repeat("line\n", 50))
+	p.ScrollUp(5)
+
+	if !p.userScrolled {
+		t.Fatal("ScrollUp should set userScrolled=true")
+	}
+
+	// New content clears the flag.
+	p.SetContent(strings.Repeat("new\n", 50))
+	if p.userScrolled {
+		t.Error("SetContent should clear userScrolled")
+	}
+}
+
+func TestPreviewResize_PreservesUserScroll(t *testing.T) {
+	// When the user has scrolled up, Resize must not snap back to last content.
+	p := &Preview{}
+	p.Resize(80, 20)
+	p.SetContent(strings.Repeat("line\n", 100))
+
+	p.ScrollUp(10)
+	offsetAfterScroll := p.vp.YOffset
+
+	// Terminal resize: height changes.
+	p.Resize(80, 25)
+
+	// The offset may be adjusted by the viewport itself (due to height change),
+	// but it should NOT have been reset to scrollToLastContent's value (which
+	// would be lastNonBlankIdx - innerH + 1, a large positive value).
+	// Concretely: it should remain close to offsetAfterScroll, not jump to ~75+.
+	if p.vp.YOffset > offsetAfterScroll+5 {
+		t.Errorf("Resize with userScrolled: YOffset jumped to %d after scroll at %d; should preserve user position",
+			p.vp.YOffset, offsetAfterScroll)
+	}
+}
+
 func TestPreviewUpdatedMsg_Fields(t *testing.T) {
 	msg := PreviewUpdatedMsg{
 		SessionID:  "sess-123",

--- a/internal/tui/flow_session_test.go
+++ b/internal/tui/flow_session_test.go
@@ -531,8 +531,11 @@ func TestFlow_KillSession_LastInGroup(t *testing.T) {
 	f.AssertActiveSession("sess-2")
 }
 
-// TestFlow_StatusUpdate_UpdatesPreview tests that StatusesDetectedMsg
-// updates the preview for the active session.
+// TestFlow_StatusUpdate_UpdatesPreview tests that the preview is updated by
+// PreviewUpdatedMsg (PollPreview), not by StatusesDetectedMsg.
+// StatusesDetectedMsg updates the content snapshot for the grid / session-switch
+// cache, but must not update the live preview to avoid scroll jumps caused by
+// alternating 50-line (WatchStatuses) and 500-line (PollPreview) content.
 func TestFlow_StatusUpdate_UpdatesPreview(t *testing.T) {
 	m, mock := testFlowModel(t)
 	f := newFlowRunner(t, m, mock)
@@ -540,7 +543,7 @@ func TestFlow_StatusUpdate_UpdatesPreview(t *testing.T) {
 	// Initially no content.
 	f.ViewContains("Waiting for output")
 
-	// Send status update with content for active session.
+	// StatusesDetectedMsg must NOT update the preview — preview stays "Waiting".
 	f.Send(escape.StatusesDetectedMsg{
 		Statuses: map[string]state.SessionStatus{
 			"sess-1": state.StatusRunning,
@@ -549,7 +552,15 @@ func TestFlow_StatusUpdate_UpdatesPreview(t *testing.T) {
 			"sess-1": "Fresh output from agent",
 		},
 	})
+	f.ViewContains("Waiting for output")
 
+	// PreviewUpdatedMsg (from PollPreview) IS the authoritative preview source.
+	gen := f.Model().previewPollGen
+	f.Send(components.PreviewUpdatedMsg{
+		SessionID:  "sess-1",
+		Content:    "Fresh output from agent",
+		Generation: gen,
+	})
 	f.ViewContains("Fresh output from agent")
 	f.Snapshot("01-status-updated")
 }

--- a/internal/tui/handle_session.go
+++ b/internal/tui/handle_session.go
@@ -161,12 +161,12 @@ func (m Model) handleStatusesDetected(msg escape.StatusesDetectedMsg) (tea.Model
 			m.gridView.SetPaneTitles(m.paneTitles)
 		}
 	}
-	// If the status watcher captured new content for the active session, update
-	// the preview immediately rather than waiting for the next PollPreview tick.
-	if content, ok := msg.Contents[m.appState.ActiveSessionID]; ok {
-		m.appState.PreviewContent = content
-		m.preview.SetContent(content)
-	}
+	// NOTE: do NOT update m.preview from WatchStatuses content here.  WatchStatuses
+	// captures only 50 lines of scrollback while PollPreview captures 500.  Calling
+	// SetContent alternately with shallow (50-line) and deep (500-line) content causes
+	// the scroll offset to jump visibly because lastNonBlankIdx refers to completely
+	// different line indices in the two captures.  PollPreview is already running on
+	// every refresh tick and is the sole authoritative source for preview content.
 	// Forward terminal bell and mark sessions with pending bell indicator.
 	// The tmux bell flag stays set until the window is selected, so we use
 	// bellPending as edge tracking: only emit \a for sessions that aren't


### PR DESCRIPTION
## Summary

- **Root cause**: `capture-pane` pads the terminal height with blank rows below the cursor. `GotoBottom()` would land on those blank rows, making both the sidebar preview and grid cell appear almost empty even when the session has real content.
- **Sidebar jumping**: `WatchStatuses` (50-line capture) and `PollPreview` (500-line capture) were both calling `SetContent`, causing `lastNonBlankIdx` to swing ~460 lines every poll → visible scroll jump.
- **Alternate screen sessions**: Added `IsAlternateScreen` detection so TUI sessions (Claude Code, Codex, etc.) capture the `-a` (alternate) screen buffer instead of the stale normal-screen buffer.

## Changes

**`internal/tmux/capture.go`**
- `IsAlternateScreen`: checks `#{alternate_on}` via `display-message`
- `CapturePane` / `CapturePaneRaw`: use `-a` flag when pane is in alternate screen mode

**`internal/tui/components/preview.go`**
- Replace `GotoBottom()` with `scrollToLastContent()`: positions viewport so the last non-blank line is visible at the bottom
- High-water-mark on `lastNonBlankIdx`: absorbs cursor oscillation (TUI apps redraw spinners ±few lines) without jumping; resets on genuine clears (>50-line drop)
- `PollPreview` (500-line) is now the **sole** source for `SetContent`; removed the `WatchStatuses` path that was alternating shallow/deep content

**`internal/tui/components/gridview.go`**
- `lastNContentLines`: new helper that strips trailing blank rows before taking the last N lines — same fix applied to grid cell rendering

**`internal/tui/handle_session.go`**
- Removed `m.preview.SetContent` call from `handleStatusesDetected`; content snapshots (for grid/session-switching) are still updated

## Test plan

- [ ] Sidebar preview shows real session content (not blank rows) for active session
- [ ] Sidebar preview does not jump/flicker while session is running
- [ ] Grid cell previews show real content (not blank rows / "…")
- [ ] Sessions using alternate screen (Claude Code, Codex) show their TUI content in preview
- [ ] Sessions using normal screen still show scrollback correctly
- [ ] Session switch clears preview cleanly, "Waiting for output…" shown until first poll
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)