### PR TITLE
fix(release): sort prerelease tags below release in PREV_TAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ own session daemon, replacing the v1 tmux + Bubble Tea architecture.
 - No telemetry in shipped binaries.
 
 [Unreleased]: https://github.com/lucascaro/hive/compare/v2.0.1...HEAD
-[2.0.1]: https://github.com/lucascaro/hive/compare/v2.0.0-alpha.2...v2.0.1
+[2.0.1]: https://github.com/lucascaro/hive/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/lucascaro/hive/compare/v2.0.0-alpha.2...v2.0.0
 [2.0.0-alpha.2]: https://github.com/lucascaro/hive/compare/v2.0.0-alpha.1...v2.0.0-alpha.2
 [2.0.0-alpha.1]: https://github.com/lucascaro/hive/releases/tag/v2.0.0-alpha.1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -78,7 +78,10 @@ fi
 
 echo "Stamping changelog..."
 
-PREV_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
+# git's -v:refname sorts prerelease tags ABOVE the matching release
+# (e.g. v2.0.0-alpha.2 > v2.0.0), which produces wrong compare links.
+# Tell sort to treat "-" as a prerelease marker so v2.0.0 > v2.0.0-alpha.2.
+PREV_TAG=$(git -c versionsort.suffix=- tag -l 'v*' --sort=-v:refname | head -1)
 [[ -n "$PREV_TAG" ]] || PREV_TAG="v0.0.0"
 
 sed -i.bak "s/^## \[Unreleased\]/## [Unreleased]\n\n## [${VERSION}] — ${TODAY}/" CHANGELOG.md


### PR DESCRIPTION
## Summary

- `git tag --sort=-v:refname` was ordering `v2.0.0-alpha.2` above `v2.0.0`, so `release.sh` resolved the wrong PREV_TAG and produced a bad compare link in the v2.0.1 CHANGELOG entry (`v2.0.0-alpha.2...v2.0.1` instead of `v2.0.0...v2.0.1`).
- Pass `versionsort.suffix=-` so git treats `-` as a prerelease marker and orders `v2.0.0` above `v2.0.0-alpha.2`.
- Corrects the existing v2.0.1 compare link in CHANGELOG.

## Test plan

- [x] `git -c versionsort.suffix=- tag -l 'v*' --sort=-v:refname` puts `v2.0.0` above `v2.0.0-alpha.2`
- [ ] Next release picks correct PREV_TAG

🤖 Generated with [Claude Code](https://claude.com/claude-code)