### PR TITLE
fix(registry): revive sessions in project cwd, not daemon launch dir

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -465,6 +465,13 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 // agent ID is unknown (e.g. a future agent rolled back), we fall back
 // to a generic shell.
 //
+// The cwd is taken from the entry's project (overridden by the
+// worktree path when one exists). The caller's opts.Cwd is ignored
+// when the entry has a project — daemon startup has no useful cwd
+// to contribute, and using the daemon's launch dir leads to PATH
+// resolution failures (e.g. project-local `node_modules/.bin`
+// symlinks like `codex` won't be found if revive runs from `/`).
+//
 // Note: Phase 1.7 (disk-backed scrollback) will replay prior content
 // on revive. Today the slot is preserved but starts blank.
 func (r *Registry) Revive(id string, opts session.Options) error {
@@ -480,12 +487,20 @@ func (r *Registry) Revive(id string, opts session.Options) error {
 	}
 	agentID := e.Agent
 	wtPath := e.WorktreePath
+	projectCwd := ""
+	if p, ok := r.projects[e.ProjectID]; ok {
+		projectCwd = p.Cwd
+	}
 	r.mu.Unlock()
 
 	if agentID != "" && len(opts.Cmd) == 0 {
 		if def, ok := agent.Get(agent.ID(agentID)); ok && len(def.Cmd) > 0 {
 			opts.Cmd = def.Cmd
 		}
+	}
+
+	if projectCwd != "" {
+		opts.Cwd = projectCwd
 	}
 
 	// If the entry is supposed to live in a worktree, prefer the

--- a/internal/registry/worktree_test.go
+++ b/internal/registry/worktree_test.go
@@ -347,3 +347,38 @@ func TestRevive_StaleWorktreePath_SelfHeals(t *testing.T) {
 	// Cleanup the new live session.
 	_ = r.Kill(e.ID, true)
 }
+
+// Revive must use the entry's project cwd, ignoring whatever cwd
+// the caller passed in opts. This matches the daemon-startup case
+// where hived's launch dir (often `/`) is meaningless and using it
+// breaks PATH resolution for project-local binaries (e.g. a
+// `node_modules/.bin/codex` symlink installed by `npm ci`).
+func TestRevive_UsesProjectCwd_NotCallerOpts(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	e, err := r.Create(wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	time.Sleep(80 * time.Millisecond)
+
+	// Pretend the daemon restarted: detach the live session.
+	if e.sess != nil {
+		_ = e.sess.Close()
+		r.mu.Lock()
+		e.sess = nil
+		r.mu.Unlock()
+	}
+
+	// Pass a bogus cwd that does not exist. If Revive honored it,
+	// session.Start would fail with ENOENT. If Revive correctly
+	// substitutes the project cwd, the session starts cleanly.
+	bogus := filepath.Join(t.TempDir(), "does", "not", "exist")
+	if err := r.Revive(e.ID, session.Options{Shell: "/bin/bash", Cwd: bogus}); err != nil {
+		t.Fatalf("Revive: %v (expected project cwd to override bogus opts.Cwd)", err)
+	}
+	_ = r.Kill(e.ID, true)
+}


### PR DESCRIPTION
## Summary
- Revived sessions on daemon startup were spawning in the hived process's launch dir (often `/` when launched from the GUI/launchd), not the session's project cwd.
- Fish then couldn't find project-local binaries — e.g. `codex` installed by `npm ci` as a `node_modules/.bin` symlink — and reported `codex not found`. Sessions created after the restart worked because `Create` already passes the project cwd.
- `Revive` now mirrors `Restart`: it looks up the entry's project cwd and uses it as `opts.Cwd`. Worktree path still takes precedence. The caller's `opts.Cwd` is ignored when the entry has a project (the daemon-startup caller has no useful cwd to contribute).

## Test plan
- [x] `go test ./...` — all packages green
- [x] New regression test `TestRevive_UsesProjectCwd_NotCallerOpts` passes a bogus `opts.Cwd`; if Revive honored it, `session.Start` would ENOENT — instead it succeeds because project cwd takes over
- [ ] Manual repro on the affected machine: stop hived, restart it from `/`, confirm revived codex session no longer prints `codex not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)