### PR TITLE
feat(grid): in-place session input mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **In-place session input from grid view**: press `(i)` on a focused grid cell to enter input mode — keystrokes (including `Esc`, arrows, `Enter`, and common `Ctrl+` sequences) are forwarded directly to that session without a full attach. A `·· INPUT ··` badge appears in the cell header while active. Press `Ctrl+Q` to exit input mode and return to grid navigation. The preview refresh rate for the focused session automatically increases to 100 ms in input mode for responsive feedback. Can be disabled by setting `disable_grid_input: true` in `~/.config/hive/config.json`.
+- **In-place session input from grid view**: press `(i)` on a focused grid cell to enter input mode — keystrokes (including `Esc`, arrows, `Enter`, and common `Ctrl+` sequences) are forwarded directly to that session without a full attach. A `·· INPUT ··` badge appears in the cell header while active. Press `Ctrl+Q` to exit input mode and return to grid navigation. The preview refresh rate is automatically tuned in input mode: the focused session polls at 50 ms while all other sessions poll at 250 ms (2× the default 500 ms background rate), giving fast feedback without hammering inactive sessions. Can be disabled by setting `disable_grid_input: true` in `~/.config/hive/config.json`.
 
 ## [0.9.0] — 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **In-place session input from grid view**: press `(i)` on a focused grid cell to enter input mode — keystrokes (including `Esc`, arrows, `Enter`, and common `Ctrl+` sequences) are forwarded directly to that session without a full attach. A `·· INPUT ··` badge appears in the cell header while active. Press `Ctrl+Q` to exit input mode and return to grid navigation. Can be disabled by setting `disable_grid_input: true` in `~/.config/hive/config.json`.
+
 ## [0.9.0] — 2026-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **In-place session input from grid view**: press `(i)` on a focused grid cell to enter input mode — keystrokes (including `Esc`, arrows, `Enter`, and common `Ctrl+` sequences) are forwarded directly to that session without a full attach. A `·· INPUT ··` badge appears in the cell header while active. Press `Ctrl+Q` to exit input mode and return to grid navigation. Can be disabled by setting `disable_grid_input: true` in `~/.config/hive/config.json`.
+- **In-place session input from grid view**: press `(i)` on a focused grid cell to enter input mode — keystrokes (including `Esc`, arrows, `Enter`, and common `Ctrl+` sequences) are forwarded directly to that session without a full attach. A `·· INPUT ··` badge appears in the cell header while active. Press `Ctrl+Q` to exit input mode and return to grid navigation. The preview refresh rate for the focused session automatically increases to 100 ms in input mode for responsive feedback. Can be disabled by setting `disable_grid_input: true` in `~/.config/hive/config.json`.
 
 ## [0.9.0] — 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **In-place session input from grid view**: press `(i)` on a focused grid cell to enter input mode — keystrokes (including `Esc`, arrows, `Enter`, and common `Ctrl+` sequences) are forwarded directly to that session without a full attach. A `·· INPUT ··` badge appears in the cell header while active. Press `Ctrl+Q` to exit input mode and return to grid navigation. The preview refresh rate is automatically tuned in input mode: the focused session polls at 50 ms while all other sessions poll at 250 ms (2× the default 500 ms background rate), giving fast feedback without hammering inactive sessions. Can be disabled by setting `disable_grid_input: true` in `~/.config/hive/config.json`.
+- **In-place session input from grid view**: press `(i)` on a focused grid cell to enter input mode — keystrokes (including `Esc`, arrows, `Enter`, and common `Ctrl+` sequences) are forwarded directly to that session without a full attach. A `INPUT · C-Q` badge appears in the cell header while active. Press `Ctrl+Q` to exit input mode and return to grid navigation. The preview refresh rate is automatically tuned in input mode: the focused session polls at 50 ms while all other sessions poll at 250 ms (2× the default 500 ms background rate), giving fast feedback without hammering inactive sessions. Can be disabled by setting `disable_grid_input: true` in `~/.config/hive/config.json`.
 
 ## [0.9.0] — 2026-04-13
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -61,6 +61,24 @@
 | `H` | Open tmux shortcuts reference |
 | `q` | Quit app |
 | `Esc` | Exit grid view |
+| `i` | Enter input mode on focused cell (forward keystrokes to that session) |
+
+### Grid Input Mode
+
+When input mode is active, all keystrokes — including `Esc`, arrow keys, `Enter`, and `Ctrl+` combinations — are forwarded directly to the focused session. This lets you send quick confirmations (`y`/`n`), interrupt a running command (`Ctrl+C`), or nudge an agent without leaving the grid overview.
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+Q` | Exit input mode and return to grid navigation |
+| `Esc` | Forward `Esc` byte (`\033`) to the session |
+| `↑` / `↓` / `←` / `→` | Forward ANSI arrow sequences to the session |
+| `Enter` | Forward carriage return (`\r`) to the session |
+| `Ctrl+C` | Forward interrupt (`\x03`) to the session |
+| Any printable key | Forward that character to the session |
+
+> **Visual indicator:** A `·· INPUT ··` badge appears in the focused cell's header while input mode is active.
+
+> **Opt-out:** Set `disable_grid_input: true` in `~/.config/hive/config.json` to disable this feature entirely (the `i` key becomes a no-op in grid view).
 
 ## Status Indicator
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -76,7 +76,7 @@ When input mode is active, all keystrokes — including `Esc`, arrow keys, `Ente
 | `Ctrl+C` | Forward interrupt (`\x03`) to the session |
 | Any printable key | Forward that character to the session |
 
-> **Visual indicator:** A `·· INPUT ··` badge appears in the focused cell's header while input mode is active.
+> **Visual indicator:** A `INPUT · C-Q` badge appears in the focused cell's header while input mode is active.
 
 > **Opt-out:** Set `disable_grid_input: true` in `~/.config/hive/config.json` to disable this feature entirely (the `i` key becomes a no-op in grid view).
 

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,7 +7,7 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| — | — | [In-place session input from grid view](in-place-grid-typing.md) | RESEARCH | M |
+| — | — | [In-place session input from grid view](in-place-grid-typing.md) | IMPLEMENT | M |
 
 ## Rejected
 

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,7 +7,6 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| — | — | [In-place session input from grid view](in-place-grid-typing.md) | IMPLEMENT | M |
 
 ## Rejected
 
@@ -61,3 +60,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | #98 | Constrain settings panel max-width on wide screens | #99 | 2026-04-12 |
 | #100 | Fix arrow key navigation in sidepanel view | #102 | — |
 | #101 | Fix arrow key navigation when grid cells are expanded | #104 | — |
+| #105 | In-place session input from grid view | #106 | — |

--- a/features/completed/105-in-place-session-input-from-grid-view.md
+++ b/features/completed/105-in-place-session-input-from-grid-view.md
@@ -59,12 +59,13 @@ Preview polling continues unchanged — cell content updates within ~500ms of ea
 - `DisableGridInput bool` config field (JSON: `disable_grid_input`) added to `config.Config` for opt-out
 - `GridView.InputEnabled` field is set from config on model construction and on each settings save
 - `InputMode()` uses a value receiver so it can be called on the non-pointer `gridView` field in `Model`
-- The `·· INPUT ··` badge is overlaid at the right edge of the selected cell header, replacing the last N chars so total header width is preserved
+- The `INPUT · C-Q` badge is overlaid at the right edge of the selected cell header, replacing the last N chars so total header width is preserved
 - `keyToBytes()` handles printable runes, Enter→`\r`, Esc→`\033`, arrows→ANSI seqs, and common `Ctrl+` codes
 - Keys that have no sensible byte representation (e.g. F1) return `""` and are silently ignored
-- `scheduleGridPoll()` uses a 100 ms interval when `gridView.InputMode()` is true (vs. the configured ~500 ms default); entering input mode triggers an immediate re-poll to kick off the fast cycle
+- Dual-rate polling in input mode: focused session polls at 50 ms (`inputModeFocusedMs`), all others at 250 ms (`inputModeBackgroundMs`). `handleGridPreviewsUpdated` uses `MergeContents` for fast-poll messages to avoid blanking non-focused cells between background sweeps
 - `GridView.Hide()` now also clears `inputMode` so re-opened grids always start in nav mode
 - `(i) input` added to `GridKeyMap.ShortHelp()` for hint-bar discoverability
+- First-use hint: `ViewGridInputHint` overlay shown on first activation; `d` sets `HideGridInputHint=true`, `esc`/`q` also exits input mode
 
 ## Plan
 

--- a/features/completed/105-in-place-session-input-from-grid-view.md
+++ b/features/completed/105-in-place-session-input-from-grid-view.md
@@ -1,7 +1,8 @@
 # Feature: In-place session input from grid view
 
-- **GitHub Issue:** —
-- **Stage:** IMPLEMENT
+- **GitHub Issue:** #105
+- **Stage:** DONE
+- **PR:** #106
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** —

--- a/features/in-place-grid-typing.md
+++ b/features/in-place-grid-typing.md
@@ -1,11 +1,11 @@
 # Feature: In-place session input from grid view
 
 - **GitHub Issue:** —
