### PR TITLE
Resizable sidebar; no horizontal scroll

### DIFF
--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -17,6 +17,7 @@
     <footer class="hints">
       ⌘N new · ⌘W close · ⌘G grid · ⇧⌘G all · ⌘[/] project · ⌘S sidebar · ⇧⌘P new project
     </footer>
+    <div id="sidebar-resizer" title="Drag to resize"></div>
   </aside>
   <div id="launcher" class="hidden" role="menu"></div>
   <div id="project-editor" class="hidden" role="dialog">

--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -17,7 +17,12 @@
     <footer class="hints">
       ⌘N new · ⌘W close · ⌘G grid · ⇧⌘G all · ⌘[/] project · ⌘S sidebar · ⇧⌘P new project
     </footer>
-    <div id="sidebar-resizer" title="Drag to resize"></div>
+    <div id="sidebar-resizer"
+         role="separator"
+         aria-orientation="vertical"
+         aria-label="Resize sidebar"
+         tabindex="0"
+         title="Drag to resize (← / → to adjust, ⇧ for larger steps)"></div>
   </aside>
   <div id="launcher" class="hidden" role="menu"></div>
   <div id="project-editor" class="hidden" role="dialog">

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1851,6 +1851,29 @@ window.addEventListener('resize', () => {
   // Belt-and-braces: if focus leaves the window mid-drag, end the drag so a
   // stray mousemove on return doesn't snap the sidebar to the cursor.
   window.addEventListener('blur', endDrag);
+
+  // Keyboard a11y: when the resizer has focus, arrow keys adjust width
+  // (Shift = larger step). Persist + refit on each change.
+  function nudge(delta) {
+    const cur = parseInt(getComputedStyle(app).getPropertyValue('--sidebar-width'), 10);
+    const base = Number.isFinite(cur) ? cur : 200;
+    const w = Math.max(MIN, Math.min(MAX, base + delta));
+    app.style.setProperty('--sidebar-width', `${w}px`);
+    localStorage.setItem('hive.sidebarWidth', String(w));
+    if (state.view === 'single') {
+      const t = state.activeId && state.terms.get(state.activeId);
+      if (t) t.refit();
+    } else {
+      renderGrid();
+    }
+  }
+  handle.addEventListener('keydown', (e) => {
+    const step = e.shiftKey ? 50 : 10;
+    if (e.key === 'ArrowLeft')       { e.preventDefault(); nudge(-step); }
+    else if (e.key === 'ArrowRight') { e.preventDefault(); nudge(+step); }
+    else if (e.key === 'Home')       { e.preventDefault(); nudge(-MAX); }
+    else if (e.key === 'End')        { e.preventDefault(); nudge(+MAX); }
+  });
 })();
 
 // ---------- bootstrap ----------

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1811,23 +1811,13 @@ window.addEventListener('resize', () => {
   const app = document.getElementById('app');
   const handle = document.getElementById('sidebar-resizer');
   if (!app || !handle) return;
-  const saved = parseInt(localStorage.getItem('hive.sidebarWidth') ?? '', 10);
+  const saved = parseInt(localStorage.getItem('hive.sidebarWidth') || '', 10);
   if (Number.isFinite(saved)) {
     app.style.setProperty('--sidebar-width', `${Math.max(MIN, Math.min(MAX, saved))}px`);
   }
+  // #app spans the viewport, so pointer clientX maps directly to sidebar width.
   let dragging = false;
-  handle.addEventListener('mousedown', (e) => {
-    e.preventDefault();
-    dragging = true;
-    document.body.classList.add('resizing-sidebar');
-    handle.classList.add('dragging');
-  });
-  window.addEventListener('mousemove', (e) => {
-    if (!dragging) return;
-    const w = Math.max(MIN, Math.min(MAX, e.clientX));
-    app.style.setProperty('--sidebar-width', `${w}px`);
-  });
-  window.addEventListener('mouseup', () => {
+  function endDrag() {
     if (!dragging) return;
     dragging = false;
     document.body.classList.remove('resizing-sidebar');
@@ -1842,7 +1832,25 @@ window.addEventListener('resize', () => {
     } else {
       renderGrid();
     }
+  }
+  handle.addEventListener('pointerdown', (e) => {
+    e.preventDefault();
+    dragging = true;
+    document.body.classList.add('resizing-sidebar');
+    handle.classList.add('dragging');
+    // Capture so we keep getting moves/ups even if the cursor leaves the window.
+    handle.setPointerCapture(e.pointerId);
   });
+  handle.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    const w = Math.max(MIN, Math.min(MAX, e.clientX));
+    app.style.setProperty('--sidebar-width', `${w}px`);
+  });
+  handle.addEventListener('pointerup', endDrag);
+  handle.addEventListener('pointercancel', endDrag);
+  // Belt-and-braces: if focus leaves the window mid-drag, end the drag so a
+  // stray mousemove on return doesn't snap the sidebar to the cursor.
+  window.addEventListener('blur', endDrag);
 })();
 
 // ---------- bootstrap ----------

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1801,6 +1801,50 @@ window.addEventListener('resize', () => {
   }, 100);
 });
 
