### PR TITLE
GUI: keybinding overhaul, command palette, delete-project, terminal title surfacing

### DIFF
--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -11,11 +11,11 @@
   <aside id="sidebar">
     <header>
       <span class="brand">Hive</span>
-      <button id="new-project-btn" title="New project (⇧⌘P)">＋</button>
+      <button id="new-project-btn" title="New project (⌘N)">＋</button>
     </header>
     <ul id="projects"></ul>
     <footer class="hints">
-      ⌘N new · ⌘W close · ⌘G grid · ⇧⌘G all · ⌘[/] project · ⌘S sidebar · ⇧⌘P new project
+      ⌘N project · ⌘T session · ⇧⌘T worktree · ⌘W close · ⌘G grid · ⌘K commands
     </footer>
   </aside>
   <div id="launcher" class="hidden" role="menu"></div>
@@ -40,6 +40,10 @@
       <button id="project-editor-cancel">Cancel</button>
       <button id="project-editor-save" class="primary">Save</button>
     </div>
+  </div>
+  <div id="command-palette" class="hidden" role="dialog" aria-label="Command palette">
+    <input id="command-palette-input" type="text" placeholder="Search actions, shortcuts…" autocomplete="off"/>
+    <div id="command-palette-list" role="listbox"></div>
   </div>
   <main id="terms"></main>
   <div id="status">connecting…</div>

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -909,16 +909,26 @@ function switchTo(id) {
 // it to both document.title and the native window title bar. The
 // termTitle slot is whatever the running TUI most recently set via
 // the OSC 0/2 escape sequence; empty if the program never set one.
+//
+// Throttled with a trailing-edge timer: programs like fish prompts
+// or progress encoders can fire OSC 0/2 dozens of times per second,
+// and each WindowSetTitle is a Wails IPC round-trip. 100ms keeps the
+// title visibly responsive without flooding the bridge.
+let _appTitleTimer = null;
 function updateAppTitle() {
-  const id = state.activeId;
-  const info = id ? state.sessions.find((s) => s.id === id) : null;
-  const parts = ['Hive'];
-  if (info?.name) parts.push(info.name);
-  const t = id ? state.terms.get(id) : null;
-  if (t?.termTitle && t.termTitle !== info?.name) parts.push(t.termTitle);
-  const title = parts.join(' — ');
-  document.title = title;
-  try { WindowSetTitle(title); } catch (_) { /* runtime not ready */ }
+  if (_appTitleTimer) return;
+  _appTitleTimer = setTimeout(() => {
+    _appTitleTimer = null;
+    const id = state.activeId;
+    const info = id ? state.sessions.find((s) => s.id === id) : null;
+    const parts = ['Hive'];
+    if (info?.name) parts.push(info.name);
+    const t = id ? state.terms.get(id) : null;
+    if (t?.termTitle && t.termTitle !== info?.name) parts.push(t.termTitle);
+    const title = parts.join(' — ');
+    document.title = title;
+    try { WindowSetTitle(title); } catch (_) { /* runtime not ready */ }
+  }, 100);
 }
 
 // switchToProject activates a project: in grid-project mode it
@@ -1676,7 +1686,7 @@ window.addEventListener('keydown', (e) => {
     return;
   }
 
-  if (e.key === 'k' || e.key === 'K') {
+  if ((e.key === 'k' || e.key === 'K') && !e.shiftKey) {
     swallow();
     openCommandPalette();
     return;
@@ -1928,6 +1938,9 @@ function openCommandPalette() {
 
 function closeCommandPalette() {
   paletteEl.classList.add('hidden');
+  // Return focus to the active terminal. activatePalette()'s deferred
+  // run() will overwrite focus if the action opens its own modal.
+  focusActiveTerm();
 }
 
 function activatePalette(i) {

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -12,7 +12,7 @@ import {
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
   IsGitRepo, OpenURL, Notify,
 } from '../wailsjs/go/main/App';
-import { EventsOn } from '../wailsjs/runtime/runtime';
+import { EventsOn, WindowSetTitle } from '../wailsjs/runtime/runtime';
 
 // ---------- session terminal ----------
 
@@ -45,7 +45,12 @@ class SessionTerm {
     }
     this.tileProject = document.createElement('span');
     this.tileProject.className = 'tile-project';
-    this.header.append(this.tileColor, this.tileName, this.tileWorktree, this.tileProject);
+    // OSC-set window title from the running TUI (vim, htop, claude…).
+    // Sits between the session name and the project label so the
+    // user can tell at a glance what each tile is currently doing.
+    this.tileTermTitle = document.createElement('span');
+    this.tileTermTitle.className = 'tile-term-title';
+    this.header.append(this.tileColor, this.tileName, this.tileWorktree, this.tileTermTitle, this.tileProject);
 
     this.body = document.createElement('div');
     this.body.className = 'term-body';
@@ -117,6 +122,16 @@ class SessionTerm {
 
     this.attached = false;
     this.phase = 'replay';
+
+    // Track the OSC-set window title from the running TUI (vim, htop,
+    // claude code, etc.) so the app title bar can show it after the
+    // session name when this session is active.
+    this.termTitle = '';
+    this.term.onTitleChange((title) => {
+      this.termTitle = title || '';
+      this._renderTermTitle();
+      if (state.activeId === this.info.id) updateAppTitle();
+    });
 
     this.term.onData((data) => {
       const bytes = new TextEncoder().encode(data);
@@ -229,6 +244,21 @@ class SessionTerm {
     } else {
       this.tileWorktree.style.display = 'none';
       this.tileWorktree.title = '';
+    }
+    this._renderTermTitle();
+  }
+
+  _renderTermTitle() {
+    // Hide the slot when the TUI hasn't set a title or it just echoes
+    // the session name (avoids "foo — foo").
+    const t = this.termTitle || '';
+    if (!t || t === this.info.name) {
+      this.tileTermTitle.textContent = '';
+      this.tileTermTitle.style.display = 'none';
+    } else {
+      this.tileTermTitle.textContent = t;
+      this.tileTermTitle.title = t;
+      this.tileTermTitle.style.display = '';
     }
   }
 
@@ -591,7 +621,24 @@ function renderProject(p, activePID) {
     openProjectEditor(p);
   });
 
-  actions.append(newBtn, editBtn);
+  const delBtn = document.createElement('button');
+  delBtn.textContent = '✕';
+  delBtn.title = 'Delete project';
+  delBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const sessions = state.sessions.filter(
+      (s) => (s.projectId ?? s.project_id) === p.id,
+    );
+    const msg = sessions.length
+      ? `Delete project "${p.name}" and kill ${sessions.length} session${sessions.length === 1 ? '' : 's'}?`
+      : `Delete project "${p.name}"?`;
+    if (!window.confirm(msg)) return;
+    KillProject(p.id, sessions.length > 0).catch((err) => {
+      setStatus(`delete failed: ${err}`, true);
+    });
+  });
+
+  actions.append(newBtn, editBtn, delBtn);
 
   header.append(caret, colorEl, name, actions);
   header.addEventListener('click', (e) => {
@@ -850,6 +897,28 @@ function switchTo(id) {
   else renderGrid();
   updateSidebarSelection();
   setStatus(info ? info.name : '');
+  updateAppTitle();
+  // setActive() called focusActiveTerm() before ensureTerm() existed
+  // for a brand-new session — re-focus now that the SessionTerm is
+  // created and visible. Without this, typing after creating a
+  // session lands in whichever terminal had focus before.
+  if (id) focusActiveTerm();
+}
+
+// updateAppTitle composes "Hive — <session> — <termTitle>" and pushes
+// it to both document.title and the native window title bar. The
+// termTitle slot is whatever the running TUI most recently set via
+// the OSC 0/2 escape sequence; empty if the program never set one.
+function updateAppTitle() {
+  const id = state.activeId;
+  const info = id ? state.sessions.find((s) => s.id === id) : null;
+  const parts = ['Hive'];
+  if (info?.name) parts.push(info.name);
+  const t = id ? state.terms.get(id) : null;
+  if (t?.termTitle && t.termTitle !== info?.name) parts.push(t.termTitle);
+  const title = parts.join(' — ');
+  document.title = title;
+  try { WindowSetTitle(title); } catch (_) { /* runtime not ready */ }
 }
 
 // switchToProject activates a project: in grid-project mode it
@@ -1264,6 +1333,7 @@ EventsOn('session:event', (jsonStr) => {
       const proj = state.projects.find((p) => p.id === pid);
       st.setProjectName(proj?.name ?? '');
     }
+    if (state.activeId === ev.session.id) updateAppTitle();
   }
   renderSidebar();
 });
@@ -1570,6 +1640,10 @@ window.addEventListener('keydown', (e) => {
   if (!editorEl.classList.contains('hidden')) {
     return; // editor's own listener handles keys
   }
+  const _palette = document.getElementById('command-palette');
+  if (_palette && !_palette.classList.contains('hidden')) {
+    return; // palette's own listener handles keys
+  }
 
   // Dead-session overlay: route Enter/Escape to the active session's
   // overlay if it's shown. In grid mode the user can still click any
@@ -1602,9 +1676,21 @@ window.addEventListener('keydown', (e) => {
     return;
   }
 
+  if (e.key === 'k' || e.key === 'K') {
+    swallow();
+    openCommandPalette();
+    return;
+  }
   if ((e.key === 'p' || e.key === 'P') && e.shiftKey) {
     swallow();
     openProjectEditor(null);
+  } else if (e.key === 't' || e.key === 'T') {
+    swallow();
+    if (e.shiftKey) openLauncher(undefined, { forceWorktree: true });
+    else openLauncher();
+  } else if (e.key === 'Backspace' && e.shiftKey) {
+    swallow();
+    deleteActiveProject();
   } else if (e.key === 's' || e.key === 'S') {
     swallow();
     const app = document.getElementById('app');
@@ -1637,13 +1723,9 @@ window.addEventListener('keydown', (e) => {
       OpenNewWindow().catch((err) => {
         setStatus(`window failed: ${err}`, true);
       });
-    } else if (e.altKey) {
-      // ⌥⌘N — open launcher with the worktree checkbox forced on.
-      // (Originally proposed as ⌃⌘N but ctrl-Cmd is awkward to hit
-      //  on US keyboards; alt-Cmd is right next to ⌘N.)
-      openLauncher(undefined, { forceWorktree: true });
     } else {
-      openLauncher();
+      // ⌘N — new project. (⌥⌘N is reserved by macOS Spotlight.)
+      openProjectEditor(null);
     }
   } else if (e.key === 'w' || e.key === 'W') {
     swallow();
@@ -1736,6 +1818,8 @@ const menuActions = {
   'menu:new-session': () => openLauncher(),
   'menu:new-session-worktree': () => openLauncher(undefined, { forceWorktree: true }),
   'menu:new-project': () => openProjectEditor(null),
+  'menu:delete-project': () => deleteActiveProject(),
+  'menu:command-palette': () => openCommandPalette(),
   'menu:close-session': () => { if (state.activeId) KillSession(state.activeId, false); },
   'menu:zoom-in': () => bumpFontSize(+1),
   'menu:zoom-out': () => bumpFontSize(-1),
@@ -1756,6 +1840,129 @@ for (const [name, fn] of Object.entries(menuActions)) {
 for (let i = 1; i <= 9; i++) {
   EventsOn(`menu:switch-${i}`, () => switchToNthSession(i));
 }
+
+// ---------- delete project ----------
+
+function deleteActiveProject() {
+  const pid = activeProjectId();
+  const proj = state.projects.find((p) => p.id === pid);
+  if (!proj) return;
+  const sessions = state.sessions.filter(
+    (s) => (s.projectId ?? s.project_id) === pid,
+  );
+  const msg = sessions.length
+    ? `Delete project "${proj.name}" and kill ${sessions.length} session${sessions.length === 1 ? '' : 's'}?`
+    : `Delete project "${proj.name}"?`;
+  if (!window.confirm(msg)) return;
+  KillProject(pid, sessions.length > 0).catch((err) => {
+    setStatus(`delete failed: ${err}`, true);
+  });
+}
+
+// ---------- command palette ----------
+
+const paletteCommands = [
+  { id: 'new-project',          name: 'New Project…',                shortcut: '⌘N',     run: () => openProjectEditor(null) },
+  { id: 'new-session',          name: 'New Session',                 shortcut: '⌘T',     run: () => openLauncher() },
+  { id: 'new-session-worktree', name: 'New Session in Worktree',     shortcut: '⇧⌘T',    run: () => openLauncher(undefined, { forceWorktree: true }) },
+  { id: 'delete-project',       name: 'Delete Active Project…',      shortcut: '⇧⌘⌫',    run: () => deleteActiveProject() },
+  { id: 'close-session',        name: 'Close Session',               shortcut: '⌘W',     run: () => { if (state.activeId) KillSession(state.activeId, false); } },
+  { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch((err) => setStatus(`window failed: ${err}`, true)) },
+  { id: 'close-window',         name: 'Close Window',                shortcut: '⇧⌘W',    run: () => CloseWindow() },
+  { id: 'toggle-sidebar',       name: 'Toggle Sidebar',              shortcut: '⌘S',     run: toggleSidebar },
+  { id: 'toggle-project-grid',  name: 'Toggle Project Grid',         shortcut: '⌘G',     run: toggleProjectGrid },
+  { id: 'toggle-all-grid',      name: 'Toggle All Sessions Grid',    shortcut: '⇧⌘G',    run: toggleAllGrid },
+  { id: 'zoom-in',              name: 'Zoom In',                     shortcut: '⌘=',     run: () => bumpFontSize(+1) },
+  { id: 'zoom-out',             name: 'Zoom Out',                    shortcut: '⌘-',     run: () => bumpFontSize(-1) },
+  { id: 'zoom-reset',           name: 'Actual Size',                 shortcut: '⌘0',     run: () => resetFontSize() },
+  { id: 'next-session',         name: 'Next Session',                shortcut: '⌘↓',     run: () => navSession(+1) },
+  { id: 'prev-session',         name: 'Previous Session',            shortcut: '⌘↑',     run: () => navSession(-1) },
+  { id: 'move-forward',         name: 'Move Session Forward',        shortcut: '⇧⌘↓',    run: () => reorderActive(+1) },
+  { id: 'move-backward',        name: 'Move Session Backward',       shortcut: '⇧⌘↑',    run: () => reorderActive(-1) },
+  { id: 'next-project',         name: 'Next Project',                shortcut: '⌘]',     run: () => shiftActiveProject(+1) },
+  { id: 'prev-project',         name: 'Previous Project',            shortcut: '⌘[',     run: () => shiftActiveProject(-1) },
+];
+
+const paletteEl = document.getElementById('command-palette');
+const paletteInput = document.getElementById('command-palette-input');
+const paletteList = document.getElementById('command-palette-list');
+const paletteState = { items: [], selected: 0 };
+
+function renderPalette() {
+  const q = paletteInput.value.trim().toLowerCase();
+  paletteList.innerHTML = '';
+  paletteState.items = paletteCommands.filter((c) => {
+    if (!q) return true;
+    return c.name.toLowerCase().includes(q) || c.shortcut.toLowerCase().includes(q);
+  });
+  if (paletteState.selected >= paletteState.items.length) {
+    paletteState.selected = 0;
+  }
+  paletteState.items.forEach((c, i) => {
+    const row = document.createElement('div');
+    row.className = 'palette-item' + (i === paletteState.selected ? ' selected' : '');
+    const name = document.createElement('span');
+    name.className = 'palette-name';
+    name.textContent = c.name;
+    const sc = document.createElement('span');
+    sc.className = 'palette-shortcut';
+    sc.textContent = c.shortcut;
+    row.append(name, sc);
+    row.addEventListener('mouseenter', () => {
+      paletteState.selected = i;
+      for (const el of paletteList.children) el.classList.remove('selected');
+      row.classList.add('selected');
+    });
+    row.addEventListener('click', () => activatePalette(i));
+    paletteList.appendChild(row);
+  });
+}
+
+function openCommandPalette() {
+  paletteInput.value = '';
+  paletteState.selected = 0;
+  renderPalette();
+  paletteEl.classList.remove('hidden');
+  paletteInput.focus();
+}
+
+function closeCommandPalette() {
+  paletteEl.classList.add('hidden');
+}
+
+function activatePalette(i) {
+  const c = paletteState.items[i];
+  if (!c) return;
+  closeCommandPalette();
+  // Defer so the palette is fully closed before the action runs
+  // (some actions open another modal that owns focus).
+  setTimeout(() => c.run(), 0);
+}
+
+paletteInput.addEventListener('input', renderPalette);
+paletteEl.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    e.preventDefault(); e.stopPropagation();
+    closeCommandPalette();
+  } else if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey)) {
+    e.preventDefault(); e.stopPropagation();
+    if (paletteState.items.length === 0) return;
+    paletteState.selected = (paletteState.selected + 1) % paletteState.items.length;
+    renderPalette();
+  } else if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey)) {
+    e.preventDefault(); e.stopPropagation();
+    if (paletteState.items.length === 0) return;
+    paletteState.selected = (paletteState.selected - 1 + paletteState.items.length) % paletteState.items.length;
+    renderPalette();
+  } else if (e.key === 'Enter') {
+    e.preventDefault(); e.stopPropagation();
+    activatePalette(paletteState.selected);
+  }
+});
+document.addEventListener('mousedown', (e) => {
+  if (paletteEl.classList.contains('hidden')) return;
+  if (!paletteEl.contains(e.target)) closeCommandPalette();
+});
 
 // moveActiveSession walks the (project_order, session_order) list.
 // reorder=true moves the session within its project only.

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -626,16 +626,7 @@ function renderProject(p, activePID) {
   delBtn.title = 'Delete project';
   delBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    const sessions = state.sessions.filter(
-      (s) => (s.projectId ?? s.project_id) === p.id,
-    );
-    const msg = sessions.length
-      ? `Delete project "${p.name}" and kill ${sessions.length} session${sessions.length === 1 ? '' : 's'}?`
-      : `Delete project "${p.name}"?`;
-    if (!window.confirm(msg)) return;
-    KillProject(p.id, sessions.length > 0).catch((err) => {
-      setStatus(`delete failed: ${err}`, true);
-    });
+    confirmAndDeleteProject(p);
   });
 
   actions.append(newBtn, editBtn, delBtn);
@@ -1853,20 +1844,26 @@ for (let i = 1; i <= 9; i++) {
 
 // ---------- delete project ----------
 
-function deleteActiveProject() {
-  const pid = activeProjectId();
-  const proj = state.projects.find((p) => p.id === pid);
+// confirmAndDeleteProject is the single confirm + KillProject path
+// shared by the sidebar ✕ button and the ⇧⌘⌫ shortcut. Kept as one
+// function so the prompt text and killSessions logic can't drift.
+function confirmAndDeleteProject(proj) {
   if (!proj) return;
   const sessions = state.sessions.filter(
-    (s) => (s.projectId ?? s.project_id) === pid,
+    (s) => (s.projectId ?? s.project_id) === proj.id,
   );
   const msg = sessions.length
     ? `Delete project "${proj.name}" and kill ${sessions.length} session${sessions.length === 1 ? '' : 's'}?`
     : `Delete project "${proj.name}"?`;
   if (!window.confirm(msg)) return;
-  KillProject(pid, sessions.length > 0).catch((err) => {
+  KillProject(proj.id, sessions.length > 0).catch((err) => {
     setStatus(`delete failed: ${err}`, true);
   });
+}
+
+function deleteActiveProject() {
+  const pid = activeProjectId();
+  confirmAndDeleteProject(state.projects.find((p) => p.id === pid));
 }
 
 // ---------- command palette ----------

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -489,7 +489,22 @@ html, body {
   flex-shrink: 0;
   box-shadow: 0 0 4px color-mix(in srgb, var(--session-color, #888) 60%, transparent);
 }
-.term-host .tile-name { flex: 1; }
+.term-host .tile-name { flex: 0 0 auto; }
+.term-host .tile-term-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 11px;
+  margin-left: 4px;
+}
+.term-host .tile-term-title::before {
+  content: "—";
+  margin-right: 6px;
+  color: rgba(255, 255, 255, 0.3);
+}
 .term-host .tile-name-input {
   flex: 1;
   background: rgba(0, 0, 0, 0.55);
@@ -501,6 +516,7 @@ html, body {
   outline: none;
 }
 .term-host .tile-project {
+  margin-left: auto;
   color: rgba(255, 255, 255, 0.6);
   font-size: 10px;
   text-transform: uppercase;
@@ -703,6 +719,57 @@ html, body {
   border-radius: 3px;
 }
 #status.error { color: #ff7a7a; }
+
+/* ---------- command palette ---------- */
+#command-palette {
+  position: fixed;
+  top: 12%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 480px;
+  max-width: 90vw;
+  max-height: 60vh;
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(0,0,0,0.7);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+#command-palette.hidden { display: none; }
+#command-palette-input {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid #1f1f1f;
+  outline: none;
+  color: #eee;
+  font-size: 14px;
+  padding: 12px 14px;
+}
+#command-palette-input::placeholder { color: #555; }
+#command-palette-list {
+  overflow-y: auto;
+  padding: 4px;
+}
+.palette-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #ccc;
+  font-size: 13px;
+}
+.palette-item.selected { background: rgba(255,255,255,0.08); color: #fff; }
+.palette-name { flex: 1; }
+.palette-shortcut {
+  font: 11.5px Menlo, monospace;
+  color: #888;
+}
+.palette-item.selected .palette-shortcut { color: #bbb; }
 
 /* Dead-session overlay — shown over a tile (grid or single mode)
    when the underlying process has exited. */

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -489,7 +489,14 @@ html, body {
   flex-shrink: 0;
   box-shadow: 0 0 4px color-mix(in srgb, var(--session-color, #888) 60%, transparent);
 }
-.term-host .tile-name { flex: 0 0 auto; }
+.term-host .tile-name {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .term-host .tile-term-title {
   flex: 1 1 auto;
   min-width: 0;

--- a/cmd/hivegui/menu.go
+++ b/cmd/hivegui/menu.go
@@ -31,13 +31,11 @@ func buildAppMenu(a *App) *menu.Menu {
 	m.Append(menu.AppMenu()) // About / Hide / Quit (⌘Q)
 
 	file := m.AddSubmenu("File")
-	file.AddText("New Session", keys.CmdOrCtrl("n"), emit("menu:new-session"))
+	file.AddText("New Project…", keys.CmdOrCtrl("n"), emit("menu:new-project"))
+	file.AddText("New Session", keys.CmdOrCtrl("t"), emit("menu:new-session"))
 	file.AddText("New Session in Worktree",
-		keys.Combo("n", keys.OptionOrAltKey, keys.CmdOrCtrlKey),
+		keys.Combo("t", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:new-session-worktree"))
-	file.AddText("New Project…",
-		keys.Combo("p", keys.ShiftKey, keys.CmdOrCtrlKey),
-		emit("menu:new-project"))
 	file.AddSeparator()
 	file.AddText("New Window",
 		keys.Combo("n", keys.ShiftKey, keys.CmdOrCtrlKey),
@@ -46,6 +44,10 @@ func buildAppMenu(a *App) *menu.Menu {
 	file.AddText("Close Window",
 		keys.Combo("w", keys.ShiftKey, keys.CmdOrCtrlKey),
 		func(_ *menu.CallbackData) { a.CloseWindow() })
+	file.AddSeparator()
+	file.AddText("Delete Project…",
+		keys.Combo("backspace", keys.ShiftKey, keys.CmdOrCtrlKey),
+		emit("menu:delete-project"))
 
 	m.Append(menu.EditMenu()) // Cut / Copy / Paste / Select All
 
@@ -91,6 +93,9 @@ func buildAppMenu(a *App) *menu.Menu {
 	}
 
 	m.Append(menu.WindowMenu()) // Minimize / Zoom / Front
+
+	help := m.AddSubmenu("Help")
+	help.AddText("Command Palette…", keys.CmdOrCtrl("k"), emit("menu:command-palette"))
 
 	return m
 }

--- a/cmd/hivegui/menu.go
+++ b/cmd/hivegui/menu.go
@@ -52,6 +52,8 @@ func buildAppMenu(a *App) *menu.Menu {
 	m.Append(menu.EditMenu()) // Cut / Copy / Paste / Select All
 
 	view := m.AddSubmenu("View")
+	view.AddText("Command Palette…", keys.CmdOrCtrl("k"), emit("menu:command-palette"))
+	view.AddSeparator()
 	view.AddText("Zoom In", keys.CmdOrCtrl("="), emit("menu:zoom-in"))
 	view.AddText("Zoom Out", keys.CmdOrCtrl("-"), emit("menu:zoom-out"))
 	view.AddText("Actual Size", keys.CmdOrCtrl("0"), emit("menu:zoom-reset"))
@@ -93,9 +95,6 @@ func buildAppMenu(a *App) *menu.Menu {
 	}
 
 	m.Append(menu.WindowMenu()) // Minimize / Zoom / Front
-
-	help := m.AddSubmenu("Help")
-	help.AddText("Command Palette…", keys.CmdOrCtrl("k"), emit("menu:command-palette"))
 
 	return m
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -254,10 +254,6 @@ func (r *Registry) Get(id string) *Entry {
 func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	r.mu.Lock()
 	id := uuid.NewString()
-	name := spec.Name
-	if name == "" {
-		name = agent.RandomName(agent.ID(spec.Agent))
-	}
 	// Resolve agent default color if the spec didn't override it.
 	color := spec.Color
 	if color == "" && spec.Agent != "" {
@@ -273,6 +269,48 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	if projectID == "" {
 		projectID = r.defaultProjectIDLocked()
 	}
+	// Resolve cwd up front (under the same lock) so we can decide on a
+	// worktree branch BEFORE naming the session — the session name is
+	// derived from the worktree branch when one is in play, so the
+	// user can find the worktree directory from the session label.
+	cwd := spec.Cwd
+	if cwd == "" {
+		if p, ok := r.projects[projectID]; ok && p.Cwd != "" {
+			cwd = p.Cwd
+		}
+	}
+	r.mu.Unlock()
+
+	// Pre-resolve the worktree branch+path so the session name can
+	// match the worktree directory. ResolveBranchAndPath only picks a
+	// free name; the actual `git worktree add` happens further down.
+	var wtPath, wtBranch string
+	if spec.UseWorktree && cwd != "" && worktree.IsGitRepo(cwd) {
+		if root, err := worktree.Root(cwd); err == nil {
+			if b, p, rerr := worktree.ResolveBranchAndPath(root, spec.Branch); rerr == nil {
+				wtBranch, wtPath = b, p
+			} else {
+				log.Printf("registry: worktree.ResolveBranchAndPath: %v", rerr)
+			}
+		}
+	}
+
+	name := spec.Name
+	if name == "" {
+		if wtBranch != "" {
+			// Tie the session name to the worktree directory so the
+			// user can find the worktree from the session label.
+			suffix := spec.Agent
+			if suffix == "" {
+				suffix = "shell"
+			}
+			name = wtBranch + " " + suffix
+		} else {
+			name = agent.RandomName(agent.ID(spec.Agent))
+		}
+	}
+
+	r.mu.Lock()
 	e := &Entry{
 		ID: id, Name: name, Color: color,
 		Order: len(r.order), Created: time.Now().UTC(),
@@ -281,7 +319,6 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	r.entries[id] = e
 	r.order = append(r.order, id)
 	if err := r.persistEntryLocked(e); err != nil {
-		// Roll back the in-memory state so the registry stays consistent.
 		delete(r.entries, id)
 		r.order = r.order[:len(r.order)-1]
 		r.mu.Unlock()
@@ -304,38 +341,24 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 			cmd = def.Cmd
 		}
 	}
-	// If no explicit cwd, fall back to the project's cwd.
-	cwd := spec.Cwd
-	if cwd == "" {
-		r.mu.Lock()
-		if p, ok := r.projects[projectID]; ok && p.Cwd != "" {
-			cwd = p.Cwd
-		}
-		r.mu.Unlock()
-	}
 
-	// Worktree opt-in: if requested AND the resolved cwd is a git
-	// repo, create a worktree under <gitRoot>/.worktrees/ and run
-	// the session inside it. Failure here is non-fatal — the session
-	// falls back to the plain project cwd. Aborting create on
-	// worktree failure would block users on marginal repos (shallow
-	// clones, sandbox restrictions, slow filesystems).
-	var (
-		wtPath, wtBranch string
-	)
-	if spec.UseWorktree && cwd != "" && worktree.IsGitRepo(cwd) {
+	// Now actually create the worktree (heavy `git worktree add`).
+	// Failure here is non-fatal — the session falls back to the plain
+	// project cwd. Aborting create on worktree failure would block
+	// users on marginal repos (shallow clones, sandbox restrictions,
+	// slow filesystems).
+	if wtBranch != "" {
 		if root, err := worktree.Root(cwd); err == nil {
-			b, p, rerr := worktree.ResolveBranchAndPath(root, spec.Branch)
-			if rerr != nil {
-				log.Printf("registry: worktree.ResolveBranchAndPath: %v", rerr)
-			} else if cerr := worktree.CreateWorktree(root, b, p); cerr != nil {
+			if cerr := worktree.CreateWorktree(root, wtBranch, wtPath); cerr != nil {
 				log.Printf("registry: worktree create failed (falling back to plain session): %v", cerr)
+				wtPath, wtBranch = "", ""
 			} else {
-				wtPath, wtBranch = p, b
-				cwd = p
+				cwd = wtPath
 				worktree.EnsureGitignore(root)
-				log.Printf("registry: created worktree %s on branch %s", p, b)
+				log.Printf("registry: created worktree %s on branch %s", wtPath, wtBranch)
 			}
+		} else {
+			wtPath, wtBranch = "", ""
 		}
 	}
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -296,6 +296,11 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	}
 
 	name := spec.Name
+	// nameFromBranch records whether the name was derived from the
+	// pre-resolved worktree branch. If `git worktree add` later fails
+	// we'll rename to a random label so the persisted name doesn't
+	// claim a worktree that doesn't exist.
+	nameFromBranch := false
 	if name == "" {
 		if wtBranch != "" {
 			// Tie the session name to the worktree directory so the
@@ -307,6 +312,7 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 				suffix = "shell"
 			}
 			name = strings.ReplaceAll(wtBranch, "/", "-") + " " + suffix
+			nameFromBranch = true
 		} else {
 			name = agent.RandomName(agent.ID(spec.Agent))
 		}
@@ -368,6 +374,16 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 		} else {
 			wtPath, wtBranch = "", ""
 		}
+	}
+	// If the name was derived from a worktree branch but the worktree
+	// failed to materialize, the persisted name would lie about reality
+	// ("feature-foo claude" with no worktree). Rename to a random label
+	// and re-persist so the session label matches what actually exists.
+	if nameFromBranch && wtBranch == "" {
+		r.mu.Lock()
+		e.Name = agent.RandomName(agent.ID(spec.Agent))
+		_ = r.persistEntryLocked(e)
+		r.mu.Unlock()
 	}
 
 	sess, err := session.Start(session.Options{

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -300,17 +300,25 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 		if wtBranch != "" {
 			// Tie the session name to the worktree directory so the
 			// user can find the worktree from the session label.
+			// Slashes (e.g. `feature/foo`) get folded to `-` so the
+			// name is safe to use in paths and shell-quoted contexts.
 			suffix := spec.Agent
 			if suffix == "" {
 				suffix = "shell"
 			}
-			name = wtBranch + " " + suffix
+			name = strings.ReplaceAll(wtBranch, "/", "-") + " " + suffix
 		} else {
 			name = agent.RandomName(agent.ID(spec.Agent))
 		}
 	}
 
 	r.mu.Lock()
+	// Re-validate projectID after the unlock window above: a concurrent
+	// KillProject could have removed it. Fall back to the default
+	// project rather than persisting a dangling reference.
+	if _, ok := r.projects[projectID]; !ok {
+		projectID = r.defaultProjectIDLocked()
+	}
 	e := &Entry{
 		ID: id, Name: name, Color: color,
 		Order: len(r.order), Created: time.Now().UTC(),

--- a/internal/registry/worktree_test.go
+++ b/internal/registry/worktree_test.go
@@ -76,6 +76,7 @@ func TestCreate_WorktreeHappyPath(t *testing.T) {
 	e, err := r.Create(wire.CreateSpec{
 		ProjectID:   p.ID,
 		Shell:       "/bin/bash",
+		Agent:       "claude",
 		UseWorktree: true,
 	})
 	if err != nil {
@@ -85,6 +86,18 @@ func TestCreate_WorktreeHappyPath(t *testing.T) {
 
 	if e.WorktreePath == "" {
 		t.Fatalf("expected WorktreePath to be set; got empty")
+	}
+	// Session name should be derived from the worktree branch so the
+	// user can find the worktree dir from the session label, with the
+	// agent appended and any "/" in the branch folded to "-".
+	if !strings.Contains(e.Name, e.WorktreeBranch) && !strings.Contains(e.Name, strings.ReplaceAll(e.WorktreeBranch, "/", "-")) {
+		t.Errorf("session name %q should contain worktree branch %q", e.Name, e.WorktreeBranch)
+	}
+	if !strings.HasSuffix(e.Name, " claude") {
+		t.Errorf("session name %q should end with agent suffix \" claude\"", e.Name)
+	}
+	if strings.Contains(e.Name, "/") {
+		t.Errorf("session name %q must not contain slashes (path-unsafe)", e.Name)
 	}
 	// macOS resolves /var → /private/var; compare canonicalized paths.
 	wtReal, _ := filepath.EvalSymlinks(e.WorktreePath)


### PR DESCRIPTION
## Summary

- **Keybindings**: ⌘N → new project, ⌘T → new session, ⇧⌘T → new session in worktree (frees ⌥⌘N which collided with macOS Spotlight). Adds ⇧⌘⌫ for delete-project and ⌘K for the command palette under a new Help menu.
- **Delete project**: per-project ✕ button in the sidebar with confirmation; passes `killSessions=true` when sessions exist.
- **Command palette**: searchable list of every action with its shortcut. Arrow/Tab to navigate, Enter to run, Esc / click-outside to dismiss.
- **Terminal title surfacing**: xterm `onTitleChange` is now wired into both the native window title bar (via `WindowSetTitle`) and each tile header, so what each session is currently doing (vim foo.go, claude code, htop…) is visible at a glance. Hidden when empty or when it just echoes the session name.
- **Worktree-aware session naming** (`registry.Create`): pre-resolves the worktree branch+path before picking the session name, then names the session `<branch> <agent>` so the worktree directory can always be found from the session label. Plain sessions still use `agent.RandomName`.
- **Focus on new sessions**: `switchTo` re-focuses the active terminal after `ensureTerm` creates the `SessionTerm`, fixing a bug where typing immediately after creating a session went to the previously-focused terminal.

## Test plan

- [ ] Restart the GUI (so the freshly-built `hived` is spawned).
- [ ] ⌘N opens the project editor; ⌘T opens the launcher; ⇧⌘T opens the launcher with the worktree checkbox forced on.
- [ ] ⌥⌘N no longer triggers anything in Hive (Spotlight opens normally).
- [ ] ⌘K opens the command palette; typing filters; Enter runs; Esc closes.
- [ ] ✕ next to a project deletes it after confirm; ⇧⌘⌫ deletes the active project.
- [ ] Create a worktree session — session name and `.worktrees/<dir>` match (e.g. session `calm-cliff claude` → `.worktrees/calm-cliff`).
- [ ] Create a new session — typing immediately afterwards goes into the new terminal.
- [ ] Run `vim`, `htop`, or `claude` in a session — title shows in the macOS title bar and the tile header; switches live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)