-- **Stage:** RESEARCH
+- **Stage:** IMPLEMENT
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** —
-- **Branch:** —
+- **Branch:** feature/grid-input-mode
 
 ## Description
 
@@ -52,25 +52,78 @@ Preview polling continues unchanged — cell content updates within ~500ms of ea
 - **Key conflicts**: single-char bindings (`r`, `x`, `g`, etc.) must be excluded from input mode. Using explicit `i` to enter (rather than "any printable key") avoids accidental mode entry.
 - **Native backend**: needs `SendKeys` wired to PTY write; tmux backend uses `tmux send-keys`.
 
-## Plan
+## Implementation Notes
 
-_To be filled during PLAN stage._
+- `Ctrl+Q` exits input mode (not `Esc`); `Esc` is forwarded as `\033` to the session per user request
+- `DisableGridInput bool` config field (JSON: `disable_grid_input`) added to `config.Config` for opt-out
+- `GridView.InputEnabled` field is set from config on model construction and on each settings save
+- `InputMode()` uses a value receiver so it can be called on the non-pointer `gridView` field in `Model`
+- The `·· INPUT ··` badge is overlaid at the right edge of the selected cell header, replacing the last N chars so total header width is preserved
+- `keyToBytes()` handles printable runes, Enter→`\r`, Esc→`\033`, arrows→ANSI seqs, and common `Ctrl+` codes
+- Keys that have no sensible byte representation (e.g. F1) return `""` and are silently ignored
+- `scheduleGridPoll()` uses a 100 ms interval when `gridView.InputMode()` is true (vs. the configured ~500 ms default); entering input mode triggers an immediate re-poll to kick off the fast cycle
+- `GridView.Hide()` now also clears `inputMode` so re-opened grids always start in nav mode
+- `(i) input` added to `GridKeyMap.ShortHelp()` for hint-bar discoverability
+
+## Plan
 
 ### Files to Change
 
-1. `internal/mux/interface.go` — add `SendKeys(target, text string) error` to `Backend`
-2. `internal/mux/tmux/` — implement `SendKeys` via `tmux send-keys -t <target> <text> ""`
-3. `internal/mux/native/` — implement `SendKeys` via PTY write
-4. `internal/tui/components/gridview.go` — `inputMode` flag, key forwarding in `Update()`, badge in `renderCell()`
-5. `internal/tui/handle_keys.go` — gate grid shortcuts behind `!inputMode`
+1. **`internal/tmux/window.go`** — Add `SendKeys(target, keys string) error` using `tmux send-keys -t <target> -l -- <text>` (the `-l` flag sends raw bytes, bypassing tmux key-name interpretation)
+
+2. **`internal/mux/interface.go`** — Add `SendKeys(target, keys string) error` to the `Backend` interface; add package-level `mux.SendKeys` forwarding function with nil-guard
+
+3. **`internal/mux/tmux/backend.go`** — Implement `Backend.SendKeys` delegating to `tmux.SendKeys`
+
+4. **`internal/mux/native/pane.go`** — Add `writeInput(keys string) error` that writes bytes directly to `p.ptm` (the PTY master fd); no locking needed — PTY writes are async-safe
+
+5. **`internal/mux/native/manager.go`** — Add `sendKeys(target, keys string) error` calling `paneByTarget(target).writeInput(keys)`
+
+6. **`internal/mux/native/protocol.go`** — Add `Keys string` field to `Request`
+
+7. **`internal/mux/native/daemon.go`** — Add `"send_keys"` case in `handleConn` dispatching to `mgr.sendKeys(req.Target, req.Keys)`
+
+8. **`internal/mux/native/backend_unix.go`** — Implement `Backend.SendKeys` as `b.client.do(Request{Op: "send_keys", Target: target, Keys: keys})`
+
+9. **`internal/mux/native/backend_windows.go`** — Add `SendKeys` stub returning `errors.New("not supported")`
+
+10. **`internal/mux/muxtest/mock.go`** — Add `SendKeys` to mock; add exported `LastSentTarget`, `LastSentKeys` fields for test assertions
+
+11. **`internal/config/config.go`** — Add `DisableGridInput bool` field (default false = feature enabled; set to true to opt out)
+
+12. **`internal/tui/components/gridview.go`**:
+    - Add `inputMode bool` field to `GridView`
+    - Add `InputMode() bool` accessor (used by `handle_keys.go` and tests)
+    - Add `keyToBytes(msg tea.KeyMsg) string` helper: printable runes → `string(msg.Runes)`; enter → `"\r"`; **esc → `"\033"`** (forwarded to session); backspace/delete → `"\x7f"`; tab → `"\t"`; arrows → ANSI seqs (`"\033[A/B/C/D"`); common ctrl+keys (`\x01`–`\x1a`)
+    - Modify `Update()`:
+      - If `inputMode`: **`Ctrl+Q` → exit input mode** (`gv.inputMode = false`); all other keys (including `Esc`) → return cmd calling `mux.SendKeys(target, keyToBytes(msg))`
+      - If `!inputMode`: add `"i"` case — if selected session exists, `gv.inputMode = true`
+    - Modify `renderCell()`: when `gv.inputMode && selected`, append `·· INPUT ··` to the header after the title
+
+13. **`internal/tui/handle_keys.go`** — At the top of `handleGridKey()` (after ctrl+c check), add early return: `if m.gridView.InputMode() { cmd, _ := m.gridView.Update(msg); return cmd }` — this bypasses all nav shortcuts when in input mode. Also gate `"i"` activation behind `!m.cfg.DisableGridInput`
+
+14. **`internal/tui/keys.go`** — Add `InputMode key.Binding` to `GridKeyMap`; add a static `(i) input` entry to `ShortHelp()` (hidden if `DisableGridInput` is set — pass config bool through); also add `ctrl+q: exit input` entry shown only when `InputMode()` is true
+
+15. **`CHANGELOG.md`** — Add `[Unreleased]` entry under `Added`
+
+16. **`docs/keybindings.md`** — Document `i` to enter input mode and `Ctrl+Q` to exit in grid view
 
 ### Test Strategy
 
-- Unit test `SendKeys` tmux command construction
-- Integration: verify grid stays visible and cell content updates after key forward
-- Verify `Esc` exits input mode without exiting grid
+**Unit tests** (`internal/tui/components/gridview_input_test.go`):
+- `TestKeyToBytes_PrintableRunes` — `tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")}` → `"y"`
+- `TestKeyToBytes_SpecialKeys` — enter → `"\r"`, backspace → `"\x7f"`, esc → `"\033"`, up → `"\033[A"`, etc.
+
+**Functional flow tests** (`internal/tui/grid_input_flow_test.go`):
+- `TestGridInputMode_EnterAndExit` — open grid (`g`), press `i` → `gridView.InputMode()` is true; press `Ctrl+Q` → false; grid stays open
+- `TestGridInputMode_EscForwarded` — in input mode, press `Esc` → `mock.LastSentKeys == "\033"` (not exit)
+- `TestGridInputMode_KeysForwarded` — in input mode, press `y` → `mock.CallCount("SendKeys") == 1`, `mock.LastSentKeys == "y"`
+- `TestGridInputMode_NavSuppressedInInputMode` — in input mode, press `x` → no ConfirmActionMsg; key goes to SendKeys
+- `TestGridInputMode_ArrowsForwarded` — in input mode, press `tea.KeyUp` → `mock.LastSentKeys == "\033[A"` (not navigation)
+- `TestGridInputMode_DisabledByConfig` — with `cfg.DisableGridInput = true`, press `i` → `gridView.InputMode()` remains false
 
 ### Risks
 
