### PR TITLE
feat(gui): in-app update-available banner + ⌘D duplicate session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   worktree directory is only cleaned up when the last session in it
   is killed. New entries also appear in the command palette and the
   File menu.
+- GUI: in-app "Update available" banner. The desktop app now polls
+  GitHub releases on load and every 6h, surfacing a banner with a
+  one-click link to the release page when a newer tagged build
+  exists. Manual trigger via File → "Check for Updates…". Untagged
+  dev builds skip the check.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ GOOS=linux GOARCH=amd64 go build -o cmd/hivegui/build/bin/hived ./cmd/hived
 `hivegui` and `hived` must live in the same directory; the GUI
 auto-spawns the daemon at startup.
 
+## Updating
+
+Tagged release builds check GitHub for newer releases automatically:
+once on launch and every six hours. When a newer tag is found, the
+GUI shows an "Update available" banner with a one-click link to the
+release page. The check is also reachable manually from
+**File → Check for Updates…**.
+
+The check is a single anonymous `GET` to
+`api.github.com/repos/lucascaro/hive/releases/latest` (no
+identifying data beyond a `User-Agent: hivegui/<build-id>` header).
+Untagged dev builds — anything built without `./build.sh --version
+<tag>` — skip the check entirely and never call out.
+
 ## Layout
 
 ```

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,15 @@ case "$platform" in
   *) echo "error: --platform must be one of: macos, windows, all" >&2; exit 2 ;;
 esac
 
+# Reject versions with characters that would break the -ldflags
+# string we splice this into. Real release tags are dotted digits
+# with optional pre-release suffixes (e.g. "0.4.1", "1.0.0-rc1") so
+# this is conservative.
+if [[ ! "$version" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+  echo "error: --version contains unsupported characters: $version" >&2
+  exit 2
+fi
+
 if ! command -v wails >/dev/null 2>&1; then
   if [[ -x "$(go env GOPATH)/bin/wails" ]]; then
     export PATH="$(go env GOPATH)/bin:$PATH"
@@ -72,7 +81,14 @@ if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
   build_id="${build_id}-dirty"
 fi
 buildinfo_pkg="github.com/lucascaro/hive/internal/buildinfo"
-echo "==> BuildID: ${build_id}"
+# Stamp both the commit-hash BuildID (always) and the release version
+# (only when --version was passed; otherwise the linker leaves it
+# empty and Version() returns "dev").
+ldflags_id="-X ${buildinfo_pkg}.buildIDOverride=${build_id}"
+if [[ "$version" != "dev" ]]; then
+  ldflags_id="${ldflags_id} -X ${buildinfo_pkg}.versionOverride=${version}"
+fi
+echo "==> BuildID: ${build_id}  Version: ${version}"
 
 build_macos() {
   if ! command -v lipo >/dev/null 2>&1; then
@@ -82,15 +98,15 @@ build_macos() {
 
   echo "==> [macos] Building Wails universal .app"
   ( cd cmd/hivegui && wails build -platform darwin/universal -clean \
-      -ldflags "-X ${buildinfo_pkg}.buildIDOverride=${build_id}" )
+      -ldflags "${ldflags_id}" )
 
   echo "==> [macos] Building hived (universal)"
   mkdir -p .build
   GOOS=darwin GOARCH=amd64 go build -trimpath \
-    -ldflags="-s -w -X ${buildinfo_pkg}.buildIDOverride=${build_id}" \
+    -ldflags="-s -w ${ldflags_id}" \
     -o .build/hived-darwin-amd64 ./cmd/hived
   GOOS=darwin GOARCH=arm64 go build -trimpath \
-    -ldflags="-s -w -X ${buildinfo_pkg}.buildIDOverride=${build_id}" \
+    -ldflags="-s -w ${ldflags_id}" \
     -o .build/hived-darwin-arm64 ./cmd/hived
   lipo -create -output cmd/hivegui/build/bin/hivegui.app/Contents/MacOS/hived \
     .build/hived-darwin-amd64 .build/hived-darwin-arm64
@@ -117,12 +133,12 @@ build_macos() {
 build_windows() {
   echo "==> [windows] Building Wails hivegui.exe (amd64)"
   ( cd cmd/hivegui && wails build -platform windows/amd64 -clean \
-      -ldflags "-X ${buildinfo_pkg}.buildIDOverride=${build_id}" )
+      -ldflags "${ldflags_id}" )
 
   echo "==> [windows] Building hived.exe (amd64)"
   mkdir -p .build
   GOOS=windows GOARCH=amd64 go build -trimpath \
-    -ldflags="-s -w -X ${buildinfo_pkg}.buildIDOverride=${build_id}" \
+    -ldflags="-s -w ${ldflags_id}" \
     -o .build/hived.exe ./cmd/hived
 
   BIN=cmd/hivegui/build/bin

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -101,6 +101,7 @@ func (a *App) startup(ctx context.Context) {
 		go wruntime.EventsEmit(ctx, "bell-click", tag)
 	})
 	go a.persistGeometryLoop(ctx)
+	a.startUpdateCheckLoop(ctx)
 }
 
 func (a *App) shutdown(ctx context.Context) {

--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -13,6 +13,11 @@
     <button id="daemon-banner-restart" type="button">Restart Hive</button>
     <button id="daemon-banner-dismiss" type="button" aria-label="Dismiss">×</button>
   </div>
+  <div id="update-banner" class="hidden" role="status">
+    <span id="update-banner-text"></span>
+    <button id="update-banner-download" type="button">Download</button>
+    <button id="update-banner-dismiss" type="button" aria-label="Dismiss">×</button>
+  </div>
   <aside id="sidebar">
     <header>
       <span class="brand">Hive</span>

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1715,6 +1715,11 @@ function showUpdateBanner(text, { downloadUrl = '', showDownload = true, autoHid
   updateBannerText.textContent = text;
   updateBannerDownload.style.display = showDownload && downloadUrl ? '' : 'none';
   updateBannerEl.dataset.url = downloadUrl;
+  // Clear the per-version dismissal key on every show — only the
+  // "available" branch sets it back. Without this, dismissing a
+  // transient banner ("up to date", "checking…") would write a
+  // stale version into localStorage.
+  delete updateBannerEl.dataset.version;
   updateBannerEl.classList.remove('hidden');
   if (updateBannerAutoHideTimer) {
     clearTimeout(updateBannerAutoHideTimer);
@@ -1759,11 +1764,17 @@ function applyUpdateInfo(info, { manual = false } = {}) {
     let dismissed = '';
     try { dismissed = localStorage.getItem(UPDATE_DISMISS_KEY) || ''; } catch {}
     if (!manual && dismissed === info.latest) return;
+    // info.url is empty when the Go side rejected the release's
+    // html_url for failing the github.com/<repo>/ prefix check
+    // (defense-in-depth against a tampered or spoofed response).
+    // Still tell the user an update exists; just don't expose a
+    // one-click Download for an untrusted target.
+    const trustedURL = !!info.url;
+    const text = trustedURL
+      ? `Hive ${info.latest} is available (you have ${info.current}).`
+      : `Hive ${info.latest} is available (you have ${info.current}). Open releases page manually.`;
+    showUpdateBanner(text, { downloadUrl: info.url });
     updateBannerEl.dataset.version = info.latest;
-    showUpdateBanner(
-      `Hive ${info.latest} is available (you have ${info.current}).`,
-      { downloadUrl: info.url },
-    );
     return;
   }
   if (manual) {
@@ -1774,13 +1785,19 @@ function applyUpdateInfo(info, { manual = false } = {}) {
 
 EventsOn('update:available', (info) => applyUpdateInfo(info));
 
-// Pull once on load. Closes the race where the backend's startup
-// goroutine emits update:available before this listener exists (slow
-// WebView load). The Go side's 5s delay also still fires, but a
-// duplicate result is a no-op here.
+// Pull once on load. The Go side's periodic loop only fires every
+// 6h, so without this the user wouldn't see an "available" banner
+// until 6h after launch.
 CheckForUpdate().then((info) => applyUpdateInfo(info)).catch(() => {});
 
+// Guard against double-firing CheckForUpdate from the menu — clicking
+// "Check for Updates…" repeatedly should not produce N parallel
+// GitHub API calls.
+let updateCheckInFlight = false;
+
 async function manualUpdateCheck() {
+  if (updateCheckInFlight) return;
+  updateCheckInFlight = true;
   showUpdateBanner('Checking for updates…', { showDownload: false });
   try {
     const info = await CheckForUpdate();
@@ -1788,6 +1805,8 @@ async function manualUpdateCheck() {
   } catch (err) {
     showUpdateBanner(`Update check failed: ${err}`,
       { showDownload: false, autoHideMs: UPDATE_TRANSIENT_MS });
+  } finally {
+    updateCheckInFlight = false;
   }
 }
 

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -11,7 +11,7 @@ import {
   CreateProject, KillProject, UpdateProject,
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
   IsGitRepo, OpenURL, OpenTerminalAt, Notify, Confirm,
-  RestartDaemon,
+  RestartDaemon, CheckForUpdate,
 } from '../wailsjs/go/main/App';
 import { EventsOn, WindowSetTitle } from '../wailsjs/runtime/runtime';
 
@@ -1695,6 +1695,102 @@ EventsOn('daemon:stale', (ev) => {
   }
 });
 
+// Update-available banner. Backend's startUpdateCheckLoop emits
+// "update:available" on startup + every 6h when a newer GitHub
+// release tag than buildinfo.Version() is found. The user can also
+// trigger it manually via the "Check for Updates…" menu item, which
+// calls CheckForUpdate() and surfaces *all* outcomes (including
+// "you're up to date" and "skipped: dev build") so the click feels
+// responsive. Dismissals are remembered per-version in localStorage
+// so the 6h tick doesn't re-nag for a release the user has already
+// seen.
+const updateBannerEl = document.getElementById('update-banner');
+const updateBannerText = document.getElementById('update-banner-text');
+const updateBannerDownload = document.getElementById('update-banner-download');
+const updateBannerDismiss = document.getElementById('update-banner-dismiss');
+const UPDATE_DISMISS_KEY = 'hive.updateDismissedFor';
+let updateBannerAutoHideTimer = null;
+
+function showUpdateBanner(text, { downloadUrl = '', showDownload = true, autoHideMs = 0 } = {}) {
+  updateBannerText.textContent = text;
+  updateBannerDownload.style.display = showDownload && downloadUrl ? '' : 'none';
+  updateBannerEl.dataset.url = downloadUrl;
+  updateBannerEl.classList.remove('hidden');
+  if (updateBannerAutoHideTimer) {
+    clearTimeout(updateBannerAutoHideTimer);
+    updateBannerAutoHideTimer = null;
+  }
+  if (autoHideMs > 0) {
+    updateBannerAutoHideTimer = setTimeout(() => {
+      hideUpdateBanner();
+      updateBannerAutoHideTimer = null;
+    }, autoHideMs);
+  }
+}
+function hideUpdateBanner() { updateBannerEl.classList.add('hidden'); }
+
+updateBannerDownload.addEventListener('click', () => {
+  const url = updateBannerEl.dataset.url;
+  if (url) OpenURL(url);
+});
+updateBannerDismiss.addEventListener('click', () => {
+  const v = updateBannerEl.dataset.version || '';
+  if (v) {
+    try { localStorage.setItem(UPDATE_DISMISS_KEY, v); } catch {}
+  }
+  hideUpdateBanner();
+});
+
+// Transient (non-actionable) banners auto-hide so they don't linger
+// after the user has registered the message. The "available" banner
+// stays sticky — it has a Download button the user actually needs.
+const UPDATE_TRANSIENT_MS = 4000;
+
+function applyUpdateInfo(info, { manual = false } = {}) {
+  if (!info) return;
+  if (info.skipped) {
+    if (manual) {
+      showUpdateBanner('Update check skipped — this is a dev build.',
+        { showDownload: false, autoHideMs: UPDATE_TRANSIENT_MS });
+    }
+    return;
+  }
+  if (info.available) {
+    let dismissed = '';
+    try { dismissed = localStorage.getItem(UPDATE_DISMISS_KEY) || ''; } catch {}
+    if (!manual && dismissed === info.latest) return;
+    updateBannerEl.dataset.version = info.latest;
+    showUpdateBanner(
+      `Hive ${info.latest} is available (you have ${info.current}).`,
+      { downloadUrl: info.url },
+    );
+    return;
+  }
+  if (manual) {
+    showUpdateBanner(`Hive ${info.current} is up to date.`,
+      { showDownload: false, autoHideMs: UPDATE_TRANSIENT_MS });
+  }
+}
+
+EventsOn('update:available', (info) => applyUpdateInfo(info));
+
+// Pull once on load. Closes the race where the backend's startup
+// goroutine emits update:available before this listener exists (slow
+// WebView load). The Go side's 5s delay also still fires, but a
+// duplicate result is a no-op here.
+CheckForUpdate().then((info) => applyUpdateInfo(info)).catch(() => {});
+
+async function manualUpdateCheck() {
+  showUpdateBanner('Checking for updates…', { showDownload: false });
+  try {
+    const info = await CheckForUpdate();
+    applyUpdateInfo(info, { manual: true });
+  } catch (err) {
+    showUpdateBanner(`Update check failed: ${err}`,
+      { showDownload: false, autoHideMs: UPDATE_TRANSIENT_MS });
+  }
+}
+
 // User clicked a notification toast. Route to that session in the
 // current view (single keeps single, grid keeps grid) without toggling
 // modes. switchTo handles the view-aware repaint.
@@ -2292,6 +2388,7 @@ const menuActions = {
   'menu:move-session-backward': () => reorderActive(-1),
   'menu:next-project': () => shiftActiveProject(+1),
   'menu:prev-project': () => shiftActiveProject(-1),
+  'menu:check-for-updates': () => manualUpdateCheck(),
 };
 for (const [name, fn] of Object.entries(menuActions)) {
   EventsOn(name, fn);

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -44,15 +44,17 @@ html, body {
 #app {
   display: grid;
   grid-template-columns: var(--sidebar-width, 200px) 1fr;
-  /* Row 1 is the daemon-mismatch banner (collapses to 0 when hidden);
-     row 2 is the normal sidebar + terms layout. */
-  grid-template-rows: auto 1fr;
+  /* Row 1 is the daemon-mismatch banner, row 2 is the update-available
+     banner — both collapse to 0 when hidden. Row 3 is the normal
+     sidebar + terms layout. */
+  grid-template-rows: auto auto 1fr;
   height: 100vh;
   transition: grid-template-columns 120ms ease;
 }
-#sidebar { grid-row: 2; grid-column: 1; }
-#sidebar-resizer { grid-row: 2; grid-column: 1; }
-#terms { grid-row: 2; grid-column: 2; }
+#sidebar { grid-row: 3; grid-column: 1; }
+#sidebar-resizer { grid-row: 3; grid-column: 1; }
+#terms { grid-row: 3; grid-column: 2; }
+#update-banner { grid-row: 2; grid-column: 1 / -1; }
 
 body.resizing-sidebar { cursor: col-resize; user-select: none; }
 body.resizing-sidebar #app { transition: none; }
@@ -858,6 +860,39 @@ body.resizing-sidebar #app { transition: none; }
   padding: 0 6px;
 }
 #daemon-banner button:hover { filter: brightness(1.1); }
+
+/* Update-available banner: same shape as the daemon banner but
+   green-tinted so the two are visually distinct when both are
+   showing (rare, but possible). */
+#update-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  background: #08221a;
+  border-bottom: 1px solid #10b981;
+  color: #b9f1d6;
+  font: 12px Menlo, monospace;
+}
+#update-banner.hidden { display: none; }
+#update-banner #update-banner-text { flex: 1; }
+#update-banner button {
+  background: #10b981;
+  color: #000;
+  border: 0;
+  border-radius: 3px;
+  padding: 4px 10px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+#update-banner #update-banner-dismiss {
+  background: transparent;
+  color: #b9f1d6;
+  font-size: 18px;
+  padding: 0 6px;
+}
+#update-banner button:hover { filter: brightness(1.1); }
 
 /* ---------- command palette ---------- */
 #command-palette {

--- a/cmd/hivegui/menu.go
+++ b/cmd/hivegui/menu.go
@@ -54,6 +54,8 @@ func buildAppMenu(a *App) *menu.Menu {
 	file.AddText("Delete Project…",
 		keys.Combo("backspace", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:delete-project"))
+	file.AddSeparator()
+	file.AddText("Check for Updates…", nil, emit("menu:check-for-updates"))
 
 	m.Append(menu.EditMenu()) // Cut / Copy / Paste / Select All
 

--- a/cmd/hivegui/update.go
+++ b/cmd/hivegui/update.go
@@ -39,8 +39,15 @@ var updateURLPrefix = "https://github.com/" + updateRepo + "/"
 var updateCheckInterval = 6 * time.Hour
 
 // UpdateInfo is the payload of both CheckForUpdate's return value and
-// the "update:available" Wails event. Frontend reads .Available to
-// decide whether to show the banner; .URL goes to OpenURL on click.
+// the "update:available" Wails event.
+//
+// Available means strictly "a newer tagged release than the running
+// build exists" — it does NOT also imply that we trust the URL. URL
+// is set only when the release's html_url passes updateURLPrefix; the
+// frontend renders without a Download button when it's empty so a
+// suspicious response can't push a file:// or javascript: URL into
+// BrowserOpenURL, but the user is still told an update exists rather
+// than being silently rewritten to "up to date".
 type UpdateInfo struct {
 	Available bool   `json:"available"`
 	Current   string `json:"current"`
@@ -67,7 +74,15 @@ func (a *App) CheckForUpdate() (UpdateInfo, error) {
 		return info, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Derive from a.ctx (the Wails runtime context) when set so an
+	// in-flight check is cancelled at shutdown instead of holding the
+	// process for ~5s. Falls back to Background for the rare case
+	// where startup() hasn't run yet.
+	parent := context.Background()
+	if a.ctx != nil {
+		parent = a.ctx
+	}
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, updateReleasesAPI, nil)
 	if err != nil {
@@ -95,7 +110,11 @@ func (a *App) CheckForUpdate() (UpdateInfo, error) {
 	if strings.HasPrefix(rel.HTMLURL, updateURLPrefix) {
 		info.URL = rel.HTMLURL
 	}
-	if latest != "" && info.URL != "" && compareSemver(current, latest) < 0 {
+	// Available reflects ONLY whether there's a newer release. URL
+	// trust is reported separately via info.URL (empty = don't show a
+	// Download button) so a tampered html_url can't silently rewrite
+	// "available" into "up to date".
+	if latest != "" && compareSemver(current, latest) < 0 {
 		info.Available = true
 	}
 	return info, nil

--- a/cmd/hivegui/update.go
+++ b/cmd/hivegui/update.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lucascaro/hive/internal/buildinfo"
+	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// updateRepo is the upstream "owner/repo" used for both the API
+// endpoint and the prefix we accept in the release URL we hand to
+// the OS browser. Forks that want their own update check should
+// patch this one constant (or set updateReleasesAPI + updateURLPrefix
+// directly via an init in a fork-specific file).
+const updateRepo = "lucascaro/hive"
+
+// updateReleasesAPI is the GitHub releases endpoint we poll. Var so
+// tests can point it at a stub server.
+var updateReleasesAPI = "https://api.github.com/repos/" + updateRepo + "/releases/latest"
+
+// updateURLPrefix is the only URL prefix we'll accept from the
+// release JSON's html_url before passing it to the OS browser.
+// Defense in depth: GitHub's html_url is always under github.com,
+// but if the response were ever spoofed (compromised mirror, MITM
+// without TLS, or a future GitHub bug), this stops us from handing
+// a file:// or javascript: URL to BrowserOpenURL.
+var updateURLPrefix = "https://github.com/" + updateRepo + "/"
+
+// updateCheckInterval is how often the background loop re-checks
+// after the initial post-startup probe. Var, not const, so tests can
+// shrink it.
+var updateCheckInterval = 6 * time.Hour
+
+// UpdateInfo is the payload of both CheckForUpdate's return value and
+// the "update:available" Wails event. Frontend reads .Available to
+// decide whether to show the banner; .URL goes to OpenURL on click.
+type UpdateInfo struct {
+	Available bool   `json:"available"`
+	Current   string `json:"current"`
+	Latest    string `json:"latest"`
+	URL       string `json:"url"`
+	// Skipped is true when the running build is "dev" (untagged) — the
+	// frontend uses this to differentiate a real "you're up to date"
+	// from "we can't tell" in the manual-check flow.
+	Skipped bool `json:"skipped"`
+}
+
+// CheckForUpdate hits the GitHub releases API and reports whether a
+// newer tagged release than the running build exists. Bound to Wails
+// so the frontend can trigger a manual check from the menu.
+//
+// Network errors are returned to the caller; a "dev" build is not an
+// error — it returns Skipped=true so the UI can show a sensible
+// message instead of a misleading "up to date".
+func (a *App) CheckForUpdate() (UpdateInfo, error) {
+	current := buildinfo.Version()
+	info := UpdateInfo{Current: current}
+	if current == "dev" {
+		info.Skipped = true
+		return info, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, updateReleasesAPI, nil)
+	if err != nil {
+		return info, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "hivegui/"+buildinfo.BuildID())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return info, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return info, fmt.Errorf("github releases: HTTP %d", resp.StatusCode)
+	}
+	var rel struct {
+		TagName string `json:"tag_name"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return info, fmt.Errorf("decode release: %w", err)
+	}
+	latest := strings.TrimPrefix(rel.TagName, "v")
+	info.Latest = latest
+	if strings.HasPrefix(rel.HTMLURL, updateURLPrefix) {
+		info.URL = rel.HTMLURL
+	}
+	if latest != "" && info.URL != "" && compareSemver(current, latest) < 0 {
+		info.Available = true
+	}
+	return info, nil
+}
+
+// startUpdateCheckLoop runs a periodic background check every
+// updateCheckInterval and emits "update:available" on a positive
+// result. The frontend handles the first-load check itself by
+// calling CheckForUpdate() once on startup, so this loop is only
+// responsible for catching releases that ship while the GUI is
+// running. Failures are logged once and ignored — the next tick
+// will retry.
+func (a *App) startUpdateCheckLoop(ctx context.Context) {
+	go func() {
+		t := time.NewTicker(updateCheckInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				a.runUpdateCheck()
+			}
+		}
+	}()
+}
+
+func (a *App) runUpdateCheck() {
+	info, err := a.CheckForUpdate()
+	if err != nil {
+		log.Printf("hivegui: update check failed: %v", err)
+		return
+	}
+	if info.Available && a.ctx != nil {
+		wruntime.EventsEmit(a.ctx, "update:available", info)
+	}
+}
+
+// compareSemver returns -1 if a < b, 0 if equal, +1 if a > b. Inputs
+// are dotted version strings without a leading "v" (e.g. "1.2.3").
+// Pre-release suffixes (anything after "-") sort *before* the same
+// version with no suffix: "1.0.0-rc1" < "1.0.0".
+//
+// Limitation: pre-release identifiers are compared lexically, so
+// "rc10" sorts BEFORE "rc2". Hive doesn't ship -rcN tags through the
+// release script today; if that ever changes, switch to semver.org
+// rule 11 (numeric identifiers compared numerically).
+//
+// Unparseable components compare as 0 with whatever's been compared
+// so far — so completely garbage input ("foo" vs "bar") returns 0
+// rather than panicking.
+func compareSemver(a, b string) int {
+	aCore, aPre := splitPre(a)
+	bCore, bPre := splitPre(b)
+	aParts := strings.Split(aCore, ".")
+	bParts := strings.Split(bCore, ".")
+	n := len(aParts)
+	if len(bParts) > n {
+		n = len(bParts)
+	}
+	for i := 0; i < n; i++ {
+		var av, bv int
+		if i < len(aParts) {
+			av, _ = strconv.Atoi(aParts[i])
+		}
+		if i < len(bParts) {
+			bv, _ = strconv.Atoi(bParts[i])
+		}
+		if av != bv {
+			if av < bv {
+				return -1
+			}
+			return 1
+		}
+	}
+	// Cores equal; pre-release loses to no-pre-release.
+	switch {
+	case aPre == "" && bPre == "":
+		return 0
+	case aPre == "" && bPre != "":
+		return 1
+	case aPre != "" && bPre == "":
+		return -1
+	default:
+		return strings.Compare(aPre, bPre)
+	}
+}
+
+func splitPre(v string) (core, pre string) {
+	if i := strings.Index(v, "-"); i >= 0 {
+		return v[:i], v[i+1:]
+	}
+	return v, ""
+}

