### PR TITLE
fix: orphan recovery dialog hidden in grid mode + false-positive grouped sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Grouped sessions no longer flagged as orphans**: per-instance tmux sessions (e.g. `hive-sessions-12345-a1b2`) are now correctly skipped during orphan detection, preventing false positives in the recovery picker.
+- **Startup overlays visible in grid mode**: orphan-picker and recovery-picker overlays now appear on top of the grid view instead of being hidden beneath it.
+
 ## [0.14.1] — 2026-04-19
 
 ### Fixed

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -312,6 +312,11 @@ func detectOrphanContainers(appState *state.AppState) (orphans []string, recover
 		if !strings.HasPrefix(name, "hive-") {
 			continue
 		}
+		// Skip per-instance grouped sessions — they are transient mirrors
+		// of the canonical session and not true orphans.
+		if muxtmux.IsGroupedSession(name) {
+			continue
+		}
 		if _, known := knownSessions[name]; known {
 			continue
 		}

--- a/internal/mux/tmux/grouping.go
+++ b/internal/mux/tmux/grouping.go
@@ -134,6 +134,13 @@ func newInstanceName(pid int) string {
 	return fmt.Sprintf("hive-sessions-%d-%s", pid, hex.EncodeToString(buf[:]))
 }
 
+// IsGroupedSession reports whether name matches the per-instance grouped
+// session pattern (e.g. "hive-sessions-12345-a1b2"). These sessions are
+// transient and should not be treated as orphans.
+func IsGroupedSession(name string) bool {
+	return groupedSessionPattern.MatchString(name)
+}
+
 // parseInstancePID returns the pid embedded in a grouped session name, or
 // ok=false if name is not a grouped session (e.g. the canonical session,
 // unrelated tmux sessions).

--- a/internal/mux/tmux/grouping_test.go
+++ b/internal/mux/tmux/grouping_test.go
@@ -91,3 +91,31 @@ func TestGroupedSessionPattern_OnlyMatchesGrouped(t *testing.T) {
 		t.Errorf("groupedSessionPattern did not match grouped %q", sample)
 	}
 }
+
+func TestIsGroupedSession(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Positive matches:
+		{"hive-sessions-12345-abcd", true},
+		{"hive-sessions-1-0000", true},
+		{"hive-sessions-999999-ffff", true},
+		{fmt.Sprintf("hive-sessions-%d-a1b2", os.Getpid()), true},
+		// Negative matches:
+		{"hive-sessions", false},                // canonical
+		{"hive-sessions-abc-1234", false},       // non-numeric pid
+		{"hive-sessions-123-xyz1", false},       // non-hex suffix
+		{"hive-sessions-123-abcde", false},      // 5 hex chars, not 4
+		{"hive-sessions-123-abc", false},         // 3 hex chars
+		{"hive-old-123-abcd", false},            // wrong prefix
+		{"hive-sessions-123-abcd-extra", false}, // trailing garbage
+		{"", false},
+		{"not-hive", false},
+	}
+	for _, tc := range tests {
+		if got := IsGroupedSession(tc.name); got != tc.want {
+			t.Errorf("IsGroupedSession(%q) = %v; want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -223,13 +223,6 @@ func New(cfg config.Config, appState state.AppState, whatsNewContent string) Mod
 		m.sidebar.SyncActiveSession(m.appState.ActiveSessionID)
 		debugLog.Printf("synced cursor to existing active session %s", m.appState.ActiveSessionID)
 	}
-	// Push startup overlays onto the view stack if they were activated by constructors.
-	if m.recoveryPicker.Active {
-		m.PushView(ViewRecovery)
-	}
-	if m.orphanPicker.Active {
-		m.PushView(ViewOrphan)
-	}
 	// Restore the grid view if the user detached from a grid-initiated session.
 	m.restoreGrid()
 	// Open the preferred startup view if no attach-restore already pushed a grid.
@@ -246,6 +239,14 @@ func New(cfg config.Config, appState state.AppState, whatsNewContent string) Mod
 		default:
 			debugLog.Printf("unknown StartupView %q, defaulting to sidebar", m.cfg.StartupView)
 		}
+	}
+	// Push startup overlays onto the view stack AFTER grid/startup-view
+	// restoration so they appear on top (visible in grid mode too).
+	if m.recoveryPicker.Active {
+		m.PushView(ViewRecovery)
+	}
+	if m.orphanPicker.Active {
+		m.PushView(ViewOrphan)
 	}
 	// Show "What's New" overlay if there's changelog content.
 	// Pushed last so it appears on top of any restored grid or recovery overlays.