-- Arrow key semantics change in input mode may surprise users — needs clear visual cue
-- Native backend PTY write path may need locking if daemon is concurrent
+- `Ctrl+Q` is already used by some terminals/shells; conflicts unlikely in grid view context but noted
+- `tmux send-keys -l` requires tmux ≥ 1.3 (released 2009; safe to assume)
+- Native backend PTY write: `p.ptm.Write()` is already exercised by the attach path; no additional locking needed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,12 @@ type Config struct {
 	// "tmux" (default) uses the external tmux binary.
 	// "native" uses Go's built-in PTY daemon; no external binary needed.
 	Multiplexer                 string                    `json:"multiplexer,omitempty"`
+	// DisableGridInput disables the in-place input mode in grid view.
+	// When false (default), pressing 'i' on a focused grid cell enters input
+	// mode and forwards keystrokes to that session without a full attach.
+	// Set to true to opt out of this feature (e.g. if 'i' is needed for
+	// another keybinding or the forwarding latency is unacceptable).
+	DisableGridInput bool `json:"disable_grid_input,omitempty"`
 	// DetachKey is the single-key combination that returns the user from an
 	// attached session back to the Hive TUI. Accepted form is
 	// "ctrl+<lowercase-letter>" (e.g. "ctrl+q", "ctrl+d"). Defaults to

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,10 @@ type Config struct {
 	// "tmux" (default) uses the external tmux binary.
 	// "native" uses Go's built-in PTY daemon; no external binary needed.
 	Multiplexer                 string                    `json:"multiplexer,omitempty"`
+	// HideGridInputHint suppresses the first-use hint shown when entering grid
+	// input mode. Set to true (via the "d" key in the hint dialog) to skip the
+	// hint on subsequent activations. Tracked independently from HideAttachHint.
+	HideGridInputHint bool `json:"hide_grid_input_hint,omitempty"`
 	// DisableGridInput disables the in-place input mode in grid view.
 	// When false (default), pressing 'i' on a focused grid cell enters input
 	// mode and forwards keystrokes to that session without a full attach.

--- a/internal/mux/interface.go
+++ b/internal/mux/interface.go
@@ -64,6 +64,11 @@ type Backend interface {
 	// IsPaneDead reports whether the pane's process has exited.
 	IsPaneDead(target string) bool
 
+	// SendKeys sends a literal string of bytes (which may include ANSI escape
+	// sequences for special keys such as arrows) to the pane at target.
+	// The bytes are written directly to the pane's stdin without interpretation.
+	SendKeys(target, keys string) error
+
 	// Attach takes over the current terminal and connects it to the window
 	// at target, allowing the user to interact with the running process.
 	// Returns when the user detaches (backend-specific detach key) or the
@@ -195,6 +200,15 @@ func IsPaneDead(target string) bool {
 		return false
 	}
 	return active.IsPaneDead(target)
+}
+
+// SendKeys sends a literal string of bytes to the pane at target.
+// Returns nil if no backend has been set (e.g. in tests).
+func SendKeys(target, keys string) error {
+	if active == nil {
+		return nil
+	}
+	return active.SendKeys(target, keys)
 }
 
 func Attach(target string) error { return active.Attach(target) }

--- a/internal/mux/muxtest/mock.go
+++ b/internal/mux/muxtest/mock.go
@@ -20,6 +20,11 @@ type MockBackend struct {
 	paneBells     map[string]bool              // "session:idx" → bell flag
 	calls         map[string]int               // method name → call count
 	errors        map[string]error             // method name → error to return
+
+	// LastSentTarget and LastSentKeys record the most-recent SendKeys call.
+	// Exported for use in test assertions.
+	LastSentTarget string
+	LastSentKeys   string
 }
 
 // Compile-time check that MockBackend satisfies mux.Backend.
@@ -259,6 +264,17 @@ func (m *MockBackend) GetCurrentCommand(target string) (string, error) {
 		return "", err
 	}
 	return "sh", nil
+}
+
+func (m *MockBackend) SendKeys(target, keys string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := m.record("SendKeys"); err != nil {
+		return err
+	}
+	m.LastSentTarget = target
+	m.LastSentKeys = keys
+	return nil
 }
 
 func (m *MockBackend) Attach(target string) error {

--- a/internal/mux/native/backend_unix.go
+++ b/internal/mux/native/backend_unix.go
@@ -135,6 +135,11 @@ func (b *Backend) GetCurrentCommand(_ string) (string, error) {
 
 func (b *Backend) IsPaneDead(_ string) bool { return false }
 
+func (b *Backend) SendKeys(target, keys string) error {
+	_, err := b.client.do(Request{Op: "send_keys", Target: target, Keys: keys})
+	return err
+}
+
 func (b *Backend) Attach(target string) error {
 	return clientAttach(b.client, target, b.spec.Byte)
 }

--- a/internal/mux/native/backend_windows.go
+++ b/internal/mux/native/backend_windows.go
@@ -53,6 +53,7 @@ func (b *Backend) DetachKey() string                                       { ret
 func (b *Backend) SupportsPopup() bool                                     { return false }
 func (b *Backend) PopupAttach(_, _ string) error                           { return errNotSupported }
 func (b *Backend) UseExecAttach() bool                                     { return false }
+func (b *Backend) SendKeys(_, _ string) error                              { return errNotSupported }
 
 // SockPath returns an empty string on Windows (no socket used).
 func SockPath() string { return "" }

--- a/internal/mux/native/daemon.go
+++ b/internal/mux/native/daemon.go
@@ -143,6 +143,13 @@ func handleConn(conn net.Conn) {
 		content := p.capture(req.Lines)
 		logWriteErr(conn, writeMsg(conn, Response{OK: true, Content: content}))
 
+	case "send_keys":
+		if err := mgr.sendKeys(req.Target, req.Keys); err != nil {
+			logWriteErr(conn, writeMsg(conn, errResp(err.Error())))
+			return
+		}
+		logWriteErr(conn, writeMsg(conn, okResp()))
+
 	case "attach":
 		handleAttach(conn, req.Target)
 

--- a/internal/mux/native/manager.go
+++ b/internal/mux/native/manager.go
@@ -195,6 +195,15 @@ type windowEntry struct {
 	name string
 }
 
+// sendKeys writes a literal byte string to the pane at target.
+func (m *manager) sendKeys(target, keys string) error {
+	p := m.paneByTarget(target)
+	if p == nil {
+		return fmt.Errorf("window not found: %s", target)
+	}
+	return p.writeInput(keys)
+}
+
 // paneByTarget returns the pane for "session:index", or nil if not found.
 func (m *manager) paneByTarget(target string) *pane {
 	sessionName, idx, err := parseTarget(target)

--- a/internal/mux/native/pane.go
+++ b/internal/mux/native/pane.go
@@ -108,6 +108,13 @@ func (p *pane) resize(rows, cols uint16) {
 	pty.Setsize(p.ptm, &pty.Winsize{Rows: rows, Cols: cols}) //nolint:errcheck
 }
 
+// writeInput writes a literal byte string to the PTY master (stdin of the process).
+// PTY master writes are async-safe; no mutex is required.
+func (p *pane) writeInput(keys string) error {
+	_, err := p.ptm.Write([]byte(keys))
+	return err
+}
+
 // setAttachWriter atomically updates the writer that receives new PTY output.
 // Pass nil to disable fan-out.
 func (p *pane) setAttachWriter(w io.Writer) {

--- a/internal/mux/native/protocol.go
+++ b/internal/mux/native/protocol.go
@@ -21,6 +21,7 @@ type Request struct {
 	Target     string   `json:"target,omitempty"`
 	Lines      int      `json:"lines,omitempty"`
 	NewName    string   `json:"new_name,omitempty"`
+	Keys       string   `json:"keys,omitempty"`
 }
 
 // Response is the JSON envelope sent from the daemon to the client.

--- a/internal/mux/tmux/backend.go
+++ b/internal/mux/tmux/backend.go
@@ -82,6 +82,8 @@ func (b *Backend) GetCurrentCommand(target string) (string, error) {
 
 func (b *Backend) IsPaneDead(target string) bool { return tmux.IsPaneDead(target) }
 
+func (b *Backend) SendKeys(target, keys string) error { return tmux.SendKeys(target, keys) }
+
 // DetachKey returns the configured detach key in human-readable form
 // (e.g. "Ctrl+Q"). The actual binding is installed by AttachScript.
 func (b *Backend) DetachKey() string { return b.spec.Display }

--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -52,6 +52,13 @@ func RenameWindow(target, newName string) error {
 }
 
 
+// SendKeys sends a literal string of bytes to the pane at target.
+// The -l flag bypasses tmux key-name interpretation so raw bytes (including
+// ANSI escape sequences) are written directly to the pane's stdin.
+func SendKeys(target, keys string) error {
+	return ExecSilent("send-keys", "-t", target, "-l", "--", keys)
+}
+
 func ListWindows(tmuxSession string) ([]WindowInfo, error) {
 	out, err := Exec(
 		"list-windows",

--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -51,7 +51,6 @@ func RenameWindow(target, newName string) error {
 	return ExecSilent("rename-window", "-t", target, newName)
 }
 
-
 // SendKeys sends a literal string of bytes to the pane at target.
 // The -l flag bypasses tmux key-name interpretation so raw bytes (including
 // ANSI escape sequences) are written directly to the pane's stdin.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -415,6 +415,8 @@ func (m Model) View() string {
 		return m.helpView()
 	case ViewTmuxHelp:
 		return m.tmuxHelpView()
+	case ViewGridInputHint:
+		return m.overlayView(m.gridInputHintView())
 	case ViewAttachHint:
 		return m.overlayView(m.attachHintView())
 	case ViewConfirm:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -179,6 +179,7 @@ func New(cfg config.Config, appState state.AppState, whatsNewContent string) Mod
 		helpModel:           newStyledHelp(),
 		gridHelpModel:       newStyledHelp(),
 	}
+	m.gridView.InputEnabled = !cfg.DisableGridInput
 	// Clear the transient fields now that the pickers own their lists.
 	m.appState.OrphanSessions = nil
 	m.appState.RecoverableSessions = nil

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -21,8 +21,11 @@ type GridSessionSelectedMsg struct {
 }
 
 // GridPreviewsUpdatedMsg carries fresh capture-pane content for all sessions.
+// Fast=true indicates this is from the input-mode focused-session poll loop;
+// the handler uses this to reschedule the correct loop.
 type GridPreviewsUpdatedMsg struct {
 	Contents map[string]string
+	Fast     bool
 }
 
 // PollGridPreviews returns a tea.Cmd that captures pane content for all sessions.
@@ -40,6 +43,24 @@ func PollGridPreviews(sessions []*state.Session, interval time.Duration) tea.Cmd
 			}
 		}
 		return GridPreviewsUpdatedMsg{Contents: contents}
+	})
+}
+
+// PollFocusedGridPreview returns a tea.Cmd that captures pane content for a
+// single session at the given interval. Used for the fast poll in input mode.
+// The returned message has Fast=true so the handler reschedules this loop.
+func PollFocusedGridPreview(sess *state.Session, interval time.Duration) tea.Cmd {
+	if sess == nil || sess.TmuxSession == "" {
+		return nil
+	}
+	target := mux.Target(sess.TmuxSession, sess.TmuxWindow)
+	sessID := sess.ID
+	return tea.Tick(interval, func(_ time.Time) tea.Msg {
+		contents := make(map[string]string, 1)
+		if content, err := mux.CapturePane(target, 200); err == nil {
+			contents[sessID] = sanitizePreviewContent(content)
+		}
+		return GridPreviewsUpdatedMsg{Contents: contents, Fast: true}
 	})
 }
 

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -112,6 +112,18 @@ func (gv *GridView) SetContents(contents map[string]string) {
 	gv.contents = contents
 }
 
+// MergeContents updates only the keys present in contents, leaving other
+// sessions' content untouched. Used by the focused-session fast poll so it
+// doesn't blank out non-focused cells.
+func (gv *GridView) MergeContents(contents map[string]string) {
+	if gv.contents == nil {
+		gv.contents = make(map[string]string, len(contents))
+	}
+	for k, v := range contents {
+		gv.contents[k] = v
+	}
+}
+
 // SetProjectNames provides a projectID→name lookup used in cell headers.
 func (gv *GridView) SetProjectNames(names map[string]string) {
 	gv.projectNames = names
@@ -505,7 +517,7 @@ func (gv *GridView) renderCell(sess *state.Session, w, h int, selected bool) str
 
 	// When input mode is active on this cell, overlay a badge at the right edge.
 	if gv.inputMode && selected {
-		badge := " ·· INPUT ··"
+		badge := " INPUT · C-Q"
 		badgeStyle := lipgloss.NewStyle().
 			Background(styles.ColorAccent).
 			Foreground(lipgloss.Color("#000000")).

--- a/internal/tui/components/gridview.go
+++ b/internal/tui/components/gridview.go
@@ -59,6 +59,8 @@ type GridView struct {
 	bellPending   map[string]bool   // sessionID → true when an unacknowledged bell has fired
 	bellBlinkOn   bool              // toggled by the bell-blink ticker; true = show ♪, false = show status dot
 	atExtended    bool              // true when cursor is visually at the extended (lower) portion of a cell
+	inputMode     bool              // true when keystrokes are forwarded to the focused session
+	InputEnabled  bool              // when false, 'i' is a no-op (set from cfg.DisableGridInput)
 }
 
 // Show activates the grid with the given sessions.
@@ -78,7 +80,11 @@ func (gv *GridView) Show(sessions []*state.Session, mode state.GridRestoreMode) 
 // Hide deactivates the grid.
 // atExtended is intentionally not reset here — Show() clears it on the next
 // grid open, and Update() is gated on Active so the stale value is never read.
-func (gv *GridView) Hide() { gv.Active = false }
+// inputMode is cleared so a re-opened grid always starts in nav mode.
+func (gv *GridView) Hide() {
+	gv.Active = false
+	gv.inputMode = false
+}
 
 // SetContents updates the captured preview content map.
 func (gv *GridView) SetContents(contents map[string]string) {
@@ -131,6 +137,17 @@ func (gv *GridView) AtExtendedForTest() bool {
 	return gv.atExtended
 }
 
+// InputMode reports whether the grid is in keystroke-forwarding mode.
+func (gv GridView) InputMode() bool {
+	return gv.inputMode
+}
+
+// ExitInputMode clears input mode without any other side-effect.
+// Used externally when the grid is hidden while in input mode.
+func (gv *GridView) ExitInputMode() {
+	gv.inputMode = false
+}
+
 // Selected returns the currently focused session, or nil.
 func (gv *GridView) Selected() *state.Session {
 	if !gv.Active || gv.Cursor < 0 || gv.Cursor >= len(gv.sessions) {
@@ -170,12 +187,40 @@ func (gv *GridView) Update(msg tea.KeyMsg) (tea.Cmd, bool) {
 	if !gv.Active {
 		return nil, false
 	}
+
+	// Input mode: forward all keystrokes to the focused session.
+	// Ctrl+Q exits input mode; everything else (including Esc) is forwarded.
+	if gv.inputMode {
+		if msg.String() == "ctrl+q" {
+			gv.inputMode = false
+			return nil, true
+		}
+		sess := gv.Selected()
+		if sess != nil && sess.TmuxSession != "" {
+			target := mux.Target(sess.TmuxSession, sess.TmuxWindow)
+			keys := keyToBytes(msg)
+			if keys != "" {
+				return func() tea.Msg {
+					mux.SendKeys(target, keys) //nolint:errcheck // best-effort
+					return nil
+				}, true
+			}
+		}
+		return nil, true
+	}
+
 	n := len(gv.sessions)
 	cols := gridColumns(gv.Width, gv.Height, n)
 
 	rows := (n + cols - 1) / cols
 
 	switch msg.String() {
+	case "i":
+		if gv.InputEnabled {
+			if sess := gv.Selected(); sess != nil && sess.TmuxSession != "" {
+				gv.inputMode = true
+			}
+		}
 	case "esc":
 		gv.Hide()
 	case "enter", "a":
@@ -436,6 +481,24 @@ func (gv *GridView) renderCell(sess *state.Session, w, h int, selected bool) str
 		}
 		headerContent = prefixStr + flat
 	}
+
+	// When input mode is active on this cell, overlay a badge at the right edge.
+	if gv.inputMode && selected {
+		badge := " ·· INPUT ··"
+		badgeStyle := lipgloss.NewStyle().
+			Background(styles.ColorAccent).
+			Foreground(lipgloss.Color("#000000")).
+			Bold(true)
+		badgeStr := badgeStyle.Render(badge)
+		badgeW := ansi.StringWidth(badge)
+		// Replace the last badgeW chars of the header with the badge so the
+		// total width stays constant.
+		headerW := ansi.StringWidth(headerContent)
+		if headerW > badgeW {
+			headerContent = ansi.Truncate(headerContent, headerW-badgeW, "") + badgeStr
+		}
+	}
+
 	headerLine := headerContent
 
 	// Optional pane-title subtitle: only render when the cell is tall enough
@@ -642,6 +705,85 @@ func (gv *GridView) CellAt(x, y int) (idx int, ok bool) {
 		return -1, false
 	}
 	return i, true
+}
+
+// keyToBytes converts a BubbleTea key message to the raw bytes to forward to a
+// session in input mode. Returns "" for keys that have no sensible byte
+// representation (e.g. unknown function keys).
+func keyToBytes(msg tea.KeyMsg) string {
+	switch msg.Type {
+	case tea.KeyRunes:
+		return string(msg.Runes)
+	case tea.KeyEnter:
+		return "\r"
+	case tea.KeyBackspace:
+		return "\x7f"
+	case tea.KeyDelete:
+		return "\x1b[3~"
+	case tea.KeyTab:
+		return "\t"
+	case tea.KeySpace:
+		return " "
+	case tea.KeyUp:
+		return "\033[A"
+	case tea.KeyDown:
+		return "\033[B"
+	case tea.KeyRight:
+		return "\033[C"
+	case tea.KeyLeft:
+		return "\033[D"
+	case tea.KeyEscape:
+		return "\033"
+	// Common Ctrl+letter keys.
+	case tea.KeyCtrlA:
+		return "\x01"
+	case tea.KeyCtrlB:
+		return "\x02"
+	case tea.KeyCtrlC:
+		return "\x03"
+	case tea.KeyCtrlD:
+		return "\x04"
+	case tea.KeyCtrlE:
+		return "\x05"
+	case tea.KeyCtrlF:
+		return "\x06"
+	case tea.KeyCtrlG:
+		return "\x07"
+	case tea.KeyCtrlH:
+		return "\x08"
+	case tea.KeyCtrlJ:
+		return "\x0a"
+	case tea.KeyCtrlK:
+		return "\x0b"
+	case tea.KeyCtrlL:
+		return "\x0c"
+	case tea.KeyCtrlN:
+		return "\x0e"
+	case tea.KeyCtrlO:
+		return "\x0f"
+	case tea.KeyCtrlP:
+		return "\x10"
+	case tea.KeyCtrlR:
+		return "\x12"
+	case tea.KeyCtrlS:
+		return "\x13"
+	case tea.KeyCtrlT:
+		return "\x14"
+	case tea.KeyCtrlU:
+		return "\x15"
+	case tea.KeyCtrlV:
+		return "\x16"
+	case tea.KeyCtrlW:
+		return "\x17"
+	case tea.KeyCtrlX:
+		return "\x18"
+	case tea.KeyCtrlY:
+		return "\x19"
+	case tea.KeyCtrlZ:
+		return "\x1a"
+	default:
+		return ""
+	}
 }
 
 // gridColumns computes the number of columns that best tiles n sessions inside

--- a/internal/tui/components/gridview_input_test.go
+++ b/internal/tui/components/gridview_input_test.go
@@ -1,0 +1,66 @@
+package components
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestKeyToBytes_PrintableRunes(t *testing.T) {
+	cases := []struct {
+		rune string
+		want string
+	}{
+		{"y", "y"},
+		{"n", "n"},
+		{"a", "a"},
+		{"Z", "Z"},
+		{"1", "1"},
+		{" ", " "},
+	}
+	for _, tc := range cases {
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tc.rune)}
+		got := keyToBytes(msg)
+		if got != tc.want {
+			t.Errorf("keyToBytes(%q) = %q, want %q", tc.rune, got, tc.want)
+		}
+	}
+}
+
+func TestKeyToBytes_SpecialKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  tea.KeyMsg
+		want string
+	}{
+		{"enter", tea.KeyMsg{Type: tea.KeyEnter}, "\r"},
+		{"backspace", tea.KeyMsg{Type: tea.KeyBackspace}, "\x7f"},
+		{"delete", tea.KeyMsg{Type: tea.KeyDelete}, "\x1b[3~"},
+		{"tab", tea.KeyMsg{Type: tea.KeyTab}, "\t"},
+		{"space", tea.KeyMsg{Type: tea.KeySpace}, " "},
+		{"up", tea.KeyMsg{Type: tea.KeyUp}, "\033[A"},
+		{"down", tea.KeyMsg{Type: tea.KeyDown}, "\033[B"},
+		{"right", tea.KeyMsg{Type: tea.KeyRight}, "\033[C"},
+		{"left", tea.KeyMsg{Type: tea.KeyLeft}, "\033[D"},
+		{"esc", tea.KeyMsg{Type: tea.KeyEscape}, "\033"},
+		{"ctrl+c", tea.KeyMsg{Type: tea.KeyCtrlC}, "\x03"},
+		{"ctrl+d", tea.KeyMsg{Type: tea.KeyCtrlD}, "\x04"},
+		{"ctrl+a", tea.KeyMsg{Type: tea.KeyCtrlA}, "\x01"},
+		{"ctrl+u", tea.KeyMsg{Type: tea.KeyCtrlU}, "\x15"},
+	}
+	for _, tc := range cases {
+		got := keyToBytes(tc.msg)
+		if got != tc.want {
+			t.Errorf("keyToBytes(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestKeyToBytes_UnknownKeyReturnsEmpty(t *testing.T) {
+	// An unrecognised key type should return "" (not forwarded).
+	msg := tea.KeyMsg{Type: tea.KeyF1}
+	got := keyToBytes(msg)
+	if got != "" {
+		t.Errorf("keyToBytes(F1) = %q, want empty string", got)
+	}
+}

--- a/internal/tui/components/gridview_input_test.go
+++ b/internal/tui/components/gridview_input_test.go
@@ -64,3 +64,30 @@ func TestKeyToBytes_UnknownKeyReturnsEmpty(t *testing.T) {
 		t.Errorf("keyToBytes(F1) = %q, want empty string", got)
 	}
 }
+
+func TestMergeContents_PreservesExistingKeys(t *testing.T) {
+	gv := &GridView{}
+	// Seed with two sessions.
+	gv.SetContents(map[string]string{
+		"sess-a": "content-a",
+		"sess-b": "content-b",
+	})
+
+	// Merge only updates sess-a; sess-b must be preserved.
+	gv.MergeContents(map[string]string{"sess-a": "content-a-new"})
+
+	if got := gv.contents["sess-a"]; got != "content-a-new" {
+		t.Errorf("sess-a = %q, want %q", got, "content-a-new")
+	}
+	if got := gv.contents["sess-b"]; got != "content-b" {
+		t.Errorf("sess-b = %q, want %q (should be unchanged)", got, "content-b")
+	}
+}
+
+func TestMergeContents_NilMapInitialised(t *testing.T) {
+	gv := &GridView{} // contents is nil
+	gv.MergeContents(map[string]string{"sess-a": "hello"})
+	if got := gv.contents["sess-a"]; got != "hello" {
+		t.Errorf("contents[sess-a] = %q, want %q", got, "hello")
+	}
+}

--- a/internal/tui/flow_grid_input_test.go
+++ b/internal/tui/flow_grid_input_test.go
@@ -1,0 +1,207 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/lucascaro/hive/internal/config"
+	"github.com/lucascaro/hive/internal/mux"
+	"github.com/lucascaro/hive/internal/mux/muxtest"
+	"github.com/lucascaro/hive/internal/state"
+)
+
+// TestGridInputMode_EnterAndExit verifies that pressing 'i' enters input mode
+// and Ctrl+Q exits it, leaving the grid active in both cases.
+func TestGridInputMode_EnterAndExit(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	// Open grid.
+	f.SendKey("g")
+	f.AssertGridActive(true)
+
+	if f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should be false before pressing i")
+	}
+
+	// Press 'i' to enter input mode.
+	f.SendKey("i")
+	if !f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should be true after pressing i")
+	}
+	// Grid must still be active.
+	f.AssertGridActive(true)
+
+	// Press Ctrl+Q to exit input mode.
+	f.Send(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	if f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should be false after Ctrl+Q")
+	}
+	// Grid must remain active after exiting input mode.
+	f.AssertGridActive(true)
+}
+
+// TestGridInputMode_EscForwardedToSession verifies that Esc in input mode
+// is forwarded to the session (as \033) rather than closing the grid.
+func TestGridInputMode_EscForwardedToSession(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.SendKey("i")
+
+	// Esc should NOT exit grid or input mode; it should be forwarded.
+	cmd := f.SendSpecialKey(tea.KeyEscape)
+	f.ExecCmdChain(cmd)
+
+	// Grid must still be active and in input mode.
+	f.AssertGridActive(true)
+	if !f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should still be true after Esc")
+	}
+	// The mock should have received the Esc as \033.
+	if mock.LastSentKeys != "\033" {
+		t.Errorf("LastSentKeys = %q, want %q", mock.LastSentKeys, "\033")
+	}
+}
+
+// TestGridInputMode_KeysForwarded verifies that printable keys in input mode
+// are forwarded to the focused session via SendKeys.
+func TestGridInputMode_KeysForwarded(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.SendKey("i")
+
+	// Press 'y' — should forward to session.
+	cmd := f.SendKey("y")
+	f.ExecCmdChain(cmd)
+
+	if mock.CallCount("SendKeys") != 1 {
+		t.Errorf("SendKeys call count = %d, want 1", mock.CallCount("SendKeys"))
+	}
+	if mock.LastSentKeys != "y" {
+		t.Errorf("LastSentKeys = %q, want %q", mock.LastSentKeys, "y")
+	}
+}
+
+// TestGridInputMode_NavSuppressedInInputMode verifies that nav shortcuts like
+// 'x' (kill) are not triggered when input mode is active; instead the key is
+// forwarded to the session.
+func TestGridInputMode_NavSuppressedInInputMode(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.SendKey("i")
+
+	// 'x' in nav mode would push a kill-session confirm dialog.
+	// In input mode it must be forwarded instead.
+	cmd := f.SendKey("x")
+	f.ExecCmdChain(cmd)
+
+	// No confirm dialog should have been pushed.
+	if f.model.TopView() == ViewConfirm {
+		t.Error("ViewConfirm was pushed — 'x' should be forwarded in input mode, not kill-session")
+	}
+	// Key should have been forwarded.
+	if mock.CallCount("SendKeys") == 0 {
+		t.Error("SendKeys was not called — 'x' should be forwarded to session in input mode")
+	}
+	if mock.LastSentKeys != "x" {
+		t.Errorf("LastSentKeys = %q, want %q", mock.LastSentKeys, "x")
+	}
+}
+
+// TestGridInputMode_ArrowsForwarded verifies that arrow keys in input mode are
+// sent as ANSI escape sequences rather than navigating the grid cursor.
+func TestGridInputMode_ArrowsForwarded(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	// Open all-sessions grid so we have multiple cells to navigate.
+	f.SendKey("G")
+	initialCursor := f.Model().gridView.Cursor
+	f.SendKey("i")
+
+	// Press Up arrow — should be forwarded as \033[A, not move cursor.
+	cmd := f.Send(tea.KeyMsg{Type: tea.KeyUp})
+	f.ExecCmdChain(cmd)
+
+	if f.Model().gridView.Cursor != initialCursor {
+		t.Error("cursor moved on Up in input mode — arrow should be forwarded, not navigate")
+	}
+	if mock.LastSentKeys != "\033[A" {
+		t.Errorf("LastSentKeys = %q, want %q (ANSI up)", mock.LastSentKeys, "\033[A")
+	}
+}
+
+// TestGridInputMode_DisabledByConfig verifies that setting DisableGridInput=true
+// prevents the feature from activating.
+func TestGridInputMode_DisabledByConfig(t *testing.T) {
+	tmp := t.TempDir()
+	setHomePersist(t, tmp)
+	ensureConfigDir(t)
+	t.Setenv("TERM", "dumb")
+
+	mock := muxtest.New()
+	mux.SetBackend(mock)
+	t.Cleanup(func() { mux.SetBackend(nil) })
+
+	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
+	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
+
+	cfg := config.DefaultConfig()
+	cfg.HideAttachHint = true
+	cfg.PreviewRefreshMs = 1
+	cfg.DisableGridInput = true // opt-out
+
+	appState := testAppStateWithTwoProjects()
+	appState.TermWidth = 120
+	appState.TermHeight = 40
+
+	m := New(cfg, appState, "")
+	m.appState.TermWidth = 120
+	m.appState.TermHeight = 40
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.AssertGridActive(true)
+
+	// 'i' should be a no-op.
+	f.SendKey("i")
+	if f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should remain false when DisableGridInput=true")
+	}
+}
+
+// TestGridInputMode_HideExitsInputMode verifies that hiding the grid (e.g. via
+// Esc in nav mode, which can't happen in input mode, but via programmatic Hide)
+// always resets input mode so the next open starts in nav mode.
+func TestGridInputMode_HideExitsInputMode(t *testing.T) {
+	m, mock := testFlowModel(t)
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.SendKey("i")
+
+	if !f.model.gridView.InputMode() {
+		t.Fatal("pre-condition: input mode should be active")
+	}
+
+	// Exit input mode then close grid normally with 'g'.
+	f.Send(tea.KeyMsg{Type: tea.KeyCtrlQ})
+	f.SendKey("g") // closes grid in nav mode
+
+	f.AssertGridActive(false)
+
+	// Re-open grid; input mode must be false.
+	f.SendKey("g")
+	if f.model.gridView.InputMode() {
+		t.Fatal("inputMode should be false after re-opening the grid")
+	}
+
+	_ = mock // avoid "declared and not used" if mock.* not referenced
+	_ = state.GridRestoreProject // keep import used
+}

--- a/internal/tui/flow_grid_input_test.go
+++ b/internal/tui/flow_grid_input_test.go
@@ -205,3 +205,140 @@ func TestGridInputMode_HideExitsInputMode(t *testing.T) {
 	_ = mock // avoid "declared and not used" if mock.* not referenced
 	_ = state.GridRestoreProject // keep import used
 }
+
+// TestGridInputMode_HintShownOnFirstUse verifies that pressing 'i' shows the
+// grid-input-hint overlay when HideGridInputHint=false.
+func TestGridInputMode_HintShownOnFirstUse(t *testing.T) {
+	tmp := t.TempDir()
+	setHomePersist(t, tmp)
+	ensureConfigDir(t)
+	t.Setenv("TERM", "dumb")
+
+	mock := muxtest.New()
+	mux.SetBackend(mock)
+	t.Cleanup(func() { mux.SetBackend(nil) })
+
+	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
+	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
+
+	cfg := config.DefaultConfig()
+	cfg.HideAttachHint = true
+	cfg.HideGridInputHint = false // hint enabled
+	cfg.PreviewRefreshMs = 1
+
+	appState := testAppStateWithTwoProjects()
+	appState.TermWidth = 120
+	appState.TermHeight = 40
+
+	m := New(cfg, appState, "")
+	m.appState.TermWidth = 120
+	m.appState.TermHeight = 40
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.AssertGridActive(true)
+
+	f.SendKey("i")
+	if f.model.TopView() != ViewGridInputHint {
+		t.Fatalf("expected top view to be ViewGridInputHint, got %s", f.model.TopView())
+	}
+	if !f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should be true after pressing i")
+	}
+}
+
+// TestGridInputMode_HintDontShowAgain verifies that pressing 'd' in the hint
+// dialog sets HideGridInputHint=true and dismisses the overlay.
+func TestGridInputMode_HintDontShowAgain(t *testing.T) {
+	tmp := t.TempDir()
+	setHomePersist(t, tmp)
+	ensureConfigDir(t)
+	t.Setenv("TERM", "dumb")
+
+	mock := muxtest.New()
+	mux.SetBackend(mock)
+	t.Cleanup(func() { mux.SetBackend(nil) })
+
+	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
+	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
+
+	cfg := config.DefaultConfig()
+	cfg.HideAttachHint = true
+	cfg.HideGridInputHint = false // hint enabled
+	cfg.PreviewRefreshMs = 1
+
+	appState := testAppStateWithTwoProjects()
+	appState.TermWidth = 120
+	appState.TermHeight = 40
+
+	m := New(cfg, appState, "")
+	m.appState.TermWidth = 120
+	m.appState.TermHeight = 40
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.SendKey("i")
+	if f.model.TopView() != ViewGridInputHint {
+		t.Fatalf("expected ViewGridInputHint, got %s", f.model.TopView())
+	}
+
+	// Press 'd' to dismiss and suppress future hints.
+	f.SendKey("d")
+	if f.model.TopView() == ViewGridInputHint {
+		t.Fatal("hint overlay should be dismissed after 'd'")
+	}
+	if !f.model.cfg.HideGridInputHint {
+		t.Fatal("cfg.HideGridInputHint should be true after 'd'")
+	}
+	// Input mode should still be active.
+	if !f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should remain true after dismissing hint with 'd'")
+	}
+}
+
+// TestGridInputMode_HintEscCancelsInputMode verifies that pressing 'esc' in the
+// hint dialog pops the overlay and also exits input mode.
+func TestGridInputMode_HintEscCancelsInputMode(t *testing.T) {
+	tmp := t.TempDir()
+	setHomePersist(t, tmp)
+	ensureConfigDir(t)
+	t.Setenv("TERM", "dumb")
+
+	mock := muxtest.New()
+	mux.SetBackend(mock)
+	t.Cleanup(func() { mux.SetBackend(nil) })
+
+	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
+	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
+
+	cfg := config.DefaultConfig()
+	cfg.HideAttachHint = true
+	cfg.HideGridInputHint = false // hint enabled
+	cfg.PreviewRefreshMs = 1
+
+	appState := testAppStateWithTwoProjects()
+	appState.TermWidth = 120
+	appState.TermHeight = 40
+
+	m := New(cfg, appState, "")
+	m.appState.TermWidth = 120
+	m.appState.TermHeight = 40
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.SendKey("i")
+	if f.model.TopView() != ViewGridInputHint {
+		t.Fatalf("expected ViewGridInputHint, got %s", f.model.TopView())
+	}
+
+	// Press 'esc' to cancel — should dismiss hint AND exit input mode.
+	f.SendSpecialKey(tea.KeyEsc)
+	if f.model.TopView() == ViewGridInputHint {
+		t.Fatal("hint overlay should be dismissed after 'esc'")
+	}
+	if f.model.gridView.InputMode() {
+		t.Fatal("gridView.InputMode() should be false after 'esc' in hint")
+	}
+	// Grid should still be active.
+	f.AssertGridActive(true)
+}

