### PR TITLE
feat(gui): restart session command (resume same conversation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- GUI: Restart Session command (palette + File menu) recycles the
+  active session's agent process in place. The sidebar slot, name,
+  color, order, and worktree are preserved; the agent is relaunched
+  with its resume flag (`claude --continue`, `codex resume --last`,
+  etc.) so the prior conversation is picked back up. Useful for
+  picking up new skills/config without losing state.
 - GUI: ⌘P duplicates the active session into the same cwd/worktree;
   ⇧⌘P opens the launcher pinned to that cwd to pick a different tool.
   The duplicate adopts the source's worktree (no nested `.worktrees/*`

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -489,6 +489,21 @@ func (a *App) KillSession(id string, force bool) error {
 	})
 }
 
+// RestartSession asks the daemon to recycle the agent process for
+// the given session in place. The session entry (name/color/order/
+// worktree) is preserved; the new process uses the agent's resume
+// flag (e.g. `claude --continue`) when available so the prior
+// conversation is picked back up.
+func (a *App) RestartSession(id string) error {
+	cs, err := a.requireControl()
+	if err != nil {
+		return err
+	}
+	return cs.writeJSON(wire.FrameRestartSession, wire.RestartSessionReq{
+		SessionID: id,
+	})
+}
+
 // IsGitRepo reports whether path is inside a git repository. The GUI
 // uses this to gate the launcher's worktree checkbox.
 func (a *App) IsGitRepo(path string) bool {

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1504,6 +1504,13 @@ function processAliveTransition(info) {
       try { t.term.reset(); } catch {}
       t.attached = false;
       t.setDead(false);
+      // Restart leaves the cached SessionTerm detached. If it's currently
+      // visible (single-mode active, or any tile in grid), re-attach now —
+      // otherwise the user only sees output after switching away and back.
+      const visible =
+        (state.view === 'single' && state.activeId === info.id) ||
+        (state.view !== 'single' && t.host.classList.contains('in-grid'));
+      if (visible) t.ensureAttached();
     }
   }
 }

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -7,7 +7,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import {
   ConnectControl, OpenSession, CloseAttach,
   WriteStdin, ResizeSession,
-  CreateSession, DuplicateSession, KillSession, UpdateSession, ListAgents,
+  CreateSession, DuplicateSession, KillSession, RestartSession, UpdateSession, ListAgents,
   CreateProject, KillProject, UpdateProject,
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
   IsGitRepo, OpenURL, OpenTerminalAt, Notify, Confirm,
@@ -2096,6 +2096,15 @@ function duplicateActiveSession() {
   DuplicateSession(s.agent || '', pid, cwd);
 }
 
+function restartActiveSession() {
+  const s = state.sessions.find((x) => x.id === state.activeId);
+  if (!s) {
+    setStatus('no active session to restart', true);
+    return;
+  }
+  RestartSession(s.id);
+}
+
 function duplicateActiveSessionChooseTool() {
   const s = state.sessions.find((x) => x.id === state.activeId);
   if (!s) return;
@@ -2391,6 +2400,7 @@ const menuActions = {
   'menu:new-session-worktree': () => openLauncher(undefined, { forceWorktree: true }),
   'menu:duplicate-session': duplicateActiveSession,
   'menu:duplicate-session-choose-tool': duplicateActiveSessionChooseTool,
+  'menu:restart-session': restartActiveSession,
   'menu:new-project': () => openProjectEditor(null),
   'menu:delete-project': () => deleteActiveProject(),
   'menu:command-palette': () => openCommandPalette(),
@@ -2449,6 +2459,7 @@ const paletteCommands = [
   { id: 'new-session-worktree', name: 'New Session in Worktree',     shortcut: '⇧⌘T',    run: () => openLauncher(undefined, { forceWorktree: true }) },
   { id: 'duplicate-session',    name: 'Duplicate Session',           shortcut: '⌘P',     run: duplicateActiveSession },
   { id: 'duplicate-session-choose-tool', name: 'Duplicate Session (choose tool)…', shortcut: '⇧⌘P', run: duplicateActiveSessionChooseTool },
+  { id: 'restart-session',      name: 'Restart Session',             shortcut: '',       run: restartActiveSession },
   { id: 'delete-project',       name: 'Delete Active Project…',      shortcut: '⇧⌘⌫',    run: () => deleteActiveProject() },
   { id: 'close-session',        name: 'Close Session',               shortcut: '⌘W',     run: () => { if (state.activeId) KillSession(state.activeId, false); } },
   { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch((err) => setStatus(`window failed: ${err}`, true)) },

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -205,6 +205,12 @@ class SessionTerm {
     });
 
     this.attached = false;
+    // needsReattach is set by pty:disconnect when our attach connection
+    // drops (e.g. Restart Session closes the daemon-side PTY). The next
+    // session:event(updated, alive=true) consumes the flag and triggers
+    // ensureAttached so the new PTY's stream resumes without the user
+    // having to switch sessions and back.
+    this.needsReattach = false;
     this.phase = 'replay';
 
     // Track the OSC-set window title from the running TUI (vim, htop,
@@ -1504,13 +1510,6 @@ function processAliveTransition(info) {
       try { t.term.reset(); } catch {}
       t.attached = false;
       t.setDead(false);
-      // Restart leaves the cached SessionTerm detached. If it's currently
-      // visible (single-mode active, or any tile in grid), re-attach now —
-      // otherwise the user only sees output after switching away and back.
-      const visible =
-        (state.view === 'single' && state.activeId === info.id) ||
-        (state.view !== 'single' && t.host.classList.contains('in-grid'));
-      if (visible) t.ensureAttached();
     }
   }
 }
@@ -1569,6 +1568,20 @@ EventsOn('session:event', (jsonStr) => {
       const pid = ev.session.projectId ?? ev.session.project_id;
       const proj = state.projects.find((p) => p.id === pid);
       st.setProject(proj?.name ?? '', proj?.color ?? '');
+      // Restart Session path: pty:disconnect already flipped attached
+      // off and set needsReattach. Now that the daemon has confirmed
+      // a fresh alive=true PTY, reattach the visible term so its
+      // resumed stream starts flowing without a manual switch.
+      // Hidden terms are left dirty; switchTo/showSingle/renderGrid
+      // will ensureAttached when they next become visible.
+      if (st.needsReattach && ev.session.alive) {
+        st.needsReattach = false;
+        try { st.term.reset(); } catch {}
+        const visible =
+          (state.view === 'single' && state.activeId === ev.session.id) ||
+          (state.view !== 'single' && st.host.classList.contains('in-grid'));
+        if (visible) st.ensureAttached();
+      }
     }
     if (state.activeId === ev.session.id) updateAppTitle();
   }
@@ -1602,7 +1615,13 @@ EventsOn('pty:event', (id, jsonStr) => {
 
 EventsOn('pty:disconnect', (id) => {
   const st = state.terms.get(id);
-  if (st) st.attached = false;
+  if (st) {
+    st.attached = false;
+    // Mark the term as needing reattach. Restart Session closes the
+    // daemon-side PTY (which lands here) and respawns; the subsequent
+    // session:event(updated, alive=true) is where we re-OpenSession.
+    st.needsReattach = true;
+  }
 });
 
 EventsOn('pty:error', (id, jsonStr) => {

--- a/cmd/hivegui/menu.go
+++ b/cmd/hivegui/menu.go
@@ -42,6 +42,7 @@ func buildAppMenu(a *App) *menu.Menu {
 	file.AddText("Duplicate Session (choose tool)…",
 		keys.Combo("p", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:duplicate-session-choose-tool"))
+	file.AddText("Restart Session", nil, emit("menu:restart-session"))
 	file.AddSeparator()
 	file.AddText("New Window",
 		keys.Combo("n", keys.ShiftKey, keys.CmdOrCtrlKey),

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,6 +7,7 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
+| 1 | —     | [Resume conversations on daemon restart](active/resume-on-daemon-restart.md) | TRIAGE | M |
 
 ## Rejected
 

--- a/features/active/resume-on-daemon-restart.md
+++ b/features/active/resume-on-daemon-restart.md
@@ -1,0 +1,52 @@
+# Feature: Resume conversations on daemon restart
+
+- **GitHub Issue:** —
+- **Stage:** TRIAGE
+- **Type:** enhancement
+- **Complexity:** M
+- **Priority:** —
+- **Branch:** —
+
+## Description
+
+When `hived` restarts (manually or via `RestartDaemon`), persisted
+sessions are revived but the agent process starts fresh — the prior
+conversation is lost from the user's POV. The Restart Session feature
+already plumbs per-agent resume commands (`ResumeCmd` on `agent.Def`);
+this extends that to `Registry.Revive` so daemon restarts also recover
+state.
+
+## Why this is not a one-liner
+
+Flipping `Revive` to use `ResumeCmd` is trivial but **wrong for
+duplicated sessions**: `claude --continue` / `codex resume --last`
+resume the most recent conversation *in the cwd*, not the most
+recent conversation for that specific hive session. Two hive sessions
+sharing a project cwd (e.g. via ⌘P duplicate) would both revive onto
+the same agent conversation.
+
+To do it right we need a per-hive-session conversation ID.
+
+## Plan sketch
+
+1. Capture the agent's conversation ID at runtime (each agent stores
+   it differently — Claude writes JSONL under `~/.claude/projects/<cwd>/`,
+   Codex similar). Probably a per-agent `ResumeIDLocator` func that
+   scans the on-disk store for the most recent file modified since
+   the session started.
+2. Persist `ConversationID` on `registry.MetaFile` (and the in-memory
+   `Entry`).
+3. Extend each `agent.Def` with a `ResumeWithIDCmd(id) []string`
+   builder so resume can be `claude --resume <id>` instead of
+   `--continue`.
+4. `Revive` uses `ResumeWithIDCmd(e.ConversationID)` when set,
+   falling back to plain `Cmd` (fresh start, no resume).
+5. `Restart` (already shipped) can opt into the same per-session ID
+   path once it's wired.
+
+## Open questions
+
+- Aider and Copilot may not expose a usable conversation ID. Acceptable
+  to leave them on plain `Cmd` for revive.
+- When does the locator run? Probably on session exit / write activity,
+  not at revive time (the agent process is already gone by then).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,6 +29,7 @@ type Def struct {
 	ID         ID       // canonical identifier; persisted in session metadata
 	Name       string   // display name shown in the launcher
 	Cmd        []string // argv; first element is resolved via PATH at spawn
+	ResumeCmd  []string // argv used by Restart; falls back to Cmd if empty
 	Color      string   // default sidebar color
 	InstallCmd []string // shown to the user when not detected; never auto-run
 }
@@ -56,6 +57,7 @@ var (
 			ID:         IDClaude,
 			Name:       "Claude",
 			Cmd:        []string{"claude"},
+			ResumeCmd:  []string{"claude", "--continue"},
 			Color:      "#f59e0b",
 			InstallCmd: []string{"npm", "install", "-g", "@anthropic-ai/claude-code"},
 		},
@@ -63,6 +65,7 @@ var (
 			ID:         IDCodex,
 			Name:       "Codex",
 			Cmd:        []string{"codex"},
+			ResumeCmd:  []string{"codex", "resume", "--last"},
 			Color:      "#10b981",
 			InstallCmd: []string{"npm", "install", "-g", "@openai/codex"},
 		},
@@ -70,6 +73,7 @@ var (
 			ID:         IDGemini,
 			Name:       "Gemini",
 			Cmd:        []string{"gemini"},
+			ResumeCmd:  []string{"gemini", "--continue"},
 			Color:      "#3b82f6",
 			InstallCmd: []string{"npm", "install", "-g", "@google/gemini-cli"},
 		},
@@ -77,6 +81,7 @@ var (
 			ID:         IDCopilot,
 			Name:       "Copilot",
 			Cmd:        []string{"copilot"},
+			ResumeCmd:  []string{"copilot", "--resume"},
 			Color:      "#8b5cf6",
 			InstallCmd: []string{"npm", "install", "-g", "@github/copilot"},
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -315,6 +315,15 @@ func (d *Daemon) serveControl(conn net.Conn) {
 					sendError("kill_failed", err.Error())
 				}
 			}
+		case wire.FrameRestartSession:
+			var req wire.RestartSessionReq
+			if err := jsonUnmarshal(payload, &req); err != nil {
+				sendError("bad_payload", err.Error())
+				continue
+			}
+			if err := d.reg.Restart(req.SessionID); err != nil {
+				sendError("restart_failed", err.Error())
+			}
 		case wire.FrameUpdateSession:
 			var req wire.UpdateSessionReq
 			if err := jsonUnmarshal(payload, &req); err != nil {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -550,7 +550,6 @@ func (r *Registry) Restart(id string) error {
 	}
 	sess := e.sess
 	agentID := e.Agent
-	wtPath := e.WorktreePath
 	projectCwd := ""
 	if p, ok := r.projects[e.ProjectID]; ok {
 		projectCwd = p.Cwd
@@ -581,11 +580,11 @@ func (r *Registry) Restart(id string) error {
 			opts.Cmd = def.Cmd
 		}
 	}
-	if wtPath != "" {
-		opts.Cwd = wtPath
-	} else {
-		opts.Cwd = projectCwd
-	}
+	// Pass the project cwd as the fallback. Revive promotes opts.Cwd to
+	// wtPath when the worktree directory still exists; if the user removed
+	// it out-of-band, Revive's self-heal clears the worktree fields but
+	// leaves opts.Cwd alone — projectCwd is what session.Start should use.
+	opts.Cwd = projectCwd
 
 	return r.Revive(id, opts)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -529,6 +529,67 @@ func (r *Registry) Revive(id string, opts session.Options) error {
 	return nil
 }
 
+// Restart terminates the agent process running in the session and
+// respawns it in place. The Entry (its ID, Name, Color, Order, and
+// worktree binding) is preserved — only the underlying PTY/process
+// is recycled. If the agent has a ResumeCmd defined we use it so
+// the new process picks up the prior conversation; otherwise we
+// fall back to the agent's normal Cmd. If the session is already
+// dead (e.sess == nil) we just respawn.
+//
+// Use cases:
+//   - User updated agent skills/config and wants the agent to
+//     re-read them without losing the conversation.
+//   - (Future) recovering after RestartDaemon.
+func (r *Registry) Restart(id string) error {
+	r.mu.Lock()
+	e, ok := r.entries[id]
+	if !ok {
+		r.mu.Unlock()
+		return ErrNotFound
+	}
+	sess := e.sess
+	agentID := e.Agent
+	wtPath := e.WorktreePath
+	projectCwd := ""
+	if p, ok := r.projects[e.ProjectID]; ok {
+		projectCwd = p.Cwd
+	}
+	r.mu.Unlock()
+
+	// Tear down the current PTY. watchSessionExit also observes the
+	// close, but it races with our Revive call below — Revive's
+	// "already alive" guard short-circuits if e.sess hasn't been
+	// cleared yet. Wait for the readLoop to drain, then clear e.sess
+	// ourselves under the lock so Revive sees a vacant slot.
+	// watchSessionExit will then no-op (it checks e.sess == sess).
+	if sess != nil {
+		_ = sess.Close()
+		<-sess.Done()
+		r.mu.Lock()
+		if e2, ok := r.entries[id]; ok && e2.sess == sess {
+			e2.sess = nil
+		}
+		r.mu.Unlock()
+	}
+
+	var opts session.Options
+	if def, ok := agent.Get(agent.ID(agentID)); ok {
+		if len(def.ResumeCmd) > 0 {
+			opts.Cmd = def.ResumeCmd
+		} else {
+			opts.Cmd = def.Cmd
+		}
+	}
+	if wtPath != "" {
+		opts.Cwd = wtPath
+	} else {
+		opts.Cwd = projectCwd
+	}
+
+	return r.Revive(id, opts)
+}
+
 // Adopt registers an externally-started session under the given
 // metadata. Used by the daemon for its bootstrap session in Phase 2
 // transitional code (before the GUI calls CREATE_SESSION explicitly).

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -123,6 +123,48 @@ func TestSessionExitBroadcastsDead(t *testing.T) {
 	}
 }
 
+func TestRestart_PreservesEntry(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	a, err := r.Create(wire.CreateSpec{Name: "alpha", Color: "#abc", Shell: "/bin/bash"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	origSess := a.Session()
+	if origSess == nil {
+		t.Fatalf("expected live session before restart")
+	}
+
+	if err := r.Restart(a.ID); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	got := r.List()
+	if len(got) != 1 || got[0].ID != a.ID {
+		t.Fatalf("expected single entry with same ID after restart, got %+v", got)
+	}
+	if got[0].Name != "alpha" || got[0].Color != "#abc" {
+		t.Errorf("entry metadata changed after restart: %+v", got[0])
+	}
+	if !got[0].Alive {
+		t.Errorf("entry should be alive after restart")
+	}
+
+	// The original session should have been closed and replaced.
+	select {
+	case <-origSess.Done():
+	case <-time.After(2 * time.Second):
+		t.Errorf("original session never exited")
+	}
+	r.mu.Lock()
+	newSess := r.entries[a.ID].sess
+	r.mu.Unlock()
+	if newSess == nil || newSess == origSess {
+		t.Errorf("expected a fresh session after restart")
+	}
+}
+
 func TestUpdateRenameAndColor(t *testing.T) {
 	skipOnWindows(t)
 	r := freshRegistry(t)

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -105,6 +105,14 @@ type KillSessionReq struct {
 	Force     bool   `json:"force,omitempty"`
 }
 
+// RestartSessionReq is the RESTART_SESSION payload. The daemon
+// terminates the agent process in place (preserving the session
+// entry, its name/color/order/worktree) and respawns it using the
+// agent's ResumeCmd if defined, otherwise its Cmd.
+type RestartSessionReq struct {
+	SessionID string `json:"session_id"`
+}
+
 // UpdateSessionReq mutates session metadata. Pointer fields are
 // "omit if not setting". Order is *int because 0 is a valid value
 // and we need to distinguish "no change" from "set to zero".

--- a/internal/wire/frame.go
+++ b/internal/wire/frame.go
@@ -59,6 +59,8 @@ const (
 	FrameKillProject   FrameType = 0x10 // C → S, JSON, control
 	FrameUpdateProject FrameType = 0x11 // C → S, JSON, control
 	FrameProjectEvent  FrameType = 0x12 // S → C, JSON, control
+
+	FrameRestartSession FrameType = 0x13 // C → S, JSON, control
 )
 
 func (t FrameType) String() string {
@@ -99,6 +101,8 @@ func (t FrameType) String() string {
 		return "UPDATE_PROJECT"
 	case FrameProjectEvent:
 		return "PROJECT_EVENT"
+	case FrameRestartSession:
+		return "RESTART_SESSION"
 	default:
 		return fmt.Sprintf("UNKNOWN(0x%02x)", byte(t))
 	}


### PR DESCRIPTION
## Summary

- Adds a **Restart Session** command (command palette + File menu) that recycles the active session's agent process in place. The sidebar slot, name, color, order, and worktree binding are preserved; the agent is relaunched with its resume flag (`claude --continue`, `codex resume --last`, `gemini --continue`, `copilot --resume`) so the prior conversation is picked back up.
- Useful when you've added a skill or changed agent config and want to bounce just that one agent without losing the conversation.
- Also lays groundwork for recovering conversations after a daemon restart — tracked as a follow-up in `features/active/resume-on-daemon-restart.md` (needs per-session conversation IDs to handle duplicated sessions correctly).

### How it works

- `agent.Def` gets a `ResumeCmd` field. Empty falls back to `Cmd`, so unverified agents still get a fresh start.
- `registry.Restart(id)` closes the live PTY, waits for `Done()`, clears `e.sess` under the lock to dodge a race with `watchSessionExit`, then calls `Revive` with the agent's `ResumeCmd`. No worktree cleanup, no entry removal.
- New wire frame `FrameRestartSession` (0x13) + `RestartSessionReq{SessionID}`. Daemon dispatch + Wails binding + frontend palette/menu entry.

## Test plan

- [x] `go test ./internal/...` — all green; new `TestRestart_PreservesEntry` covers entry preservation + fresh PTY
- [ ] Build the GUI (`./build.sh`) and manually verify:
  - [ ] Claude session: start, send a message, palette → Restart Session, confirm conversation continues (`claude --continue`)
  - [ ] Codex session: same flow with `codex resume --last`
  - [ ] Shell session: restart relaunches a fresh shell cleanly
  - [ ] Worktree-backed session: cwd stays in the worktree, no `git worktree remove` runs
  - [ ] Dead session (`e.sess == nil`): restart respawns without erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)