### PR TITLE
fix(gui): Enter reliably saves inline rename in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- GUI: Pressing Enter while editing a session or project name in the
+  sidebar now reliably commits the new name and exits edit mode,
+  matching the tile-rename behavior. Previously the input could linger,
+  fire `UpdateSession` twice via the blur path, or be swallowed by the
+  dead-session overlay's Enter handler. (#155)
+
 ## [2.1.0] — 2026-05-07
 
 ### Added

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1026,19 +1026,23 @@ function beginRenameSession(sess, li, nameEl) {
   nameEl.replaceWith(input);
   input.focus();
   input.select();
+  let done = false;
   const finish = (commit) => {
-    if (commit && input.value.trim() && input.value !== sess.name) {
-      UpdateSession(sess.id, input.value.trim(), '', -1);
-    } else {
-      renderSidebar();
+    if (done) return;
+    done = true;
+    const next = input.value.trim();
+    input.replaceWith(nameEl);
+    if (commit && next && next !== sess.name) {
+      UpdateSession(sess.id, next, '', -1);
     }
     refocusActiveTerm();
   };
   input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') finish(true);
-    else if (e.key === 'Escape') finish(false);
+    if (e.key === 'Enter') { e.stopPropagation(); finish(true); }
+    else if (e.key === 'Escape') { e.stopPropagation(); finish(false); }
   });
   input.addEventListener('blur', () => finish(true));
