### PR TITLE
fix: eliminate attach/detach flashes (terminal buffer + grid sidebar)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ escape.Watcher polls CapturePaneRaw every 500ms
 ### Testing Conventions
 
 - **TDD — tests come with every change.** Never ship a bug fix, new feature, or behaviour change without adding or updating tests that would have caught the regression or verify the new behaviour. If you're in a hurry, write the test first.
-- **"Boil the lake" philosophy — do more now, not later.** When fixing a bug, also add the test that would have caught it. When adding a feature, cover the golden path and key edge cases. Do not defer test coverage to a follow-up. Address all code review feedback in the same PR rather than deferring to follow-ups.
+- **"Boil the lake" philosophy — do more now, not later.** When fixing a bug, also add the test that would have caught it. When adding a feature, cover the golden path and key edge cases. Do not defer test coverage to a follow-up. Address all code review feedback in the same PR rather than deferring to follow-ups. **Auto-fix every high-confidence, low-risk review finding in the same PR** — minor code-review nits (comments, constants, helper extraction, API consistency fixes that don't change behaviour) must be applied in the PR where they are raised, not left for "later." Only defer when the fix is high-risk (behaviour change, cross-cutting refactor) or low-confidence (taste, unclear improvement).
 - **All changes require both unit tests and functional tests.** Unit tests verify pure logic (state reducers, helpers). Functional tests verify end-to-end behaviour through the TUI using the `flowRunner` pattern in `internal/tui/flow_test.go`.
 - **`internal/state/`** — pure unit tests, no I/O mocking needed
 - **`internal/config/`** — tests use `t.TempDir()` for isolation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,12 +113,15 @@ escape.Watcher polls CapturePaneRaw every 500ms
 
 ### Testing Conventions
 
+- **TDD — tests come with every change.** Never ship a bug fix, new feature, or behaviour change without adding or updating tests that would have caught the regression or verify the new behaviour. If you're in a hurry, write the test first.
+- **"Boil the lake" philosophy — do more now, not later.** When fixing a bug, also add the test that would have caught it. When adding a feature, cover the golden path and key edge cases. Do not defer test coverage to a follow-up. Address all code review feedback in the same PR rather than deferring to follow-ups.
 - **All changes require both unit tests and functional tests.** Unit tests verify pure logic (state reducers, helpers). Functional tests verify end-to-end behaviour through the TUI using the `flowRunner` pattern in `internal/tui/flow_test.go`.
 - **`internal/state/`** — pure unit tests, no I/O mocking needed
 - **`internal/config/`** — tests use `t.TempDir()` for isolation
 - **`internal/tui/`** — component tests use `tea.NewProgram` with a fake model or direct `Update()` calls
 - **`internal/tui/` functional tests** — use `flowRunner` from `flow_test.go`: `testFlowModel()` creates an isolated Model with mock backend; `SendKey()`/`SendSpecialKey()` simulate input; assertion helpers like `ViewContains()`, `AssertActiveSession()`, `AssertGridActive()` verify outcomes. New features must include flow tests covering the golden path and key edge cases.
 - **`internal/tui/` tick intervals** — always set `cfg.PreviewRefreshMs = 1` in test helpers to avoid blocking on real-time `tea.Tick` intervals (default 500ms). Tests should verify behaviour, not wait on timers.
+- **`muxtest.MockBackend`** — use `SetUseExecAttach(true)` to exercise the `tea.ExecProcess` attach path; inject `model.attachOut = &bytes.Buffer{}` to capture pre-attach escape sequences.
 - Run all tests: `go test ./...`
 - Tests live alongside source (e.g., `model_test.go` next to `model.go`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Grid-mode attach/detach sidebar flash (regression)**: the sidebar no longer briefly renders when attaching to or detaching from a session opened from grid view. `handleGridSessionSelected` now keeps `ViewGrid` on the view stack through the attach so the render frame before `tea.Exec`/`tea.Quit` shows grid content rather than sidebar. `restoreGrid()` is idempotent so the detach-side re-push does not duplicate the grid on the stack. As a side effect, pressing `esc` on the attach hint when opened from grid now returns to grid (previously returned to sidebar) (#111).
+
 ## [0.10.1] — 2026-04-14
 
 ### Fixed

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,6 +121,10 @@ func runStart(_ *cobra.Command, _ []string) error {
 	// tea.ExecProcess). For the tmux backend the TUI handles attach internally
 	// via tea.ExecProcess and never sets LastAttach(); the loop runs only once.
 	for {
+		// Pre-clear the primary screen buffer so that BubbleTea's internal
+		// alt-screen exit/enter transitions during attach/detach are invisible
+		// (blank primary instead of terminal history).
+		writePrimaryBufferClear(os.Stdout)
 		model := tui.New(cfg, appState, whatsNewContent)
 		whatsNewContent = "" // only show on first loop iteration
 		p := tea.NewProgram(model,
@@ -154,6 +159,20 @@ func runStart(_ *cobra.Command, _ []string) error {
 		break
 	}
 	return nil
+}
+
+// writePrimaryBufferClear writes the ANSI sequence that clears the primary
+// screen buffer (the non-alt-screen buffer that holds shell history). This
+// must be called before tea.NewProgram so that BubbleTea saves a blank
+// primary buffer when it enters alt-screen. Any subsequent exit of alt-screen
+// during attach/detach then reveals a blank screen instead of the user's
+// terminal history.
+//
+// The sequence must be \033[2J\033[H (erase entire display + cursor home).
+// It must NOT contain \033[?1049l (exit alt-screen), which would expose the
+// primary buffer before it has been cleared.
+func writePrimaryBufferClear(w io.Writer) {
+	fmt.Fprint(w, "\033[2J\033[H")
 }
 
 // initMuxBackend selects and sets the active mux backend based on config.

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestWritePrimaryBufferClear verifies that writePrimaryBufferClear writes
+// exactly the right ANSI escape sequence to blank the primary screen buffer.
+//
+// Background: before entering alt-screen BubbleTea saves the primary buffer.
+// Any exit of alt-screen (during attach or detach) then reveals that saved
+// buffer. If it contains old terminal history the user sees a flash. By
+// writing \033[2J\033[H to the primary buffer first we ensure the saved
+// snapshot is blank.
+//
+// The sequence must:
+//   - contain \033[2J (erase entire display)
+//   - contain \033[H  (cursor home)
+//   - NOT contain \033[?1049l (exit alt-screen), which would itself trigger
+//     a flash of the primary buffer before it has been cleared.
+func TestWritePrimaryBufferClear(t *testing.T) {
+	var buf bytes.Buffer
+	writePrimaryBufferClear(&buf)
+	got := buf.String()
+
+	if !strings.Contains(got, "\033[2J") {
+		t.Errorf("writePrimaryBufferClear output missing \\033[2J; got %q", got)
+	}
+	if !strings.Contains(got, "\033[H") {
+		t.Errorf("writePrimaryBufferClear output missing \\033[H; got %q", got)
+	}
+	if strings.Contains(got, "\033[?1049l") {
+		t.Errorf("writePrimaryBufferClear output contains \\033[?1049l (alt-screen exit), which would cause a terminal flash; got %q", got)
+	}
+}

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,7 +7,6 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| P1 | #111 | fix(grid): sidebar view flashes during attach/detach | IMPLEMENT | S |
 
 ## Rejected
 
@@ -64,3 +63,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | — | In-place session input from grid view | #106 | 2026-04-14 |
 | #105 | Add tabs to help panel with comprehensive usage and feature reference | #107 | 2026-04-14 |
 | #109 | Fix performance: cyber view flashes and slow preview refresh on slow machines | #110 | — |
+| #111 | fix(grid): sidebar view flashes during attach/detach | #113 | 2026-04-14 |

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,6 +7,7 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
+| P1 | #111 | fix(grid): sidebar view flashes during attach/detach | IMPLEMENT | S |
 
 ## Rejected
 

--- a/features/active/111-fix-grid-sidebar-flash-attach-detach.md
+++ b/features/active/111-fix-grid-sidebar-flash-attach-detach.md
@@ -1,0 +1,233 @@
+# Feature: fix(grid): sidebar view flashes during attach/detach in grid mode
+
+- **GitHub Issue:** #111
+- **Stage:** IMPLEMENT
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P1
+- **Branch:** —
+
+## Description
+
+Regression: when in grid mode and pressing `a`/Enter to attach (or on detach), the sidebar view briefly flashes before the attach transition completes.
+
+PR #110 was intended to fix this, but the fix is incomplete. `internal/tui/handle_preview.go:handleGridSessionSelected` pops the grid view unconditionally before calling `doAttach()`. With `HideAttachHint=true` (the default), no view is pushed over the top, so the next `View()` render falls back to the sidebar (`TopView() == ViewMain`) for at least one frame before BubbleTea executes the `tea.Quit`/`tea.Exec` returned by `doAttach()`.
+
+Current tests missed it because:
+- `TestFlow_GridKeyAttachNoFlash` only asserts grid state immediately after the key event, not after the returned `Cmd` resolves.
+- `TestFlow_GridAttachDetachRestoresGrid` exercises only the native backend, not the `tea.Exec` tmux path used by default.
+- No test calls `View()` between `doAttach()` returning and the `Cmd` executing — the flashed frame is invisible to the suite.
+
+### Acceptance criteria
+
+- In grid mode, pressing `a`/Enter to attach shows no sidebar frame.
+- On detach, restoring back to grid mode shows no sidebar frame.
+- Regression tests: flow tests that (a) render `View()` after the attach `Cmd` resolves and before `tea.Quit`/`tea.Exec` runs, and (b) cover both native and tmux backend paths.
+
+## Research
+
+### Root Cause
+
+`handleGridSessionSelected` at `internal/tui/handle_preview.go:53-92` unconditionally pops `ViewGrid` before deciding the next step:
+
+```go
+if m.HasView(ViewGrid) {
+    m.PopView()                    // grid removed → TopView becomes ViewMain
+}
+// ... build attach details ...
+if !m.cfg.HideAttachHint {
+    m.pendingAttach = attach
+    m.PushView(ViewAttachHint)     // push happens after pop, same Update — no frame between
+    return m, nil
+}
+cmd := m.doAttach(*attach)         // HideAttachHint=true: nothing pushed over ViewMain
+return m, cmd                      // cmd is tea.Exec (tmux) or tea.Quit (native)
+```
+
+After `Update` returns, BubbleTea renders `View()` once before running the returned `Cmd`. `app.go:410 View()` dispatches on `TopView()`:
+
+```go
+case ViewGrid:   return m.gridView.View(...)
+// ... (no case for ViewMain — falls through to sidebar+preview+status layout at line 460)
+```
+
+With the grid popped and nothing pushed, `TopView() == ViewMain` → sidebar is rendered for one frame before `tea.Exec` releases the terminal. Same flash fires on `enter` in the hint overlay at `handle_keys.go:819-827`: `PopView()` (hint) → `doAttach()` → render frame with `TopView == ViewMain` → `tea.Exec`.
+
+On **detach** (tmux backend), `bubbletea/exec.go` calls `p.RestoreTerminal()` and enables the renderer *before* sending `AttachDoneMsg` via `go p.Send(...)`. The renderer calls `View()` while state is still "grid popped" → sidebar renders briefly before `handleAttachDone` pushes the grid back via `restoreGrid()` at `app.go:254-265`.
+
+### Proposed Fix
+
+Keep `ViewGrid` on the stack throughout the attach/detach lifecycle. The grid is re-rendered for every frame — no "ViewMain" gap.
+
+1. **`handle_preview.go:57-59`** — Remove the `PopView()` call. Attach hint already renders via `overlayView` (dark background + centered hint; does not show underlying grid content, but no sidebar flash either), and it gets popped correctly in `handle_keys.go:819-845`.
+
+2. **`app.go:restoreGrid()`** — Make `PushView(ViewGrid)` idempotent. Currently pushes unconditionally; with the fix, grid is already on the stack on detach, so the push would warn about a duplicate and break the stack invariant.
+
+3. **Sidebar-origin attach stays sidebar.** `handleSessionAttach` in `handle_session.go:71-76` is not in the grid path; it just calls `doAttach`. `RestoreGridMode = None` there, so `restoreGrid()` early-returns. Sidebar flash is a non-issue because user is coming from sidebar.
+
+### Flow Walk-Through with Fix
+
+- **From grid, HideAttachHint=true**: Enter → `GridSessionSelectedMsg` → `doAttach` (no pop). Render: `TopView=ViewGrid` ✓. `tea.Exec` attaches. Detach → renderer re-enabled → render `TopView=ViewGrid` ✓. `AttachDoneMsg` → `restoreGrid` no-op (already on stack).
+- **From grid, HideAttachHint=false**: Enter → `PushView(ViewAttachHint)` over grid. Render: hint ✓. Enter on hint → `PopView` (back to grid) → `doAttach`. Render: `TopView=ViewGrid` ✓. Exec/detach as above. Esc on hint → pop → back to grid. No attach.
+- **From sidebar**: grid never pushed; `RestoreGridMode=None`; renders stay sidebar throughout; no regression.
+
+### Existing Test Gaps
+
+- `flow_grid_test.go:382-401 TestFlow_GridKeyAttachNoFlash` — `SendSpecialKey(KeyEnter)` only runs `Update(KeyMsg)` → `gridview.Update` returns the Cmd. The assertion runs **before** the Cmd produces `GridSessionSelectedMsg` and **before** `handleGridSessionSelected` executes. It's checking state pre-handler, so it can't catch the pop-then-render flash.
+- `flow_grid_test.go:407-439 TestFlow_GridMouseAttachNoFlash` — sends `GridSessionSelectedMsg` directly then asserts `gridView.Active == false` (line 436-438). That asserts the OPPOSITE of what we want — it treats the pop as correct.
+- `flow_grid_test.go:14-74 TestFlow_GridAttachDetachRestoresGrid` — exercises only the native `tea.Quit` path (`mock.SetUseExecAttach(false)`); doesn't reach the `tea.Exec` path.
+- None of the above call `f.Model().View()` between `GridSessionSelectedMsg` processing and the returned Cmd — so the sidebar-rendered frame is invisible to the suite.
+
+### Relevant Code
+
+- `internal/tui/handle_preview.go:53-92` — `handleGridSessionSelected` (bug site).
+- `internal/tui/app.go:254-265` — `restoreGrid` (needs idempotency).
+- `internal/tui/app.go:410-460` — `View()` TopView dispatch (sidebar fallback).
+- `internal/tui/views.go:17-32, 178-207` — `overlayView` and `doAttach`.
+- `internal/tui/handle_session.go:71-106` — `handleSessionAttach` and `handleAttachDone`.
+- `internal/tui/handle_keys.go:819-845` — attach hint confirm/cancel handlers.
+- `internal/tui/viewstack.go:31-72` — `PushView` / `PopView` / `HasView` / `TopView`.
+- `internal/tui/components/gridview.go:337-339` — grid `View()` early-return when `!Active`.
+- `internal/tui/flow_test.go:32-97` — `Send` / `SendKey` / `ExecCmdChain` runner semantics (Send calls Update once; does NOT auto-execute returned Cmd).
+- `internal/mux/muxtest/mock.go` — `MockBackend.SetUseExecAttach(true)` flips `doAttach` to the `tea.Exec` path.
+
+### Constraints / Dependencies
+
+- Must not reintroduce the renderer race that PR #110 fixed: no `Hide()` in the gridview key handler, no writes to terminal that race with the renderer.
+- `restoreGrid()` is also called during startup (`cmd/start.go` reload path) with `appState.RestoreGridMode` pre-seeded; must still push grid when stack has only `ViewMain`.
+- `PushView` emits a `debugLog WARNING` on duplicate stack entries (viewstack.go:33-38). Adding the `HasView` guard is required to keep the stack clean on detach-restore.
+
+## Plan
+
+### Files to Change
+
+1. **`internal/tui/handle_preview.go`** (lines 53-92 `handleGridSessionSelected`)
+   - **Delete** the unconditional pop at lines 57-59:
+     ```go
+     if m.HasView(ViewGrid) {
+         m.PopView()
+     }
+     ```
+   - Keep the rest of the function unchanged. The attach-hint branch (`!HideAttachHint`) will push `ViewAttachHint` on top of `ViewGrid`; the direct-attach branch will leave `ViewGrid` on top while `tea.Exec`/`tea.Quit` fires. Update the function doc comment accordingly (remove reference to "pop the grid from the view stack here").
+
+2. **`internal/tui/handle_keys.go`** (lines 819-845 — the attach-hint `enter`/`d`/`esc` handlers)
+   - `enter` and `d` currently `PopView()` (removes hint) then call `doAttach`. With the fix, `TopView()` after the pop is `ViewGrid` (if user came from grid) or `ViewMain` (sidebar origin) — both behaviors are now correct:
+     - Grid origin → grid renders the pre-exec frame ✓
+     - Sidebar origin → sidebar renders (expected for sidebar attach) ✓
+   - `esc` pops the hint and clears `pendingAttach`; with the fix, the view stack naturally returns to whatever was under the hint — grid if the user came from grid, sidebar if they came from sidebar. **Behavior change for the grid-origin path only**: previously `esc` always flattened to sidebar (because the grid was popped before the hint was pushed); now it returns to the prior view. Sidebar-origin behavior is unchanged. Update `TestFlow_GridAttachHintCancelReturnsToSidebar` (`flow_grid_test.go:441-469`) — rename to `TestFlow_GridAttachHintCancelReturnsToGrid` and flip the final assertion to `AssertGridActive(true)` + a grid-content `ViewContains`.
+   - No code changes in `handle_keys.go` itself — only the test expectation.
+
+3. **`internal/tui/app.go`** (lines 254-265 `restoreGrid`)
+   - Make idempotent. Change the trailing `m.PushView(ViewGrid)` to:
+     ```go
+     if !m.HasView(ViewGrid) {
+         m.PushView(ViewGrid)
+     }
+     ```
+   - Needed because on the tmux `tea.Exec` detach path the grid is already on the stack when `AttachDoneMsg` arrives.
+
+4. **`internal/tui/flow_grid_test.go`** — update existing tests and add regression tests (see Test Strategy).
+
+5. **`CHANGELOG.md`** — append to `[Unreleased] → Fixed`:
+   - `Sidebar view no longer flashes briefly when attaching or detaching from grid mode (regression from #109 / PR #110).`
+
+### Test Strategy
+
+Per `AGENTS.md`: every behaviour change needs unit + functional tests; bug fixes must include the test that would have caught the regression. All tests live in `internal/tui/flow_grid_test.go` (and `flow_attach_test.go` for sidebar-origin cases).
+
+#### Flow matrix to cover
+
+Render frames that previously flashed (now must stay on the origin view):
+
+| # | Origin | Hint? | Trigger | Backend | Pre-exec frame | Post-detach frame |
+|---|--------|-------|---------|---------|----------------|-------------------|
+| 1 | Grid (project) | off | key Enter | native | grid | grid (via New()) |
+| 2 | Grid (project) | off | key Enter | tmux  | grid | grid (pre-AttachDone) |
+| 3 | Grid (project) | off | mouse click | native | grid | — |
+| 4 | Grid (project) | off | mouse click | tmux | grid | — |
+| 5 | Grid (all) | off | key Enter | tmux | grid | grid |
+| 6 | Grid (project) | on | Enter on hint | tmux | grid | grid |
+| 7 | Grid (project) | on | "d" on hint | tmux | grid | — |
+| 8 | Grid (project) | on | Esc on hint | — | return to grid | — |
+| 9 | Sidebar | on | Esc on hint | — | return to sidebar (regression guard) | — |
+| 10 | Sidebar | off | key "a" | tmux | sidebar (regression guard) | sidebar |
+
+Plus one pure unit test: `restoreGrid()` idempotency.
+
+#### Tests to update
+
+- **`TestFlow_GridAttachDetachRestoresGrid`** (`flow_grid_test.go:17`, covers row #1)
+  - After `f.ExecCmdChain(cmd)`: change `f.AssertGridActive(false)` to `true`, add `f.ViewContains("session-1")` and `if f.Model().TopView() != ViewGrid { t.Error(...) }` before the re-entry block to assert the pre-exec render frame is grid.
+
+- **`TestFlow_GridAllProjectsRestores`** (`flow_grid_test.go:77`, covers row #5 native half)
+  - Same edits as above for the all-projects variant.
+
+- **`TestFlow_GridKeyAttachNoFlash`** (`flow_grid_test.go:382`, strengthen row #1)
+  - Replace the post-KeyMsg assertion with a full chain: `cmd := f.SendSpecialKey(tea.KeyEnter); f.ExecCmdChain(cmd)`, then assert `TopView() == ViewGrid`, `f.AssertGridActive(true)`, and `f.ViewContains("session-1")`.
+
+- **`TestFlow_GridMouseAttachNoFlash`** (`flow_grid_test.go:407`, covers row #3)
+  - Flip the final `gridView.Active == false` assertion to `true`. Call `f.Model().View()` and assert grid content present.
+
+- **`TestFlow_GridAttachHintCancelReturnsToSidebar`** (`flow_grid_test.go:441`, now row #8)
+  - Rename to `TestFlow_GridAttachHintCancel_ReturnsToGrid`. Final assertions: `AssertGridActive(true)` + `ViewContains("session-1")`.
+
+#### New tests
+
+1. **`TestFlow_GridKey_TmuxExec_NoFlash`** (row #2) — `testFlowModel` + `mock.SetUseExecAttach(true)` + `m.attachOut = &bytes.Buffer{}`. Open project grid with `g`, send `tea.KeyEnter`, run `ExecCmdChain`. Assert `TopView()==ViewGrid`, `ViewContains("session-1")`, and that `View()` does NOT contain a sidebar-only token (e.g. the sidebar root project name when rendered in sidebar style). The canonical tmux-backend regression test.
+
+2. **`TestFlow_GridMouse_TmuxExec_NoFlash`** (row #4) — Same setup as #1 but send `components.GridSessionSelectedMsg{...}` directly (mimics mouse-click Cmd). Assert grid-still-active + grid content rendered.
+
+3. **`TestFlow_GridAll_TmuxExec_NoFlash`** (row #5 tmux half) — Open all-projects grid with `G`, repeat #1. Assert `ViewContains("session-1")` and `ViewContains("session-2")`.
+
+4. **`TestFlow_GridDetach_TmuxExec_RendersGridPreAttachDone`** (row #2 post-detach) — Open grid, send `GridSessionSelectedMsg` + run chain, then call `f.Model().View()` and assert grid content BEFORE sending `AttachDoneMsg`. Then send `AttachDoneMsg{RestoreGridMode: GridRestoreProject}` and assert grid still active and `len(viewStack) == 2` (Main + Grid, no duplicate).
+
+5. **`TestFlow_GridHint_Confirm_TmuxExec_NoFlash`** (row #6) — `testFlowModelWithHint` + `SetUseExecAttach(true)`. Open grid → Enter (hint shows) → Enter on hint. After the confirm chain, assert `TopView()==ViewGrid` and grid content rendered.
+
+6. **`TestFlow_GridHint_D_TmuxExec_NoFlash`** (row #7) — Same as #5 but press `d` on hint instead of Enter. Assert grid still rendered pre-exec AND `cfg.HideAttachHint == true` persisted.
+
+7. **`TestFlow_SidebarAttachHintCancel_ReturnsToSidebar`** (row #9) — `testFlowModelWithHint`. Press `a` from sidebar (no grid open), hint shows, press Esc. Assert `TopView() == ViewMain`, grid not active, `pendingAttach == nil`. Regression guard: proves the plan didn't accidentally break the sidebar-origin stack semantics.
+
+8. **`TestFlow_Sidebar_TmuxExec_NoGridRender`** (row #10) — `testFlowModel` + `SetUseExecAttach(true)`. Press `a` from sidebar. Assert `TopView() == ViewMain` throughout, sidebar content rendered in `View()`, grid NEVER rendered (negative assertion on a grid-only token, e.g. the grid border chars or an all-projects header). Regression guard.
+
+9. **`TestFlow_RestoreGrid_Idempotent`** — unit test on `restoreGrid()`. Build a Model with `ViewGrid` already on the stack (use `testFlowModel` + `openGrid`), capture `len(m.viewStack)`, set `appState.RestoreGridMode = state.GridRestoreAll`, call `m.restoreGrid()`. Assert:
+   - `len(m.viewStack)` unchanged (no duplicate push).
+   - `m.HasView(ViewGrid)` still true.
+   - `m.gridView.Mode == state.GridRestoreAll` (SyncState still ran — mode switched from project to all).
+   - `m.appState.RestoreGridMode == state.GridRestoreNone` (consumed).
+
+10. **`TestFlow_RestoreGrid_FromEmptyStack`** — startup path. Build Model without grid on stack, set `RestoreGridMode = state.GridRestoreProject`, call `m.restoreGrid()`. Assert `HasView(ViewGrid)` true, `len(viewStack) == 2`. Confirms startup restore still pushes.
+
+#### Rendering-assertion helpers
+
+Tests that check "grid rendered, sidebar not rendered" need stable tokens:
+- **Grid-only**: grid cell borders (`│` in specific positions) or the grid status hints that differ from sidebar. Check `internal/tui/components/gridview.go` `View()` output and pick a stable substring (e.g. a hint like `"(i) input"` that only the grid renders).
+- **Sidebar-only**: the sidebar project header format, or the preview pane divider, or a status-bar hint that's only in sidebar mode.
+
+Concrete tokens to use will be finalized during IMPLEMENT by running `go test -run TestFlow_GridKeyAttachNoFlash -v` with a `fmt.Println(view)` probe, then picking from the actual output.
+
+#### Why these tests catch the regression
+
+- Every new/updated test calls `f.Model().View()` in the frame between the Cmd chain resolving and the terminal handoff — the exact frame the existing suite skipped.
+- The `mock.SetUseExecAttach(true)` path (tmux backend) is exercised for 6 of 10 rows, closing the coverage gap called out in Research.
+- Both attach triggers (keyboard + mouse) are covered.
+- Both grid modes (project + all-projects) are covered.
+- All three hint branches (Enter / "d" / Esc) are covered.
+- Regression guards (rows #9 #10) ensure sidebar-origin flows are not collaterally broken.
+
+### Risks
+
+- **Behavior change on `esc` from hint (grid-origin only)**: previously always returned to sidebar because grid had been popped; now returns to whatever was under the hint on the stack (grid for grid-origin, sidebar for sidebar-origin). Sidebar-origin behavior is unchanged. The test `TestFlow_GridAttachHintCancelReturnsToSidebar` encoded the previous — buggy — behavior for the grid path; renaming and flipping it is intentional. Call out in the PR description.
+- **Duplicate `ViewGrid` on the stack** is prevented by the `HasView` guard in `restoreGrid()`. If any other path (not `restoreGrid`) pushes grid after detach, we'd see the `debugLog WARNING` and potentially a broken pop on `G`/`g` toggle. Mitigation: `TestFlow_RestoreGrid_Idempotent` asserts no stack growth; a grep for other `PushView(ViewGrid)` callsites beyond `openGrid` and `restoreGrid` should come back empty (already verified in Research).
+- **Startup restore path** (`cmd/start.go` reload after native detach) constructs a fresh Model with `appState.RestoreGridMode` seeded; `restoreGrid()` runs from an empty stack so `HasView(ViewGrid)` is false and `PushView` still fires. Verified by the existing `TestFlow_GridAttachDetachRestoresGrid` re-entry block.
+- **Renderer race (PR #110 regression risk)**: the fix does not touch `gridview.go` `Hide()` or any terminal writes that race with the renderer — only view-stack bookkeeping. Low risk.
+
+## Implementation Notes
+
+- Code changes were exactly as planned: (1) delete the `PopView(ViewGrid)` block in `handleGridSessionSelected` and replace with a doc-comment explaining why the grid stays on the stack; (2) wrap `restoreGrid()`'s `PushView(ViewGrid)` in a `!HasView(ViewGrid)` guard.
+- Test writing discovered that `Model.TopView()` / `HasView()` are pointer receivers, so tests must assign `f.Model()` into a local variable before calling them (`mm := f.Model(); mm.TopView()`). Several existing tests already followed this pattern — followed suit for the new ones.
+- Stable tokens picked from actual `View()` output: `"↑↓←→ navigate"` (grid-only nav hint) and `"[1] test-project-1"` (sidebar numbered project list). These are used in `ViewContains` / `ViewNotContains` assertions to differentiate grid vs sidebar rendering.
+- In the tmux-exec tests, `m.attachOut = &bytes.Buffer{}` captures the synchronous `\033[2J\033[H` pre-write from `doAttach` and prevents test-run stdout pollution.
+- All 10 planned new tests added; 6 existing tests updated. Full suite (`go test ./...`) green.
+- `TestFlow_GridAttachWithHint` (line 344) and `TestFlow_GridAttachSetsActiveSessionID` (line 593) were not in the original plan list but broke under the behavior change (expected grid hidden post-attach) — updated to assert the new grid-stays-active contract.
+
+- **PR:** —

--- a/features/completed/111-fix-grid-sidebar-flash-attach-detach.md
+++ b/features/completed/111-fix-grid-sidebar-flash-attach-detach.md
@@ -1,7 +1,7 @@
 # Feature: fix(grid): sidebar view flashes during attach/detach in grid mode
 
 - **GitHub Issue:** #111
-- **Stage:** IMPLEMENT
+- **Stage:** DONE
 - **Type:** bug
 - **Complexity:** S
 - **Priority:** P1
@@ -230,4 +230,4 @@ Concrete tokens to use will be finalized during IMPLEMENT by running `go test -r
 - All 10 planned new tests added; 6 existing tests updated. Full suite (`go test ./...`) green.
 - `TestFlow_GridAttachWithHint` (line 344) and `TestFlow_GridAttachSetsActiveSessionID` (line 593) were not in the original plan list but broke under the behavior change (expected grid hidden post-attach) — updated to assert the new grid-stays-active contract.
 
-- **PR:** —
+- **PR:** #113

--- a/internal/mux/muxtest/mock.go
+++ b/internal/mux/muxtest/mock.go
@@ -25,6 +25,10 @@ type MockBackend struct {
 	// Exported for use in test assertions.
 	LastSentTarget string
 	LastSentKeys   string
+
+	// useExecAttach controls the value returned by UseExecAttach.
+	// Defaults to false (native backend behaviour). Set via SetUseExecAttach.
+	useExecAttach bool
 }
 
 // Compile-time check that MockBackend satisfies mux.Backend.
@@ -296,11 +300,19 @@ func (m *MockBackend) PopupAttach(target, title string) error {
 	return m.record("PopupAttach")
 }
 
+// SetUseExecAttach configures whether UseExecAttach reports true.
+// Call this in tests that exercise the tea.ExecProcess attach path.
+func (m *MockBackend) SetUseExecAttach(v bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.useExecAttach = v
+}
+
 func (m *MockBackend) UseExecAttach() bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.record("UseExecAttach")
-	return false
+	return m.useExecAttach
 }
 
 func (m *MockBackend) DetachKey() string {

--- a/internal/mux/tmux/attach_script.go
+++ b/internal/mux/tmux/attach_script.go
@@ -78,10 +78,10 @@ func buildAttachScript(tmuxSession, target, title string, spec mux.DetachKeySpec
 	// single-quoted delimiters for session names containing special chars).
 	lines = append(lines, "_hive_s="+s)
 
-	// trap restores the alternate screen and unsets the status-bar option
-	// overrides on exit. Hive owns the hive-* session, so there are no
-	// user-customized values to preserve — `set-option -u` returns each
-	// option to its server/global default from ~/.tmux.conf.
+	// trap unsets the status-bar option overrides and clears the screen on
+	// exit. Hive owns the hive-* session, so there are no user-customized
+	// values to preserve — `set-option -u` returns each option to its
+	// server/global default from ~/.tmux.conf.
 	//
 	// EXIT covers normal exit; INT/TERM/HUP cover the case where
 	// tea.ExecProcess (or the user's terminal) forwards a signal from a
@@ -89,13 +89,20 @@ func buildAttachScript(tmuxSession, target, title string, spec mux.DetachKeySpec
 	// theme. The detach key binding is NOT restored here — it stays
 	// installed for the tmux server's lifetime.
 	//
+	// Order matters: the tmux cleanup runs FIRST (while still in alt-screen,
+	// so the user never sees the primary buffer during the cleanup delay),
+	// then the screen is cleared. We do NOT write \033[?1049l (exit
+	// alt-screen) — that would expose the primary terminal buffer while the
+	// tmux subprocess completes. BubbleTea's RestoreTerminal re-enters
+	// alt-screen immediately after and redraws the TUI.
+	//
 	// All unsets are batched into a single tmux invocation via \; to
 	// minimize process-spawn overhead on detach.
 	var unsetParts []string
 	for _, opt := range statusBarOpts {
 		unsetParts = append(unsetParts, fmt.Sprintf(`set-option -u -t "$_hive_s" %s`, opt))
 	}
-	trapBody := fmt.Sprintf(`printf "\033[?1049l"; tmux %s 2>/dev/null`, strings.Join(unsetParts, ` \; `))
+	trapBody := fmt.Sprintf(`tmux %s 2>/dev/null; printf "\033[2J\033[H"`, strings.Join(unsetParts, ` \; `))
 	lines = append(lines,
 		"trap '"+trapBody+"' EXIT INT TERM HUP",
 	)

--- a/internal/mux/tmux/attach_script.go
+++ b/internal/mux/tmux/attach_script.go
@@ -62,7 +62,13 @@ func buildAttachScript(tmuxSession, target, title string, spec mux.DetachKeySpec
 	var lines []string
 
 	// Enter the alternate screen first so any tmux output below stays out
-	// of the user's scrollback.
+	// of the user's scrollback. This is intentionally redundant with
+	// altScreenExecCmd.Run() in internal/tui/views.go which writes the same
+	// sequence to the terminal immediately after BubbleTea's ReleaseTerminal
+	// and before spawning this subprocess. Keeping the write here is the
+	// belt-and-suspenders guarantee that the subprocess always runs in
+	// alt-screen even if it is invoked by a caller that bypasses
+	// altScreenExecCmd (e.g. `hive attach` CLI, tmux display-popup).
 	lines = append(lines, `printf '\033[?1049h\033[2J'`)
 
 	// Install the detach key binding. Idempotent and intentionally left in

--- a/internal/mux/tmux/attach_script_test.go
+++ b/internal/mux/tmux/attach_script_test.go
@@ -117,7 +117,10 @@ func TestBuildAttachScript_StatusBarShape(t *testing.T) {
 		"shows the detach hint with display key": "Ctrl+Q: detach",
 		"restores via -u in trap":                "set-option -u",
 		"enters alt screen before attach":        `\033[?1049h`,
-		"trap leaves alt screen":                 `\033[?1049l`,
+		// Trap clears the alt-screen content on detach; it does NOT exit
+		// alt-screen (\033[?1049l was removed to prevent the primary buffer
+		// from being exposed while tmux cleanup runs).
+		"trap clears screen on detach":           `\033[2J\033[H`,
 		"hides window list (status-format)":      "window-status-format ''",
 		"hides window list (current-format)":     "window-status-current-format ''",
 		"hides window list (separator)":          "window-status-separator ''",
@@ -128,6 +131,24 @@ func TestBuildAttachScript_StatusBarShape(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Errorf("script should %s — missing %q\n--- script ---\n%s", desc, want, script)
 		}
+	}
+
+	// The trap must NOT exit alt-screen (\033[?1049l). Exiting alt-screen in
+	// the trap would expose the primary terminal buffer while tmux cleanup
+	// runs (10-30 ms), causing a visible flash of shell history on detach.
+	if strings.Contains(script, `\033[?1049l`) {
+		t.Errorf("script must not contain \\033[?1049l (alt-screen exit in trap causes flash on detach)\n--- script ---\n%s", script)
+	}
+
+	// The trap must run tmux cleanup BEFORE the screen clear, so cleanup
+	// happens while still in alt-screen (invisible to the user).
+	trapIdx := strings.Index(script, "trap '")
+	tmuxCleanupIdx := strings.Index(script[trapIdx:], "set-option -u")
+	clearIdx := strings.Index(script[trapIdx:], `\033[2J\033[H`)
+	if tmuxCleanupIdx < 0 || clearIdx < 0 {
+		t.Errorf("trap should contain both set-option -u (cleanup) and \\033[2J\\033[H (clear)")
+	} else if tmuxCleanupIdx > clearIdx {
+		t.Errorf("trap should run tmux cleanup before screen clear (cleanup at %d, clear at %d)", tmuxCleanupIdx, clearIdx)
 	}
 	if got := strings.Count(script, "#{pane_title}"); got != 1 {
 		t.Errorf("expected exactly one #{pane_title} token, got %d", got)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -261,7 +261,9 @@ func (m *Model) restoreGrid() {
 	m.gridView.SyncState(sessions, mode, m.gridProjectNames(), m.gridProjectColors(), m.gridSessionColors(), m.appState.ActiveSessionID)
 	m.gridView.SetPaneTitles(m.paneTitles)
 	m.gridView.SetContents(m.gridContentsFromSnapshots(sessions))
-	m.PushView(ViewGrid)
+	if !m.HasView(ViewGrid) {
+		m.PushView(ViewGrid)
+	}
 }
 
 // expandForActiveSession un-collapses any parent project or team that contains

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -251,6 +251,17 @@ func New(cfg config.Config, appState state.AppState, whatsNewContent string) Mod
 }
 
 // restoreGrid re-opens the grid view if RestoreGridMode is set, then clears the flag.
+//
+// SyncState/SetPaneTitles/SetContents run unconditionally — even when ViewGrid
+// is already on the stack (the #111 tmux-detach path). This is intentional:
+// after an attach the active session, pane titles, and preview snapshots may
+// have changed, so the grid must be refreshed to reflect post-attach state.
+// The side effect is that any mid-grid cursor position the user had before
+// attaching is reset to the active-session cell — acceptable trade-off because
+// the user's focus on return is the session they just attached to.
+//
+// Only the PushView is guarded by !HasView(ViewGrid) so the grid is not pushed
+// twice on detach-restore (would break the stack invariant).
 func (m *Model) restoreGrid() {
 	if m.appState.RestoreGridMode == state.GridRestoreNone {
 		return

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"regexp"
@@ -100,6 +101,10 @@ type Model struct {
 	// attached to them. Used for the visual bell indicator in the sidebar.
 	// Keyed by sessionID, cleared on attach.
 	bellPending map[string]bool
+	// attachOut is the writer used by doAttach to emit pre-attach escape
+	// sequences (e.g. the primary-buffer clear). Defaults to os.Stdout.
+	// Tests may inject a bytes.Buffer to capture and assert the output.
+	attachOut io.Writer
 	// bellBlinkOn is toggled every ~600 ms by the bell-blink ticker so the
 	// bell badge animates on/off in software (ANSI terminal blink is unreliable
 	// in modern terminals like iTerm2 which disable it by default).
@@ -163,6 +168,7 @@ func New(cfg config.Config, appState state.AppState, whatsNewContent string) Mod
 		appState:            appState,
 		keys:                km,
 		stateLastKnownMtime: initialStateMtime,
+		attachOut:           os.Stdout,
 		titleEditor:         components.NewTitleEditor(),
 		agentPicker:         components.NewAgentPicker(),
 		teamBuilder:         components.NewTeamBuilder(),

--- a/internal/tui/flow_attach_test.go
+++ b/internal/tui/flow_attach_test.go
@@ -1,6 +1,9 @@
 package tui
 
 import (
+	"bytes"
+	"os/exec"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -111,6 +114,95 @@ func TestFlow_AttachHint_DontShowAgain(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("expected tea.Quit command")
+	}
+}
+
+// TestDoAttach_ExecPath_WritesClearOnly verifies that on the tea.ExecProcess
+// attach path (tmux backend), doAttach writes exactly the screen-clear sequence
+// \033[2J\033[H to its output and does NOT write \033[?1049l (exit alt-screen).
+//
+// This is the regression test for the flash introduced by PR #110: removing
+// \033[?1049l from doAttach was correct (it raced with the renderer), but the
+// fix must never re-introduce an alt-screen exit in the pre-attach output because
+// that would expose the primary terminal buffer.
+func TestDoAttach_ExecPath_WritesClearOnly(t *testing.T) {
+	m, mock := testFlowModel(t)
+
+	// Enable the ExecProcess attach path.
+	mock.SetUseExecAttach(true)
+
+	// Inject a buffer so we can capture what doAttach writes.
+	var buf bytes.Buffer
+	m.attachOut = &buf
+
+	// Trigger doAttach via a SessionAttachMsg (same path as pressing "a").
+	msg := SessionAttachMsg{
+		TmuxSession: "hive-sessions",
+		TmuxWindow:  0,
+	}
+	m.doAttach(msg) // we only care about the side-effect on attachOut
+
+	got := buf.String()
+
+	// Must contain the clear sequence.
+	if !strings.Contains(got, "\033[2J\033[H") {
+		t.Errorf("doAttach output missing clear sequence \\033[2J\\033[H; got %q", got)
+	}
+
+	// Must NOT exit alt-screen — that would expose the primary buffer.
+	if strings.Contains(got, "\033[?1049l") {
+		t.Errorf("doAttach output contains \\033[?1049l (alt-screen exit) which causes a terminal flash; got %q", got)
+	}
+}
+
+// TestAltScreenExecCmd_Run_EntersAltScreen verifies that altScreenExecCmd.Run()
+// immediately writes the enter-alt-screen + clear sequence before starting the
+// subprocess. This minimizes the primary-buffer flash that occurs between
+// BubbleTea's ReleaseTerminal (exitAltScreen + 10ms sleep) and subprocess start.
+//
+// Critical properties:
+//   - Must write \033[?1049h (enter alt-screen) before subprocess starts
+//   - Must write \033[2J\033[H (clear screen)
+//   - Must NOT write \033[?1049l (exit alt-screen would be wrong — we're re-entering)
+func TestAltScreenExecCmd_Run_EntersAltScreen(t *testing.T) {
+	var termBuf bytes.Buffer
+
+	// Use a no-op command so the test runs fast without side effects.
+	cmd := exec.Command("true")
+	var cmdOut bytes.Buffer
+	cmd.Stdout = &cmdOut
+
+	execCmd := &altScreenExecCmd{cmd: cmd, termOut: &termBuf}
+	if err := execCmd.Run(); err != nil {
+		t.Fatalf("altScreenExecCmd.Run() unexpected error: %v", err)
+	}
+
+	got := termBuf.String()
+
+	if !strings.Contains(got, "\033[?1049h") {
+		t.Errorf("altScreenExecCmd.Run() missing alt-screen enter \\033[?1049h; got %q", got)
+	}
+	if !strings.Contains(got, "\033[2J") {
+		t.Errorf("altScreenExecCmd.Run() missing clear \\033[2J; got %q", got)
+	}
+	if strings.Contains(got, "\033[?1049l") {
+		t.Errorf("altScreenExecCmd.Run() must not exit alt-screen (\\033[?1049l causes a flash); got %q", got)
+	}
+}
+
+// TestAltScreenExecCmd_SetStdin_OnlyIfNil verifies that SetStdin/SetStdout/SetStderr
+// do not override values already set on the underlying exec.Cmd.
+func TestAltScreenExecCmd_SetStdin_OnlyIfNil(t *testing.T) {
+	var termBuf, cmdOut bytes.Buffer
+	cmd := exec.Command("true")
+	cmd.Stdout = &cmdOut // pre-set
+
+	execCmd := &altScreenExecCmd{cmd: cmd, termOut: &termBuf}
+
+	var other bytes.Buffer
+	execCmd.SetStdout(&other) // should be ignored — already set
+	if cmd.Stdout != &cmdOut {
+		t.Error("SetStdout should not override a pre-set cmd.Stdout")
 	}
 }
 

--- a/internal/tui/flow_grid_test.go
+++ b/internal/tui/flow_grid_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -36,11 +37,18 @@ func TestFlow_GridAttachDetachRestoresGrid(t *testing.T) {
 	cmd := f.SendSpecialKey(tea.KeyEnter)
 
 	// Execute the cmd chain: grid cmd → GridSessionSelectedMsg → doAttach → tea.Quit.
-	// The grid is hidden inside handleGridSessionSelected (after the message is processed).
+	// With the fix for #111, the grid STAYS on the view stack through attach so
+	// there is no one-frame sidebar flash before the terminal handoff.
 	f.ExecCmdChain(cmd)
 
-	// Grid should be hidden after the cmd chain completes.
-	f.AssertGridActive(false)
+	// Grid must still be active after the cmd chain — the pre-exec render frame
+	// renders grid content, not sidebar.
+	f.AssertGridActive(true)
+	mm := f.Model()
+	if top := mm.TopView(); top != ViewGrid {
+		t.Errorf("TopView = %q after ExecCmdChain, want ViewGrid", top)
+	}
+	f.ViewContains("↑↓←→ navigate") // grid-only hint line
 
 	// attachPending should be set with RestoreGridMode.
 	updated := f.Model()
@@ -91,9 +99,16 @@ func TestFlow_GridAllProjectsRestores(t *testing.T) {
 	// Press enter to select session → attach.
 	cmd := f.SendSpecialKey(tea.KeyEnter)
 
-	// Execute cmd chain to completion; grid is hidden inside handleGridSessionSelected.
+	// Execute cmd chain to completion. With the fix for #111 the grid stays on
+	// the view stack through attach so the pre-exec frame renders grid content.
 	f.ExecCmdChain(cmd)
-	f.AssertGridActive(false)
+	f.AssertGridActive(true)
+	mm := f.Model()
+	if top := mm.TopView(); top != ViewGrid {
+		t.Errorf("TopView = %q after ExecCmdChain, want ViewGrid", top)
+	}
+	f.ViewContains("session-1")
+	f.ViewContains("session-2")
 
 	updated := f.Model()
 	if updated.attachPending == nil {
@@ -347,10 +362,15 @@ func TestFlow_GridAttachWithHint(t *testing.T) {
 	// The grid stays active until handleGridSessionSelected processes the message.
 	cmd := f.SendSpecialKey(tea.KeyEnter)
 
-	// Execute cmd chain: GridSessionSelectedMsg → app handler shows hint.
-	// Grid is hidden inside handleGridSessionSelected (no intermediate sidebar flash).
+	// Execute cmd chain: GridSessionSelectedMsg → app handler pushes ViewAttachHint.
+	// With the fix for #111, ViewGrid stays on the stack under the hint so that
+	// dismissing the hint returns to grid and there is no mid-flow sidebar frame.
 	f.ExecCmdChain(cmd)
-	f.AssertGridActive(false)
+	f.AssertGridActive(true)
+	mmHint := f.Model()
+	if !mmHint.HasView(ViewGrid) {
+		t.Error("ViewGrid should remain on the stack under ViewAttachHint")
+	}
 
 	updated := f.Model()
 	if !updated.showAttachHint {
@@ -377,33 +397,37 @@ func TestFlow_GridAttachWithHint(t *testing.T) {
 }
 
 // TestFlow_GridKeyAttachNoFlash verifies that pressing Enter in grid view does NOT
-// produce an intermediate sidebar render frame before the attach transition.
-// The grid must stay active until handleGridSessionSelected processes the message.
+// produce a sidebar render frame before the attach transition. The grid must
+// stay on the view stack through handleGridSessionSelected and the returned Cmd
+// so the pre-exec frame renders grid content.
 func TestFlow_GridKeyAttachNoFlash(t *testing.T) {
-	m, mock := testFlowModel(t)
+	m, mock := testFlowModel(t) // HideAttachHint=true
 	f := newFlowRunner(t, m, mock)
 
 	// Open grid.
 	f.SendKey("g")
 	f.AssertGridActive(true)
 
-	// Press enter — grid must NOT hide in this update cycle.
-	// The old code called gv.Hide() inside gridview.Update, causing a one-frame
-	// sidebar render before the attach hint was pushed.
-	_ = f.SendSpecialKey(tea.KeyEnter)
-	f.AssertGridActive(true) // still active — no premature hide
+	// Press enter and run the full Cmd chain (key → gridview.Cmd →
+	// GridSessionSelectedMsg → handleGridSessionSelected → doAttach → tea.Quit).
+	cmd := f.SendSpecialKey(tea.KeyEnter)
+	f.ExecCmdChain(cmd)
 
-	// TopView should still be ViewGrid (not ViewMain) before the cmd is processed.
-	m2 := f.Model()
-	if top := m2.TopView(); top != ViewGrid {
-		t.Errorf("TopView = %q after Enter, want ViewGrid (no premature pop)", top)
+	// Grid must still be active after the chain resolves — this is the pre-exec
+	// render frame that previously flashed sidebar content.
+	f.AssertGridActive(true)
+	mm := f.Model()
+	if top := mm.TopView(); top != ViewGrid {
+		t.Errorf("TopView = %q after attach chain, want ViewGrid", top)
 	}
+	f.ViewContains("session-1")        // grid cell content
+	f.ViewContains("↑↓←→ navigate")    // grid-only hint line
+	f.ViewNotContains("[1] test-project-1") // sidebar-only numbered project list
 }
 
-// TestFlow_GridMouseAttachNoFlash verifies that receiving GridSessionSelectedMsg
-// does NOT produce an intermediate ViewMain (sidebar) frame before the attach
-// transition. This covers the path where the mouse handler previously popped
-// ViewGrid before sending the message.
+// TestFlow_GridMouseAttachNoFlash verifies the mouse-click path through
+// GridSessionSelectedMsg keeps the grid on the stack through attach so the
+// pre-exec render frame contains grid content, not sidebar.
 func TestFlow_GridMouseAttachNoFlash(t *testing.T) {
 	m, mock := testFlowModel(t)
 	f := newFlowRunner(t, m, mock)
@@ -411,61 +435,59 @@ func TestFlow_GridMouseAttachNoFlash(t *testing.T) {
 	// Open grid.
 	f.SendKey("g")
 	f.AssertGridActive(true)
-	m2pre := f.Model()
-	if m2pre.TopView() != ViewGrid {
-		t.Fatalf("TopView = %q before test, want ViewGrid", m2pre.TopView())
-	}
 
-	// Send GridSessionSelectedMsg directly (as the mouse handler would after our fix:
-	// the Cmd sends the message without pre-popping ViewGrid).
-	// Before the fix, the mouse path called PopView() before returning the Cmd,
-	// so ViewMain was the top for one frame.
+	// Mouse click in grid produces GridSessionSelectedMsg (same msg as keyboard).
 	cmd := f.Send(components.GridSessionSelectedMsg{
 		TmuxSession: "hive-sessions",
 		TmuxWindow:  0,
 	})
-
-	// The message was processed by handleGridSessionSelected which pops ViewGrid
-	// itself, then (with HideAttachHint=true) calls doAttach.
-	// Stack should NOT have gone through ViewMain as the sole entry.
 	_ = cmd
-	m2 := f.Model()
-	// Grid was popped inside the handler — Active should be false now.
-	// But we must NOT have had a transient ViewMain-only state, which
-	// is ensured by the handler doing the pop (verified by no flash in practice).
-	if m2.gridView.Active {
-		t.Error("gridView.Active = true after GridSessionSelectedMsg, want false")
+
+	// Grid must still be active (view stack unchanged) so View() renders grid.
+	f.AssertGridActive(true)
+	mm := f.Model()
+	if top := mm.TopView(); top != ViewGrid {
+		t.Errorf("TopView = %q after GridSessionSelectedMsg, want ViewGrid", top)
 	}
+	f.ViewContains("session-1")
+	f.ViewNotContains("[1] test-project-1")
 }
 
-// TestFlow_GridAttachHintCancelReturnsToSidebar verifies that pressing Esc on the
-// attach hint dismisses the hint and returns to the sidebar (not back to grid).
-func TestFlow_GridAttachHintCancelReturnsToSidebar(t *testing.T) {
+// TestFlow_GridAttachHintCancel_ReturnsToGrid verifies that pressing Esc on the
+// attach hint opened from grid mode returns to grid (not sidebar). This is the
+// natural stack behaviour once handleGridSessionSelected no longer pre-pops
+// ViewGrid before pushing ViewAttachHint.
+func TestFlow_GridAttachHintCancel_ReturnsToGrid(t *testing.T) {
 	m, mock := testFlowModelWithHint(t)
 	f := newFlowRunner(t, m, mock)
 
-	// Open grid and select a session (shows attach hint).
+	// Open grid and select a session (shows attach hint over grid).
 	f.SendKey("g")
 	f.AssertGridActive(true)
 	cmd := f.SendSpecialKey(tea.KeyEnter)
-	f.ExecCmdChain(cmd) // processes GridSessionSelectedMsg → shows attach hint
-	f.AssertGridActive(false)
+	f.ExecCmdChain(cmd)
 
-	updated := f.Model()
-	if !updated.showAttachHint {
-		t.Fatal("showAttachHint should be true")
+	if !f.Model().showAttachHint {
+		t.Fatal("showAttachHint should be true after grid session select")
+	}
+	mmCancel := f.Model()
+	if !mmCancel.HasView(ViewGrid) {
+		t.Fatal("ViewGrid should remain under ViewAttachHint")
 	}
 
 	// Press Esc to cancel the hint.
 	f.SendSpecialKey(tea.KeyEsc)
 
-	updated2 := f.Model()
-	if updated2.showAttachHint {
+	if f.Model().showAttachHint {
 		t.Fatal("showAttachHint should be false after Esc")
 	}
-	// Grid is no longer active — user returns to sidebar.
-	f.AssertGridActive(false)
-	f.ViewContains("test-project-1")
+	// Grid is the next view underneath — user returns to grid, not sidebar.
+	f.AssertGridActive(true)
+	mm := f.Model()
+	if top := mm.TopView(); top != ViewGrid {
+		t.Errorf("TopView = %q after hint cancel, want ViewGrid", top)
+	}
+	f.ViewContains("↑↓←→ navigate")
 }
 
 // TestFlow_GridAttachDoneRestoresGrid tests the tmux backend path:
@@ -605,9 +627,10 @@ func TestFlow_GridAttachSetsActiveSessionID(t *testing.T) {
 	cmd := f.SendSpecialKey(tea.KeyEnter)
 
 	// Execute the cmd chain to deliver GridSessionSelectedMsg.
-	// Grid is hidden inside handleGridSessionSelected after the message is processed.
+	// With the #111 fix, grid stays on the stack through attach so the pre-exec
+	// frame renders grid, not sidebar.
 	f.ExecCmdChain(cmd)
-	f.AssertGridActive(false)
+	f.AssertGridActive(true)
 
 	// ActiveSessionID should be sess-2 (the one we selected in the grid).
 	f.AssertActiveSession("sess-2")
@@ -1101,5 +1124,315 @@ func TestFlow_GridExtendedCellNavigation(t *testing.T) {
 	f.AssertGridCursor(4)
 	if f.model.gridView.AtExtendedForTest() {
 		t.Error("atExtended = true after leaving extended slot, want false")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// #111 — grid-mode sidebar-flash regression tests (tmux exec path + variants)
+// -----------------------------------------------------------------------------
+
+// TestFlow_GridKey_TmuxExec_NoFlash is the canonical regression test for the
+// tmux backend path (tea.Exec). Before the #111 fix, handleGridSessionSelected
+// popped ViewGrid before returning the Cmd — so the render frame between
+// Update() and tea.Exec's ReleaseTerminal rendered sidebar content. This test
+// exercises that exact window with SetUseExecAttach(true).
+func TestFlow_GridKey_TmuxExec_NoFlash(t *testing.T) {
+	m, mock := testFlowModel(t) // HideAttachHint=true
+	mock.SetUseExecAttach(true)
+	var buf bytes.Buffer
+	m.attachOut = &buf
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.AssertGridActive(true)
+
+	cmd := f.SendSpecialKey(tea.KeyEnter)
+	f.ExecCmdChain(cmd)
+
+	mm := f.Model()
+	if mm.TopView() != ViewGrid {
+		t.Errorf("TopView = %q after tmux-exec attach chain, want ViewGrid", mm.TopView())
+	}
+	f.AssertGridActive(true)
+	f.ViewContains("session-1")
+	f.ViewContains("↑↓←→ navigate")
+	f.ViewNotContains("[1] test-project-1") // sidebar-only token
+}
+
+// TestFlow_GridMouse_TmuxExec_NoFlash covers the mouse-click attach trigger on
+// the tmux exec backend. The mouse handler in gridview.go sends the same
+// GridSessionSelectedMsg as keyboard, so this closes the mouse × tmux coverage
+// gap called out in the research.
+func TestFlow_GridMouse_TmuxExec_NoFlash(t *testing.T) {
+	m, mock := testFlowModel(t)
+	mock.SetUseExecAttach(true)
+	var buf bytes.Buffer
+	m.attachOut = &buf
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.AssertGridActive(true)
+
+	// Send the msg a mouse click would produce.
+	_ = f.Send(components.GridSessionSelectedMsg{
+		TmuxSession: "hive-sessions",
+		TmuxWindow:  0,
+	})
+
+	mm := f.Model()
+	if mm.TopView() != ViewGrid {
+		t.Errorf("TopView = %q after mouse-click msg, want ViewGrid", mm.TopView())
+	}
+	f.AssertGridActive(true)
+	f.ViewContains("session-1")
+	f.ViewNotContains("[1] test-project-1")
+}
+
+// TestFlow_GridAll_TmuxExec_NoFlash covers the all-projects grid (G) on the
+// tmux exec backend. The all-projects variant uses GridRestoreAll rather than
+// GridRestoreProject, so this test guards against a mode-specific regression.
+func TestFlow_GridAll_TmuxExec_NoFlash(t *testing.T) {
+	m, mock := testFlowModel(t)
+	mock.SetUseExecAttach(true)
+	var buf bytes.Buffer
+	m.attachOut = &buf
+	f := newFlowRunner(t, m, mock)
+
+	// "G" opens the all-projects grid.
+	f.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("G")})
+	f.AssertGridActive(true)
+	f.AssertGridMode(state.GridRestoreAll)
+
+	cmd := f.SendSpecialKey(tea.KeyEnter)
+	f.ExecCmdChain(cmd)
+
+	mm := f.Model()
+	if mm.TopView() != ViewGrid {
+		t.Errorf("TopView = %q after all-projects attach chain, want ViewGrid", mm.TopView())
+	}
+	f.AssertGridActive(true)
+	f.AssertGridMode(state.GridRestoreAll)
+	f.ViewContains("session-1")
+	f.ViewContains("session-2")
+	f.ViewNotContains("[1] test-project-1")
+}
+
+// TestFlow_GridDetach_TmuxExec_RendersGridPreAttachDone simulates the post-
+// detach frame in the tmux backend: after tea.Exec returns, BubbleTea enables
+// the renderer (and the renderer runs once) before AttachDoneMsg is delivered.
+// At that moment the grid must still be on the stack. AttachDoneMsg's
+// restoreGrid() call must be idempotent so the stack does not grow.
+func TestFlow_GridDetach_TmuxExec_RendersGridPreAttachDone(t *testing.T) {
+	m, mock := testFlowModel(t)
+	mock.SetUseExecAttach(true)
+	var buf bytes.Buffer
+	m.attachOut = &buf
+	f := newFlowRunner(t, m, mock)
+
+	// Open grid, attach — grid stays on stack.
+	f.SendKey("g")
+	cmd := f.SendSpecialKey(tea.KeyEnter)
+	f.ExecCmdChain(cmd)
+
+	mmPre := f.Model()
+	if !mmPre.HasView(ViewGrid) {
+		t.Fatal("ViewGrid should be on stack after attach chain")
+	}
+	stackLenPre := len(mmPre.viewStack)
+	f.ViewContains("session-1") // pre-AttachDone frame is grid content
+
+	// Deliver AttachDoneMsg as BubbleTea would after RestoreTerminal.
+	f.Send(AttachDoneMsg{RestoreGridMode: state.GridRestoreProject})
+
+	mmPost := f.Model()
+	f.AssertGridActive(true)
+	if mmPost.TopView() != ViewGrid {
+		t.Errorf("TopView = %q after AttachDoneMsg, want ViewGrid", mmPost.TopView())
+	}
+	if got := len(mmPost.viewStack); got != stackLenPre {
+		t.Errorf("viewStack length = %d after AttachDoneMsg, want %d (restoreGrid must be idempotent)",
+			got, stackLenPre)
+	}
+}
+
+// TestFlow_GridHint_Confirm_TmuxExec_NoFlash covers row #6: HideAttachHint=false,
+// user opens grid, selects session, confirms hint with Enter, attach runs on
+// tmux exec. The pre-exec frame after the hint is confirmed must render grid
+// (the hint is popped → grid becomes TopView → tea.Exec fires).
+func TestFlow_GridHint_Confirm_TmuxExec_NoFlash(t *testing.T) {
+	m, mock := testFlowModelWithHint(t)
+	mock.SetUseExecAttach(true)
+	var buf bytes.Buffer
+	m.attachOut = &buf
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	f.AssertGridActive(true)
+
+	cmd := f.SendSpecialKey(tea.KeyEnter)
+	f.ExecCmdChain(cmd) // produces the hint overlay
+	if !f.Model().showAttachHint {
+		t.Fatal("showAttachHint should be true after grid session select")
+	}
+
+	// Enter on hint: pop hint, call doAttach (tea.Exec).
+	cmd = f.SendSpecialKey(tea.KeyEnter)
+	f.ExecCmdChain(cmd)
+
+	mm := f.Model()
+	if mm.TopView() != ViewGrid {
+		t.Errorf("TopView = %q after hint confirm, want ViewGrid", mm.TopView())
+	}
+	f.AssertGridActive(true)
+	f.ViewContains("session-1")
+	f.ViewNotContains("[1] test-project-1")
+}
+
+// TestFlow_GridHint_D_TmuxExec_NoFlash covers row #7: pressing "d" on the hint
+// attaches and persists HideAttachHint=true. Grid must still render pre-exec.
+func TestFlow_GridHint_D_TmuxExec_NoFlash(t *testing.T) {
+	m, mock := testFlowModelWithHint(t)
+	mock.SetUseExecAttach(true)
+	var buf bytes.Buffer
+	m.attachOut = &buf
+	f := newFlowRunner(t, m, mock)
+
+	f.SendKey("g")
+	cmd := f.SendSpecialKey(tea.KeyEnter)
+	f.ExecCmdChain(cmd)
+	if !f.Model().showAttachHint {
+		t.Fatal("showAttachHint should be true after grid session select")
+	}
+
+	// "d" on hint: pop hint, set HideAttachHint=true, call doAttach.
+	cmd = f.SendKey("d")
+	f.ExecCmdChain(cmd)
+
+	mm := f.Model()
+	if mm.TopView() != ViewGrid {
+		t.Errorf("TopView = %q after d-dismiss, want ViewGrid", mm.TopView())
+	}
+	if !mm.cfg.HideAttachHint {
+		t.Error("cfg.HideAttachHint should be true after pressing 'd'")
+	}
+	f.AssertGridActive(true)
+	f.ViewContains("session-1")
+}
+
+// TestFlow_SidebarAttachHintCancel_ReturnsToSidebar guards the sidebar-origin
+// stack semantics: esc on the hint when opened from sidebar must still leave
+// the user on the sidebar, not on any grid state. Regression guard for the
+// #111 fix to prove it didn't collaterally affect sidebar-origin flows.
+func TestFlow_SidebarAttachHintCancel_ReturnsToSidebar(t *testing.T) {
+	m, mock := testFlowModelWithHint(t)
+	f := newFlowRunner(t, m, mock)
+
+	// From sidebar, press "a" to open the attach hint (grid never opens).
+	cmd := f.SendKey("a")
+	f.ExecCmdChain(cmd)
+	mmBefore := f.Model()
+	if !mmBefore.showAttachHint {
+		t.Fatal("showAttachHint should be true after 'a' from sidebar")
+	}
+	if mmBefore.HasView(ViewGrid) {
+		t.Fatal("ViewGrid must NOT be on stack for sidebar-origin attach")
+	}
+
+	// Esc on hint → back to sidebar.
+	f.SendSpecialKey(tea.KeyEsc)
+
+	mm := f.Model()
+	if mm.TopView() != ViewMain {
+		t.Errorf("TopView = %q after esc on sidebar-origin hint, want ViewMain", mm.TopView())
+	}
+	f.AssertGridActive(false)
+	if mm.pendingAttach != nil {
+		t.Error("pendingAttach should be nil after esc")
+	}
+	f.ViewContains("[1] test-project-1") // sidebar rendered, as expected
+}
+
+// TestFlow_Sidebar_TmuxExec_NoGridRender guards against accidental grid
+// rendering on the sidebar-origin tmux attach path. If our #111 stack change
+// pushed ViewGrid anywhere in the sidebar flow, this would catch it.
+func TestFlow_Sidebar_TmuxExec_NoGridRender(t *testing.T) {
+	m, mock := testFlowModel(t)
+	mock.SetUseExecAttach(true)
+	var buf bytes.Buffer
+	m.attachOut = &buf
+	f := newFlowRunner(t, m, mock)
+
+	// From sidebar, press "a" to attach.
+	cmd := f.SendKey("a")
+	f.ExecCmdChain(cmd)
+
+	mm := f.Model()
+	if mm.TopView() != ViewMain {
+		t.Errorf("TopView = %q after sidebar attach, want ViewMain", mm.TopView())
+	}
+	if mm.HasView(ViewGrid) {
+		t.Error("ViewGrid must NOT be on stack for sidebar attach")
+	}
+	f.AssertGridActive(false)
+	f.ViewContains("[1] test-project-1")     // sidebar rendered
+	f.ViewNotContains("↑↓←→ navigate")        // grid-only hint absent
+}
+
+// TestFlow_RestoreGrid_Idempotent is a pure unit test on restoreGrid(): when
+// ViewGrid is already on the stack (tmux detach path), the function must not
+// push it again, yet SyncState and mode/consumption side effects must still run.
+func TestFlow_RestoreGrid_Idempotent(t *testing.T) {
+	m, mock := testFlowModel(t)
+	_ = mock
+
+	// Open grid in project mode, then request restore to All.
+	m.openGrid(state.GridRestoreProject)
+	if !m.HasView(ViewGrid) {
+		t.Fatal("precondition: ViewGrid should be on stack after openGrid")
+	}
+	stackLen := len(m.viewStack)
+
+	m.appState.RestoreGridMode = state.GridRestoreAll
+	m.restoreGrid()
+
+	if got := len(m.viewStack); got != stackLen {
+		t.Errorf("viewStack length = %d after restoreGrid, want %d (must be idempotent)",
+			got, stackLen)
+	}
+	if !m.HasView(ViewGrid) {
+		t.Error("ViewGrid should still be on stack")
+	}
+	if m.gridView.Mode != state.GridRestoreAll {
+		t.Errorf("gridView.Mode = %q, want GridRestoreAll (SyncState should still run)",
+			m.gridView.Mode)
+	}
+	if m.appState.RestoreGridMode != state.GridRestoreNone {
+		t.Errorf("RestoreGridMode = %q, want GridRestoreNone (should be consumed)",
+			m.appState.RestoreGridMode)
+	}
+}
+
+// TestFlow_RestoreGrid_FromEmptyStack covers the startup-restore path: when
+// ViewGrid is NOT on the stack (cmd/start.go's New() reload after native
+// detach), restoreGrid must push it.
+func TestFlow_RestoreGrid_FromEmptyStack(t *testing.T) {
+	m, _ := testFlowModel(t)
+
+	if m.HasView(ViewGrid) {
+		t.Fatal("precondition: ViewGrid should not be on stack at startup")
+	}
+	stackLen := len(m.viewStack)
+
+	m.appState.RestoreGridMode = state.GridRestoreProject
+	m.restoreGrid()
+
+	if !m.HasView(ViewGrid) {
+		t.Error("ViewGrid should be pushed when stack does not already contain it")
+	}
+	if got := len(m.viewStack); got != stackLen+1 {
+		t.Errorf("viewStack length = %d, want %d (one push)", got, stackLen+1)
+	}
+	if m.gridView.Mode != state.GridRestoreProject {
+		t.Errorf("gridView.Mode = %q, want GridRestoreProject", m.gridView.Mode)
 	}
 }

--- a/internal/tui/flow_grid_test.go
+++ b/internal/tui/flow_grid_test.go
@@ -12,6 +12,28 @@ import (
 	"github.com/lucascaro/hive/internal/tui/components"
 )
 
+// Stable substrings used to distinguish grid vs sidebar View() output in
+// flash-regression tests. If the grid nav hint or sidebar project format
+// changes in future UX tweaks, update these constants in one place rather
+// than each test call site.
+const (
+	gridNavHintToken       = "↑↓←→ navigate" // only rendered by gridview.View()
+	sidebarProjectListItem = "[1] test-project-1"
+)
+
+// enableTmuxExecFlow configures the given model + mock for flow tests that
+// exercise the tmux tea.Exec attach path. It wires the mock backend to
+// return true from UseExecAttach and injects a bytes.Buffer into m.attachOut
+// so ANSI escape writes from doAttach/altScreenExecCmd do not leak to
+// test-run stdout. The returned buffer is usually ignored by callers.
+func enableTmuxExecFlow(t *testing.T, m *Model, mock *muxtest.MockBackend) *bytes.Buffer {
+	t.Helper()
+	mock.SetUseExecAttach(true)
+	buf := &bytes.Buffer{}
+	m.attachOut = buf
+	return buf
+}
+
 // TestFlow_GridAttachDetachRestoresGrid tests the full grid → attach → detach → grid restore flow.
 // This is the exact regression test: after detaching from a session opened via the grid,
 // the grid must re-open automatically.
@@ -48,7 +70,7 @@ func TestFlow_GridAttachDetachRestoresGrid(t *testing.T) {
 	if top := mm.TopView(); top != ViewGrid {
 		t.Errorf("TopView = %q after ExecCmdChain, want ViewGrid", top)
 	}
-	f.ViewContains("↑↓←→ navigate") // grid-only hint line
+	f.ViewContains(gridNavHintToken)
 
 	// attachPending should be set with RestoreGridMode.
 	updated := f.Model()
@@ -421,8 +443,8 @@ func TestFlow_GridKeyAttachNoFlash(t *testing.T) {
 		t.Errorf("TopView = %q after attach chain, want ViewGrid", top)
 	}
 	f.ViewContains("session-1")        // grid cell content
-	f.ViewContains("↑↓←→ navigate")    // grid-only hint line
-	f.ViewNotContains("[1] test-project-1") // sidebar-only numbered project list
+	f.ViewContains(gridNavHintToken)
+	f.ViewNotContains(sidebarProjectListItem)
 }
 
 // TestFlow_GridMouseAttachNoFlash verifies the mouse-click path through
@@ -450,7 +472,7 @@ func TestFlow_GridMouseAttachNoFlash(t *testing.T) {
 		t.Errorf("TopView = %q after GridSessionSelectedMsg, want ViewGrid", top)
 	}
 	f.ViewContains("session-1")
-	f.ViewNotContains("[1] test-project-1")
+	f.ViewNotContains(sidebarProjectListItem)
 }
 
 // TestFlow_GridAttachHintCancel_ReturnsToGrid verifies that pressing Esc on the
@@ -487,7 +509,7 @@ func TestFlow_GridAttachHintCancel_ReturnsToGrid(t *testing.T) {
 	if top := mm.TopView(); top != ViewGrid {
 		t.Errorf("TopView = %q after hint cancel, want ViewGrid", top)
 	}
-	f.ViewContains("↑↓←→ navigate")
+	f.ViewContains(gridNavHintToken)
 }
 
 // TestFlow_GridAttachDoneRestoresGrid tests the tmux backend path:
@@ -1138,9 +1160,7 @@ func TestFlow_GridExtendedCellNavigation(t *testing.T) {
 // exercises that exact window with SetUseExecAttach(true).
 func TestFlow_GridKey_TmuxExec_NoFlash(t *testing.T) {
 	m, mock := testFlowModel(t) // HideAttachHint=true
-	mock.SetUseExecAttach(true)
-	var buf bytes.Buffer
-	m.attachOut = &buf
+	_ = enableTmuxExecFlow(t, &m, mock)
 	f := newFlowRunner(t, m, mock)
 
 	f.SendKey("g")
@@ -1155,8 +1175,8 @@ func TestFlow_GridKey_TmuxExec_NoFlash(t *testing.T) {
 	}
 	f.AssertGridActive(true)
 	f.ViewContains("session-1")
-	f.ViewContains("↑↓←→ navigate")
-	f.ViewNotContains("[1] test-project-1") // sidebar-only token
+	f.ViewContains(gridNavHintToken)
+	f.ViewNotContains(sidebarProjectListItem) // sidebar-only token
 }
 
 // TestFlow_GridMouse_TmuxExec_NoFlash covers the mouse-click attach trigger on
@@ -1165,9 +1185,7 @@ func TestFlow_GridKey_TmuxExec_NoFlash(t *testing.T) {
 // gap called out in the research.
 func TestFlow_GridMouse_TmuxExec_NoFlash(t *testing.T) {
 	m, mock := testFlowModel(t)
-	mock.SetUseExecAttach(true)
-	var buf bytes.Buffer
-	m.attachOut = &buf
+	_ = enableTmuxExecFlow(t, &m, mock)
 	f := newFlowRunner(t, m, mock)
 
 	f.SendKey("g")
@@ -1185,7 +1203,7 @@ func TestFlow_GridMouse_TmuxExec_NoFlash(t *testing.T) {
 	}
 	f.AssertGridActive(true)
 	f.ViewContains("session-1")
-	f.ViewNotContains("[1] test-project-1")
+	f.ViewNotContains(sidebarProjectListItem)
 }
 
 // TestFlow_GridAll_TmuxExec_NoFlash covers the all-projects grid (G) on the
@@ -1193,9 +1211,7 @@ func TestFlow_GridMouse_TmuxExec_NoFlash(t *testing.T) {
 // GridRestoreProject, so this test guards against a mode-specific regression.
 func TestFlow_GridAll_TmuxExec_NoFlash(t *testing.T) {
 	m, mock := testFlowModel(t)
-	mock.SetUseExecAttach(true)
-	var buf bytes.Buffer
-	m.attachOut = &buf
+	_ = enableTmuxExecFlow(t, &m, mock)
 	f := newFlowRunner(t, m, mock)
 
 	// "G" opens the all-projects grid.
@@ -1214,7 +1230,7 @@ func TestFlow_GridAll_TmuxExec_NoFlash(t *testing.T) {
 	f.AssertGridMode(state.GridRestoreAll)
 	f.ViewContains("session-1")
 	f.ViewContains("session-2")
-	f.ViewNotContains("[1] test-project-1")
+	f.ViewNotContains(sidebarProjectListItem)
 }
 
 // TestFlow_GridDetach_TmuxExec_RendersGridPreAttachDone simulates the post-
@@ -1224,9 +1240,7 @@ func TestFlow_GridAll_TmuxExec_NoFlash(t *testing.T) {
 // restoreGrid() call must be idempotent so the stack does not grow.
 func TestFlow_GridDetach_TmuxExec_RendersGridPreAttachDone(t *testing.T) {
 	m, mock := testFlowModel(t)
-	mock.SetUseExecAttach(true)
-	var buf bytes.Buffer
-	m.attachOut = &buf
+	_ = enableTmuxExecFlow(t, &m, mock)
 	f := newFlowRunner(t, m, mock)
 
 	// Open grid, attach — grid stays on stack.
@@ -1261,9 +1275,7 @@ func TestFlow_GridDetach_TmuxExec_RendersGridPreAttachDone(t *testing.T) {
 // (the hint is popped → grid becomes TopView → tea.Exec fires).
 func TestFlow_GridHint_Confirm_TmuxExec_NoFlash(t *testing.T) {
 	m, mock := testFlowModelWithHint(t)
-	mock.SetUseExecAttach(true)
-	var buf bytes.Buffer
-	m.attachOut = &buf
+	_ = enableTmuxExecFlow(t, &m, mock)
 	f := newFlowRunner(t, m, mock)
 
 	f.SendKey("g")
@@ -1285,16 +1297,14 @@ func TestFlow_GridHint_Confirm_TmuxExec_NoFlash(t *testing.T) {
 	}
 	f.AssertGridActive(true)
 	f.ViewContains("session-1")
-	f.ViewNotContains("[1] test-project-1")
+	f.ViewNotContains(sidebarProjectListItem)
 }
 
 // TestFlow_GridHint_D_TmuxExec_NoFlash covers row #7: pressing "d" on the hint
 // attaches and persists HideAttachHint=true. Grid must still render pre-exec.
 func TestFlow_GridHint_D_TmuxExec_NoFlash(t *testing.T) {
 	m, mock := testFlowModelWithHint(t)
-	mock.SetUseExecAttach(true)
-	var buf bytes.Buffer
-	m.attachOut = &buf
+	_ = enableTmuxExecFlow(t, &m, mock)
 	f := newFlowRunner(t, m, mock)
 
 	f.SendKey("g")
@@ -1349,7 +1359,7 @@ func TestFlow_SidebarAttachHintCancel_ReturnsToSidebar(t *testing.T) {
 	if mm.pendingAttach != nil {
 		t.Error("pendingAttach should be nil after esc")
 	}
-	f.ViewContains("[1] test-project-1") // sidebar rendered, as expected
+	f.ViewContains(sidebarProjectListItem) // sidebar rendered, as expected
 }
 
 // TestFlow_Sidebar_TmuxExec_NoGridRender guards against accidental grid
@@ -1357,9 +1367,7 @@ func TestFlow_SidebarAttachHintCancel_ReturnsToSidebar(t *testing.T) {
 // pushed ViewGrid anywhere in the sidebar flow, this would catch it.
 func TestFlow_Sidebar_TmuxExec_NoGridRender(t *testing.T) {
 	m, mock := testFlowModel(t)
-	mock.SetUseExecAttach(true)
-	var buf bytes.Buffer
-	m.attachOut = &buf
+	_ = enableTmuxExecFlow(t, &m, mock)
 	f := newFlowRunner(t, m, mock)
 
 	// From sidebar, press "a" to attach.
@@ -1374,8 +1382,8 @@ func TestFlow_Sidebar_TmuxExec_NoGridRender(t *testing.T) {
 		t.Error("ViewGrid must NOT be on stack for sidebar attach")
 	}
 	f.AssertGridActive(false)
-	f.ViewContains("[1] test-project-1")     // sidebar rendered
-	f.ViewNotContains("↑↓←→ navigate")        // grid-only hint absent
+	f.ViewContains(sidebarProjectListItem)
+	f.ViewNotContains(gridNavHintToken)
 }
 
 // TestFlow_RestoreGrid_Idempotent is a pure unit test on restoreGrid(): when

--- a/internal/tui/handle_preview.go
+++ b/internal/tui/handle_preview.go
@@ -51,12 +51,14 @@ func (m Model) handleGridPreviewsUpdated(msg components.GridPreviewsUpdatedMsg) 
 }
 
 func (m Model) handleGridSessionSelected(msg components.GridSessionSelectedMsg) (tea.Model, tea.Cmd) {
-	// Pop the grid from the view stack here — after the message is processed —
-	// so there is no intermediate sidebar-render frame between grid close and
-	// the attach hint or doAttach transition.
-	if m.HasView(ViewGrid) {
-		m.PopView()
-	}
+	// Do NOT pop ViewGrid here. Keeping it on the stack until detach is what
+	// prevents the one-frame sidebar flash between Update returning and the
+	// attach Cmd executing: for HideAttachHint=true, TopView() stays ViewGrid
+	// through the Exec/Quit; for HideAttachHint=false, the hint is pushed on
+	// top of ViewGrid. On detach (AttachDoneMsg path), restoreGrid() is made
+	// idempotent so the grid is not pushed again when it is already on the
+	// stack (tmux tea.Exec case). Esc on the hint naturally returns to
+	// whichever view was under it (grid or main).
 	var sessionTitle string
 	var agentType state.AgentType
 	var projectName string

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -243,7 +243,10 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 	watcher := newAttachBellWatcher()
 	watcher.start(m.cfg.BellSound, m.cfg.BellVolume, buildSessionTargets(&m.appState))
 
-	execCmd := &altScreenExecCmd{cmd: cmd, termOut: os.Stdout}
+	// Route the alt-screen enter through m.attachOut so end-to-end tests can
+	// intercept the same writer they inject for the synchronous pre-clear above.
+	// In production m.attachOut is os.Stdout (set in New()).
+	execCmd := &altScreenExecCmd{cmd: cmd, termOut: m.attachOut}
 	return tea.Exec(execCmd, func(err error) tea.Msg {
 		newBells := watcher.stop()
 		return AttachDoneMsg{Err: err, RestoreGridMode: restoreMode, NewBells: newBells}

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -175,6 +176,48 @@ func (m Model) whatsNewView() string {
 	)
 }
 
+// altScreenExecCmd wraps an exec.Cmd as a tea.ExecCommand that re-enters
+// alt-screen at the very start of Run(). BubbleTea's ReleaseTerminal exits
+// alt-screen (writing \033[?1049l) and sleeps 10ms before calling Run(),
+// during which the primary terminal buffer (blank from the startup pre-clear
+// in writePrimaryBufferClear) is briefly visible. By writing
+// \033[?1049h\033[2J\033[H immediately in Run() we minimize that gap to
+// just the 10ms sleep — down from 10ms + subprocess startup latency (~50ms).
+//
+// termOut is the writer for the enter-alt-screen sequence. It is separate
+// from cmd.Stdout so it can be injected in tests without affecting the
+// subprocess's own stdout.
+type altScreenExecCmd struct {
+	cmd     *exec.Cmd
+	termOut io.Writer
+}
+
+func (e *altScreenExecCmd) Run() error {
+	// Re-enter alt-screen and clear immediately. BubbleTea's ReleaseTerminal
+	// already exited alt-screen; this write covers the primary buffer as fast
+	// as possible, before the subprocess starts.
+	fmt.Fprint(e.termOut, "\033[?1049h\033[2J\033[H")
+	return e.cmd.Run()
+}
+
+func (e *altScreenExecCmd) SetStdin(r io.Reader) {
+	if e.cmd.Stdin == nil {
+		e.cmd.Stdin = r
+	}
+}
+
+func (e *altScreenExecCmd) SetStdout(w io.Writer) {
+	if e.cmd.Stdout == nil {
+		e.cmd.Stdout = w
+	}
+}
+
+func (e *altScreenExecCmd) SetStderr(w io.Writer) {
+	if e.cmd.Stderr == nil {
+		e.cmd.Stderr = w
+	}
+}
+
 // doAttach returns the tea.Cmd that performs session attachment.
 func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 	target := mux.Target(sess.TmuxSession, sess.TmuxWindow)
@@ -193,14 +236,15 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	os.Stdout.WriteString("\033[2J\033[H")
+	fmt.Fprint(m.attachOut, "\033[2J\033[H")
 
 	// Start background bell watcher so custom audio plays and bell badges are
 	// tracked while the BubbleTea event loop is suspended.
 	watcher := newAttachBellWatcher()
 	watcher.start(m.cfg.BellSound, m.cfg.BellVolume, buildSessionTargets(&m.appState))
 
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+	execCmd := &altScreenExecCmd{cmd: cmd, termOut: os.Stdout}
+	return tea.Exec(execCmd, func(err error) tea.Msg {
 		newBells := watcher.stop()
 		return AttachDoneMsg{Err: err, RestoreGridMode: restoreMode, NewBells: newBells}
 	})


### PR DESCRIPTION
## Summary

Two related flash regressions introduced by PR #110 and its follow-ups, fixed in separate commits on this branch:

1. **Terminal-buffer flash** — shell history visible during attach/detach. `writePrimaryBufferClear` on startup, `altScreenExecCmd` replaces `tea.ExecProcess` to re-enter alt-screen immediately in `Run()`, and the tmux detach trap no longer exits alt-screen while cleaning up status-bar options.
2. **Grid-mode sidebar flash** (#111) — sidebar layout rendered for one frame when attaching/detaching from grid view. `handleGridSessionSelected` no longer pre-pops `ViewGrid`; `restoreGrid()` is now idempotent so the detach-side re-push does not duplicate the stack.

## Behaviour changes

- Pressing `esc` on the attach hint when opened from grid now returns to **grid** (natural view-stack semantics). Previously it always flattened to sidebar regardless of origin. Sidebar-origin `esc` behaviour is unchanged.

## Test coverage

Research identified the reason existing tests missed the regression: they never rendered `View()` across the full `Cmd` chain and never exercised the tmux `tea.Exec` path. This PR:

- Exposes `MockBackend.SetUseExecAttach(true)` so flow tests can cover the tmux backend.
- Adds a 10-row flow matrix covering origin (sidebar / grid-project / grid-all), trigger (keyboard / mouse), backend (native / tmux), and hint state (on / off + confirm / `d` / `esc`).
- Adds unit tests for `altScreenExecCmd.Run()`, `writePrimaryBufferClear`, and `restoreGrid()` idempotency + empty-stack startup.
- Updates AGENTS.md with TDD + "boil the lake" conventions so future regressions must come with the test that would have caught them.

Full test suite green (`go test ./...`).

Fixes #111

## Test plan

- [ ] Attach to a session from grid view — no sidebar flash, no terminal-buffer flash.
- [ ] Detach from that session — no flashes; grid is restored.
- [ ] Open attach hint from grid (disable `hide_attach_hint`), press `esc` — returns to grid.
- [ ] Open attach hint from sidebar, press `esc` — returns to sidebar (regression guard).
- [ ] Attach from sidebar — no grid flash, behaviour unchanged.
- [ ] Repeat on both backends (`hive start` and `hive start --native`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)