### PR TITLE
fix(grid): navigate into and out of expanded cells with arrow keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bell sounds and badges when attached to a session**: custom bell audio now plays and the sidebar/grid bell badges are set correctly when a background session rings its bell while the user is directly attached to another session. Previously the bell was silenced because hive's event loop is suspended during attachment; a background poller now handles it (#85).
 - **Grid mode toggle preserves selection**: pressing `g` while in the all-projects grid (or `G` while in a single-project grid) now keeps the currently-selected session and its project, instead of resetting to a different project's first session (#80).
 - **Settings save no longer blanks the screen**: confirming a settings save (`s` → `y`) now returns to the main view instead of leaving a black, unresponsive screen. The `ViewSettings` layer was being left on the view stack after the component deactivated itself, so `View()` rendered an empty string. The failure path (save error, e.g. read-only config dir) also pops the view now so the error surfaces in the statusbar instead of a black screen (#84).
+- **Grid expanded-cell navigation**: arrow keys in grid view now navigate correctly when cells are expanded. Right from the last session in the last row moves to the extended cell; left returns to the previous position (#101).
 
 ## [0.8.0] — 2026-04-12
 

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -57,3 +57,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | #79 | Consolidate hotkey definitions and display between sidebar and grid modes | — | — |
 | #93 | Show confirmation dialog when saving settings | — | — |
 | #94 | Play bell sound on selection and add volume control in settings | — | — |
+| #101 | Fix arrow key navigation when grid cells are expanded | #104 | — |

--- a/features/completed/101-fix-arrow-key-navigation-expanded-cells.md
+++ b/features/completed/101-fix-arrow-key-navigation-expanded-cells.md
@@ -1,0 +1,70 @@
+# Feature: Fix arrow key navigation when grid cells are expanded
+
+- **GitHub Issue:** #101
+- **Stage:** DONE
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P1
+- **Branch:** —
+
+## Description
+
+When in grid view with a session cell expanded downward, arrow key navigation does not account for the visual layout of expanded cells. For example, with 5 sessions where session 3 is expanded (occupying extra rows), pressing right arrow on session 5 should navigate to the expanded session 3 (which appears after session 5 in the visual grid reading order). Pressing left arrow from there should return to session 3. Currently arrow navigation ignores expanded cell geometry, making navigation confusing and non-intuitive.
+
+## Research
+
+Arrow key navigation lives entirely in `internal/tui/components/gridview.go`.
+Extended cells are cells whose column has no session in the last row — the last
+real session in that column absorbs the empty space below it (rendered taller).
+
+### Relevant Code
+- `internal/tui/components/gridview.go:157-201` — `Update()` handles left/right/up/down. Right is bounded by `n-1` and never considers extended visual slots. This is the root of the bug.
+- `internal/tui/components/gridview.go:206-266` — `View()` renders the grid column-by-column; extended cell logic at lines 242-266: when `emptyInLastRow && r == rows-2`, the cell height is `cellH + lastCellH`.
+- `internal/tui/components/gridview.go:506-565` — `CellAt()` already maps mouse clicks to extended cells correctly; the same "owner" formula can be used for keyboard nav: `owner = (rows-2)*cols + col`.
+- `internal/tui/components/gridview_test.go:341-385` — `TestGridView_CursorWrap`: the test case `{"right at last session stays", 4, ..., 4}` will need updating (correct new target is idx=2, the extended cell owner).
+
+### Constraints / Dependencies
+- `atExtended bool` field must be added to `GridView` struct to track when the cursor is in the "virtual last row" of an extended cell; without this, left-from-extended and right-from-extended can't distinguish the extended visual position from the cell's real row-0 position.
+- `SyncCursor`, `MoveUp`, `MoveDown` must reset `atExtended = false` to stay consistent when the cursor is externally repositioned.
+
+## Plan
+
+Add `atExtended bool` to `GridView` to track when the cursor is visually at the
+extended (lower) portion of a cell. Use it in `left`/`right` to route navigation
+through the "virtual last row" instead of the session's real row-0 position.
+
+### Files to Change
+1. `internal/tui/components/gridview.go`
+   - Add `atExtended bool` field to `GridView` struct (after `bellBlinkOn`)
+   - Rewrite `case "right"` in `Update()`: compute `nextIdx = row*cols + nextCol`; if `nextIdx >= n` and the slot is an extended column (`n%cols != 0 && nextCol >= n%cols && row == rows-1`), navigate to owner `(rows-2)*cols + nextCol` and set `atExtended=true`; otherwise existing wrap logic
+   - Rewrite `case "left"` in `Update()`: when `atExtended`, navigate via `(rows-1)*cols + (col-1)` (real cell) or its owner (extended cell); else existing logic
+   - Add `gv.atExtended = false` at start of `case "up"` and `case "down"`
+   - `SyncCursor()`: add `gv.atExtended = false` after setting cursor
+   - `MoveUp()` / `MoveDown()`: add `gv.atExtended = false`
+   - `Show()`: add `gv.atExtended = false` — resets stale extended state when session count changes (e.g. spawning a new session from the grid)
+
+2. `internal/tui/components/gridview_test.go`
+   - Update `TestGridView_CursorWrap`: change `{"right at last session stays", 4, …, 4}` → wantCursor=2 (navigates to extended cell owner) and rename to `"right navigates to extended cell"`
+   - Add `TestGridView_CursorWrap_ExtendedCell`: covers right→extended, left←extended, and up/down resetting atExtended
+
+3. `internal/tui/flow_test.go`
+   - Add `AssertGridCursor(want int)` helper
+   - Add `TestFlow_GridExtendedCellNavigation`: 5-session flow; open grid; set cursor to idx 4 (session 5); press right; assert cursor=2 (session 3); press left; assert cursor=4 (session 5)
+
+### Test Strategy
+- `TestGridView_CursorWrap` (updated): `right navigates to extended cell` — cursor=4 → cursor=2 after right
+- `TestGridView_CursorWrap_ExtendedCell/right_to_extended` — cursor=4 → cursor=2, atExtended=true
+- `TestGridView_CursorWrap_ExtendedCell/left_from_extended` — cursor=2, atExtended=true → cursor=4, atExtended=false
+- `TestGridView_CursorWrap_ExtendedCell/up_clears_extended` — cursor=2, atExtended=true, press up → atExtended=false
+- `TestGridView_CursorWrap_ExtendedCell/down_clears_extended` — cursor=4, press down → does nothing (already last row); atExtended stays false
+- `TestFlow_GridExtendedCellNavigation` — end-to-end right→session3, left→session5
+
+### Risks
+- `atExtended=true` persists if cursor is moved externally without going through Update. Mitigated by resetting in SyncCursor/MoveUp/MoveDown.
+- Multi-extended-column case (n=4, cols=3): columns 1 and 2 are both extended. Right from idx=3 goes to idx=1 (atExtended=true), then right again goes to idx=2 (atExtended=true). This is correct but untested. Adding a comment is sufficient.
+
+## Implementation Notes
+
+Added `atExtended bool` to `GridView`. Rewrote `left`/`right` in `Update()` to route through virtual-last-row indices when the flag is set. `right` sets it when navigating into an extended slot; `left` clears it when leaving. `up`/`down`, `Show()`, `SyncCursor()`, `MoveUp()`, `MoveDown()` all clear the flag. No plan deviations.
+
+- **PR:** #104

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -76,6 +76,8 @@ func (gv *GridView) Show(sessions []*state.Session, mode state.GridRestoreMode) 
 }
 
 // Hide deactivates the grid.
+// atExtended is intentionally not reset here — Show() clears it on the next
+// grid open, and Update() is gated on Active so the stale value is never read.
 func (gv *GridView) Hide() { gv.Active = false }
 
 // SetContents updates the captured preview content map.
@@ -205,11 +207,10 @@ func (gv *GridView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 				}
 			}
 		} else {
-			rowStart := (gv.Cursor / cols) * cols
-			if gv.Cursor > rowStart {
+			// Both branches decrement by one: within-row move and prev-row wrap
+			// are identical operations (cursor layout is a flat index).
+			if gv.Cursor > 0 {
 				gv.Cursor--
-			} else if gv.Cursor > 0 {
-				gv.Cursor-- // wrap to last cell of previous row
 			}
 		}
 	case "right":
@@ -225,7 +226,7 @@ func (gv *GridView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 			// Normal move right within the same row.
 			gv.Cursor = nextIdx
 			gv.atExtended = false
-		case nextCol < cols && nextIdx >= n && n%cols != 0 && nextCol >= n%cols && row == rows-1:
+		case nextCol < cols && nextIdx >= n && n%cols != 0 && nextCol >= n%cols && row == rows-1 && rows > 1:
 			// Next slot is an extended cell — navigate to its owning session.
 			ownerIdx := (rows-2)*cols + nextCol
 			if ownerIdx >= 0 && ownerIdx < n {

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -58,6 +58,7 @@ type GridView struct {
 	paneTitles    map[string]string // target ("tmuxSession:windowIdx") → live pane title
 	bellPending   map[string]bool   // sessionID → true when an unacknowledged bell has fired
 	bellBlinkOn   bool              // toggled by the bell-blink ticker; true = show ♪, false = show status dot
+	atExtended    bool              // true when cursor is visually at the extended (lower) portion of a cell
 }
 
 // Show activates the grid with the given sessions.
@@ -65,6 +66,7 @@ func (gv *GridView) Show(sessions []*state.Session, mode state.GridRestoreMode) 
 	gv.Active = true
 	gv.Mode = mode
 	gv.sessions = sessions
+	gv.atExtended = false // reset when session count changes (layout may change)
 	if gv.Cursor >= len(sessions) {
 		gv.Cursor = 0
 	}
@@ -120,6 +122,13 @@ func (gv *GridView) BellPendingForTest(sessionID string) bool {
 	return gv.bellPending[sessionID]
 }
 
+// AtExtendedForTest reports whether the cursor is currently at the extended
+// (visual bottom) portion of a cell.
+// For use in tests only — not part of the production API.
+func (gv *GridView) AtExtendedForTest() bool {
+	return gv.atExtended
+}
+
 // Selected returns the currently focused session, or nil.
 func (gv *GridView) Selected() *state.Session {
 	if !gv.Active || gv.Cursor < 0 || gv.Cursor >= len(gv.sessions) {
@@ -147,6 +156,7 @@ func (gv *GridView) SyncCursor(sessionID string) {
 	for i, sess := range gv.sessions {
 		if sess.ID == sessionID {
 			gv.Cursor = i
+			gv.atExtended = false
 			return
 		}
 	}
@@ -161,6 +171,8 @@ func (gv *GridView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 	n := len(gv.sessions)
 	cols := gridColumns(gv.Width, gv.Height, n)
 
+	rows := (n + cols - 1) / cols
+
 	switch msg.String() {
 	case "esc":
 		gv.Hide()
@@ -173,27 +185,68 @@ func (gv *GridView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 			}, true
 		}
 	case "left":
-		rowStart := (gv.Cursor / cols) * cols
-		if gv.Cursor > rowStart {
-			gv.Cursor--
-		} else if gv.Cursor > 0 {
-			gv.Cursor-- // wrap to last cell of previous row
+		if gv.atExtended {
+			// Cursor is at the visual bottom (extended row) of its session.
+			// Navigate left within that virtual last row.
+			col := gv.Cursor % cols
+			if col > 0 {
+				virtualTarget := (rows-1)*cols + (col - 1)
+				if virtualTarget < n {
+					// Real session to the left in the last row.
+					gv.Cursor = virtualTarget
+					gv.atExtended = false
+				} else if n%cols != 0 && (col-1) >= n%cols {
+					// Another extended slot to the left; navigate to its owner.
+					ownerIdx := (rows-2)*cols + (col - 1)
+					if ownerIdx >= 0 && ownerIdx < n {
+						gv.Cursor = ownerIdx
+						// atExtended stays true
+					}
+				}
+			}
+		} else {
+			rowStart := (gv.Cursor / cols) * cols
+			if gv.Cursor > rowStart {
+				gv.Cursor--
+			} else if gv.Cursor > 0 {
+				gv.Cursor-- // wrap to last cell of previous row
+			}
 		}
 	case "right":
-		rowEnd := (gv.Cursor/cols)*cols + cols - 1
-		if rowEnd >= n {
-			rowEnd = n - 1
+		row := gv.Cursor / cols
+		if gv.atExtended {
+			row = rows - 1 // treat cursor as being in the visual last row
 		}
-		if gv.Cursor < rowEnd {
-			gv.Cursor++
-		} else if gv.Cursor < n-1 {
-			gv.Cursor++ // wrap to first cell of next row
+		col := gv.Cursor % cols
+		nextCol := col + 1
+		nextIdx := row*cols + nextCol
+		switch {
+		case nextCol < cols && nextIdx < n:
+			// Normal move right within the same row.
+			gv.Cursor = nextIdx
+			gv.atExtended = false
+		case nextCol < cols && nextIdx >= n && n%cols != 0 && nextCol >= n%cols && row == rows-1:
+			// Next slot is an extended cell — navigate to its owning session.
+			ownerIdx := (rows-2)*cols + nextCol
+			if ownerIdx >= 0 && ownerIdx < n {
+				gv.Cursor = ownerIdx
+				gv.atExtended = true
+			}
+		case row < rows-1:
+			// End of row: wrap to first cell of the next row.
+			nextRowStart := (row + 1) * cols
+			if nextRowStart < n {
+				gv.Cursor = nextRowStart
+				gv.atExtended = false
+			}
 		}
 	case "up":
+		gv.atExtended = false
 		if gv.Cursor >= cols {
 			gv.Cursor -= cols
 		}
 	case "down":
+		gv.atExtended = false
 		if gv.Cursor+cols < n {
 			gv.Cursor += cols
 		}
@@ -489,6 +542,7 @@ func lastNLines(s string, n int) string {
 // MoveUp moves the grid cursor up by one row.
 func (gv *GridView) MoveUp() {
 	cols := gridColumns(gv.Width, gv.Height, len(gv.sessions))
+	gv.atExtended = false
 	if gv.Cursor >= cols {
 		gv.Cursor -= cols
 	}
@@ -498,6 +552,7 @@ func (gv *GridView) MoveUp() {
 func (gv *GridView) MoveDown() {
 	n := len(gv.sessions)
 	cols := gridColumns(gv.Width, gv.Height, n)
+	gv.atExtended = false
 	if gv.Cursor+cols < n {
 		gv.Cursor += cols
 	}

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -368,8 +368,10 @@ func TestGridView_CursorWrap(t *testing.T) {
 		// Wrapping across rows
 		{"right wraps to next row", 2, tea.KeyMsg{Type: tea.KeyRight}, 3},
 		{"left wraps to prev row", 3, tea.KeyMsg{Type: tea.KeyLeft}, 2},
+		// Extended-cell navigation: right from last real cell in last row goes to
+		// the owner of the extended slot (idx 2, column 2 extended into row 1).
+		{"right navigates to extended cell", 4, tea.KeyMsg{Type: tea.KeyRight}, 2},
 		// No wrap at boundaries
-		{"right at last session stays", 4, tea.KeyMsg{Type: tea.KeyRight}, 4},
 		{"left at index 0 stays", 0, tea.KeyMsg{Type: tea.KeyLeft}, 0},
 	}
 
@@ -425,6 +427,95 @@ func TestGridView_CursorWrap_SingleColumn(t *testing.T) {
 		gv.Update(tea.KeyMsg{Type: tea.KeyLeft})
 		if gv.Cursor != 0 {
 			t.Errorf("Cursor = %d, want 0", gv.Cursor)
+		}
+	})
+}
+
+// TestGridView_CursorWrap_ExtendedCell verifies keyboard navigation into and out
+// of the extended (expanded-down) portion of a sparse grid cell.
+// Uses 5 sessions at 160×50 which yields a 3×2 grid:
+//
+//	row 0: [0][1][2]
+//	row 1: [3][4][2*]  ← col 2 is extended; session idx 2 fills both rows
+func TestGridView_CursorWrap_ExtendedCell(t *testing.T) {
+	sessions := make([]*state.Session, 5)
+	for i := range sessions {
+		sessions[i] = &state.Session{
+			ID: "s" + string(rune('1'+i)), Title: "sess",
+			AgentType: state.AgentClaude, Status: state.StatusRunning,
+		}
+	}
+	makeGV := func(cursor int, atExtended bool) *GridView {
+		gv := &GridView{Active: true, Width: 160, Height: 50}
+		gv.Show(sessions, state.GridRestoreProject)
+		gv.Cursor = cursor
+		gv.atExtended = atExtended
+		return gv
+	}
+
+	t.Run("right_to_extended", func(t *testing.T) {
+		gv := makeGV(4, false)
+		gv.Update(tea.KeyMsg{Type: tea.KeyRight})
+		if gv.Cursor != 2 {
+			t.Errorf("Cursor = %d, want 2 (extended cell owner)", gv.Cursor)
+		}
+		if !gv.atExtended {
+			t.Error("atExtended = false, want true after navigating into extended slot")
+		}
+	})
+
+	t.Run("left_from_extended", func(t *testing.T) {
+		gv := makeGV(2, true) // cursor at extended session 3, atExtended=true
+		gv.Update(tea.KeyMsg{Type: tea.KeyLeft})
+		if gv.Cursor != 4 {
+			t.Errorf("Cursor = %d, want 4 (session 5, real cell to the left)", gv.Cursor)
+		}
+		if gv.atExtended {
+			t.Error("atExtended = true, want false after leaving extended slot")
+		}
+	})
+
+	t.Run("up_clears_extended", func(t *testing.T) {
+		gv := makeGV(2, true)
+		gv.Update(tea.KeyMsg{Type: tea.KeyUp})
+		if gv.atExtended {
+			t.Error("atExtended = true after up, want false")
+		}
+	})
+
+	t.Run("down_clears_extended", func(t *testing.T) {
+		gv := makeGV(4, false)
+		gv.Update(tea.KeyMsg{Type: tea.KeyDown})
+		if gv.atExtended {
+			t.Error("atExtended = true after down from last row, want false")
+		}
+		if gv.Cursor != 4 {
+			t.Errorf("Cursor = %d, want 4 (no down from last row)", gv.Cursor)
+		}
+	})
+
+	t.Run("right_extended_then_right_stays", func(t *testing.T) {
+		// From the extended rightmost col, right should not navigate further.
+		gv := makeGV(2, true) // col 2 is the rightmost, no session to the right
+		gv.Update(tea.KeyMsg{Type: tea.KeyRight})
+		if gv.Cursor != 2 {
+			t.Errorf("Cursor = %d, want 2 (no move from rightmost extended col)", gv.Cursor)
+		}
+	})
+
+	t.Run("show_resets_extended", func(t *testing.T) {
+		gv := makeGV(2, true)
+		// Simulate a new session being added: call Show with 6 sessions.
+		newSessions := make([]*state.Session, 6)
+		for i := range newSessions {
+			newSessions[i] = &state.Session{
+				ID: "s" + string(rune('1'+i)), Title: "sess",
+				AgentType: state.AgentClaude, Status: state.StatusRunning,
+			}
+		}
+		gv.Show(newSessions, state.GridRestoreProject)
+		if gv.atExtended {
+			t.Error("atExtended = true after Show, want false (layout changed)")
 		}
 	})
 }

--- a/internal/tui/components/gridview_test.go
+++ b/internal/tui/components/gridview_test.go
@@ -481,6 +481,9 @@ func TestGridView_CursorWrap_ExtendedCell(t *testing.T) {
 		if gv.atExtended {
 			t.Error("atExtended = true after up, want false")
 		}
+		if gv.Cursor != 2 {
+			t.Errorf("Cursor = %d, want 2 (row 0, no session above to move to)", gv.Cursor)
+		}
 	})
 
 	t.Run("down_clears_extended", func(t *testing.T) {

--- a/internal/tui/flow_grid_test.go
+++ b/internal/tui/flow_grid_test.go
@@ -991,7 +991,7 @@ func TestFlow_GridExtendedCellNavigation(t *testing.T) {
 	f.AssertGridActive(true)
 
 	// Move cursor to idx 4 (session 5, row 1, col 1) — last real cell in last row.
-	f.model.gridView.Cursor = 4
+	f.SetGridCursor(4)
 
 	// Right from idx 4 should navigate to idx 2 (the extended cell owner, session 3).
 	f.SendSpecialKey(tea.KeyRight)

--- a/internal/tui/flow_grid_test.go
+++ b/internal/tui/flow_grid_test.go
@@ -935,3 +935,75 @@ func TestFlow_GridHelpOpensPushesViewHelp(t *testing.T) {
 		t.Errorf("after ? in grid: TopView=%v, want ViewHelp", f.model.TopView())
 	}
 }
+
+// TestFlow_GridExtendedCellNavigation verifies that right-arrow from the last
+// real session in the last row navigates into the extended (expanded-down) cell
+// and that left-arrow returns to the previous position.
+//
+// Grid layout for 5 sessions at 120×40 (cols=3, rows=2):
+//
+//	row 0: [0][1][2]
+//	row 1: [3][4][2*]  ← col 2 is extended; session at idx 2 fills both rows
+func TestFlow_GridExtendedCellNavigation(t *testing.T) {
+	tmp := t.TempDir()
+	setHomePersist(t, tmp)
+	ensureConfigDir(t)
+	t.Setenv("TERM", "dumb")
+
+	mock := muxtest.New()
+	mux.SetBackend(mock)
+	t.Cleanup(func() { mux.SetBackend(nil) })
+
+	appState := state.AppState{
+		ActiveProjectID: "proj-1",
+		ActiveSessionID: "sess-1",
+		AgentUsage:      make(map[string]state.AgentUsageRecord),
+		Projects: []*state.Project{
+			{
+				ID:    "proj-1",
+				Name:  "test-project-extended",
+				Color: "#7C3AED",
+				Teams: []*state.Team{},
+				Sessions: []*state.Session{
+					{ID: "sess-1", ProjectID: "proj-1", Title: "s1", TmuxSession: "hive-t", TmuxWindow: 0, Status: state.StatusRunning, AgentType: state.AgentClaude},
+					{ID: "sess-2", ProjectID: "proj-1", Title: "s2", TmuxSession: "hive-t", TmuxWindow: 1, Status: state.StatusRunning, AgentType: state.AgentClaude},
+					{ID: "sess-3", ProjectID: "proj-1", Title: "s3", TmuxSession: "hive-t", TmuxWindow: 2, Status: state.StatusRunning, AgentType: state.AgentClaude},
+					{ID: "sess-4", ProjectID: "proj-1", Title: "s4", TmuxSession: "hive-t", TmuxWindow: 3, Status: state.StatusRunning, AgentType: state.AgentClaude},
+					{ID: "sess-5", ProjectID: "proj-1", Title: "s5", TmuxSession: "hive-t", TmuxWindow: 4, Status: state.StatusRunning, AgentType: state.AgentClaude},
+				},
+			},
+		},
+	}
+	appState.TermWidth = 120
+	appState.TermHeight = 40
+
+	cfg := config.DefaultConfig()
+	cfg.HideAttachHint = true
+	cfg.PreviewRefreshMs = 1
+
+	m := New(cfg, appState, "")
+	m.appState.TermWidth = 120
+	m.appState.TermHeight = 40
+	f := newFlowRunner(t, m, mock)
+
+	// Open project grid (5 sessions → 3×2 layout, col 2 extended).
+	f.SendKey("g")
+	f.AssertGridActive(true)
+
+	// Move cursor to idx 4 (session 5, row 1, col 1) — last real cell in last row.
+	f.model.gridView.Cursor = 4
+
+	// Right from idx 4 should navigate to idx 2 (the extended cell owner, session 3).
+	f.SendSpecialKey(tea.KeyRight)
+	f.AssertGridCursor(2)
+	if !f.model.gridView.AtExtendedForTest() {
+		t.Error("atExtended = false after navigating into extended slot, want true")
+	}
+
+	// Left from extended idx 2 should return to idx 4 (session 5).
+	f.SendSpecialKey(tea.KeyLeft)
+	f.AssertGridCursor(4)
+	if f.model.gridView.AtExtendedForTest() {
+		t.Error("atExtended = true after leaving extended slot, want false")
+	}
+}

--- a/internal/tui/flow_test.go
+++ b/internal/tui/flow_test.go
@@ -162,6 +162,14 @@ func (f *flowRunner) AssertGridActive(active bool) {
 	}
 }
 
+// AssertGridCursor asserts the grid cursor index.
+func (f *flowRunner) AssertGridCursor(want int) {
+	f.t.Helper()
+	if f.model.gridView.Cursor != want {
+		f.t.Errorf("gridView.Cursor = %d, want %d", f.model.gridView.Cursor, want)
+	}
+}
+
 // AssertGridMode asserts the grid restore mode.
 func (f *flowRunner) AssertGridMode(mode state.GridRestoreMode) {
 	f.t.Helper()

--- a/internal/tui/flow_test.go
+++ b/internal/tui/flow_test.go
@@ -170,6 +170,13 @@ func (f *flowRunner) AssertGridCursor(want int) {
 	}
 }
 
+// SetGridCursor directly sets the grid cursor index.
+// Use this in tests that need to position the cursor at a specific session
+// without navigating through intermediate cells.
+func (f *flowRunner) SetGridCursor(idx int) {
+	f.model.gridView.Cursor = idx
+}
+
 // AssertGridMode asserts the grid restore mode.
 func (f *flowRunner) AssertGridMode(mode state.GridRestoreMode) {
 	f.t.Helper()


### PR DESCRIPTION
## Summary
- Adds `atExtended bool` to `GridView` to track when the cursor is at the visual bottom (extended row) of an expanded cell
- Right arrow from the last real session in the last row now navigates into the extended slot instead of doing nothing
- Left arrow from an extended cell returns to the real cell to its left in the virtual last row
- `Show()`, `SyncCursor()`, `MoveUp()`, `MoveDown()`, and up/down keys all reset the flag so stale state can't accumulate (handles new-session spawn correctly)

## Test plan
- [x] `TestGridView_CursorWrap` — updated "right at last session stays" → now expects cursor=2 (extended cell owner)
- [x] `TestGridView_CursorWrap_ExtendedCell` — new: right→extended, left←extended, up/down reset flag, Show resets flag
- [x] `TestFlow_GridExtendedCellNavigation` — end-to-end flow: 5-session grid, navigate to idx 4, right→idx 2, left→idx 4
- [x] All existing tests pass (`go test ./...`)

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)