+  input.addEventListener('keydown', (e) => e.stopPropagation(), { capture: true });
 }
 
 function beginRenameProject(proj, nameEl) {
@@ -1049,19 +1053,23 @@ function beginRenameProject(proj, nameEl) {
   nameEl.replaceWith(input);
   input.focus();
   input.select();
+  let done = false;
   const finish = (commit) => {
-    if (commit && input.value.trim() && input.value !== proj.name) {
-      UpdateProject(proj.id, input.value.trim(), '', '', -1);
-    } else {
-      renderSidebar();
+    if (done) return;
+    done = true;
+    const next = input.value.trim();
+    input.replaceWith(nameEl);
+    if (commit && next && next !== proj.name) {
+      UpdateProject(proj.id, next, '', '', -1);
     }
     refocusActiveTerm();
   };
   input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') finish(true);
-    else if (e.key === 'Escape') finish(false);
+    if (e.key === 'Enter') { e.stopPropagation(); finish(true); }
+    else if (e.key === 'Escape') { e.stopPropagation(); finish(false); }
   });
   input.addEventListener('blur', () => finish(true));
+  input.addEventListener('keydown', (e) => e.stopPropagation(), { capture: true });
 }
 
 function ensureTerm(info) {

--- a/docs/exec-plans/active/155-save-session-name-on-enter-key.md
+++ b/docs/exec-plans/active/155-save-session-name-on-enter-key.md
@@ -1,0 +1,54 @@
+# Save session name on Enter key when editing
+
+- **Spec:** [docs/product-specs/155-save-session-name-on-enter-key.md](../../product-specs/155-save-session-name-on-enter-key.md)
+- **Issue:** #155
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Make Enter commit the new value when editing a session name in the sidebar (and the project name, by the same code shape). Today the inline rename inputs in the sidebar lack the same robustness as the tile rename: no double-fire guard, no `stopPropagation`, and the input is not removed from the DOM on commit — so the input visually lingers between Enter and the next backend `session:event(updated)` and Enter can race with the blur-driven save path.
+
+## Research
+
+Three rename inputs exist in `cmd/hivegui/frontend/src/main.js`:
+
+- **Tile rename** at `cmd/hivegui/frontend/src/main.js:380` (`SessionTerm._beginRename`). Fully wired: a `done` guard prevents double-finish, Enter calls `e.stopPropagation()` then `finish(true)`, the input is `input.remove()`d on finish, and there is a capture-phase `keydown` listener that stops xterm/global hotkey handlers from grabbing keystrokes.
+- **Sidebar session rename** at `cmd/hivegui/frontend/src/main.js:1021` (`beginRenameSession`). Missing all of: `done` guard, `stopPropagation`, capture-phase swallow, and DOM removal on commit. Enter fires `finish(true)` which calls `UpdateSession` then `refocusActiveTerm()`; refocusing blurs the still-mounted input → blur fires `finish(true)` again → second redundant `UpdateSession` with the same value.
+- **Sidebar project rename** at `cmd/hivegui/frontend/src/main.js:1044` (`beginRenameProject`). Same shape and same issues as the session sidebar rename.
+
+The window-level keydown handler at `cmd/hivegui/frontend/src/main.js:2219` early-returns when no modifier is held (line 2260), so it does not directly swallow Enter from these inputs — but the dead-overlay branch at line 2254 unconditionally consumes Enter when `state.activeId` has `deadOverlayShown`, which can fire during the rename if the active tile is in dead-overlay state.
+
+The project-editor modal at `cmd/hivegui/frontend/src/main.js:2207` already handles Enter correctly via `preventDefault` + `saveProjectEditor`.
+
+## Approach
+
+Refactor `beginRenameSession` (and, for symmetry and the same bug class, `beginRenameProject`) to mirror the proven `_beginRename` pattern: add a `done` guard, `e.stopPropagation()` on Enter and Escape, remove the input from the DOM inside `finish`, and add a capture-phase `keydown` swallow so global handlers (notably the dead-overlay Enter branch) cannot intercept the keystroke.
+
+### Files to change
+
+- `cmd/hivegui/frontend/src/main.js` — update `beginRenameSession` (line 1021) and `beginRenameProject` (line 1044) to match the tile-rename pattern.
+
+### New files
+
+None.
+
+### Tests
+
+This is a UI keyboard-interaction fix in the frontend; the project has no JS unit-test harness for `main.js` (per `AGENTS.md`). Manual test plan:
+
+1. Double-click a session name in the sidebar, type a new name, press Enter → name persists, input disappears, terminal regains focus, only one `UpdateSession` call on the wire.
+2. Same flow with Escape → name reverts, no `UpdateSession` call.
+3. Same flow with the active tile showing the dead-session overlay → Enter still saves the name, does **not** trigger `_closeDead`.
+4. Repeat steps 1–3 for project rename in the sidebar.
+
+## Decision log
+
+## Progress
+
+- **2026-05-07** — Spec and exec plan created. Stage: RESEARCH.
+- **2026-05-07** — Plan approved; implemented in `cmd/hivegui/frontend/src/main.js` (sidebar session + project rename now mirror `_beginRename` pattern). Go tests pass; JS syntax-checked. Stage: IMPLEMENT.
+
+## Open questions
+
+None.

--- a/docs/exec-plans/completed/155-save-session-name-on-enter-key.md
+++ b/docs/exec-plans/completed/155-save-session-name-on-enter-key.md
@@ -2,8 +2,8 @@
 
 - **Spec:** [docs/product-specs/155-save-session-name-on-enter-key.md](../../product-specs/155-save-session-name-on-enter-key.md)
 - **Issue:** #155
-- **Stage:** IMPLEMENT
-- **Status:** active
+- **Stage:** DONE
+- **Status:** completed
 
 ## Summary
 
@@ -48,6 +48,7 @@ This is a UI keyboard-interaction fix in the frontend; the project has no JS uni
 
 - **2026-05-07** — Spec and exec plan created. Stage: RESEARCH.
 - **2026-05-07** — Plan approved; implemented in `cmd/hivegui/frontend/src/main.js` (sidebar session + project rename now mirror `_beginRename` pattern). Go tests pass; JS syntax-checked. Stage: IMPLEMENT.
+- **2026-05-07** — PR #156 opened. Converged via /hs-ralph-loop in 1 iteration (APPROVE on first review). Stage: DONE.
 
 ## Open questions
 

--- a/docs/product-specs/155-save-session-name-on-enter-key.md
+++ b/docs/product-specs/155-save-session-name-on-enter-key.md
@@ -4,7 +4,7 @@
 - **Type:** bug
 - **Complexity:** S
 - **Priority:** P2
-- **Exec plan:** [docs/exec-plans/active/155-save-session-name-on-enter-key.md](../exec-plans/active/155-save-session-name-on-enter-key.md)
+- **Exec plan:** [docs/exec-plans/completed/155-save-session-name-on-enter-key.md](../exec-plans/completed/155-save-session-name-on-enter-key.md)
 
 ## Problem
 

--- a/docs/product-specs/155-save-session-name-on-enter-key.md
+++ b/docs/product-specs/155-save-session-name-on-enter-key.md
@@ -1,0 +1,29 @@
+# Save session name on Enter key when editing
+
+- **Issue:** #155
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/155-save-session-name-on-enter-key.md](../exec-plans/active/155-save-session-name-on-enter-key.md)
+
+## Problem
+
+When editing a session name in the GUI, pressing Enter does not commit the change. Users expect Enter to save and exit edit mode (the standard inline-rename interaction). Today they must blur the input (click elsewhere) to persist the new name, which is unintuitive and inconsistent with platform conventions.
+
+## Desired behavior
+
+While the session-name input is focused, pressing Enter saves the new name and exits edit mode. Escape should still cancel without saving (if not already implemented). Empty / unchanged values follow whatever the existing blur behavior does.
+
+## Success criteria
+
+- Pressing Enter while editing a session name commits the new name and exits edit mode.
+- The saved name persists across reload (same as today's blur-to-save path).
+
+## Non-goals
+
+- Redesigning the session rename UI.
+- Changing how renames are persisted on disk / over the wire.
+
+## Notes
+
+Reported via /hs-feature-loop.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -7,13 +7,13 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Priority | Issue | Title | Stage | Spec |
 |----------|-------|-------|-------|------|
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
-| P2 | #155 | Save session name on Enter key when editing | IMPLEMENT | [155-save-session-name-on-enter-key](155-save-session-name-on-enter-key.md) |
 
 ## Completed
 
 | Issue | Title | Shipped | Spec |
 |-------|-------|---------|------|
 | #<n> | <title> | <date> | [<slug>](<slug>.md) |
+| #155 | Save session name on Enter key when editing | 2026-05-07 | [155-save-session-name-on-enter-key](155-save-session-name-on-enter-key.md) |
 
 ## Rejected
 

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -7,6 +7,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Priority | Issue | Title | Stage | Spec |
 |----------|-------|-------|-------|------|
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
+| P2 | #155 | Save session name on Enter key when editing | IMPLEMENT | [155-save-session-name-on-enter-key](155-save-session-name-on-enter-key.md) |
 
 ## Completed
 


### PR DESCRIPTION
## Summary

- Sidebar session and project rename inputs now mirror the tile-rename pattern: `done` guard against blur-after-Enter double-fire, DOM removal on commit so the input doesn't linger until the daemon rebroadcasts, `stopPropagation` on Enter/Escape, and a capture-phase keydown swallow that stops global handlers (notably the dead-session overlay's Enter handler at `main.js:2254`) from intercepting the keystroke.
- Spec at `docs/product-specs/155-save-session-name-on-enter-key.md` and exec plan at `docs/exec-plans/active/155-save-session-name-on-enter-key.md`.

Fixes #155

## Test plan

- [ ] Double-click a session name in the sidebar, type a new name, press Enter → name persists, input disappears immediately, terminal regains focus.
- [ ] Same flow with Escape → name reverts, no `UpdateSession` call.
- [ ] With the active tile showing the dead-session overlay, Enter while editing still saves the name and does **not** trigger the dead-overlay close.
- [ ] Repeat for project rename in the sidebar.
- [ ] Tile rename (double-click name on the terminal tile) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)