### PR TITLE
feat(gui): duplicate session with ⌘P / ⇧⌘P

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- GUI: ⌘P duplicates the active session into the same cwd/worktree;
+  ⇧⌘P opens the launcher pinned to that cwd to pick a different tool.
+  The duplicate adopts the source's worktree (no nested `.worktrees/*`
+  is created), shows the worktree badge in the sidebar, and the
+  worktree directory is only cleaned up when the last session in it
+  is killed. New entries also appear in the command palette and the
+  File menu.
+
 ### Changed
 
 - Sidebar: more visible selected-session styling. Selection now uses an

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -343,7 +343,7 @@ func (a *App) CreateSession(agentID, projectID, name, color string, cols, rows i
 }
 
 // DuplicateSession creates a new session pinned to an explicit cwd —
-// used by the GUI's ⌘D / ⇧⌘D shortcuts to fork the active session into
+// used by the GUI's ⌘P / ⇧⌘P shortcuts to fork the active session into
 // the same project + directory (and same worktree, if the source had
 // one). The caller resolves the cwd on the JS side from the source
 // session's worktree path or its project's cwd.

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -342,6 +342,28 @@ func (a *App) CreateSession(agentID, projectID, name, color string, cols, rows i
 	})
 }
 
+// DuplicateSession creates a new session pinned to an explicit cwd —
+// used by the GUI's ⌘D / ⇧⌘D shortcuts to fork the active session into
+// the same project + directory (and same worktree, if the source had
+// one). The caller resolves the cwd on the JS side from the source
+// session's worktree path or its project's cwd.
+//
+// UseWorktree is forced to false here: when cwd already points inside a
+// worktree, we want to *reuse* it, not stack a nested worktree on top.
+// Passing agentID="" creates a generic shell session.
+func (a *App) DuplicateSession(agentID, projectID, cwd string) error {
+	cs, err := a.requireControl()
+	if err != nil {
+		return err
+	}
+	return cs.writeJSON(wire.FrameCreateSession, wire.CreateSpec{
+		Agent:       agentID,
+		ProjectID:   projectID,
+		Cwd:         cwd,
+		UseWorktree: false,
+	})
+}
+
 // CreateProject creates a new project.
 func (a *App) CreateProject(name, color, cwd string) error {
 	cs, err := a.requireControl()

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -2331,6 +2331,8 @@ const paletteCommands = [
   { id: 'new-project',          name: 'New Project…',                shortcut: '⌘N',     run: () => openProjectEditor(null) },
   { id: 'new-session',          name: 'New Session',                 shortcut: '⌘T',     run: () => openLauncher() },
   { id: 'new-session-worktree', name: 'New Session in Worktree',     shortcut: '⇧⌘T',    run: () => openLauncher(undefined, { forceWorktree: true }) },
+  { id: 'duplicate-session',    name: 'Duplicate Session',           shortcut: '⌘P',     run: duplicateActiveSession },
+  { id: 'duplicate-session-choose-tool', name: 'Duplicate Session (choose tool)…', shortcut: '⇧⌘P', run: duplicateActiveSessionChooseTool },
   { id: 'delete-project',       name: 'Delete Active Project…',      shortcut: '⇧⌘⌫',    run: () => deleteActiveProject() },
   { id: 'close-session',        name: 'Close Session',               shortcut: '⌘W',     run: () => { if (state.activeId) KillSession(state.activeId, false); } },
   { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch((err) => setStatus(`window failed: ${err}`, true)) },
@@ -2348,6 +2350,12 @@ const paletteCommands = [
   { id: 'move-backward',        name: 'Move Session Backward',       shortcut: '⇧⌘↑',    run: () => reorderActive(-1) },
   { id: 'next-project',         name: 'Next Project',                shortcut: '⌘]',     run: () => shiftActiveProject(+1) },
   { id: 'prev-project',         name: 'Previous Project',            shortcut: '⌘[',     run: () => shiftActiveProject(-1) },
+  ...Array.from({ length: 9 }, (_, i) => ({
+    id: `switch-${i + 1}`,
+    name: `Switch to Session ${i + 1}`,
+    shortcut: `⌘${i + 1}`,
+    run: () => switchToNthSession(i + 1),
+  })),
 ];
 
 const paletteEl = document.getElementById('command-palette');

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -7,7 +7,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import {
   ConnectControl, OpenSession, CloseAttach,
   WriteStdin, ResizeSession,
-  CreateSession, KillSession, UpdateSession, ListAgents,
+  CreateSession, DuplicateSession, KillSession, UpdateSession, ListAgents,
   CreateProject, KillProject, UpdateProject,
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
   IsGitRepo, OpenURL, OpenTerminalAt, Notify, Confirm,
@@ -1746,6 +1746,12 @@ const launcherState = {
   // localStorage. ⌃⌘N opens the launcher with this forced to true
   // for the duration of that opening.
   useWorktree: localStorage.getItem('hive.worktree') === '1',
+  // duplicateFrom, when set, switches the launcher into "duplicate
+  // session" mode: cwd is fixed to duplicateCwd, the worktree toggle is
+  // hidden, and selecting an agent calls DuplicateSession instead of
+  // CreateSession.
+  duplicateFrom: null,
+  duplicateCwd: '',
 };
 
 function loadAgentUsage() {
@@ -1777,13 +1783,21 @@ function activateLauncherSelection() {
   const it = launcherState.items[launcherState.selected];
   if (!it) return;
   bumpAgentUsage(it.agent.id);
-  CreateSession(
-    it.agent.id,
-    launcherState.projectId || activeProjectId(),
-    '', '',
-    0, 0,
-    !!launcherState.useWorktree,
-  );
+  if (launcherState.duplicateFrom) {
+    DuplicateSession(
+      it.agent.id,
+      launcherState.projectId || '',
+      launcherState.duplicateCwd,
+    );
+  } else {
+    CreateSession(
+      it.agent.id,
+      launcherState.projectId || activeProjectId(),
+      '', '',
+      0, 0,
+      !!launcherState.useWorktree,
+    );
+  }
   closeLauncher();
 }
 
@@ -1796,6 +1810,13 @@ function openLauncher(projectId, opts) {
     opts && typeof opts.forceWorktree === 'boolean'
       ? opts.forceWorktree
       : localStorage.getItem('hive.worktree') === '1';
+  // duplicateFrom: when present, the launcher is forking an existing
+  // session into the same cwd — never a new worktree.
+  launcherState.duplicateFrom = (opts && opts.duplicateFrom) || null;
+  launcherState.duplicateCwd = (opts && opts.duplicateCwd) || '';
+  if (launcherState.duplicateFrom) {
+    launcherState.useWorktree = false;
+  }
   ListAgents()
     .then((agents) => {
       launcherEl.innerHTML = '';
@@ -1819,29 +1840,33 @@ function openLauncher(projectId, opts) {
       // checkbox.
       const proj = state.projects.find((p) => p.id === launcherState.projectId);
       const projCwd = proj?.cwd ?? '';
-      const wtRow = document.createElement('label');
-      wtRow.className = 'launcher-worktree';
-      const wtBox = document.createElement('input');
-      wtBox.type = 'checkbox';
-      wtBox.checked = !!launcherState.useWorktree;
-      const wtLabel = document.createElement('span');
-      wtLabel.textContent = 'Create in git worktree';
-      wtRow.append(wtBox, wtLabel);
-      wtBox.addEventListener('change', (e) => {
-        launcherState.useWorktree = e.target.checked;
-        localStorage.setItem('hive.worktree', e.target.checked ? '1' : '0');
-      });
-      launcherEl.appendChild(wtRow);
-      if (projCwd) {
-        IsGitRepo(projCwd).then((ok) => {
-          if (!ok) {
-            wtRow.classList.add('disabled');
-            wtBox.disabled = true;
-            wtBox.checked = false;
-            launcherState.useWorktree = false;
-            wtLabel.textContent = 'Worktree (project is not a git repo)';
-          }
-        }).catch(() => {});
+      // In duplicate mode the cwd is fixed to the source session, so
+      // the worktree toggle is meaningless — skip the row entirely.
+      if (!launcherState.duplicateFrom) {
+        const wtRow = document.createElement('label');
+        wtRow.className = 'launcher-worktree';
+        const wtBox = document.createElement('input');
+        wtBox.type = 'checkbox';
+        wtBox.checked = !!launcherState.useWorktree;
+        const wtLabel = document.createElement('span');
+        wtLabel.textContent = 'Create in git worktree';
+        wtRow.append(wtBox, wtLabel);
+        wtBox.addEventListener('change', (e) => {
+          launcherState.useWorktree = e.target.checked;
+          localStorage.setItem('hive.worktree', e.target.checked ? '1' : '0');
+        });
+        launcherEl.appendChild(wtRow);
+        if (projCwd) {
+          IsGitRepo(projCwd).then((ok) => {
+            if (!ok) {
+              wtRow.classList.add('disabled');
+              wtBox.disabled = true;
+              wtBox.checked = false;
+              launcherState.useWorktree = false;
+              wtLabel.textContent = 'Worktree (project is not a git repo)';
+            }
+          }).catch(() => {});
+        }
       }
       // Detection (exec.LookPath on the daemon side) is best-effort:
       // it can miss agents installed as shell aliases, functions, or
@@ -1887,13 +1912,21 @@ function openLauncher(projectId, opts) {
         }
         item.addEventListener('click', () => {
           bumpAgentUsage(a.id);
-          CreateSession(
-            a.id,
-            launcherState.projectId,
-            '', '',
-            0, 0,
-            !!launcherState.useWorktree,
-          );
+          if (launcherState.duplicateFrom) {
+            DuplicateSession(
+              a.id,
+              launcherState.projectId || '',
+              launcherState.duplicateCwd,
+            );
+          } else {
+            CreateSession(
+              a.id,
+              launcherState.projectId,
+              '', '',
+              0, 0,
+              !!launcherState.useWorktree,
+            );
+          }
           closeLauncher();
         });
         item.addEventListener('mouseenter', () => {
@@ -1913,7 +1946,42 @@ function openLauncher(projectId, opts) {
 function closeLauncher() {
   launcherEl.classList.add('hidden');
   launcherState.items = [];
+  launcherState.duplicateFrom = null;
+  launcherState.duplicateCwd = '';
   refocusActiveTerm();
+}
+
+// resolveSessionCwd picks the directory a session is actually running
+// in: its worktree path if any, otherwise the owning project's cwd.
+// Used by ⌘D / ⇧⌘D to fork a session into the same directory.
+function resolveSessionCwd(sess) {
+  if (!sess) return '';
+  if (sess.worktreePath) return sess.worktreePath;
+  const proj = state.projects.find((p) => p.id === sess.projectId);
+  return proj?.cwd ?? '';
+}
+
+function duplicateActiveSession() {
+  const s = state.sessions.find((x) => x.id === state.activeId);
+  if (!s) return;
+  const cwd = resolveSessionCwd(s);
+  if (!cwd) {
+    setStatus('cannot duplicate: source session has no cwd', true);
+    return;
+  }
+  if (s.agent) bumpAgentUsage(s.agent);
+  DuplicateSession(s.agent || '', s.projectId || '', cwd);
+}
+
+function duplicateActiveSessionChooseTool() {
+  const s = state.sessions.find((x) => x.id === state.activeId);
+  if (!s) return;
+  const cwd = resolveSessionCwd(s);
+  if (!cwd) {
+    setStatus('cannot duplicate: source session has no cwd', true);
+    return;
+  }
+  openLauncher(s.projectId, { duplicateFrom: s, duplicateCwd: cwd });
 }
 
 document.addEventListener('click', (e) => {
@@ -2067,6 +2135,10 @@ window.addEventListener('keydown', (e) => {
     swallow();
     if (e.shiftKey) openLauncher(undefined, { forceWorktree: true });
     else openLauncher();
+  } else if (e.key === 'd' || e.key === 'D') {
+    swallow();
+    if (e.shiftKey) duplicateActiveSessionChooseTool();
+    else duplicateActiveSession();
   } else if (e.key === 'Backspace' && e.shiftKey) {
     swallow();
     deleteActiveProject();
@@ -2196,6 +2268,8 @@ function switchToNthSession(n) {
 const menuActions = {
   'menu:new-session': () => openLauncher(),
   'menu:new-session-worktree': () => openLauncher(undefined, { forceWorktree: true }),
+  'menu:duplicate-session': duplicateActiveSession,
+  'menu:duplicate-session-choose-tool': duplicateActiveSessionChooseTool,
   'menu:new-project': () => openProjectEditor(null),
   'menu:delete-project': () => deleteActiveProject(),
   'menu:command-palette': () => openCommandPalette(),

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1953,11 +1953,18 @@ function closeLauncher() {
 
 // resolveSessionCwd picks the directory a session is actually running
 // in: its worktree path if any, otherwise the owning project's cwd.
-// Used by ⌘D / ⇧⌘D to fork a session into the same directory.
+// Used by ⌘P / ⇧⌘P to fork a session into the same directory.
+//
+// Wire payloads from the daemon use snake_case (see
+// internal/wire/control.go), so prefer those and fall back to the
+// camelCase variants for safety — this matches `s.projectId ??
+// s.project_id` used elsewhere in this file.
 function resolveSessionCwd(sess) {
   if (!sess) return '';
-  if (sess.worktreePath) return sess.worktreePath;
-  const proj = state.projects.find((p) => p.id === sess.projectId);
+  const wt = sess.worktree_path ?? sess.worktreePath;
+  if (wt) return wt;
+  const pid = sess.projectId ?? sess.project_id;
+  const proj = state.projects.find((p) => p.id === pid);
   return proj?.cwd ?? '';
 }
 
@@ -1969,8 +1976,9 @@ function duplicateActiveSession() {
     setStatus('cannot duplicate: source session has no cwd', true);
     return;
   }
+  const pid = s.projectId ?? s.project_id ?? '';
   if (s.agent) bumpAgentUsage(s.agent);
-  DuplicateSession(s.agent || '', s.projectId || '', cwd);
+  DuplicateSession(s.agent || '', pid, cwd);
 }
 
 function duplicateActiveSessionChooseTool() {
@@ -1981,7 +1989,8 @@ function duplicateActiveSessionChooseTool() {
     setStatus('cannot duplicate: source session has no cwd', true);
     return;
   }
-  openLauncher(s.projectId, { duplicateFrom: s, duplicateCwd: cwd });
+  const pid = s.projectId ?? s.project_id ?? '';
+  openLauncher(pid, { duplicateFrom: s, duplicateCwd: cwd });
 }
 
 document.addEventListener('click', (e) => {
@@ -2128,17 +2137,14 @@ window.addEventListener('keydown', (e) => {
     });
     return;
   }
-  if ((e.key === 'p' || e.key === 'P') && e.shiftKey) {
+  if (e.key === 'p' || e.key === 'P') {
     swallow();
-    openProjectEditor(null);
+    if (e.shiftKey) duplicateActiveSessionChooseTool();
+    else duplicateActiveSession();
   } else if (e.key === 't' || e.key === 'T') {
     swallow();
     if (e.shiftKey) openLauncher(undefined, { forceWorktree: true });
     else openLauncher();
-  } else if (e.key === 'd' || e.key === 'D') {
-    swallow();
-    if (e.shiftKey) duplicateActiveSessionChooseTool();
-    else duplicateActiveSession();
   } else if (e.key === 'Backspace' && e.shiftKey) {
     swallow();
     deleteActiveProject();

--- a/cmd/hivegui/menu.go
+++ b/cmd/hivegui/menu.go
@@ -37,10 +37,10 @@ func buildAppMenu(a *App) *menu.Menu {
 		keys.Combo("t", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:new-session-worktree"))
 	file.AddText("Duplicate Session",
-		keys.CmdOrCtrl("d"),
+		keys.CmdOrCtrl("p"),
 		emit("menu:duplicate-session"))
 	file.AddText("Duplicate Session (choose tool)…",
-		keys.Combo("d", keys.ShiftKey, keys.CmdOrCtrlKey),
+		keys.Combo("p", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:duplicate-session-choose-tool"))
 	file.AddSeparator()
 	file.AddText("New Window",

--- a/cmd/hivegui/menu.go
+++ b/cmd/hivegui/menu.go
@@ -36,6 +36,12 @@ func buildAppMenu(a *App) *menu.Menu {
 	file.AddText("New Session in Worktree",
 		keys.Combo("t", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:new-session-worktree"))
+	file.AddText("Duplicate Session",
+		keys.CmdOrCtrl("d"),
+		emit("menu:duplicate-session"))
+	file.AddText("Duplicate Session (choose tool)…",
+		keys.Combo("d", keys.ShiftKey, keys.CmdOrCtrlKey),
+		emit("menu:duplicate-session-choose-tool"))
 	file.AddSeparator()
 	file.AddText("New Window",
 		keys.Combo("n", keys.ShiftKey, keys.CmdOrCtrlKey),

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -293,12 +293,30 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 			cwd = p.Cwd
 		}
 	}
+	// Detect when cwd already lives in a worktree owned by another
+	// session in the same project (e.g. ⌘P duplicate). The new entry
+	// adopts that worktree's path+branch so the sidebar shows the
+	// worktree badge and Kill can keep the worktree alive until the
+	// last session in it goes away.
+	var adoptedPath, adoptedBranch string
+	if !spec.UseWorktree && cwd != "" {
+		for _, other := range r.entries {
+			if other.ProjectID == projectID && other.WorktreePath != "" && other.WorktreePath == cwd {
+				adoptedPath = other.WorktreePath
+				adoptedBranch = other.WorktreeBranch
+				break
+			}
+		}
+	}
 	r.mu.Unlock()
 
 	// Pre-resolve the worktree branch+path so the session name can
 	// match the worktree directory. ResolveBranchAndPath only picks a
 	// free name; the actual `git worktree add` happens further down.
 	var wtPath, wtBranch string
+	if adoptedPath != "" {
+		wtPath, wtBranch = adoptedPath, adoptedBranch
+	}
 	if spec.UseWorktree && cwd != "" && worktree.IsGitRepo(cwd) {
 		if root, err := worktree.Root(cwd); err == nil {
 			if b, p, rerr := worktree.ResolveBranchAndPath(root, spec.Branch); rerr == nil {
@@ -375,7 +393,10 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	// project cwd. Aborting create on worktree failure would block
 	// users on marginal repos (shallow clones, sandbox restrictions,
 	// slow filesystems).
-	if wtBranch != "" {
+	// Skip the create when we're adopting an existing worktree from a
+	// sibling session — the directory is already on disk and `git
+	// worktree add` would fail.
+	if wtBranch != "" && adoptedPath == "" {
 		if root, err := worktree.Root(cwd); err == nil {
 			if cerr := worktree.CreateWorktree(root, wtBranch, wtPath); cerr != nil {
 				log.Printf("registry: worktree create failed (falling back to plain session): %v", cerr)
@@ -585,11 +606,26 @@ func (r *Registry) Kill(id string, force bool) error {
 	if p, ok := r.projects[e.ProjectID]; ok {
 		projectCwd = p.Cwd
 	}
+	// Count siblings sharing this worktree. The worktree is only
+	// cleaned up when the LAST session in it is killed — duplicating
+	// (⌘P) creates extra entries that share the same worktree dir.
+	worktreeShared := false
+	if wtPath != "" {
+		for sid, other := range r.entries {
+			if sid != id && other.WorktreePath == wtPath {
+				worktreeShared = true
+				break
+			}
+		}
+	}
 	r.mu.Unlock()
 
 	// Pre-flight safety check on the worktree. Returning here leaves
-	// everything intact so the user can retry with force=true.
-	if wtPath != "" && !force {
+	// everything intact so the user can retry with force=true. Skip
+	// the check when other sessions still live in the worktree —
+	// killing this one won't remove the directory, so dirtiness is
+	// irrelevant.
+	if wtPath != "" && !worktreeShared && !force {
 		dirty, _ := worktree.HasUncommitted(wtPath)
 		if dirty {
 			return ErrWorktreeDirty
@@ -611,6 +647,18 @@ func (r *Registry) Kill(id string, force bool) error {
 			break
 		}
 	}
+	// Re-check sibling count after removing this entry, in case the
+	// world changed during the dirty check. Cleanup only runs when
+	// nobody else lives in the worktree.
+	if wtPath != "" {
+		worktreeShared = false
+		for _, other := range r.entries {
+			if other.WorktreePath == wtPath {
+				worktreeShared = true
+				break
+			}
+		}
+	}
 	// Intentionally NOT renumbering remaining entries here. Orders
 	// were assigned at create time and only change on an explicit
 	// user move. Kill leaves a hole in the sequence (e.g. 0,1,3,4)
@@ -628,7 +676,7 @@ func (r *Registry) Kill(id string, force bool) error {
 	if e.sess != nil {
 		_ = e.sess.Close()
 	}
-	if wtPath != "" {
+	if wtPath != "" && !worktreeShared {
 		root, err := worktree.Root(projectCwd)
 		switch {
 		case err != nil:

--- a/internal/registry/worktree_test.go
+++ b/internal/registry/worktree_test.go
@@ -201,7 +201,7 @@ func TestKill_DirtyWorktree_ForceRemoves(t *testing.T) {
 }
 
 // TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree pins the
-// invariant the GUI's ⌘D / ⇧⌘D shortcut relies on: when the caller
+// invariant the GUI's ⌘P / ⇧⌘P shortcut relies on: when the caller
 // passes Cwd pointing inside an existing worktree with UseWorktree=false,
 // the daemon must reuse that directory and not stack a nested
 // .worktrees/* on top. Regressions here would silently double the
@@ -225,7 +225,7 @@ func TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree(t *testing.T) {
 	time.Sleep(80 * time.Millisecond)
 
 	// Duplicate: explicit cwd inside the existing worktree, UseWorktree
-	// off. This is exactly the wire payload the GUI sends on ⌘D.
+	// off. This is exactly the wire payload the GUI sends on ⌘P.
 	dup, err := r.Create(wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash", Agent: "claude",
 		Cwd: wtPath, UseWorktree: false,

--- a/internal/registry/worktree_test.go
+++ b/internal/registry/worktree_test.go
@@ -201,11 +201,12 @@ func TestKill_DirtyWorktree_ForceRemoves(t *testing.T) {
 }
 
 // TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree pins the
-// invariant the GUI's ⌘P / ⇧⌘P shortcut relies on: when the caller
+// invariants the GUI's ⌘P / ⇧⌘P shortcut relies on: when the caller
 // passes Cwd pointing inside an existing worktree with UseWorktree=false,
-// the daemon must reuse that directory and not stack a nested
-// .worktrees/* on top. Regressions here would silently double the
-// worktree count every time the user duplicates a session.
+// the daemon must (a) NOT stack a nested .worktrees/* on top, and
+// (b) ADOPT the existing worktree's path+branch onto the new entry so
+// the sidebar shows the badge and Kill keeps the worktree alive until
+// the last session in it goes away.
 func TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
@@ -235,8 +236,11 @@ func TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree(t *testing.T) {
 	}
 	defer r.Kill(dup.ID, true)
 
-	if dup.WorktreePath != "" {
-		t.Errorf("duplicate should not own a worktree; got %q", dup.WorktreePath)
+	if dup.WorktreePath != wtPath {
+		t.Errorf("duplicate should adopt source worktree path %q; got %q", wtPath, dup.WorktreePath)
+	}
+	if dup.WorktreeBranch != src.WorktreeBranch {
+		t.Errorf("duplicate should adopt source worktree branch %q; got %q", src.WorktreeBranch, dup.WorktreeBranch)
 	}
 	// No nested .worktrees/ under the source worktree dir.
 	if _, err := os.Stat(filepath.Join(wtPath, ".worktrees")); err == nil {
@@ -252,6 +256,55 @@ func TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree(t *testing.T) {
 	if len(lines) != 2 {
 		t.Errorf("expected 2 worktree entries (main + source), got %d:\n%s",
 			len(lines), out)
+	}
+}
+
+// TestKill_SharedWorktree_KeepsWorktreeUntilLast pins the
+// last-session-wins cleanup rule: when several sessions live in the
+// same worktree (because they were duplicated from one another),
+// killing all but the last must NOT remove the directory. Only the
+// final Kill performs `git worktree remove`.
+func TestKill_SharedWorktree_KeepsWorktreeUntilLast(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	src, err := r.Create(wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create source: %v", err)
+	}
+	wtPath := src.WorktreePath
+	if wtPath == "" {
+		t.Fatalf("expected source to have a worktree")
+	}
+	time.Sleep(80 * time.Millisecond)
+
+	dup, err := r.Create(wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash",
+		Cwd: wtPath, UseWorktree: false,
+	})
+	if err != nil {
+		t.Fatalf("Create dup: %v", err)
+	}
+	time.Sleep(80 * time.Millisecond)
+
+	// Kill the source (sibling still alive in the worktree). The
+	// worktree dir must survive — and the dirty check must be
+	// skipped since dirtiness is irrelevant when others remain.
+	if err := r.Kill(src.ID, false); err != nil {
+		t.Fatalf("Kill src: %v", err)
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("worktree %q removed while sibling still uses it: %v", wtPath, err)
+	}
+
+	// Killing the last sibling cleans up.
+	if err := r.Kill(dup.ID, true); err != nil {
+		t.Fatalf("Kill dup: %v", err)
+	}
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Errorf("worktree %q should be cleaned up after last session; stat err=%v", wtPath, err)
 	}
 }
 

--- a/internal/registry/worktree_test.go
+++ b/internal/registry/worktree_test.go
@@ -200,6 +200,61 @@ func TestKill_DirtyWorktree_ForceRemoves(t *testing.T) {
 	}
 }
 
+// TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree pins the
+// invariant the GUI's ⌘D / ⇧⌘D shortcut relies on: when the caller
+// passes Cwd pointing inside an existing worktree with UseWorktree=false,
+// the daemon must reuse that directory and not stack a nested
+// .worktrees/* on top. Regressions here would silently double the
+// worktree count every time the user duplicates a session.
+func TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	// Source session: spawns a worktree under p.Cwd/.worktrees/<branch>.
+	src, err := r.Create(wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", Agent: "claude", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create source: %v", err)
+	}
+	defer r.Kill(src.ID, true)
+	wtPath := src.WorktreePath
+	if wtPath == "" {
+		t.Fatalf("expected source to have a worktree")
+	}
+	time.Sleep(80 * time.Millisecond)
+
+	// Duplicate: explicit cwd inside the existing worktree, UseWorktree
+	// off. This is exactly the wire payload the GUI sends on ⌘D.
+	dup, err := r.Create(wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", Agent: "claude",
+		Cwd: wtPath, UseWorktree: false,
+	})
+	if err != nil {
+		t.Fatalf("Create dup: %v", err)
+	}
+	defer r.Kill(dup.ID, true)
+
+	if dup.WorktreePath != "" {
+		t.Errorf("duplicate should not own a worktree; got %q", dup.WorktreePath)
+	}
+	// No nested .worktrees/ under the source worktree dir.
+	if _, err := os.Stat(filepath.Join(wtPath, ".worktrees")); err == nil {
+		t.Errorf("nested .worktrees/ created under source worktree at %q", wtPath)
+	}
+	// `git worktree list` should still show exactly two entries (main
+	// + the source's worktree). A nested worktree would show three.
+	out, err := exec.Command("git", "-C", p.Cwd, "worktree", "list").Output()
+	if err != nil {
+		t.Fatalf("git worktree list: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 worktree entries (main + source), got %d:\n%s",
+			len(lines), out)
+	}
+}
+
 func TestRevive_StaleWorktreePath_SelfHeals(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)


### PR DESCRIPTION
## Summary
- ⌘P forks the active session into the same project, cwd, and tool — adopting the source's worktree (no nested worktree gets created), so the sidebar shows the worktree badge on the duplicate.
- ⇧⌘P opens the agent launcher in "duplicate" mode so the user can pick a different tool; the cwd stays pinned to the source.
- Worktree cleanup is deferred until the LAST session in a worktree is killed (sibling sessions sharing a worktree no longer rip the directory out from under each other).
- New thin `DuplicateSession` Wails binding hardcodes `UseWorktree=false`. Daemon's `CreateSpec.Cwd` already supported explicit cwd overrides, so this is mostly a GUI affordance.
- Command palette + File menu entries added for both shortcuts (and ⌘1–⌘9 session switching).
- Regression tests in `internal/registry/worktree_test.go` pin both invariants (adopt-on-duplicate, last-session-out cleanup).

## Files
- `cmd/hivegui/app.go` — `DuplicateSession(agentID, projectID, cwd)` binding
- `cmd/hivegui/menu.go` — File-menu entries for ⌘P and ⇧⌘P
- `cmd/hivegui/frontend/src/main.js` — `resolveSessionCwd` / `duplicateActiveSession[ChooseTool]`, launcher `duplicateFrom` mode (hides worktree toggle, reroutes click), keydown branch, menu event wiring, palette entries
- `internal/registry/registry.go` — adopt source worktree on duplicate; skip cleanup while sibling sessions remain
- `internal/registry/worktree_test.go` — `TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree`, `TestKill_SharedWorktree_KeepsWorktreeUntilLast`
- `CHANGELOG.md` — `[Unreleased]` entry

Auto-focus on the duplicate is inherited from the existing `SessionEventAdded` handler — no extra wiring.

## Test plan
- [x] `go test ./internal/registry/` passes (incl. new tests)
- [x] `go vet ./internal/... ./cmd/hived/...` clean
- [x] `node --check src/main.js` parses cleanly
- [ ] `wails dev` end-to-end:
  - [ ] Worktree session → ⌘P → new session's `pwd` matches source worktree path; no new `.worktrees/<adjective-noun>` created; sidebar shows worktree badge on the duplicate
  - [ ] Plain (no-worktree) session → ⌘P → new session lands in project cwd with same agent
  - [ ] Worktree session → ⇧⌘P → launcher opens without "Create in git worktree" checkbox; pick different agent → lands in same worktree path
  - [ ] Two sessions in one worktree → kill one → worktree dir survives → kill the other → worktree is cleaned up
  - [ ] Menu bar shows "Duplicate Session ⌘P" and "Duplicate Session (choose tool)… ⇧⌘P" under File
  - [ ] Command palette lists Duplicate Session, Duplicate Session (choose tool)…, and Switch to Session 1–9

🤖 Generated with [Claude Code](https://claude.com/claude-code)