### PR TITLE
fix(gui): stop grid viewport from jumping on keyboard nav and resize

### DIFF
--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -437,6 +437,12 @@ class SessionTerm {
       ResizeSession(this.info.id, this.term.cols, this.term.rows);
     }
     if (wasAtBottom) {
+      // Sync re-pin so the same frame that paints the post-fit
+      // geometry also paints the corrected viewport — without this
+      // the user sees a one-frame "jump" on every refit. The rAF
+      // re-pin is a backstop in case fit's resize completes async
+      // and bumps the viewport again after the sync call.
+      this.term.scrollToBottom();
       requestAnimationFrame(() => this.term.scrollToBottom());
     }
   }
@@ -1086,6 +1092,11 @@ function showSingle(id) {
     else st.hide();
     st.host.classList.remove('in-grid', 'active');
   }
+  // Invalidate the grid geometry cache. Tiles get resized to fill
+  // the single-mode container while we're here, so the next
+  // renderGrid must run a refit pass even if the (rows, cols, w, h)
+  // it computes happens to match the last grid render.
+  gridLayout.geomKey = '';
   const st = id ? state.terms.get(id) : null;
   if (st) st.ensureAttached();
 }
@@ -1170,7 +1181,7 @@ function switchToProject(pid) {
 // to recompute. assignments[i] = { row, col, rowSpan } — tiles above
 // last-row empty cells extend downward to fill the grid (matches
 // current Hive's behavior). cellMap[row*cols + col] = session index.
-let gridLayout = { rows: 1, cols: 1, sessions: [], assignments: [], cellMap: [] };
+let gridLayout = { rows: 1, cols: 1, sessions: [], assignments: [], cellMap: [], geomKey: '' };
 
 // computeGridDims picks (rows, cols) that fills the container without
 // scrolling, biasing tile aspect toward typical terminal proportions
@@ -1281,14 +1292,22 @@ function renderGrid() {
     }
   }
 
-  gridLayout = { rows, cols, sessions: gridSessions, assignments, cellMap };
+  // Skip the refit pass when geometry is unchanged. Pure active-tile
+  // swaps (keyboard nav inside grid mode) don't resize anything but
+  // would otherwise call fit.fit() on every tile — and fit.fit()
+  // perturbs xterm's viewport for one frame, which the user sees as
+  // the active session "jumping up" on each arrow press.
+  const geomKey = `${rows}x${cols}@${w}x${h}:${n}`;
+  const geomChanged = geomKey !== gridLayout.geomKey;
+  gridLayout = { rows, cols, sessions: gridSessions, assignments, cellMap, geomKey };
 
-  // Refit each visible tile after the layout settles.
-  requestAnimationFrame(() => {
-    for (const info of gridSessions) {
-      state.terms.get(info.id)?.refit();
-    }
-  });
+  if (geomChanged) {
+    requestAnimationFrame(() => {
+      for (const info of gridSessions) {
+        state.terms.get(info.id)?.refit();
+      }
+    });
+  }
 }
 
 // setActive centralizes "the focused session changed" so every code

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -441,7 +441,8 @@ class SessionTerm {
       // geometry also paints the corrected viewport — without this
       // the user sees a one-frame "jump" on every refit. The rAF
       // re-pin is a backstop in case fit's resize completes async
-      // and bumps the viewport again after the sync call.
+      // and bumps the viewport again after the sync call. Both
+      // calls are intentional; do not collapse to one.
       this.term.scrollToBottom();
       requestAnimationFrame(() => this.term.scrollToBottom());
     }
@@ -1296,8 +1297,11 @@ function renderGrid() {
   // swaps (keyboard nav inside grid mode) don't resize anything but
   // would otherwise call fit.fit() on every tile — and fit.fit()
   // perturbs xterm's viewport for one frame, which the user sees as
-  // the active session "jumping up" on each arrow press.
-  const geomKey = `${rows}x${cols}@${w}x${h}:${n}`;
+  // the active session "jumping up" on each arrow press. The session
+  // id list is part of the key so a project / scope swap that lands
+  // on the same (rows, cols, w, h) still triggers refit — newly
+  // visible tiles may have stale xterm dimensions from a prior view.
+  const geomKey = `${rows}x${cols}@${w}x${h}:${gridSessions.map((s) => s.id).join(',')}`;
   const geomChanged = geomKey !== gridLayout.geomKey;
   gridLayout = { rows, cols, sessions: gridSessions, assignments, cellMap, geomKey };
 


### PR DESCRIPTION
## Summary
- `renderGrid` now skips the per-tile `fit.fit()` pass when grid geometry is unchanged. Arrow-key nav between tiles no longer perturbs xterm's viewport, which was visible as the active session "jumping up" on each arrow press (and sticking on tiles with stale `_userScrolling`).
- `refit` re-pins the viewport synchronously after `fit.fit()` (rAF call kept as a backstop). The rAF-only re-pin painted one frame at the stranded position before correcting — visible as a flicker on every window resize.
- `showSingle` invalidates `gridLayout.geomKey` so the next `renderGrid` always refits. Without this, single→grid found a matching `(rows, cols, w, h)` and skipped the refit, leaving the tile rendered at single-mode dimensions inside its smaller grid cell.

## Test plan
- [ ] In grid mode with a session producing output (e.g. codex finishing work and asking a question), arrow-nav between tiles — active session should not jump
- [ ] Drag-resize the window in grid mode — no one-frame viewport flicker
- [ ] Switch single → grid with the same session set — active tile renders at correct grid-cell size, not single-mode size
- [ ] Single mode resize still pins to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)