### PR TITLE
fix(gui): pin to bottom on resize when viewport is mostly at bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GUI: Resize no longer strands the user mid-history when the viewport
+  is 1–2 lines short of the bottom. Codex (and similar TUIs) sometimes
+  leave the viewport just above the bottom; the resize handler now
+  treats anything within 2 lines of bottom as "at bottom" and re-snaps
+  after reflow. Deliberate scrollback (3+ lines up) is still preserved.
+  (#163)
 - Session snapshot: 24-bit RGB foreground/background colors now
   round-trip across GUI reattach. Previously `writeColor` dropped the
   RGB-encoded `vt10x.Color` to default, so modern prompts (starship,

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -456,8 +456,13 @@ class SessionTerm {
     // Preserve "viewport pinned to bottom" across the resize. xterm's
     // own resize doesn't auto-snap to bottom after reflow; without this,
     // a user scrolled to the latest line would land mid-history.
+    // Tolerance: codex (and similar TUIs) sometimes leave the viewport
+    // a line or two short of the bottom; treat that as "at bottom" so
+    // resize doesn't strand the user mid-history. Anything further up
+    // is deliberate scrollback — leave it alone.
+    const STICKY_BOTTOM_LINES = 2;
     const buf = this.term.buffer.active;
-    const wasAtBottom = buf ? buf.viewportY >= buf.baseY : true;
+    const wasAtBottom = buf ? (buf.baseY - buf.viewportY) <= STICKY_BOTTOM_LINES : true;
     // Swallow throw and continue: a transient FitAddon error (e.g. a
     // race against teardown) shouldn't drop the daemon-side resize.
     try { this.fit.fit(); } catch { /* keep going with last-known dims */ }

--- a/docs/exec-plans/completed/163-resize-stick-mostly-bottom.md
+++ b/docs/exec-plans/completed/163-resize-stick-mostly-bottom.md
@@ -1,0 +1,51 @@
+# GUI: resize loses scroll position when viewport is 1-2 lines short of bottom
+
+- **Spec:** [docs/product-specs/163-resize-stick-mostly-bottom.md](../../product-specs/163-resize-stick-mostly-bottom.md)
+- **Issue:** #163
+- **Stage:** DONE
+- **Status:** completed
+
+## Summary
+
+Treat a viewport within 2 lines of the bottom as "at bottom" for the purpose of the post-resize snap in `SessionTerm._onBodyResize`. Fixes the codex case where small TUI scroll deltas leave the viewport just shy of bottom and resize strands the user mid-history.
+
+## Research
+
+`cmd/hivegui/frontend/src/main.js`:
+- `_onBodyResize` (line 442) is the single resize entry point (per 561a81c, "unify resize handling under ResizeObserver").
+- Line 460 `wasAtBottom = buf.viewportY >= buf.baseY` — strict equality (`viewportY` is bounded `0..baseY`, so `>=` is effectively `===`).
+- Line 467: snaps via `term.scrollToBottom()` only when `wasAtBottom`.
+- xterm.js v5 buffer API: `viewportY` (top of viewport), `baseY` (top of last screen of scrollback). `baseY - viewportY` is non-negative lines above bottom.
+
+The only other `scrollToBottom()` call (inside the `pty:event scrollback_replay_done` handler around line 1652) is intentionally unconditional — the user hasn't had a chance to scroll yet — and is left untouched.
+
+## Approach
+
+Replace the strict equality with a 2-line tolerance using a named local constant. Tolerance is intentionally small: catches codex's 1–2 line drift without overreaching into deliberate scrollback.
+
+### Files to change
+
+- `cmd/hivegui/frontend/src/main.js` lines 456-460 — introduce `STICKY_BOTTOM_LINES = 2` and compute `wasAtBottom = (buf.baseY - buf.viewportY) <= STICKY_BOTTOM_LINES`.
+
+### Tests
+
+No JS test framework in this project. Verification is manual:
+
+1. `wails dev`. Start a session running codex; reproduce the "1–2 lines off bottom" rest state.
+2. Resize the window or drag the sidebar. Expected: viewport snaps to bottom.
+3. Scroll ≥ 3 lines up; resize. Expected: scroll position preserved.
+4. Scroll exactly to bottom; resize. Expected: stays at bottom (regression check).
+5. ⌘\ grid ↔ single toggle while at "mostly bottom". Expected: snaps to bottom.
+
+## Decision log
+
+- **2026-05-08** — Threshold = 2 lines. Reason: matches the codex case the user reported; small enough that deliberate scrollback at 3+ lines is still preserved.
+
+## Progress
+
+- **2026-05-08** — Spec + plan created. Implemented in same commit (S-sized change).
+- **2026-05-08** — Branch off latest main (`27430c7`) in worktree `.worktrees/resize-stick`. `go test ./...` green.
+
+## Open questions
+
+None.

--- a/docs/product-specs/163-resize-stick-mostly-bottom.md
+++ b/docs/product-specs/163-resize-stick-mostly-bottom.md
@@ -1,0 +1,29 @@
+# GUI: resize loses scroll position when viewport is 1-2 lines short of bottom
+
+- **Issue:** #163
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/completed/163-resize-stick-mostly-bottom.md](../exec-plans/completed/163-resize-stick-mostly-bottom.md)
+
+## Problem
+
+The GUI's resize handler preserves "viewport pinned to bottom" only when the viewport is exactly at the bottom. Codex (and similar TUIs) sometimes rest the viewport 1–2 lines above the bottom. Resizing the window or sidebar then strands the user mid-history with no obvious way back.
+
+## Desired behavior
+
+If the viewport is within ~2 lines of the bottom when a resize fires, snap back to bottom after the reflow. Beyond that tolerance, preserve the user's scroll position — they've actively read into history.
+
+## Success criteria
+
+- Codex sessions resting 1–2 lines above bottom snap to bottom after window/sidebar resize.
+- Sessions scrolled ≥ 3 lines from bottom keep their position after resize.
+- Sessions exactly at bottom continue to snap (no regression).
+
+## Non-goals
+
+- Changing scroll behavior outside of the resize path (e.g. on output append, on scrollback replay).
+
+## Notes
+
+Follow-up to #159/#161 (focus restoration) but a separate code path.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -13,6 +13,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Issue | Title | Shipped | Spec |
 |-------|-------|---------|------|
 | #<n> | <title> | <date> | [<slug>](<slug>.md) |
+| #163 | GUI: resize loses scroll position when viewport is 1-2 lines short of bottom | 2026-05-08 | [163-resize-stick-mostly-bottom](163-resize-stick-mostly-bottom.md) |
 | #155 | Save session name on Enter key when editing | 2026-05-07 | [155-save-session-name-on-enter-key](155-save-session-name-on-enter-key.md) |
 | #144 | vt snapshot: RGB / 24-bit colors fall back to default | 2026-05-08 | [144-vt-snapshot-rgb-24-bit-colors](144-vt-snapshot-rgb-24-bit-colors.md) |
 


### PR DESCRIPTION
## Summary

- Fixes #163: codex (and similar TUIs) sometimes rest the viewport 1–2 lines above the bottom; resizing the window or sidebar then strands the user mid-history.
- `_onBodyResize` previously only re-snapped when `viewportY >= baseY` (strict). Now uses a 2-line tolerance via a named local constant `STICKY_BOTTOM_LINES = 2`.
- Deliberate scrollback (3+ lines up) is still preserved — the threshold is intentionally small.

## Test plan

- [ ] `wails dev`. Run codex (or any TUI that rests 1 line short of bottom). Resize the window or drag the sidebar — viewport snaps to the bottom; latest line visible.
- [ ] Scroll ≥ 3 lines up; resize. Scroll position is preserved (no snap).
- [ ] Scroll exactly to bottom; resize. Stays at bottom (regression check).
- [ ] ⌘\ grid ↔ single toggle while at "mostly bottom" — snaps to bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)