### PR TITLE
feat: multi-instance tmux grouping for independent per-instance zoom/focus

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,6 +75,8 @@ The `Backend` interface abstracts terminal multiplexing. Two implementations exi
 - **`native/`** — built-in PTY backend. A background daemon process (`hive mux-daemon`) owns all PTY master file descriptors. The TUI communicates with it over a Unix domain socket (`~/.config/hive/mux.sock`) using a length-prefixed JSON protocol.
 - **`tmux/`** — delegates to the `tmux` binary. Requires tmux to be installed.
 
+**Multi-instance tmux grouping** (`grouping.go`, optional `GroupedBackend` interface): when multiple hive processes run simultaneously, each creates its own tmux grouped session `hive-sessions-<pid>-<4hex>` that shares the canonical `hive-sessions` window list via `new-session -t`. Attach commands target the grouped session so each instance has independent current-window selection. Startup sweeps grouped sessions whose owning pid is no longer alive. Native PTY backend does not implement `GroupedBackend`; multi-instance independence is tmux-only.
+
 ```
 TUI → state reducers → mux backend client → Unix socket → daemon → PTY processes
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Multi-instance independence (tmux backend)**: running hive in multiple terminals no longer mirrors zoom/focus. Each instance gets its own tmux grouped session sharing the canonical window list, so you can zoom into session A on one monitor while browsing the grid on another. Crashed instances are reclaimed automatically at startup. Native PTY backend is unchanged (still mirrors). The sidebar collapsed state is now per-instance (no longer persisted) for the same reason (#117).
+
+### Fixed
+- **Tmux canonical-gone detection**: if the shared `hive-sessions` tmux session vanishes (server restart, external `tmux kill-session`), hive now exits cleanly with a status-bar error instead of silently drifting into a broken state.
+
 ## [0.13.0] — 2026-04-18
 
 ### Added

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -66,7 +66,18 @@ func runAttach(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("session not found")
 	}
 
-	muxTarget := mux.Target(target.TmuxSession, target.TmuxWindow)
+	// Same multi-instance grouping as `hive start`: sweep orphans, create a
+	// per-process grouped session, attach through it so this CLI doesn't
+	// mirror the tmux view of a running TUI.
+	if err := mux.SweepOrphanInstances(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: orphan sweep failed: %v\n", err)
+	}
+	if err := mux.InitInstance(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to create per-instance tmux session: %v\n", err)
+	}
+	defer func() { _ = mux.ShutdownInstance() }()
+
+	muxTarget := mux.Target(mux.InstanceSession(), target.TmuxWindow)
 	fmt.Fprintf(os.Stderr, "Attaching to %s (%s)…\n", target.Title, muxTarget)
 	return mux.Attach(muxTarget)
 }

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -77,7 +77,11 @@ func runAttach(_ *cobra.Command, args []string) error {
 	}
 	defer func() { _ = mux.ShutdownInstance() }()
 
-	muxTarget := mux.Target(mux.InstanceSession(), target.TmuxWindow)
+	sessName := target.TmuxSession
+	if sessName == mux.HiveSession {
+		sessName = mux.InstanceSession()
+	}
+	muxTarget := mux.Target(sessName, target.TmuxWindow)
 	fmt.Fprintf(os.Stderr, "Attaching to %s (%s)…\n", target.Title, muxTarget)
 	return mux.Attach(muxTarget)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -152,6 +152,16 @@ func runStart(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("TUI error: %w", err)
 		}
 
+		// Alt-screen teardown wipes the TUI's final frame, so any status-bar
+		// error message set immediately before tea.Quit (e.g. canonical tmux
+		// session gone) is invisible. Mirror it to stderr so the user sees why
+		// hive exited.
+		if errModel, ok := finalModel.(interface{ LastError() string }); ok {
+			if msg := errModel.LastError(); msg != "" {
+				fmt.Fprintf(os.Stderr, "hive: %s\n", msg)
+			}
+		}
+
 		// Native backend attach: re-enter TUI after detaching from the session.
 		if fm, ok := finalModel.(interface{ LastAttach() *tui.SessionAttachMsg }); ok {
 			if a := fm.LastAttach(); a != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -92,6 +92,22 @@ func runStart(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("selected backend is not available.\nFor tmux backend: install tmux (https://github.com/tmux/tmux)\nOr use the native backend: hive start --native")
 	}
 
+	// Multi-instance grouping: reclaim grouped sessions left behind by crashed
+	// hive processes, then create this process's grouped session so attach
+	// commands target a per-instance view of the shared window list. No-op on
+	// the native backend (does not implement GroupedBackend).
+	if err := mux.SweepOrphanInstances(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: orphan sweep failed: %v\n", err)
+	}
+	if err := mux.InitInstance(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to create per-instance tmux session: %v (falling back to shared canonical)\n", err)
+	}
+	defer func() {
+		if err := mux.ShutdownInstance(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to tear down per-instance tmux session: %v\n", err)
+		}
+	}()
+
 	// Load state.
 	projects, err := tui.LoadState()
 	if err != nil {

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,6 +12,11 @@ This file tracks features that are already implemented in Hive. For the feature 
   Either way the TUI resumes in place after you detach — no restart required.
 - Create new projects and sessions directly from the keyboard-driven interface.
 - Kill individual sessions or quit the app while keeping tmux sessions running.
+- Run hive in multiple terminals simultaneously with independent per-instance
+  zoom/focus and sidebar collapse state. Sessions, windows, and captured output
+  stay in sync across instances; which cell is zoomed or which projects are
+  collapsed is per-instance. Tmux backend only — the native PTY backend still
+  mirrors views across instances.
 
 ## Agents And Teams
 

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,8 +7,7 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| 1 | #117 | Sync state across multiple hive instances without mirroring zoom/focus | RESEARCH | L |
-| 2 | #124 | Detect and handle dead windows after session creation | TRIAGE | — |
+| 1 | #124 | Detect and handle dead windows after session creation | TRIAGE | — |
 
 ## Rejected
 
@@ -71,3 +70,4 @@ See `features/templates/FEATURE.md` for the feature file template.
 | #122 | Quick-reply to permission prompts from grid view without focusing | #123 | 2026-04-17 |
 | #115 | Centralize session polling behind a single PollingManager | #125 | 2026-04-18 |
 | #119 | Add command palette | #126 | 2026-04-18 |
+| #117 | Sync state across multiple hive instances without mirroring zoom/focus | #128 | 2026-04-19 |

--- a/features/active/117-sync-state-across-multiple-hive-instances.md
+++ b/features/active/117-sync-state-across-multiple-hive-instances.md
@@ -1,7 +1,7 @@
 # Feature: Sync state across multiple hive instances without mirroring zoom/focus
 
 - **GitHub Issue:** #117
-- **Stage:** RESEARCH
+- **Stage:** PLAN
 - **Type:** enhancement
 - **Complexity:** L
 - **Priority:** P4
@@ -103,9 +103,9 @@ Advantages:
 ### Relevant Code
 - `internal/mux/interface.go:13` — `HiveSession = "hive-sessions"` (single global tmux session)
 - `internal/mux/interface.go:25-106` — `Backend` interface; `SendKeys`, `CapturePane`, `Attach` methods
-- `internal/tui/components/gridview.go:307-324` — grid input mode: `SendKeys` forwarding without attach
-- `internal/tui/components/gridview.go:757` — `keyToBytes()` — translates Bubble Tea key messages to tmux send-keys bytes
-- `internal/mux/tmux/attach_script.go:49-137` — current attach script (the conflict point)
+- `internal/tui/components/gridview.go:307-350` — grid input mode: `SendKeys` forwarding without attach (`keyToBytes` at line 317; numeric quick-reply at 337)
+- `internal/tui/components/gridview.go:860-`+ — `keyToBytes()` — translates Bubble Tea key messages to tmux send-keys bytes
+- `internal/mux/tmux/attach_script.go:49-134` — current attach script (the conflict point; `tmux attach-session` at line 134)
 - `internal/tui/handle_preview.go:240-287` — poll scheduling; focused (50ms) vs background (1s)
 - `internal/tui/components/preview.go:260-448` — `Preview` component; could be extended for virtual attach
 - `internal/tui/views.go:222-253` — `doAttach()` — current attach via `tea.Exec`
@@ -122,19 +122,169 @@ Advantages:
 
 ## Plan
 
-<Filled during PLAN stage.>
+### Approach: Option B — tmux Session Grouping (tmux-only)
+
+Each hive instance creates its own tmux grouped session sharing the window list with a canonical `hive-sessions`. Attach targets the instance's grouped session, giving per-instance window selection with zero latency. Native PTY backend is out of scope — multi-instance independence is tmux-only; native falls back to current mirroring behavior.
+
+### Architecture
+
+```
+                      ┌─────────────────────────┐
+                      │  hive-sessions (canon)  │  authoritative window list
+                      │  windows: [0,1,2,3]     │
+                      └────────────┬────────────┘
+                                   │ shares windows (new-session -t)
+                 ┌─────────────────┼─────────────────┐
+                 ▼                 ▼                 ▼
+       hive-sessions-<pid>-<rand>  (one per hive instance, each with
+       current-window selection independent of other grouped sessions)
+                 ▲
+                 │ tmux attach-session -t hive-sessions-<pid>-<rand>
+            hive instance
+```
+
+**Lifecycle:**
+1. On startup: ensure canonical `hive-sessions` exists (idempotent `new-session -A -d`); sweep orphan `hive-sessions-*-*` groups whose pid is dead; create own grouped session.
+2. On exit (SIGTERM/clean shutdown): `tmux kill-session -t hive-sessions-<pid>-<rand>`.
+3. On crash (SIGKILL): next instance's startup sweep cleans the orphan.
+4. On canonical-gone externally: treat as fatal, show popup "tmux session gone — restart hive", exit cleanly (D4=B).
+
+**Decisions locked:**
+- D1=A — Instance ID: `hive-sessions-<pid>-<4char-rand>`
+- D2=C — View fields (`ActiveSessionID`, sidebar `Collapsed`) no longer persisted; in-memory per-instance only
+- D3=A — Native PTY backend unchanged; document limitation
+- D4=B — Canonical-gone is fatal; show popup + exit
 
 ### Files to Change
-1. `path/to/file.go` — <what and why>
+
+1. `internal/mux/interface.go` — add `Backend` methods: `InitInstance(instanceID string) error`, `ShutdownInstance(instanceID string) error`, `SweepOrphanInstances() error`. Replace `HiveSession` const usage at call sites with canonical-vs-instance distinction (`CanonicalSession()`, `InstanceSession(id)`).
+2. `internal/mux/tmux/` (new file: `grouping.go`) — implement: `newGroupedSession(pid, rand)` via `tmux new-session -d -t hive-sessions -s <name>`; `killGroupedSession`; `sweepOrphans` (parse `tmux list-sessions`, regex `hive-sessions-(\d+)-[a-f0-9]{4}`, `kill -0 pid`, kill dead). Native backend gets no-op stubs.
+3. `internal/mux/native/` — stub `InitInstance`/`ShutdownInstance`/`SweepOrphanInstances` as no-ops. Document in package doc that multi-instance independence is tmux-only.
+4. `internal/mux/tmux/attach_script.go:134` — rewrite attach target from `hive-sessions:N` to `hive-sessions-<pid>-<rand>:N`. Add a `select-window` before `attach-session` so the grouped session's current-window matches the user's intent. Detach keys unchanged.
+5. `internal/state/model.go` — remove `json` tags on view fields: `ActiveSessionID` (line 148), sidebar `Collapsed` (lines 100, 115) become `json:"-"` so they no longer round-trip through state.json. Leave in-memory usage unchanged.
+6. `internal/tui/persist.go` — load path ignores any legacy values in those fields (auto-migration: readers silently drop). Save path omits them (already achieved by `json:"-"`).
+7. `internal/tui/app.go` — generate instance ID on startup (`fmt.Sprintf("%d-%04x", os.Getpid(), rand.Uint32()&0xffff)`); call `mux.SweepOrphanInstances()` then `mux.InitInstance(id)` before first render; register `mux.ShutdownInstance(id)` in the existing quit/cleanup path. Add canonical-gone detection: watcher path that notices `hive-sessions` missing triggers a new `CanonicalGoneMsg` → show fatal dialog → exit.
+8. `internal/tui/components/dialog.go` (or wherever fatal dialogs live) — add "Canonical tmux session vanished. Restart hive to recover." popup with a single `[enter] quit` action.
+9. `internal/tui/messages.go` — add `CanonicalGoneMsg` with `var _ tea.Msg = CanonicalGoneMsg{}`.
+10. `cmd/mux-daemon.go` (if applicable) — ensure daemon-mode doesn't spawn grouped sessions (daemon owns canonical only).
+11. `docs/architecture.md` / `ARCHITECTURE.md` — document instance-grouping model.
+12. `docs/features.md` — note multi-instance independence (tmux backend only).
+13. `CHANGELOG.md` — Added: "Run hive in multiple terminals with independent per-instance zoom/focus (tmux backend)."
+
+### Data model change
+
+```go
+// internal/state/model.go
+type AppState struct {
+    // ... shared, persisted fields ...
+    ActiveSessionID string `json:"-"` // per-instance view state; in-memory only
+    // ...
+}
+
+type SidebarState struct {
+    Collapsed bool `json:"-"` // per-instance view state; in-memory only
+}
+```
+
+One-time migration: existing `state.json` files containing `active_session_id` / `collapsed` fields are silently ignored on load (unknown-field tolerance is Go's default for `json.Unmarshal` but we're going the other way — removing fields from marshal. Old clients reading new state.json won't see these fields; acceptable because single-instance use of old hive still works.)
 
 ### Test Strategy
-- <how to verify>
+
+**Unit tests (new: `internal/mux/tmux/grouping_test.go`):**
+- Instance-name format: parses back to pid + rand
+- Orphan sweep: given a list of session names and a fake pid-liveness function, kills only dead-pid-owned ones
+- Regex matches only `hive-sessions-<pid>-<4hex>`, not the canonical or unrelated sessions
+
+**Unit tests (`internal/state/model_test.go`):**
+- `ActiveSessionID` and sidebar `Collapsed` round-trip through marshal/unmarshal as zero values (json tag suppresses)
+- Legacy state.json with those fields loads without error, values are ignored
+
+**Functional tests (`internal/tui/flow_test.go` — extend `MockBackend`):**
+- `MockBackend` grows `InitInstance`/`ShutdownInstance`/`SweepOrphanInstances` recorders
+- Two `testFlowModel` instances in one test share a mock backend and a tmpdir state.json; verify:
+  - Each gets a unique instance ID
+  - Instance A's `ActiveSessionID` change doesn't leak to instance B's in-memory state
+  - Window created in A appears in B's state after watcher reload
+  - Instance A quit → `ShutdownInstance` called with A's id
+  - Simulated orphan (pre-populated session name with dead pid) gets swept on instance C startup
+- `CanonicalGoneMsg`: inject a "canonical vanished" event, assert fatal dialog renders and enter exits cleanly
+
+**Manual / integration (documented in PR):**
+- Open hive in two terminals. Zoom into session X in terminal 1; confirm terminal 2 stays on grid view.
+- Kill `hive-sessions` via external `tmux kill-session`; confirm both instances show fatal popup.
+- `kill -9` one hive; start a third instance; confirm orphan gets swept (check `tmux ls`).
+
+### Failure Modes
+
+| Scenario | Detection | Handling | User impact |
+|---|---|---|---|
+| Hive SIGKILL | startup sweep of next run | `kill -0 <pid>` → kill orphan tmux session | none; silent cleanup |
+| tmux server restart | canonical + all groups gone | fatal popup → exit | user restarts hive |
+| Canonical killed externally | watcher detects missing | `CanonicalGoneMsg` → fatal popup → exit (D4=B) | user restarts hive |
+| Two instances boot simultaneously | `new-session -A` is idempotent for canonical | benign race on orphan sweep (both try to kill same dead session; one errors harmlessly) | none |
+| PID reuse after long uptime | 4-hex random suffix disambiguates | no false orphan-kill | none |
+| Native backend + multi-instance | not detected in code | falls back to current mirroring behavior | documented limitation |
+
+**Critical gap check:** Canonical-gone without the watcher seeing it (e.g., watcher polling interval misses a brief tmux restart that recreates empty canonical) — could leave grouped sessions pointing to empty canonical. Mitigation: on every window-list capture, if returned list is empty but state.json says windows exist, treat as canonical-gone. (Cheap belt-and-suspenders check; add if not already present.)
 
 ### Risks
-- <what could go wrong>
+
+1. **Orphan sweep regex false-positive** — if a user manually created a tmux session named `hive-sessions-123-abcd`, sweep could kill it. Mitigation: format is strict enough (`^hive-sessions-\d+-[0-9a-f]{4}$`) that accidental collision is remote.
+2. **State.json view-field removal breaks resume UX** — single-instance users who relied on persisted `ActiveSessionID` to resume their selection lose that on restart. Acceptable trade per D2=C; noted in CHANGELOG.
+3. **Canonical-gone is fatal, not recoverable** — accepted per D4=B. Alternative (auto-recover from state.json) deferred to a follow-up TODO if users report pain.
+4. **Instance ID collision under extreme load** — `pid + 16 bits random` collision is ~1-in-65k per matching pid; orphan sweep happens first so canonical risk is near-zero in practice.
+5. **tmux version compatibility** — `new-session -t` has been in tmux since 1.9 (2014). No concern on any supported platform.
+
+### NOT in scope
+
+- Native PTY backend multi-instance independence (D3=A; separate feature)
+- Canonical-session auto-recovery from state.json (D4=B; TODO if users ask)
+- Persisting per-instance view state across restarts (D2=C)
+- Cross-machine sync / remote hive instances
+- Per-instance config (keybindings etc. remain shared)
+
+### What already exists
+
+- **State.json flock + mtime watcher** (`persist.go`, `watcher.go`) — already handles cross-instance shared-state sync; no changes needed
+- **Canonical-session creation pattern** — hive already creates `hive-sessions` idempotently on first run
+- **Backend interface** (`mux/interface.go`) — clean extension point for new instance lifecycle methods
+- **Fatal-dialog infrastructure** — existing dialog system can render the canonical-gone popup without new primitives
+- **MockBackend** test harness — extends naturally for new methods
 
 ## Implementation Notes
 
-<Filled during IMPLEMENT stage.>
+### Deviations from plan
+
+- **Optional `GroupedBackend` interface instead of adding methods to `Backend`.** The plan said "add `Backend` methods: `InitInstance`, `ShutdownInstance`, `SweepOrphanInstances`". Implemented as an optional extension interface in `internal/mux/grouping.go` (like `AttachScript`'s type assertion), so the native PTY backend doesn't need no-op stubs. Same behaviour, less boilerplate.
+- **Canonical-gone handling uses the existing state watcher instead of a new message/dialog.** The plan called for a dedicated `CanonicalGoneMsg` + fatal popup (D4=B). Implemented as a `canonicalGone` flag on `stateWatchMsg`: when set, the watch handler sets `LastError` and returns `tea.Quit`. Same outcome (clean exit with a visible reason), one fewer message type and no new dialog component.
+- **`ActiveSessionID` already non-persisted.** The plan said to change its tag to `json:"-"`. Verified that `persist.go:saveState` only marshals `appState.Projects` — `AppState.ActiveSessionID` was never persisted. No change needed; the leakage path was `Project.Collapsed` / `Team.Collapsed` (both now `json:"-"`).
+- **No new `grouping_test.go` for `MockBackend`.** Chose the simpler path: pure unit tests for the grouping helpers (name format, pid parsing, orphan regex) plus `mux` package tests using a stub `GroupedBackend`. Adding two parallel `testFlowModel` instances to exercise cross-instance state was out of scope for this PR — the tmux grouping is a runtime concern and the state-level leak fix (`Collapsed → json:"-"`) has its own unit test.
+
+### Decisions locked
+
+- D1=A: Instance ID is `hive-sessions-<pid>-<4hex>`.
+- D2=C: `Project.Collapsed` / `Team.Collapsed` are now `json:"-"` (per-instance, in-memory only). `ActiveSessionID` was already in-memory.
+- D3=A: Native PTY backend unchanged — documented in `ARCHITECTURE.md` that grouping is tmux-only.
+- D4=B: Canonical-gone is fatal — sets status-bar error and quits via the existing watcher.
+
+### Files changed
+
+- `internal/mux/grouping.go` (new): package-level helpers + `GroupedBackend` interface.
+- `internal/mux/grouping_test.go` (new): assertion tests for grouping dispatch.
+- `internal/mux/tmux/grouping.go` (new): tmux implementation — `new-session -t`, pid-based orphan sweep.
+- `internal/mux/tmux/grouping_test.go` (new): unit tests for name format, regex, pid liveness.
+- `internal/state/model.go`: `Project.Collapsed` / `Team.Collapsed` marked `json:"-"`.
+- `internal/state/model_test.go`: round-trip tests for non-persistence.
+- `internal/tui/views.go`: `doAttach` targets `mux.InstanceSession()` instead of the canonical name.
+- `internal/tui/watcher.go`: watcher also checks `mux.CanonicalExists()`.
+- `internal/tui/handle_system.go`: exits cleanly on canonical-gone.
+- `cmd/start.go`: sweep orphans + init instance on startup, shutdown on exit.
+- `cmd/attach.go`: same grouping wrapper for the headless `hive attach` CLI.
+- `ARCHITECTURE.md`, `CHANGELOG.md`: document the change.
+
+### Manual verification
+
+- `go build ./... && go test ./... && go vet ./...` — all pass.
+- Manual test plan for PR: two terminals, zoom into different sessions; `kill -9` one hive and start a third to verify orphan sweep; external `tmux kill-session -t hive-sessions` to verify canonical-gone exit.
 
 - **PR:** —

--- a/features/completed/117-sync-state-across-multiple-hive-instances.md
+++ b/features/completed/117-sync-state-across-multiple-hive-instances.md
@@ -1,7 +1,7 @@
 # Feature: Sync state across multiple hive instances without mirroring zoom/focus
 
 - **GitHub Issue:** #117
-- **Stage:** PLAN
+- **Stage:** DONE
 - **Type:** enhancement
 - **Complexity:** L
 - **Priority:** P4
@@ -287,4 +287,4 @@ One-time migration: existing `state.json` files containing `active_session_id` /
 - `go build ./... && go test ./... && go vet ./...` — all pass.
 - Manual test plan for PR: two terminals, zoom into different sessions; `kill -9` one hive and start a third to verify orphan sweep; external `tmux kill-session -t hive-sessions` to verify canonical-gone exit.
 
-- **PR:** —
+- **PR:** https://github.com/lucascaro/hive/pull/128

--- a/internal/mux/grouping.go
+++ b/internal/mux/grouping.go
@@ -1,0 +1,66 @@
+package mux
+
+// GroupedBackend is an optional extension implemented by backends that
+// support per-instance grouped sessions. tmux implements it; the native PTY
+// backend does not (multi-instance independence is tmux-only).
+//
+// The interface is exposed via type assertion rather than added to Backend so
+// backends without this concept stay free of boilerplate no-op methods.
+type GroupedBackend interface {
+	InitInstance() error
+	ShutdownInstance() error
+	SweepOrphanInstances() error
+	InstanceSession() string
+	CanonicalExists() bool
+}
+
+// InitInstance creates this process's grouped session. No-op on backends that
+// do not implement GroupedBackend (the native backend).
+func InitInstance() error {
+	if gb, ok := active.(GroupedBackend); ok {
+		return gb.InitInstance()
+	}
+	return nil
+}
+
+// ShutdownInstance tears down this process's grouped session. No-op on
+// backends that do not implement GroupedBackend.
+func ShutdownInstance() error {
+	if gb, ok := active.(GroupedBackend); ok {
+		return gb.ShutdownInstance()
+	}
+	return nil
+}
+
+// SweepOrphanInstances reclaims grouped sessions left behind by crashed hive
+// processes. No-op on backends that do not implement GroupedBackend.
+func SweepOrphanInstances() error {
+	if gb, ok := active.(GroupedBackend); ok {
+		return gb.SweepOrphanInstances()
+	}
+	return nil
+}
+
+// InstanceSession returns the grouped-session name attached to this process.
+// Returns the canonical HiveSession name when the backend does not support
+// grouping or no instance has been initialised — preserving the single-
+// session semantics callers assumed before multi-instance support landed.
+func InstanceSession() string {
+	if gb, ok := active.(GroupedBackend); ok {
+		if name := gb.InstanceSession(); name != "" {
+			return name
+		}
+	}
+	return HiveSession
+}
+
+// CanonicalExists reports whether the backend's canonical session is alive.
+// Returns true on backends that do not implement GroupedBackend (they have
+// no separate canonical concept, so the question is meaningless and we
+// default to "fine").
+func CanonicalExists() bool {
+	if gb, ok := active.(GroupedBackend); ok {
+		return gb.CanonicalExists()
+	}
+	return true
+}

--- a/internal/mux/grouping_test.go
+++ b/internal/mux/grouping_test.go
@@ -55,8 +55,9 @@ func (f *fakeGroupedBackend) InstanceSession() string     { return f.instance }
 func (f *fakeGroupedBackend) CanonicalExists() bool       { return f.canonical }
 
 func TestInstanceSession_FallsBackToCanonicalWhenNoGroup(t *testing.T) {
+	prev := active
 	SetBackend(fakeBackend{})
-	defer SetBackend(nil)
+	defer func() { active = prev }()
 	if got := InstanceSession(); got != HiveSession {
 		t.Errorf("InstanceSession() with non-grouped backend = %q; want %q", got, HiveSession)
 	}
@@ -64,8 +65,9 @@ func TestInstanceSession_FallsBackToCanonicalWhenNoGroup(t *testing.T) {
 
 func TestInstanceSession_ReturnsGroupedName(t *testing.T) {
 	gb := &fakeGroupedBackend{canonical: true}
+	prev := active
 	SetBackend(gb)
-	defer SetBackend(nil)
+	defer func() { active = prev }()
 
 	// Before InitInstance: backend reports empty → fall back to canonical.
 	if got := InstanceSession(); got != HiveSession {
@@ -90,8 +92,9 @@ func TestInstanceSession_ReturnsGroupedName(t *testing.T) {
 
 func TestSweepOrphanInstances_ForwardsToGroupedBackend(t *testing.T) {
 	gb := &fakeGroupedBackend{}
+	prev := active
 	SetBackend(gb)
-	defer SetBackend(nil)
+	defer func() { active = prev }()
 	if err := SweepOrphanInstances(); err != nil {
 		t.Fatalf("SweepOrphanInstances: %v", err)
 	}
@@ -101,8 +104,9 @@ func TestSweepOrphanInstances_ForwardsToGroupedBackend(t *testing.T) {
 }
 
 func TestCanonicalExists_TrueForNonGroupedBackend(t *testing.T) {
+	prev := active
 	SetBackend(fakeBackend{})
-	defer SetBackend(nil)
+	defer func() { active = prev }()
 	// Non-grouped backends don't track a canonical session, so the helper
 	// returns true (no false negatives that would trigger the fatal dialog).
 	if !CanonicalExists() {

--- a/internal/mux/grouping_test.go
+++ b/internal/mux/grouping_test.go
@@ -1,0 +1,111 @@
+package mux
+
+import "testing"
+
+// fakeBackend is the minimal mux.Backend used by grouping tests. It is
+// deliberately stubby: the grouping test surface only exercises the package-
+// level functions that type-assert for GroupedBackend.
+type fakeBackend struct{}
+
+func (fakeBackend) IsAvailable() bool                                                   { return true }
+func (fakeBackend) IsServerRunning() bool                                               { return true }
+func (fakeBackend) CreateSession(string, string, string, []string) error                { return nil }
+func (fakeBackend) SessionExists(string) bool                                           { return true }
+func (fakeBackend) KillSession(string) error                                            { return nil }
+func (fakeBackend) ListSessionNames() ([]string, error)                                 { return nil, nil }
+func (fakeBackend) CreateWindow(string, string, string, []string) (int, error)          { return 0, nil }
+func (fakeBackend) WindowExists(string) bool                                            { return true }
+func (fakeBackend) KillWindow(string) error                                             { return nil }
+func (fakeBackend) RenameWindow(string, string) error                                   { return nil }
+func (fakeBackend) ListWindows(string) ([]WindowInfo, error)                            { return nil, nil }
+func (fakeBackend) GetPaneTitles(string) (map[string]string, map[string]bool, error)    { return nil, nil, nil }
+func (fakeBackend) CapturePane(string, int) (string, error)                             { return "", nil }
+func (fakeBackend) CapturePaneRaw(string, int) (string, error)                          { return "", nil }
+func (fakeBackend) BatchCapturePane(map[string]int, bool) (map[string]string, error)    { return nil, nil }
+func (fakeBackend) GetCurrentCommand(string) (string, error)                            { return "", nil }
+func (fakeBackend) IsPaneDead(string) bool                                              { return false }
+func (fakeBackend) SendKeys(string, string) error                                       { return nil }
+func (fakeBackend) Attach(string) error                                                 { return nil }
+func (fakeBackend) SupportsPopup() bool                                                 { return false }
+func (fakeBackend) PopupAttach(string, string) error                                    { return nil }
+func (fakeBackend) UseExecAttach() bool                                                 { return false }
+func (fakeBackend) DetachKey() string                                                   { return "" }
+
+type fakeGroupedBackend struct {
+	fakeBackend
+	instance    string
+	canonical   bool
+	initCalled  bool
+	downCalled  bool
+	sweepCalled bool
+}
+
+func (f *fakeGroupedBackend) InitInstance() error {
+	f.initCalled = true
+	f.instance = "hive-sessions-1-abcd"
+	return nil
+}
+func (f *fakeGroupedBackend) ShutdownInstance() error {
+	f.downCalled = true
+	f.instance = ""
+	return nil
+}
+func (f *fakeGroupedBackend) SweepOrphanInstances() error { f.sweepCalled = true; return nil }
+func (f *fakeGroupedBackend) InstanceSession() string     { return f.instance }
+func (f *fakeGroupedBackend) CanonicalExists() bool       { return f.canonical }
+
+func TestInstanceSession_FallsBackToCanonicalWhenNoGroup(t *testing.T) {
+	SetBackend(fakeBackend{})
+	defer SetBackend(nil)
+	if got := InstanceSession(); got != HiveSession {
+		t.Errorf("InstanceSession() with non-grouped backend = %q; want %q", got, HiveSession)
+	}
+}
+
+func TestInstanceSession_ReturnsGroupedName(t *testing.T) {
+	gb := &fakeGroupedBackend{canonical: true}
+	SetBackend(gb)
+	defer SetBackend(nil)
+
+	// Before InitInstance: backend reports empty → fall back to canonical.
+	if got := InstanceSession(); got != HiveSession {
+		t.Errorf("InstanceSession() before Init = %q; want canonical %q", got, HiveSession)
+	}
+	if err := InitInstance(); err != nil {
+		t.Fatalf("InitInstance: %v", err)
+	}
+	if !gb.initCalled {
+		t.Error("InitInstance did not forward to GroupedBackend.InitInstance")
+	}
+	if got := InstanceSession(); got != "hive-sessions-1-abcd" {
+		t.Errorf("InstanceSession() after Init = %q; want grouped name", got)
+	}
+	if err := ShutdownInstance(); err != nil {
+		t.Fatalf("ShutdownInstance: %v", err)
+	}
+	if !gb.downCalled {
+		t.Error("ShutdownInstance did not forward to GroupedBackend.ShutdownInstance")
+	}
+}
+
+func TestSweepOrphanInstances_ForwardsToGroupedBackend(t *testing.T) {
+	gb := &fakeGroupedBackend{}
+	SetBackend(gb)
+	defer SetBackend(nil)
+	if err := SweepOrphanInstances(); err != nil {
+		t.Fatalf("SweepOrphanInstances: %v", err)
+	}
+	if !gb.sweepCalled {
+		t.Error("SweepOrphanInstances did not forward to GroupedBackend.SweepOrphanInstances")
+	}
+}
+
+func TestCanonicalExists_TrueForNonGroupedBackend(t *testing.T) {
+	SetBackend(fakeBackend{})
+	defer SetBackend(nil)
+	// Non-grouped backends don't track a canonical session, so the helper
+	// returns true (no false negatives that would trigger the fatal dialog).
+	if !CanonicalExists() {
+		t.Error("CanonicalExists() on non-grouped backend = false; want true")
+	}
+}

--- a/internal/mux/tmux/grouping.go
+++ b/internal/mux/tmux/grouping.go
@@ -1,0 +1,168 @@
+package muxtmux
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"sync"
+	"syscall"
+
+	"github.com/lucascaro/hive/internal/mux"
+	"github.com/lucascaro/hive/internal/tmux"
+)
+
+// CanonicalSession is the authoritative tmux session that owns the shared
+// window list. Every hive instance reads its windows from this session.
+const CanonicalSession = mux.HiveSession
+
+// groupedSessionPattern matches per-instance grouped sessions:
+// "hive-sessions-<pid>-<4 hex chars>".
+var groupedSessionPattern = regexp.MustCompile(`^hive-sessions-(\d+)-[0-9a-f]{4}$`)
+
+// InstanceSession holds the grouped-session name for this process. Empty when
+// the backend has not initialised an instance (e.g. canonical-only test mode),
+// in which case attach falls back to the canonical session.
+var (
+	instanceMu   sync.RWMutex
+	instanceName string
+)
+
+// InstanceSession returns the active grouped-session name for this process,
+// or an empty string if not initialised.
+func (b *Backend) InstanceSession() string {
+	instanceMu.RLock()
+	defer instanceMu.RUnlock()
+	return instanceName
+}
+
+// InitInstance creates a per-process tmux session that shares its window list
+// with the canonical hive session via `new-session -t`. Each instance gets its
+// own current-window selection so attaching in one hive does not mirror the
+// view in another.
+//
+// The canonical session is created first if it does not exist. The returned
+// error is non-nil only if tmux refuses to create either session.
+func (b *Backend) InitInstance() error {
+	if err := ensureCanonical(); err != nil {
+		return fmt.Errorf("ensure canonical session: %w", err)
+	}
+	name := newInstanceName(os.Getpid())
+	if err := tmux.ExecSilent(
+		"new-session", "-d",
+		"-t", CanonicalSession,
+		"-s", name,
+	); err != nil {
+		return fmt.Errorf("create grouped session %q: %w", name, err)
+	}
+	instanceMu.Lock()
+	instanceName = name
+	instanceMu.Unlock()
+	return nil
+}
+
+// ShutdownInstance kills this process's grouped session. Safe to call
+// multiple times and when InitInstance was never called (no-op).
+func (b *Backend) ShutdownInstance() error {
+	instanceMu.Lock()
+	name := instanceName
+	instanceName = ""
+	instanceMu.Unlock()
+	if name == "" {
+		return nil
+	}
+	// Ignore "session not found" errors — the server or session may already
+	// have been torn down.
+	_ = tmux.KillSession(name)
+	return nil
+}
+
+// SweepOrphanInstances enumerates grouped hive sessions and kills any whose
+// owning pid is no longer alive. Called at startup before InitInstance to
+// reclaim sessions left behind by crashed hive processes.
+func (b *Backend) SweepOrphanInstances() error {
+	names, err := tmux.ListSessionNames()
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		pid, ok := parseInstancePID(name)
+		if !ok {
+			continue
+		}
+		if pidAlive(pid) {
+			continue
+		}
+		_ = tmux.KillSession(name)
+	}
+	return nil
+}
+
+// CanonicalExists reports whether the canonical hive session is still alive.
+// Used by the canonical-gone watcher to detect tmux-level teardown (server
+// restart, external kill-session) so the TUI can exit cleanly rather than
+// drift into a state where its grouped session points at nothing.
+func (b *Backend) CanonicalExists() bool {
+	return tmux.SessionExists(CanonicalSession)
+}
+
+// ensureCanonical creates the canonical session if absent. new-session -A is
+// idempotent: if the session already exists, tmux attaches in-place
+// (harmless because -d keeps it detached and we discard the result).
+func ensureCanonical() error {
+	if tmux.SessionExists(CanonicalSession) {
+		return nil
+	}
+	// Create an empty holder session. The first window will be created by
+	// the usual CreateSession path when the user creates their first session.
+	// Using `-A` (attach-if-exists) makes concurrent startup benign.
+	return tmux.ExecSilent(
+		"new-session", "-A", "-d",
+		"-s", CanonicalSession,
+	)
+}
+
+// newInstanceName returns "hive-sessions-<pid>-<4 hex chars>".
+func newInstanceName(pid int) string {
+	var buf [2]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// Fall back to pid only. The regex still matches (parseInstancePID
+		// uses 4 hex chars), so downstream code keeps working; callers that
+		// hit this path just lose the pid-reuse disambiguation bit.
+		return fmt.Sprintf("hive-sessions-%d-0000", pid)
+	}
+	return fmt.Sprintf("hive-sessions-%d-%s", pid, hex.EncodeToString(buf[:]))
+}
+
+// parseInstancePID returns the pid embedded in a grouped session name, or
+// ok=false if name is not a grouped session (e.g. the canonical session,
+// unrelated tmux sessions).
+func parseInstancePID(name string) (int, bool) {
+	m := groupedSessionPattern.FindStringSubmatch(name)
+	if m == nil {
+		return 0, false
+	}
+	var pid int
+	if _, err := fmt.Sscanf(m[1], "%d", &pid); err != nil {
+		return 0, false
+	}
+	return pid, true
+}
+
+// pidAlive reports whether a process with the given pid is currently running.
+// Uses `kill(pid, 0)` which performs the permission/existence check without
+// delivering a signal.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	// ESRCH = no such process → dead. EPERM = process exists but not ours
+	// (treat as alive; safer than killing a tmux session we don't own).
+	return !errors.Is(err, syscall.ESRCH)
+}

--- a/internal/mux/tmux/grouping_test.go
+++ b/internal/mux/tmux/grouping_test.go
@@ -1,0 +1,93 @@
+package muxtmux
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestNewInstanceName_Format(t *testing.T) {
+	name := newInstanceName(12345)
+	matched, _ := regexp.MatchString(`^hive-sessions-12345-[0-9a-f]{4}$`, name)
+	if !matched {
+		t.Errorf("newInstanceName(12345) = %q; want hive-sessions-12345-<4 hex chars>", name)
+	}
+}
+
+func TestNewInstanceName_Unique(t *testing.T) {
+	// Two calls with the same pid should produce different names with very
+	// high probability (collision is 1/65536). This guards against a
+	// regression where the random suffix becomes deterministic.
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		name := newInstanceName(42)
+		seen[name] = true
+	}
+	if len(seen) < 50 {
+		t.Errorf("newInstanceName produced only %d unique names over 100 calls", len(seen))
+	}
+}
+
+func TestParseInstancePID(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantPID int
+		wantOK  bool
+	}{
+		{"hive-sessions-12345-abcd", 12345, true},
+		{"hive-sessions-1-0000", 1, true},
+		{"hive-sessions-999999-ffff", 999999, true},
+		// Non-matches:
+		{"hive-sessions", 0, false},                 // canonical
+		{"hive-sessions-abc-1234", 0, false},        // non-numeric pid
+		{"hive-sessions-123-xyz1", 0, false},        // non-hex suffix
+		{"hive-sessions-123-abcde", 0, false},       // 5 hex chars, not 4
+		{"hive-sessions-123-abc", 0, false},         // 3 hex chars
+		{"hive-old-123-abcd", 0, false},             // wrong prefix
+		{"hive-sessions-123-abcd-extra", 0, false},  // trailing garbage
+		{"", 0, false},
+	}
+	for _, tc := range tests {
+		pid, ok := parseInstancePID(tc.name)
+		if ok != tc.wantOK || pid != tc.wantPID {
+			t.Errorf("parseInstancePID(%q) = (%d, %v); want (%d, %v)",
+				tc.name, pid, ok, tc.wantPID, tc.wantOK)
+		}
+	}
+}
+
+func TestPidAlive_Self(t *testing.T) {
+	if !pidAlive(os.Getpid()) {
+		t.Error("pidAlive(self) = false; want true")
+	}
+}
+
+func TestPidAlive_Dead(t *testing.T) {
+	// PID 1 is always alive on Unix (init/launchd). Use an impossibly high
+	// pid instead to simulate "dead".
+	if pidAlive(2_000_000_000) {
+		t.Error("pidAlive(2e9) = true; want false")
+	}
+}
+
+func TestPidAlive_Zero(t *testing.T) {
+	if pidAlive(0) {
+		t.Error("pidAlive(0) = true; want false")
+	}
+	if pidAlive(-1) {
+		t.Error("pidAlive(-1) = true; want false")
+	}
+}
+
+func TestGroupedSessionPattern_OnlyMatchesGrouped(t *testing.T) {
+	// Canonical session must NOT match — otherwise sweep would kill it.
+	if groupedSessionPattern.MatchString(CanonicalSession) {
+		t.Errorf("groupedSessionPattern matched canonical %q", CanonicalSession)
+	}
+	// A realistic grouped name must match.
+	sample := fmt.Sprintf("hive-sessions-%d-abcd", os.Getpid())
+	if !groupedSessionPattern.MatchString(sample) {
+		t.Errorf("groupedSessionPattern did not match grouped %q", sample)
+	}
+}

--- a/internal/state/model.go
+++ b/internal/state/model.go
@@ -97,7 +97,7 @@ type Project struct {
 	Directory      string            `json:"directory,omitempty"` // working directory for all sessions in this project
 	Teams          []*Team           `json:"teams"`
 	Sessions       []*Session        `json:"sessions"` // standalone (no team)
-	Collapsed      bool              `json:"collapsed"`
+	Collapsed      bool              `json:"-"`               // per-instance view state; not persisted so two hive instances can collapse independently
 	SessionCounter int               `json:"session_counter"` // monotonically increasing; never reset on delete
 	CreatedAt      time.Time         `json:"created_at"`
 	Meta           map[string]string `json:"meta,omitempty"`
@@ -112,7 +112,7 @@ type Team struct {
 	OrchestratorID string            `json:"orchestrator_id"`
 	Sessions       []*Session        `json:"sessions"`
 	SharedWorkDir  string            `json:"shared_work_dir"`
-	Collapsed      bool              `json:"collapsed"`
+	Collapsed      bool              `json:"-"` // per-instance view state; not persisted (see Project.Collapsed)
 	CreatedAt      time.Time         `json:"created_at"`
 	Meta           map[string]string `json:"meta,omitempty"`
 }

--- a/internal/state/model_test.go
+++ b/internal/state/model_test.go
@@ -1,7 +1,9 @@
 package state
 
 import (
+	"encoding/json"
 	"math"
+	"strings"
 	"testing"
 	"time"
 )
@@ -161,5 +163,37 @@ func TestActiveProject_NotFound(t *testing.T) {
 	s.ActiveProjectID = "nope"
 	if got := s.ActiveProject(); got != nil {
 		t.Errorf("ActiveProject() = %+v, want nil", got)
+	}
+}
+
+func TestProjectCollapsed_NotPersisted(t *testing.T) {
+	p := Project{ID: "p1", Name: "P", Collapsed: true}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "collapsed") {
+		t.Errorf("Project.Collapsed should not appear in JSON (per-instance view state); got %s", data)
+	}
+	// Unmarshal legacy data with "collapsed" field: should load cleanly and
+	// leave Collapsed at its zero value (not populated from persisted state).
+	legacy := []byte(`{"id":"p1","name":"P","collapsed":true,"teams":[],"sessions":[]}`)
+	var out Project
+	if err := json.Unmarshal(legacy, &out); err != nil {
+		t.Fatalf("legacy Unmarshal: %v", err)
+	}
+	if out.Collapsed {
+		t.Error("legacy collapsed=true leaked into in-memory Project.Collapsed; want false (field is json:\"-\")")
+	}
+}
+
+func TestTeamCollapsed_NotPersisted(t *testing.T) {
+	team := Team{ID: "t1", Name: "T", Collapsed: true}
+	data, err := json.Marshal(team)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "collapsed") {
+		t.Errorf("Team.Collapsed should not appear in JSON; got %s", data)
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -123,6 +123,12 @@ type Model struct {
 // LastAttach returns the pending attach request after the TUI exits, or nil.
 func (m Model) LastAttach() *SessionAttachMsg { return m.attachPending }
 
+// LastError returns the last error message surfaced by the TUI, or empty if
+// none. Callers inspect this after tea.Program.Run() to print fatal-exit
+// messages (e.g. canonical tmux session gone) that alt-screen teardown wipes
+// from the final render.
+func (m Model) LastError() string { return m.appState.LastError }
+
 // newStyledHelp returns a help.Model pre-configured with Hive's color palette.
 func newStyledHelp() help.Model {
 	h := help.New()

--- a/internal/tui/handle_system.go
+++ b/internal/tui/handle_system.go
@@ -43,6 +43,14 @@ func (m Model) handleWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleStateWatch(msg stateWatchMsg) (tea.Model, tea.Cmd) {
+	if msg.canonicalGone {
+		// The tmux canonical session vanished (server restart or external
+		// kill-session). Grouped sessions now point at nothing, so continuing
+		// would silently corrupt attach/capture behaviour. Surface the error
+		// and quit cleanly — the user restarts hive to recover.
+		m.appState.LastError = "tmux session gone — restart hive to recover"
+		return m, tea.Quit
+	}
 	if !msg.mtime.Equal(m.stateLastKnownMtime) {
 		debugLog.Printf("stateWatchMsg: external change detected (mtime=%v), reloading", msg.mtime)
 		m.stateLastKnownMtime = msg.mtime

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -220,7 +220,6 @@ func (e *altScreenExecCmd) SetStderr(w io.Writer) {
 
 // doAttach returns the tea.Cmd that performs session attachment.
 func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
-	target := mux.Target(sess.TmuxSession, sess.TmuxWindow)
 	restoreMode := sess.RestoreGridMode
 
 	if !mux.UseExecAttach() {
@@ -228,6 +227,12 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 		m.attachPending = &sess
 		return tea.Quit
 	}
+
+	// Route the attach through this process's grouped session so two hive
+	// instances can zoom into different windows without fighting each other
+	// for tmux's shared current-window selection. Falls back to the canonical
+	// session when grouping is not active (tests, backends without support).
+	target := mux.Target(mux.InstanceSession(), sess.TmuxWindow)
 
 	header := buildSessionHeader(sess)
 	script := mux.AttachScript(target, header)

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -228,11 +228,16 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 		return tea.Quit
 	}
 
-	// Route the attach through this process's grouped session so two hive
-	// instances can zoom into different windows without fighting each other
-	// for tmux's shared current-window selection. Falls back to the canonical
-	// session when grouping is not active (tests, backends without support).
-	target := mux.Target(mux.InstanceSession(), sess.TmuxWindow)
+	// Route canonical-named sessions through this process's grouped session so
+	// two hive instances can zoom into different windows without fighting for
+	// tmux's shared current-window selection. Legacy/recovered sessions keep
+	// their original tmux session name — the grouped session shares windows
+	// only with the canonical, so substituting would target the wrong tmux.
+	sessName := sess.TmuxSession
+	if sessName == mux.HiveSession {
+		sessName = mux.InstanceSession()
+	}
+	target := mux.Target(sessName, sess.TmuxWindow)
 
 	header := buildSessionHeader(sess)
 	script := mux.AttachScript(target, header)
@@ -259,6 +264,8 @@ func (m *Model) doAttach(sess SessionAttachMsg) tea.Cmd {
 }
 
 // RunAttach handles the attach flow for the native backend.
+// Native does not implement GroupedBackend, so attach targets the stored
+// session name directly — no grouped-session substitution (unlike doAttach).
 func RunAttach(sess SessionAttachMsg) error {
 	fmt.Print("\033[22;0t")
 	fmt.Printf("\033]0;%s\007", buildAttachTitle(sess))

--- a/internal/tui/watcher.go
+++ b/internal/tui/watcher.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/lucascaro/hive/internal/config"
+	"github.com/lucascaro/hive/internal/mux"
 )
 
 const stateWatchInterval = 500 * time.Millisecond
@@ -13,9 +14,12 @@ const stateWatchInterval = 500 * time.Millisecond
 // stateWatchMsg is the internal tick returned by the background watcher
 // goroutine.  mtime is the observed modification time of state.json; the
 // Update handler compares it against Model.stateLastKnownMtime to decide
-// whether an external instance wrote the file.
+// whether an external instance wrote the file. canonicalGone is true when
+// the backend's canonical session has disappeared (tmux server restart or
+// external kill); the TUI treats this as fatal and exits cleanly.
 type stateWatchMsg struct {
-	mtime time.Time
+	mtime         time.Time
+	canonicalGone bool
 }
 
 // scheduleWatchState returns a command that sleeps for stateWatchInterval
@@ -23,12 +27,16 @@ type stateWatchMsg struct {
 func scheduleWatchState(lastMod time.Time) tea.Cmd {
 	return func() tea.Msg {
 		time.Sleep(stateWatchInterval)
-		info, err := os.Stat(config.StatePath())
-		if err != nil {
-			// File missing or unreadable — keep the last known mtime so the
-			// next cycle has a stable baseline without triggering a reload.
-			return stateWatchMsg{mtime: lastMod}
+		msg := stateWatchMsg{mtime: lastMod}
+		if info, err := os.Stat(config.StatePath()); err == nil {
+			msg.mtime = info.ModTime()
 		}
-		return stateWatchMsg{mtime: info.ModTime()}
+		// Detect tmux-level teardown. Non-grouped backends always report
+		// canonicalExists=true (see mux.CanonicalExists), so this is a
+		// no-op on the native backend.
+		if !mux.CanonicalExists() {
+			msg.canonicalGone = true
+		}
+		return msg
 	}
 }


### PR DESCRIPTION
## Summary

- Each hive process creates its own tmux grouped session (`hive-sessions-<pid>-<4hex>`) sharing the canonical `hive-sessions` window list via `new-session -t`. Attach commands target the grouped session, so two instances can zoom into different windows without fighting over tmux's shared current-window selection.
- Sidebar `Collapsed` state is now per-instance (`json:"-"`) so it stops leaking across hives via `state.json`.
- Canonical-gone detection: if the shared tmux session vanishes (server restart, external `kill-session`), the TUI exits cleanly with a status-bar error instead of drifting into a broken state.
- Native PTY backend is unchanged — multi-instance independence is tmux-only (documented).

Fixes #117

## Implementation notes

- Optional `GroupedBackend` interface in `internal/mux` (tmux implements, native no-ops via type assertion — same pattern as `AttachScript`).
- Startup: `mux.SweepOrphanInstances()` reclaims grouped sessions whose owning pid is dead (`kill(pid, 0)` → `ESRCH`), then `mux.InitInstance()` creates this process's group. `defer mux.ShutdownInstance()` tears it down on exit.
- Canonical-gone check piggybacks on the existing 500 ms `stateWatchMsg` — no new dialog component.
- Headless `hive attach` CLI uses the same wrapper.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (new: grouping helpers, `GroupedBackend` dispatch, `Collapsed` non-persistence)
- [x] `go vet ./...`
- [ ] Manual: open hive in two terminals; zoom into session A in terminal 1; confirm terminal 2 stays on grid view.
- [ ] Manual: `kill -9` one hive; start a third instance; confirm orphan gets swept (check `tmux ls`).
- [ ] Manual: `tmux kill-session -t hive-sessions` externally; confirm the TUI exits with the canonical-gone message.
- [ ] Manual: native backend (`hive start --native`) still works (no grouping, same behaviour as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)