--- a/internal/tui/viewstack_test.go
+++ b/internal/tui/viewstack_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lucascaro/hive/internal/config"
 	"github.com/lucascaro/hive/internal/state"
+	"github.com/lucascaro/hive/internal/tui/components"
 )
 
 func testModelForStack() Model {
@@ -325,6 +326,69 @@ func TestIntegration_GridKill_Cancel_ReturnsToGrid(t *testing.T) {
 	}
 }
 
+// Scenario tests for orphan/recovery overlays over grid.
+
+func TestScenario_GridOrphan_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	m.PushView(ViewGrid)
+	m.PushView(ViewOrphan)
+
+	if m.TopView() != ViewOrphan {
+		t.Fatalf("top = %q, want ViewOrphan", m.TopView())
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should be in stack under orphan")
+	}
+
+	m.PopView()
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after pop, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestScenario_GridRecovery_ReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	m.PushView(ViewGrid)
+	m.PushView(ViewRecovery)
+
+	if m.TopView() != ViewRecovery {
+		t.Fatalf("top = %q, want ViewRecovery", m.TopView())
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should be in stack under recovery")
+	}
+
+	m.PopView()
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after pop, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestScenario_GridRecoveryOrphan_DismissBothReturnsToGrid(t *testing.T) {
+	m := testModelForStack()
+
+	// Simulate startup: grid first, then recovery, then orphan on top.
+	m.PushView(ViewGrid)
+	m.PushView(ViewRecovery)
+	m.PushView(ViewOrphan)
+
+	if m.TopView() != ViewOrphan {
+		t.Fatalf("top = %q, want ViewOrphan", m.TopView())
+	}
+
+	m.PopView()
+	if m.TopView() != ViewRecovery {
+		t.Fatalf("after first pop, top = %q, want ViewRecovery", m.TopView())
+	}
+
+	m.PopView()
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after second pop, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
 func TestIntegration_GridRename_Enter_ReturnsToGrid(t *testing.T) {
 	m := testModelForStack()
 
@@ -345,5 +409,152 @@ func TestIntegration_GridRename_Enter_ReturnsToGrid(t *testing.T) {
 
 	if m.TopView() != ViewGrid {
 		t.Fatalf("after enter from rename, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+// Integration tests for orphan/recovery overlays initialized via New() with grid startup.
+
+func TestIntegration_GridStartup_OrphanOverlayOnTop(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.PreviewRefreshMs = 1
+	cfg.StartupView = "grid"
+
+	appState := state.AppState{
+		Projects: []*state.Project{{
+			ID:   "proj-1",
+			Name: "test",
+			Sessions: []*state.Session{{
+				ID:          "sess-1",
+				ProjectID:   "proj-1",
+				Title:       "session-1",
+				AgentType:   state.AgentClaude,
+				TmuxSession: "hive-test",
+				TmuxWindow:  0,
+				Status:      state.StatusRunning,
+			}},
+		}},
+		ActiveProjectID: "proj-1",
+		ActiveSessionID: "sess-1",
+		AgentUsage:      make(map[string]state.AgentUsageRecord),
+		TermWidth:       120,
+		TermHeight:      40,
+		OrphanSessions:  []string{"hive-stale-abc"},
+	}
+
+	m := New(cfg, appState, "")
+
+	// Orphan overlay must be on top of grid, not hidden beneath it.
+	if m.TopView() != ViewOrphan {
+		t.Fatalf("top = %q, want ViewOrphan (orphan overlay should be above grid)", m.TopView())
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should be in the stack beneath the orphan overlay")
+	}
+
+	// Dismiss orphan overlay with esc — should return to grid.
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = result.(Model)
+	// Process the OrphanPickerDoneMsg.
+	result, _ = m.Update(components.OrphanPickerDoneMsg{})
+	m = result.(Model)
+
+	if m.TopView() != ViewGrid {
+		t.Fatalf("after dismissing orphan, top = %q, want ViewGrid", m.TopView())
+	}
+}
+
+func TestIntegration_GridStartup_RecoveryOverlayOnTop(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.PreviewRefreshMs = 1
+	cfg.StartupView = "grid"
+
+	appState := state.AppState{
+		Projects: []*state.Project{{
+			ID:   "proj-1",
+			Name: "test",
+			Sessions: []*state.Session{{
+				ID:          "sess-1",
+				ProjectID:   "proj-1",
+				Title:       "session-1",
+				AgentType:   state.AgentClaude,
+				TmuxSession: "hive-test",
+				TmuxWindow:  0,
+				Status:      state.StatusRunning,
+			}},
+		}},
+		ActiveProjectID: "proj-1",
+		ActiveSessionID: "sess-1",
+		AgentUsage:      make(map[string]state.AgentUsageRecord),
+		TermWidth:       120,
+		TermHeight:      40,
+		RecoverableSessions: []state.RecoverableSession{
+			{
+				TmuxSession:       "hive-old-abc",
+				WindowIndex:       0,
+				WindowName:        "main",
+				DetectedAgentType: state.AgentClaude,
+				PanePreview:       "$ claude",
+			},
+		},
+	}
+
+	m := New(cfg, appState, "")
+
+	// Recovery overlay must be on top of grid.
+	if m.TopView() != ViewRecovery {
+		t.Fatalf("top = %q, want ViewRecovery (recovery overlay should be above grid)", m.TopView())
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should be in the stack beneath the recovery overlay")
+	}
+}
+
+func TestIntegration_GridStartup_BothOverlays_CorrectOrder(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.PreviewRefreshMs = 1
+	cfg.StartupView = "grid"
+
+	appState := state.AppState{
+		Projects: []*state.Project{{
+			ID:   "proj-1",
+			Name: "test",
+			Sessions: []*state.Session{{
+				ID:          "sess-1",
+				ProjectID:   "proj-1",
+				Title:       "session-1",
+				AgentType:   state.AgentClaude,
+				TmuxSession: "hive-test",
+				TmuxWindow:  0,
+				Status:      state.StatusRunning,
+			}},
+		}},
+		ActiveProjectID: "proj-1",
+		ActiveSessionID: "sess-1",
+		AgentUsage:      make(map[string]state.AgentUsageRecord),
+		TermWidth:       120,
+		TermHeight:      40,
+		OrphanSessions:  []string{"hive-stale-abc"},
+		RecoverableSessions: []state.RecoverableSession{
+			{
+				TmuxSession:       "hive-old-abc",
+				WindowIndex:       0,
+				WindowName:        "main",
+				DetectedAgentType: state.AgentClaude,
+				PanePreview:       "$ claude",
+			},
+		},
+	}
+
+	m := New(cfg, appState, "")
+
+	// Orphan is pushed after recovery, so orphan is on top.
+	if m.TopView() != ViewOrphan {
+		t.Fatalf("top = %q, want ViewOrphan", m.TopView())
+	}
+	if !m.HasView(ViewRecovery) {
+		t.Fatal("recovery should be in the stack")
+	}
+	if !m.HasView(ViewGrid) {
+		t.Fatal("grid should be in the stack")
 	}
 }


### PR DESCRIPTION
## Summary
- **Orphan false positives**: Per-instance grouped sessions (`hive-sessions-<pid>-<hex>`) were incorrectly detected as orphans because they match the `hive-` prefix but aren't in state's known sessions map. Added `IsGroupedSession()` filter to skip them.
- **Dialog hidden in grid mode**: Orphan/recovery overlay views were pushed onto the view stack before grid restoration, so the grid ended up on top and the dialogs were never rendered. Moved the overlay pushes after grid/startup-view setup so they appear on top.

## Test plan
- [ ] Start hive in grid mode with orphaned tmux sessions present — recovery dialog should appear
- [ ] Start hive with active grouped sessions from another instance — they should NOT show as orphans
- [ ] Start hive in sidebar mode — recovery dialog still works as before
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)