--- a/cmd/hivegui/update_test.go
+++ b/cmd/hivegui/update_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestCompareSemver(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.2.3", "1.2.4", -1},
+		{"1.2.4", "1.2.3", 1},
+		{"1.2.3", "1.2.3", 0},
+		{"1.10.0", "1.9.9", 1},
+		{"1.9.9", "1.10.0", -1},
+		{"2.0.0", "1.99.99", 1},
+		{"1.0.0-rc1", "1.0.0", -1},
+		{"1.0.0", "1.0.0-rc1", 1},
+		{"1.0.0-rc1", "1.0.0-rc2", -1},
+		{"1.0", "1.0.0", 0},
+		{"foo", "bar", 0},
+	}
+	for _, c := range cases {
+		if got := compareSemver(c.a, c.b); got != c.want {
+			t.Errorf("compareSemver(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/cmd/hivegui/update_test.go
+++ b/cmd/hivegui/update_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lucascaro/hive/internal/buildinfo"
+)
 
 func TestCompareSemver(t *testing.T) {
 	cases := []struct {
@@ -23,5 +29,116 @@ func TestCompareSemver(t *testing.T) {
 		if got := compareSemver(c.a, c.b); got != c.want {
 			t.Errorf("compareSemver(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
 		}
+	}
+}
+
+// stubReleases swaps updateReleasesAPI / updateURLPrefix for the
+// duration of one test and restores them on cleanup. The handler is
+// the test's stub for the GitHub releases endpoint.
+func stubReleases(t *testing.T, handler http.HandlerFunc, urlPrefix string) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	prevAPI, prevPrefix := updateReleasesAPI, updateURLPrefix
+	updateReleasesAPI = srv.URL + "/releases/latest"
+	if urlPrefix == "" {
+		updateURLPrefix = srv.URL + "/"
+	} else {
+		updateURLPrefix = urlPrefix
+	}
+	t.Cleanup(func() {
+		updateReleasesAPI = prevAPI
+		updateURLPrefix = prevPrefix
+	})
+}
+
+func TestCheckForUpdate_DevBuildSkipped(t *testing.T) {
+	defer buildinfo.SetVersionForTest("dev")()
+	stubReleases(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("dev build must not call the releases API")
+	}, "")
+	a := &App{}
+	info, err := a.CheckForUpdate()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !info.Skipped || info.Available {
+		t.Fatalf("dev build: want Skipped && !Available, got %+v", info)
+	}
+}
+
+func TestCheckForUpdate_NewerAvailable(t *testing.T) {
+	defer buildinfo.SetVersionForTest("0.4.1")()
+	stubReleases(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v0.5.0","html_url":"` + updateURLPrefix + `releases/tag/v0.5.0"}`))
+	}, "")
+	a := &App{}
+	info, err := a.CheckForUpdate()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !info.Available || info.Latest != "0.5.0" || info.URL == "" {
+		t.Fatalf("want Available=true, Latest=0.5.0, URL set; got %+v", info)
+	}
+}
+
+func TestCheckForUpdate_SameVersionNotAvailable(t *testing.T) {
+	defer buildinfo.SetVersionForTest("0.5.0")()
+	stubReleases(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v0.5.0","html_url":"` + updateURLPrefix + `releases/tag/v0.5.0"}`))
+	}, "")
+	a := &App{}
+	info, err := a.CheckForUpdate()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if info.Available {
+		t.Fatalf("same version: want !Available, got %+v", info)
+	}
+}
+
+func TestCheckForUpdate_BadURLPrefixStillReportsAvailable(t *testing.T) {
+	// Regression: a tampered html_url must NOT silently rewrite
+	// Available=true into Available=false. The URL is dropped (so the
+	// frontend hides the Download button), but the user is still told
+	// an update exists.
+	defer buildinfo.SetVersionForTest("0.4.1")()
+	stubReleases(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v0.5.0","html_url":"file:///etc/passwd"}`))
+	}, "https://github.com/lucascaro/hive/")
+	a := &App{}
+	info, err := a.CheckForUpdate()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !info.Available {
+		t.Fatalf("want Available=true even with bad URL; got %+v", info)
+	}
+	if info.URL != "" {
+		t.Fatalf("want URL='' when prefix fails; got %q", info.URL)
+	}
+}
+
+func TestCheckForUpdate_Non200Errors(t *testing.T) {
+	defer buildinfo.SetVersionForTest("0.4.1")()
+	stubReleases(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}, "")
+	a := &App{}
+	_, err := a.CheckForUpdate()
+	if err == nil {
+		t.Fatal("want error on non-200")
+	}
+}
+
+func TestCheckForUpdate_MalformedJSON(t *testing.T) {
+	defer buildinfo.SetVersionForTest("0.4.1")()
+	stubReleases(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{not json`))
+	}, "")
+	a := &App{}
+	_, err := a.CheckForUpdate()
+	if err == nil {
+		t.Fatal("want error on malformed JSON")
 	}
 }

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -92,6 +92,15 @@ func Version() string {
 	return versionOverride
 }
 
+// SetVersionForTest overrides Version() for the lifetime of the
+// caller's test. Use t.Cleanup with the returned restore function.
+// Tests that mutate this must not run with t.Parallel().
+func SetVersionForTest(value string) (restore func()) {
+	prev := versionOverride
+	versionOverride = value
+	return func() { versionOverride = prev }
+}
+
 func vcsBuildID() string {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -21,6 +21,19 @@ import (
 // feature exists to surface.
 var buildIDOverride = ""
 
+// versionOverride is set at link time to the human-readable release
+// version (e.g. "0.4.1"), e.g.
+//
+//	go build -ldflags "-X github.com/lucascaro/hive/internal/buildinfo.versionOverride=0.4.1"
+//
+// It is set by ./build.sh when invoked with --version, and by
+// scripts/release.sh during a tagged release. Plain `go build` and
+// `./build.sh` (no --version) leave this empty, in which case
+// Version() reports "dev" — the GUI's update checker treats "dev" as
+// "skip update check" so untagged local builds don't get pestered
+// with banners.
+var versionOverride = ""
+
 var (
 	mu       sync.Mutex
 	resolved string
@@ -66,6 +79,17 @@ func BuildID() string {
 	}
 	cached = true
 	return resolved
+}
+
+// Version returns the human-readable release version (e.g. "0.4.1")
+// stamped at link time, or "dev" when unset. Unlike BuildID this is
+// suitable for comparing against a remote release tag — see the GUI
+// update checker.
+func Version() string {
+	if versionOverride == "" {
+		return "dev"
+	}
+	return versionOverride
 }
 
 func vcsBuildID() string {


### PR DESCRIPTION
## Summary

Two GUI features landing together on this branch:

- **In-app update-available banner.** The desktop app polls GitHub releases on load and every 6h, surfacing a banner with a one-click link to the release page when a newer tag exists. Manual check via **File → Check for Updates…**. Untagged dev builds skip the check. Per-version dismissals persist in `localStorage`. URL handed to the OS browser is validated to start with `https://github.com/lucascaro/hive/` as defense in depth.
- **Duplicate Session** via ⌘D / ⇧⌘D (pre-existing commit on this branch — `6886305`).

The release banner relies on a new `buildinfo.Version()` stamped via `build.sh --version <tag>` (already wired by `scripts/release.sh`).

## Test plan

- [ ] `go build ./...` clean
- [ ] `go test ./cmd/hivegui/... ./internal/...` green (incl. new `TestCompareSemver`)
- [ ] `./build.sh --version 0.0.1 --open` → banner appears within ~5s, **Download** opens the real release page in the system browser
- [ ] `./build.sh --version 999.0.0 --open` → no banner; **File → Check for Updates…** shows "up to date" (auto-hides after 4s)
- [ ] Plain `./build.sh` (no `--version`) → no banner, no network call; manual check shows "skipped — dev build"
- [ ] Offline launch → no banner, no crash; check failure logged
- [ ] Dismiss banner → relaunch within same release window keeps it dismissed; new release re-surfaces it
- [ ] Daemon-stale banner and update-available banner both visible simultaneously stack cleanly
- [ ] Duplicate Session: ⌘D duplicates current session with same agent; ⇧⌘D opens tool picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)