--- a/internal/tui/flow_grid_input_test.go
+++ b/internal/tui/flow_grid_input_test.go
@@ -209,30 +209,7 @@ func TestGridInputMode_HideExitsInputMode(t *testing.T) {
 // TestGridInputMode_HintShownOnFirstUse verifies that pressing 'i' shows the
 // grid-input-hint overlay when HideGridInputHint=false.
 func TestGridInputMode_HintShownOnFirstUse(t *testing.T) {
-	tmp := t.TempDir()
-	setHomePersist(t, tmp)
-	ensureConfigDir(t)
-	t.Setenv("TERM", "dumb")
-
-	mock := muxtest.New()
-	mux.SetBackend(mock)
-	t.Cleanup(func() { mux.SetBackend(nil) })
-
-	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
-	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
-
-	cfg := config.DefaultConfig()
-	cfg.HideAttachHint = true
-	cfg.HideGridInputHint = false // hint enabled
-	cfg.PreviewRefreshMs = 1
-
-	appState := testAppStateWithTwoProjects()
-	appState.TermWidth = 120
-	appState.TermHeight = 40
-
-	m := New(cfg, appState, "")
-	m.appState.TermWidth = 120
-	m.appState.TermHeight = 40
+	m, mock := testFlowModelWithGridHint(t)
 	f := newFlowRunner(t, m, mock)
 
 	f.SendKey("g")
@@ -250,30 +227,7 @@ func TestGridInputMode_HintShownOnFirstUse(t *testing.T) {
 // TestGridInputMode_HintDontShowAgain verifies that pressing 'd' in the hint
 // dialog sets HideGridInputHint=true and dismisses the overlay.
 func TestGridInputMode_HintDontShowAgain(t *testing.T) {
-	tmp := t.TempDir()
-	setHomePersist(t, tmp)
-	ensureConfigDir(t)
-	t.Setenv("TERM", "dumb")
-
-	mock := muxtest.New()
-	mux.SetBackend(mock)
-	t.Cleanup(func() { mux.SetBackend(nil) })
-
-	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
-	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
-
-	cfg := config.DefaultConfig()
-	cfg.HideAttachHint = true
-	cfg.HideGridInputHint = false // hint enabled
-	cfg.PreviewRefreshMs = 1
-
-	appState := testAppStateWithTwoProjects()
-	appState.TermWidth = 120
-	appState.TermHeight = 40
-
-	m := New(cfg, appState, "")
-	m.appState.TermWidth = 120
-	m.appState.TermHeight = 40
+	m, mock := testFlowModelWithGridHint(t)
 	f := newFlowRunner(t, m, mock)
 
 	f.SendKey("g")
@@ -299,30 +253,7 @@ func TestGridInputMode_HintDontShowAgain(t *testing.T) {
 // TestGridInputMode_HintEscCancelsInputMode verifies that pressing 'esc' in the
 // hint dialog pops the overlay and also exits input mode.
 func TestGridInputMode_HintEscCancelsInputMode(t *testing.T) {
-	tmp := t.TempDir()
-	setHomePersist(t, tmp)
-	ensureConfigDir(t)
-	t.Setenv("TERM", "dumb")
-
-	mock := muxtest.New()
-	mux.SetBackend(mock)
-	t.Cleanup(func() { mux.SetBackend(nil) })
-
-	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
-	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
-
-	cfg := config.DefaultConfig()
-	cfg.HideAttachHint = true
-	cfg.HideGridInputHint = false // hint enabled
-	cfg.PreviewRefreshMs = 1
-
-	appState := testAppStateWithTwoProjects()
-	appState.TermWidth = 120
-	appState.TermHeight = 40
-
-	m := New(cfg, appState, "")
-	m.appState.TermWidth = 120
-	m.appState.TermHeight = 40
+	m, mock := testFlowModelWithGridHint(t)
 	f := newFlowRunner(t, m, mock)
 
 	f.SendKey("g")

--- a/internal/tui/flow_test.go
+++ b/internal/tui/flow_test.go
@@ -243,6 +243,39 @@ func testFlowModel(t *testing.T) (Model, *muxtest.MockBackend) {
 	return m, mock
 }
 
+// testFlowModelWithGridHint is like testFlowModel but with HideGridInputHint=false,
+// so the grid input mode hint overlay is shown on first activation.
+func testFlowModelWithGridHint(t *testing.T) (Model, *muxtest.MockBackend) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	setHomePersist(t, tmp)
+	ensureConfigDir(t)
+	t.Setenv("TERM", "dumb")
+
+	mock := muxtest.New()
+	mux.SetBackend(mock)
+	t.Cleanup(func() { mux.SetBackend(nil) })
+
+	mock.SetPaneContent("hive-sessions:0", "$ claude\nSession started.")
+	mock.SetPaneContent("hive-sessions:1", "$ codex\nReady.")
+
+	cfg := config.DefaultConfig()
+	cfg.HideAttachHint = true
+	cfg.HideGridInputHint = false // hint enabled — shown on first 'i'
+	cfg.PreviewRefreshMs = 1
+
+	appState := testAppStateWithTwoProjects()
+	appState.TermWidth = 120
+	appState.TermHeight = 40
+
+	m := New(cfg, appState, "")
+	m.appState.TermWidth = 120
+	m.appState.TermHeight = 40
+
+	return m, mock
+}
+
 // testFlowModelWithHint is like testFlowModel but with HideAttachHint=false.
 func testFlowModelWithHint(t *testing.T) (Model, *muxtest.MockBackend) {
 	t.Helper()

--- a/internal/tui/flow_test.go
+++ b/internal/tui/flow_test.go
@@ -229,6 +229,7 @@ func testFlowModel(t *testing.T) (Model, *muxtest.MockBackend) {
 
 	cfg := config.DefaultConfig()
 	cfg.HideAttachHint = true
+	cfg.HideGridInputHint = true
 	cfg.PreviewRefreshMs = 1 // near-zero tick interval to keep tests fast
 
 	appState := testAppStateWithTwoProjects()

--- a/internal/tui/handle_keys.go
+++ b/internal/tui/handle_keys.go
@@ -219,6 +219,7 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 		}
 	}
 	prevSel := m.gridView.Selected()
+	prevInputMode := m.gridView.InputMode()
 	// Remaining keys (including h/l) are delegated to the grid component.
 	// CollapseItem/ExpandItem (h/l) are intentionally not wired here — in grid
 	// mode h/l navigate the cursor left/right, which is the expected behavior.
@@ -228,6 +229,11 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 	if !m.gridView.Active && prevSel != nil {
 		m.popGridState(prevSel)
 		return tea.Batch(cmd, m.schedulePollPreview())
+	}
+	// If input mode was just activated, schedule a fast poll immediately so the
+	// user sees session output within 100 ms of their first keystroke.
+	if !prevInputMode && m.gridView.InputMode() {
+		return tea.Batch(cmd, m.scheduleGridPoll())
 	}
 	return cmd
 }

--- a/internal/tui/handle_keys.go
+++ b/internal/tui/handle_keys.go
@@ -230,10 +230,11 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 		m.popGridState(prevSel)
 		return tea.Batch(cmd, m.schedulePollPreview())
 	}
-	// If input mode was just activated, schedule a fast poll immediately so the
-	// user sees session output within 100 ms of their first keystroke.
+	// If input mode was just activated, kick off the fast focused-session poll
+	// (50 ms) so the user sees output quickly. The background poll continues
+	// at 250 ms from the existing loop.
 	if !prevInputMode && m.gridView.InputMode() {
-		return tea.Batch(cmd, m.scheduleGridPoll())
+		return tea.Batch(cmd, m.scheduleFocusedSessionPoll())
 	}
 	return cmd
 }

--- a/internal/tui/handle_keys.go
+++ b/internal/tui/handle_keys.go
@@ -34,6 +34,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case ViewWhatsNew:
 		return m.handleWhatsNew(msg)
+	case ViewGridInputHint:
+		return m.handleGridInputHint(msg)
 	case ViewAttachHint:
 		return m.handleAttachHint(msg)
 	case ViewConfirm:
@@ -232,8 +234,12 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 	}
 	// If input mode was just activated, kick off the fast focused-session poll
 	// (50 ms) so the user sees output quickly. The background poll continues
-	// at 250 ms from the existing loop.
+	// at 250 ms from the existing loop. Also show the first-use hint if not
+	// suppressed.
 	if !prevInputMode && m.gridView.InputMode() {
+		if !m.cfg.HideGridInputHint {
+			m.PushView(ViewGridInputHint)
+		}
 		return tea.Batch(cmd, m.scheduleFocusedSessionPoll())
 	}
 	return cmd
@@ -777,6 +783,24 @@ func (m Model) handleWhatsNew(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.whatsNewViewport.LineDown(1)
 	case "k", "up":
 		m.whatsNewViewport.LineUp(1)
+	}
+	return m, nil
+}
+
+func (m Model) handleGridInputHint(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter", "y", " ":
+		// Continue: dismiss overlay, stay in input mode.
+		m.PopView()
+	case "d":
+		// Don't show again: dismiss and save preference.
+		m.PopView()
+		m.cfg.HideGridInputHint = true
+		_ = config.Save(m.cfg)
+	case "esc", "q":
+		// Cancel: dismiss overlay and exit input mode.
+		m.PopView()
+		m.gridView.ExitInputMode()
 	}
 	return m, nil
 }

