### PR TITLE
GUI: project-inherited session color gradient + random palette

### DIFF
--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -341,8 +341,9 @@ class SessionTerm {
     input.addEventListener('keydown', (e) => e.stopPropagation(), { capture: true });
   }
 
-  setProjectName(name) {
+  setProject(name, color) {
     this.tileProject.textContent = name || '';
+    this.host.style.setProperty('--project-color', color || '#888');
   }
 
   show() {
@@ -972,7 +973,7 @@ function ensureTerm(info) {
     st.setInfo(info);
   }
   const proj = state.projects.find((p) => p.id === (info.projectId ?? info.project_id));
-  st.setProjectName(proj?.name ?? '');
+  st.setProject(proj?.name ?? '', proj?.color ?? '');
   return st;
 }
 
@@ -1373,6 +1374,15 @@ EventsOn('project:event', (jsonStr) => {
     }
   } else if (ev.kind === 'updated') {
     if (i >= 0) state.projects[i] = ev.project;
+    // Refresh tile-header project color for every session belonging
+    // to this project so grid/single-mode title bars reflect rename
+    // and recolor in real time.
+    for (const s of state.sessions) {
+      const pid = s.projectId ?? s.project_id;
+      if (pid !== ev.project.id) continue;
+      const st = state.terms.get(s.id);
+      if (st) st.setProject(ev.project.name, ev.project.color);
+    }
   }
   state.projects.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   renderSidebar();
@@ -1457,7 +1467,7 @@ EventsOn('session:event', (jsonStr) => {
       st.setInfo(ev.session);
       const pid = ev.session.projectId ?? ev.session.project_id;
       const proj = state.projects.find((p) => p.id === pid);
-      st.setProjectName(proj?.name ?? '');
+      st.setProject(proj?.name ?? '', proj?.color ?? '');
     }
     if (state.activeId === ev.session.id) updateAppTitle();
   }

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -700,7 +700,7 @@ function renderProject(p, activePID) {
     .filter((s) => (s.projectId ?? s.project_id) === p.id)
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   for (const s of sessions) {
-    ul.appendChild(renderSession(s));
+    ul.appendChild(renderSession(s, p.color || '#888'));
   }
   li.appendChild(ul);
 
@@ -778,13 +778,14 @@ function reorderDroppedProject(draggedID, targetID, above) {
   UpdateProject(draggedID, '', '', '', newOrder);
 }
 
-function renderSession(s) {
+function renderSession(s, projectColor) {
   const li = document.createElement('li');
   li.className = 'session-item';
   if (s.id === state.activeId) li.classList.add('selected');
   if (!s.alive) li.classList.add('dead');
   if (state.attention.has(s.id)) li.classList.add('attention');
   li.style.setProperty('--session-color', s.color || '#888');
+  li.style.setProperty('--project-color', projectColor || '#888');
   li.dataset.sid = s.id;
   li.dataset.pid = s.projectId ?? s.project_id ?? '';
   li.draggable = true;

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -359,7 +359,15 @@ body.resizing-sidebar #app { transition: none; }
 .session-item .name {
   flex: 1;
   min-width: 0;
-  background: linear-gradient(90deg, var(--project-color, #888) 0%, var(--session-color, #fff) 100%);
+  /* Project → session gradient. The right-end stop blends 80% of the
+     session color with white so a user-picked dark hex stays readable
+     on the dark sidebar; palette-default colors are bright enough that
+     this barely shifts them. */
+  background: linear-gradient(
+    90deg,
+    var(--project-color, #888) 0%,
+    color-mix(in srgb, var(--session-color, #fff) 80%, #fff) 100%
+  );
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -526,11 +534,13 @@ body.resizing-sidebar #app { transition: none; }
   align-items: center;
   gap: 6px;
   padding: 4px 8px;
-  /* Title bar tinted with the session color — subtle for unfocused
-     tiles, brighter when focused. */
+  /* Title bar gradient: project color (left) → session color (right),
+     each mixed into the dark base so the bar reads as a tinted strip
+     rather than a solid block. Mirrors the sidebar gradient so the
+     same visual encoding applies in grid and single mode. */
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--session-color, #888) 40%, #0a0a0a) 0%,
+    color-mix(in srgb, var(--project-color, var(--session-color, #888)) 40%, #0a0a0a) 0%,
     color-mix(in srgb, var(--session-color, #888) 12%, #0a0a0a) 100%
   );
   border-bottom: 1px solid color-mix(in srgb, var(--session-color, #888) 35%, #1a1a1a);
@@ -541,7 +551,7 @@ body.resizing-sidebar #app { transition: none; }
 .term-host.term-focused .tile-header {
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--session-color, #888) 65%, #0a0a0a) 0%,
+    color-mix(in srgb, var(--project-color, var(--session-color, #888)) 65%, #0a0a0a) 0%,
     color-mix(in srgb, var(--session-color, #888) 28%, #0a0a0a) 100%
   );
   color: #fff;

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -359,7 +359,7 @@ body.resizing-sidebar #app { transition: none; }
 .session-item .name {
   flex: 1;
   min-width: 0;
-  background: linear-gradient(90deg, var(--session-color, #888) 0%, #fff 90%);
+  background: linear-gradient(90deg, var(--project-color, #888) 0%, var(--session-color, #fff) 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;

--- a/internal/registry/projects.go
+++ b/internal/registry/projects.go
@@ -140,7 +140,8 @@ func (r *Registry) CreateProject(req wire.CreateProjectReq) (*Project, error) {
 	}
 	color := req.Color
 	if color == "" {
-		color = pickColor(len(r.projectOrder))
+		color = pickColor(r.lastProjectColor)
+		r.lastProjectColor = color
 	}
 	p := &Project{
 		ID: id, Name: name, Color: color, Cwd: req.Cwd,

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,9 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -263,18 +264,24 @@ func (r *Registry) Get(id string) *Entry {
 func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	r.mu.Lock()
 	id := uuid.NewString()
+	// Resolve owning project first so we can avoid its color when
+	// auto-picking the session color (otherwise the gradient could
+	// collapse to a flat hue).
+	projectID := spec.ProjectID
+	if projectID == "" {
+		projectID = r.defaultProjectIDLocked()
+	}
+	var projectColor string
+	if p, ok := r.projects[projectID]; ok {
+		projectColor = p.Color
+	}
 	// Color is reserved for project/session identity; agent identity
 	// is conveyed by the badge/icon. So skip the agent-default tier
 	// and pick a random palette color when the caller didn't choose.
 	color := spec.Color
 	if color == "" {
-		color = pickColor(r.lastSessionColor)
+		color = pickColor(r.lastSessionColor, projectColor)
 		r.lastSessionColor = color
-	}
-	// Resolve owning project: fall back to the default if unset.
-	projectID := spec.ProjectID
-	if projectID == "" {
-		projectID = r.defaultProjectIDLocked()
 	}
 	// Resolve cwd up front (under the same lock) so we can decide on a
 	// worktree branch BEFORE naming the session — the session name is
@@ -838,27 +845,18 @@ var colorPalette = []string{
 	"#eab308", // yellow
 }
 
-// colorRand is a package-local PRNG used solely for palette selection.
-// Seeded once so sequential picks are not deterministic across runs.
-var colorRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-// pickColor returns a random palette color. When avoid is a palette
-// entry it is guaranteed to be excluded, so consecutive calls with
-// the previous result as avoid never repeat. Empty avoid = uniform
-// across the full palette.
-func pickColor(avoid string) string {
-	if avoid == "" {
-		return colorPalette[colorRand.Intn(len(colorPalette))]
-	}
-	// Pick uniformly from palette \ {avoid}. If avoid isn't in the
-	// palette, this still picks uniformly across all entries.
+// pickColor returns a random palette color, excluding any entry
+// listed in avoid. Uses math/rand/v2 top-level helpers so it's
+// goroutine-safe without needing a lock at the call site.
+func pickColor(avoid ...string) string {
 	n := len(colorPalette)
-	idx := colorRand.Intn(n)
+	idx := rand.IntN(n)
 	for i := range n {
 		c := colorPalette[(idx+i)%n]
-		if c != avoid {
+		if !slices.Contains(avoid, c) {
 			return c
 		}
 	}
+	// Every palette entry is in avoid — fall back to a uniform pick.
 	return colorPalette[idx]
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -842,13 +842,23 @@ var colorPalette = []string{
 // Seeded once so sequential picks are not deterministic across runs.
 var colorRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-// pickColor returns a random palette color, retrying once if the
-// result equals avoid (the previously-picked color). Empty avoid =
-// no bias.
+// pickColor returns a random palette color. When avoid is a palette
+// entry it is guaranteed to be excluded, so consecutive calls with
+// the previous result as avoid never repeat. Empty avoid = uniform
+// across the full palette.
 func pickColor(avoid string) string {
-	c := colorPalette[colorRand.Intn(len(colorPalette))]
-	if c == avoid {
-		c = colorPalette[colorRand.Intn(len(colorPalette))]
+	if avoid == "" {
+		return colorPalette[colorRand.Intn(len(colorPalette))]
 	}
-	return c
+	// Pick uniformly from palette \ {avoid}. If avoid isn't in the
+	// palette, this still picks uniformly across all entries.
+	n := len(colorPalette)
+	idx := colorRand.Intn(n)
+	for i := range n {
+		c := colorPalette[(idx+i)%n]
+		if c != avoid {
+			return c
+		}
+	}
+	return colorPalette[idx]
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
@@ -105,6 +106,12 @@ type Registry struct {
 
 	projects     map[string]*Project
 	projectOrder []string
+
+	// lastProjectColor / lastSessionColor remember the most recent
+	// auto-assigned palette color so consecutive creates pick a
+	// different one. Empty string = no bias.
+	lastProjectColor string
+	lastSessionColor string
 
 	// Listeners are notified of every change. Slow listeners are dropped.
 	listeners map[Listener]struct{}
@@ -256,15 +263,13 @@ func (r *Registry) Get(id string) *Entry {
 func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	r.mu.Lock()
 	id := uuid.NewString()
-	// Resolve agent default color if the spec didn't override it.
+	// Color is reserved for project/session identity; agent identity
+	// is conveyed by the badge/icon. So skip the agent-default tier
+	// and pick a random palette color when the caller didn't choose.
 	color := spec.Color
-	if color == "" && spec.Agent != "" {
-		if def, ok := agent.Get(agent.ID(spec.Agent)); ok {
-			color = def.Color
-		}
-	}
 	if color == "" {
-		color = pickColor(len(r.order))
+		color = pickColor(r.lastSessionColor)
+		r.lastSessionColor = color
 	}
 	// Resolve owning project: fall back to the default if unset.
 	projectID := spec.ProjectID
@@ -513,7 +518,8 @@ func (r *Registry) Adopt(s *session.Session, name, color string) (*Entry, error)
 		name = agent.RandomName("")
 	}
 	if color == "" {
-		color = pickColor(len(r.order))
+		color = pickColor(r.lastSessionColor)
+		r.lastSessionColor = color
 	}
 	e := &Entry{
 		ID: id, Name: name, Color: color,
@@ -812,16 +818,37 @@ func (r *Registry) broadcastLocked(kind string, info wire.SessionInfo) {
 	}
 }
 
-// pickColor returns a default color for the nth session. Six fixed
-// hues that rotate; users can override via Update.
-func pickColor(n int) string {
-	palette := []string{
-		"#f59e0b", // amber
-		"#8b5cf6", // violet
-		"#10b981", // emerald
-		"#3b82f6", // sky
-		"#ef4444", // red
-		"#ec4899", // pink
+// colorPalette is the curated set of "good" hues used for auto-
+// assigned project and session colors. All are readable as text on
+// the dark sidebar. Users can override via Update.
+var colorPalette = []string{
+	"#f59e0b", // amber
+	"#f97316", // orange
+	"#ef4444", // red
+	"#ec4899", // pink
+	"#d946ef", // fuchsia
+	"#a855f7", // purple
+	"#8b5cf6", // violet
+	"#6366f1", // indigo
+	"#3b82f6", // sky
+	"#06b6d4", // cyan
+	"#14b8a6", // teal
+	"#10b981", // emerald
+	"#84cc16", // lime
+	"#eab308", // yellow
+}
+
+// colorRand is a package-local PRNG used solely for palette selection.
+// Seeded once so sequential picks are not deterministic across runs.
+var colorRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// pickColor returns a random palette color, retrying once if the
+// result equals avoid (the previously-picked color). Empty avoid =
+// no bias.
+func pickColor(avoid string) string {
+	c := colorPalette[colorRand.Intn(len(colorPalette))]
+	if c == avoid {
+		c = colorPalette[colorRand.Intn(len(colorPalette))]
 	}
-	return palette[n%len(palette)]
+	return c
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"runtime"
+	"slices"
 	"testing"
 	"time"
 
@@ -202,28 +203,40 @@ func TestPersistenceAcrossOpen(t *testing.T) {
 	}
 }
 
-func TestPickColorAvoidsPrevious(t *testing.T) {
-	// pickColor must never return the avoid color when avoid is a
-	// palette entry, even with adversarial RNG that always picks the
-	// avoided index first.
+func TestPickColorExcludesAvoid(t *testing.T) {
+	// Structural guarantee: when avoid is a palette entry, pickColor
+	// must never return it. Sample 100 calls per palette entry.
 	for _, avoid := range colorPalette {
 		for i := 0; i < 100; i++ {
 			got := pickColor(avoid)
 			if got == avoid {
 				t.Fatalf("pickColor(%q) returned avoided color", avoid)
 			}
-			if !contains(colorPalette, got) {
+			if !slices.Contains(colorPalette, got) {
 				t.Fatalf("pickColor returned %q, not in palette", got)
 			}
 		}
 	}
 }
 
+func TestPickColorExcludesMultipleAvoid(t *testing.T) {
+	// Variadic avoid: pickColor must skip every entry in the avoid
+	// list, so the session-create path can avoid both the previous
+	// session color and the project color.
+	a, b := colorPalette[0], colorPalette[1]
+	for i := 0; i < 200; i++ {
+		got := pickColor(a, b)
+		if got == a || got == b {
+			t.Fatalf("pickColor(%q,%q) returned avoided color %q", a, b, got)
+		}
+	}
+}
+
 func TestPickColorEmptyAvoidUsesPalette(t *testing.T) {
 	for i := 0; i < 50; i++ {
-		got := pickColor("")
-		if !contains(colorPalette, got) {
-			t.Fatalf("pickColor(\"\") returned %q, not in palette", got)
+		got := pickColor()
+		if !slices.Contains(colorPalette, got) {
+			t.Fatalf("pickColor() returned %q, not in palette", got)
 		}
 	}
 }
@@ -244,11 +257,3 @@ func TestAutoAssignedProjectColorsDifferConsecutively(t *testing.T) {
 	}
 }
 
-func contains(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -201,3 +201,54 @@ func TestPersistenceAcrossOpen(t *testing.T) {
 		t.Errorf("expected entries to be inactive after reopen")
 	}
 }
+
+func TestPickColorAvoidsPrevious(t *testing.T) {
+	// pickColor must never return the avoid color when avoid is a
+	// palette entry, even with adversarial RNG that always picks the
+	// avoided index first.
+	for _, avoid := range colorPalette {
+		for i := 0; i < 100; i++ {
+			got := pickColor(avoid)
+			if got == avoid {
+				t.Fatalf("pickColor(%q) returned avoided color", avoid)
+			}
+			if !contains(colorPalette, got) {
+				t.Fatalf("pickColor returned %q, not in palette", got)
+			}
+		}
+	}
+}
+
+func TestPickColorEmptyAvoidUsesPalette(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		got := pickColor("")
+		if !contains(colorPalette, got) {
+			t.Fatalf("pickColor(\"\") returned %q, not in palette", got)
+		}
+	}
+}
+
+func TestAutoAssignedProjectColorsDifferConsecutively(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+	var prev string
+	for i := 0; i < 20; i++ {
+		p, err := r.CreateProject(wire.CreateProjectReq{Name: "p", Cwd: t.TempDir()})
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		if i > 0 && p.Color == prev {
+			t.Fatalf("consecutive auto-assigned project colors repeated: %q", p.Color)
+		}
+		prev = p.Color
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Sessions render with a `project-color → session-color` gradient so the owning project is visible at a glance.
- Auto-assigned colors come from a curated 14-color palette picked randomly (avoiding the previous pick) — successive creates produce varied colors instead of the fixed 6-color rotation.
- Session create no longer falls back to the agent's default color; agent identity stays in the badge, color is reserved for project/session identity.

## Test plan
- [ ] Create several projects in a row → colors are visibly varied, no two consecutive identical
- [ ] Create several sessions in one project → each title shows a left-to-right gradient from the project color to a distinct session color
- [ ] Change a project's color via the swatch → all its sessions' gradient left edges update
- [ ] Restart the daemon → persisted colors restored, gradient still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)