+// ---------- sidebar resize ----------
+//
+// Drag the right edge of the sidebar to resize. Width persists across
+// reloads. Constrained to a sane min/max so the resizer can't be lost
+// off-screen or eat the whole window.
+(function setupSidebarResize() {
+  const MIN = 140, MAX = 480;
+  const app = document.getElementById('app');
+  const handle = document.getElementById('sidebar-resizer');
+  if (!app || !handle) return;
+  const saved = parseInt(localStorage.getItem('hive.sidebarWidth') ?? '', 10);
+  if (Number.isFinite(saved)) {
+    app.style.setProperty('--sidebar-width', `${Math.max(MIN, Math.min(MAX, saved))}px`);
+  }
+  let dragging = false;
+  handle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    dragging = true;
+    document.body.classList.add('resizing-sidebar');
+    handle.classList.add('dragging');
+  });
+  window.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    const w = Math.max(MIN, Math.min(MAX, e.clientX));
+    app.style.setProperty('--sidebar-width', `${w}px`);
+  });
+  window.addEventListener('mouseup', () => {
+    if (!dragging) return;
+    dragging = false;
+    document.body.classList.remove('resizing-sidebar');
+    handle.classList.remove('dragging');
+    const px = app.style.getPropertyValue('--sidebar-width');
+    const w = parseInt(px, 10);
+    if (Number.isFinite(w)) localStorage.setItem('hive.sidebarWidth', String(w));
+    // Main pane width changed — reflow terminals.
+    if (state.view === 'single') {
+      const t = state.activeId && state.terms.get(state.activeId);
+      if (t) t.refit();
+    } else {
+      renderGrid();
+    }
+  });
+})();
+
 // ---------- bootstrap ----------
 
 (async () => {

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -391,6 +391,7 @@ body.resizing-sidebar #app { transition: none; }
   line-height: 1.4;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 #terms {

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -82,9 +82,11 @@ body.resizing-sidebar #app { transition: none; }
   transition: background 120ms ease;
 }
 #sidebar-resizer:hover,
-#sidebar-resizer.dragging {
+#sidebar-resizer.dragging,
+#sidebar-resizer:focus-visible {
   background: color-mix(in srgb, #f59e0b 35%, transparent);
 }
+#sidebar-resizer:focus-visible { outline: none; }
 #app.sidebar-hidden #sidebar-resizer { display: none; }
 
 #sidebar header {

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -43,10 +43,13 @@ html, body {
 
 #app {
   display: grid;
-  grid-template-columns: 200px 1fr;
+  grid-template-columns: var(--sidebar-width, 200px) 1fr;
   height: 100vh;
   transition: grid-template-columns 120ms ease;
 }
+
+body.resizing-sidebar { cursor: col-resize; user-select: none; }
+body.resizing-sidebar #app { transition: none; }
 
 #app.sidebar-hidden {
   grid-template-columns: 0 1fr;
@@ -62,7 +65,27 @@ html, body {
   display: flex;
   flex-direction: column;
   user-select: none;
+  position: relative;
+  min-width: 0;
+  overflow-x: hidden;
 }
+
+#sidebar-resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 5px;
+  cursor: col-resize;
+  z-index: 20;
+  background: transparent;
+  transition: background 120ms ease;
+}
+#sidebar-resizer:hover,
+#sidebar-resizer.dragging {
+  background: color-mix(in srgb, #f59e0b 35%, transparent);
+}
+#app.sidebar-hidden #sidebar-resizer { display: none; }
 
 #sidebar header {
   display: flex;
@@ -77,6 +100,10 @@ html, body {
   font-size: 13px;
   letter-spacing: 0.04em;
   color: #f59e0b;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 #new-project-btn {
@@ -98,6 +125,7 @@ html, body {
   padding: 4px 0;
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .project {
@@ -133,6 +161,7 @@ html, body {
   color: #888;
   cursor: pointer;
   user-select: none;
+  min-width: 0;
 }
 
 .project-header:hover { background: rgba(255,255,255,0.02); color: #ddd; }
@@ -175,6 +204,7 @@ html, body {
 
 .project-header .project-name {
   flex: 1;
+  min-width: 0;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -235,6 +265,7 @@ html, body {
   font-size: 12.5px;
   color: #aaa;
   position: relative;
+  min-width: 0;
 }
 
 .session-item:hover {
@@ -297,6 +328,7 @@ html, body {
 /* Title gradient — color stays visible even when selected. */
 .session-item .name {
   flex: 1;
+  min-width: 0;
   background: linear-gradient(90deg, var(--session-color, #888) 0%, #fff 90%);
   -webkit-background-clip: text;
   background-clip: text;
@@ -357,6 +389,8 @@ html, body {
   font-size: 10.5px;
   color: #555;
   line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #terms {


### PR DESCRIPTION
## Summary
- Drag the right edge of the sidebar to resize, clamped to 140–480px; width persists in `localStorage` (`hive.sidebarWidth`).
- Sidebar lists clip horizontally instead of scrolling. Project and session titles ellipsis-truncate when the sidebar is narrowed; same for the brand text and the keyboard-hint footer.
- Terminals refit on resize release so the main pane reflows correctly in both single and grid views.

## Test plan
- [ ] Build and launch the app, drag the sidebar resizer — width changes smoothly down to ~140px and up to ~480px.
- [ ] Reload the app — sidebar width is restored.
- [ ] At minimum width, long project/session names show \`…\`; no horizontal scrollbar appears in the sidebar; shift-wheel / two-finger horizontal swipe does not scroll the sidebar.
- [ ] Toggle the sidebar with ⌘S — resizer hides with the sidebar, terminals refit.
- [ ] Resize while in grid view — grid re-tiles to the new pane width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)