--- a/internal/tui/handle_keys.go
+++ b/internal/tui/handle_keys.go
@@ -77,6 +77,13 @@ func (m *Model) handleGridKey(msg tea.KeyMsg) tea.Cmd {
 	m.gridView.Width = m.appState.TermWidth
 	m.gridView.Height = m.appState.TermHeight
 
+	// Input mode: all keys (except ctrl+c which always quits) are forwarded to
+	// the focused session. Ctrl+Q exits input mode (handled inside GridView.Update).
+	if m.gridView.InputMode() {
+		cmd, _ := m.gridView.Update(msg)
+		return cmd
+	}
+
 	// Actions that work consistently across sidebar and grid.
 	if key.Matches(msg, m.keys.Quit) {
 		return tea.Quit

--- a/internal/tui/handle_preview.go
+++ b/internal/tui/handle_preview.go
@@ -30,7 +30,12 @@ func (m Model) handlePreviewUpdated(msg components.PreviewUpdatedMsg) (tea.Model
 }
 
 func (m Model) handleGridPreviewsUpdated(msg components.GridPreviewsUpdatedMsg) (tea.Model, tea.Cmd) {
-	m.gridView.SetContents(msg.Contents)
+	if msg.Fast {
+		// Fast poll only has the focused session — merge to preserve other cells.
+		m.gridView.MergeContents(msg.Contents)
+	} else {
+		m.gridView.SetContents(msg.Contents)
+	}
 	if !m.HasView(ViewGrid) {
 		return m, nil
 	}

--- a/internal/tui/handle_preview.go
+++ b/internal/tui/handle_preview.go
@@ -31,10 +31,18 @@ func (m Model) handlePreviewUpdated(msg components.PreviewUpdatedMsg) (tea.Model
 
 func (m Model) handleGridPreviewsUpdated(msg components.GridPreviewsUpdatedMsg) (tea.Model, tea.Cmd) {
 	m.gridView.SetContents(msg.Contents)
-	if m.HasView(ViewGrid) {
-		return m, m.scheduleGridPoll()
+	if !m.HasView(ViewGrid) {
+		return m, nil
 	}
-	return m, nil
+	if msg.Fast {
+		// Fast-poll loop: reschedule only if still in input mode.
+		if m.gridView.InputMode() {
+			return m, m.scheduleFocusedSessionPoll()
+		}
+		return m, nil
+	}
+	// Background loop: always reschedule while grid is visible.
+	return m, m.scheduleGridPoll()
 }
 
 func (m Model) handleGridSessionSelected(msg components.GridSessionSelectedMsg) (tea.Model, tea.Cmd) {
@@ -81,23 +89,44 @@ func (m *Model) scheduleBellBlink() tea.Cmd {
 	})
 }
 
+// inputModeBackgroundMs is the background poll interval (all sessions) during
+// input mode — 2× faster than the default 500 ms.
+const inputModeBackgroundMs = 250
+
+// inputModeFocusedMs is the focused-session poll interval during input mode.
+const inputModeFocusedMs = 50
+
 func (m *Model) scheduleGridPoll() tea.Cmd {
 	sessions := m.gridSessions(m.gridView.Mode)
 	if len(sessions) == 0 {
 		return nil
 	}
 	interval := time.Duration(m.cfg.PreviewRefreshMs) * time.Millisecond
-	// In input mode use a faster refresh (100 ms) so the user sees the effect
-	// of forwarded keystrokes quickly. Capped at the configured interval so
-	// tests that set PreviewRefreshMs=1 still run at their requested speed.
-	const inputModeRefreshMs = 100
+	// In input mode use a faster background rate (250 ms, 2× the default) so
+	// non-focused sessions are also more responsive. Capped at the configured
+	// interval so tests that set PreviewRefreshMs=1 run at their requested speed.
 	if m.gridView.InputMode() {
-		fast := time.Duration(inputModeRefreshMs) * time.Millisecond
+		fast := time.Duration(inputModeBackgroundMs) * time.Millisecond
 		if fast < interval {
 			interval = fast
 		}
 	}
 	return components.PollGridPreviews(sessions, interval)
+}
+
+// scheduleFocusedSessionPoll returns a tea.Cmd that polls just the focused
+// session at 50 ms. Used for the fast poll loop in input mode.
+func (m *Model) scheduleFocusedSessionPoll() tea.Cmd {
+	sel := m.gridView.Selected()
+	if sel == nil {
+		return nil
+	}
+	interval := time.Duration(inputModeFocusedMs) * time.Millisecond
+	// Respect the configured interval if it's already faster (e.g. tests set 1 ms).
+	if cfg := time.Duration(m.cfg.PreviewRefreshMs) * time.Millisecond; cfg < interval {
+		interval = cfg
+	}
+	return components.PollFocusedGridPreview(sel, interval)
 }
 
 func (m *Model) schedulePollPreview() tea.Cmd {

--- a/internal/tui/handle_preview.go
+++ b/internal/tui/handle_preview.go
@@ -87,6 +87,16 @@ func (m *Model) scheduleGridPoll() tea.Cmd {
 		return nil
 	}
 	interval := time.Duration(m.cfg.PreviewRefreshMs) * time.Millisecond
+	// In input mode use a faster refresh (100 ms) so the user sees the effect
+	// of forwarded keystrokes quickly. Capped at the configured interval so
+	// tests that set PreviewRefreshMs=1 still run at their requested speed.
+	const inputModeRefreshMs = 100
+	if m.gridView.InputMode() {
+		fast := time.Duration(inputModeRefreshMs) * time.Millisecond
+		if fast < interval {
+			interval = fast
+		}
+	}
 	return components.PollGridPreviews(sessions, interval)
 }
 

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -70,6 +70,7 @@ func (m Model) handleSettingsSaveRequest(msg components.SettingsSaveRequestMsg) 
 	}
 	m.cfg = newCfg
 	m.keys = NewKeyMap(newCfg.Keybindings)
+	m.gridView.InputEnabled = !newCfg.DisableGridInput
 	return m, func() tea.Msg { return ConfigSavedMsg{Config: newCfg} }
 }
 

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -138,10 +138,11 @@ type GridKeyMap struct {
 	ColorPrev key.Binding
 	SessionColorNext key.Binding
 	SessionColorPrev key.Binding
-	ExitGrid key.Binding
+	ExitGrid  key.Binding
 	ToggleAll key.Binding
-	Help     key.Binding
-	Quit     key.Binding
+	InputMode key.Binding
+	Help      key.Binding
+	Quit      key.Binding
 }
 
 // NewGridKeyMap builds a GridKeyMap from the main KeyMap.
@@ -160,10 +161,11 @@ func NewGridKeyMap(km KeyMap) GridKeyMap {
 		ColorPrev: key.NewBinding(key.WithKeys(km.ColorPrev.Keys()...), key.WithHelp("", "")),
 		SessionColorNext: key.NewBinding(key.WithKeys("v"), key.WithHelp("v/V", "session color")),
 		SessionColorPrev: key.NewBinding(key.WithKeys("V"), key.WithHelp("", "")),
-		ExitGrid: key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc/g/G", "exit")),
+		ExitGrid:  key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc/g/G", "exit")),
 		ToggleAll: key.NewBinding(key.WithKeys("G"), key.WithHelp("", "")),
-		Help:     key.NewBinding(key.WithKeys(km.Help.Keys()...), key.WithHelp(km.Help.Help().Key, "help")),
-		Quit:     key.NewBinding(key.WithKeys(km.Quit.Keys()...), key.WithHelp(km.Quit.Help().Key, "quit")),
+		InputMode: key.NewBinding(key.WithKeys("i"), key.WithHelp("(i)", "input")),
+		Help:      key.NewBinding(key.WithKeys(km.Help.Keys()...), key.WithHelp(km.Help.Help().Key, "help")),
+		Quit:      key.NewBinding(key.WithKeys(km.Quit.Keys()...), key.WithHelp(km.Quit.Help().Key, "quit")),
 	}
 }
 
@@ -178,6 +180,7 @@ func (gk GridKeyMap) ShortHelp() []key.Binding {
 		gk.Rename,
 		gk.ColorNext,
 		gk.SessionColorNext,
+		gk.InputMode,
 		gk.ExitGrid,
 		gk.Help,
 		gk.Quit,

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -138,6 +138,26 @@ func (m Model) tmuxHelpView() string {
 	)
 }
 
+// gridInputHintView renders the first-use hint for grid input mode.
+func (m Model) gridInputHintView() string {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(styles.ColorAccent).
+		Padding(1, 3).
+		Render(
+			styles.TitleStyle.Render("Grid Input Mode") + "\n\n" +
+				"Keystrokes are now forwarded to this session.\n" +
+				"The grid stays visible — you remain in overview.\n\n" +
+				lipgloss.NewStyle().Bold(true).Render("To return to navigation:") + "  press  " +
+				lipgloss.NewStyle().
+					Foreground(styles.ColorAccent).
+					Bold(true).
+					Render("Ctrl+Q") +
+				"\n\n" +
+				styles.MutedStyle.Render("enter: continue  d: don't show again  esc: cancel"),
+		)
+}
+
 // attachHintView renders the attach hint dialog content.
 func (m Model) attachHintView() string {
 	return lipgloss.NewStyle().

--- a/internal/tui/viewstack.go
+++ b/internal/tui/viewstack.go
@@ -25,6 +25,7 @@ const (
 	ViewWorktreeBranch ViewID = "worktree-branch"
 	ViewFilter         ViewID = "filter"
 	ViewWhatsNew       ViewID = "whats-new"
+	ViewGridInputHint  ViewID = "grid-input-hint"
 )
 
 // PushView pushes a view onto the stack and syncs legacy flags.


### PR DESCRIPTION
## Summary

- Adds an input mode to the grid view — press `i` on a focused cell to forward keystrokes directly to that session without a full attach
- `Ctrl+Q` exits input mode; `Esc` is forwarded to the session (useful for agent interactions)
- `·· INPUT · C-Q` badge overlays the focused cell header so the exit key is always visible
- First-use hint dialog explains the mode and lets users suppress it permanently (`d`)
- Opt-out via `disable_grid_input: true` in config

## How it works

- New `SendKeys(target, keys string)` added to the `mux.Backend` interface, implemented for both tmux (`tmux send-keys -l`) and the native PTY backend
- `GridView` gains an `inputMode` state; nav-mode shortcuts are gated out while active
- Dual-rate polling when in input mode: focused session at **50 ms**, all others at **250 ms** (vs. the configured default ~500 ms)
- Fast poll uses `MergeContents` instead of `SetContents` so non-focused cells don't flicker blank between background sweeps

## Test plan

- [x] `TestKeyToBytes_*` — key→byte conversion unit tests
- [x] `TestGridInputMode_EnterAndExit` — `i` enters, `Ctrl+Q` exits, grid stays open
- [x] `TestGridInputMode_EscForwardedToSession` — `Esc` sends `\033`, not exit
- [x] `TestGridInputMode_KeysForwarded` — printable chars reach `mock.LastSentKeys`
- [x] `TestGridInputMode_NavSuppressedInInputMode` — `x` doesn't trigger kill while in input mode
- [x] `TestGridInputMode_ArrowsForwarded` — arrow keys send ANSI sequences to session
- [x] `TestGridInputMode_DisabledByConfig` — `DisableGridInput=true` keeps `i` inert
- [x] `TestGridInputMode_HintShownOnFirstUse` — hint overlay pushed on first `i`
- [x] `TestGridInputMode_HintDontShowAgain` — `d` sets `HideGridInputHint=true`
- [x] `TestGridInputMode_HintEscCancelsInputMode` — `esc` in hint exits input mode too

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)