### PR TITLE
feat(daemon,registry): HIVE_SOCKET / HIVE_STATE_DIR env overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HIVE_SOCKET` and `HIVE_STATE_DIR` environment variables override the
   daemon socket path and state directory respectively. Setting both
   lets you run an isolated dev daemon (and dev GUI build) alongside a
-  production one without touching its sessions or registry. The
-  platform defaults are unchanged when the variables are unset.
+  production one without touching its sessions or registry. Export the
+  variables in every process that talks to the daemon (the daemon
+  itself and any client — GUI or CLI); a client without them will
+  dial or spawn the platform-default daemon instead. The platform
+  defaults are unchanged when the variables are unset.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `HIVE_SOCKET` and `HIVE_STATE_DIR` environment variables override the
+  daemon socket path and state directory respectively. Setting both
+  lets you run an isolated dev daemon (and dev GUI build) alongside a
+  production one without touching its sessions or registry. The
+  platform defaults are unchanged when the variables are unset.
+
 ### Fixed
 
 - GUI: Toggling between grid and single view (⌘\, ⌘[) now reliably

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -10,7 +10,14 @@ import (
 // SocketPath returns the canonical hived socket path for the current
 // user and platform. Phase 1 uses Unix domain sockets on all platforms
 // (Windows 10 1803+ supports AF_UNIX).
+//
+// Setting HIVE_SOCKET overrides the platform default — useful for
+// running an isolated dev daemon alongside a production one without
+// touching its sessions.
 func SocketPath() string {
+	if s := os.Getenv("HIVE_SOCKET"); s != "" {
+		return s
+	}
 	switch runtime.GOOS {
 	case "linux", "freebsd", "openbsd", "netbsd":
 		if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {

--- a/internal/daemon/socket_test.go
+++ b/internal/daemon/socket_test.go
@@ -1,0 +1,21 @@
+package daemon
+
+import "testing"
+
+func TestSocketPathHIVESocketOverride(t *testing.T) {
+	t.Setenv("HIVE_SOCKET", "/tmp/hive-iso/test.sock")
+	if got := SocketPath(); got != "/tmp/hive-iso/test.sock" {
+		t.Errorf("HIVE_SOCKET ignored: got %q", got)
+	}
+}
+
+func TestSocketPathDefaultsWithoutOverride(t *testing.T) {
+	t.Setenv("HIVE_SOCKET", "")
+	got := SocketPath()
+	if got == "" {
+		t.Error("default SocketPath returned empty string")
+	}
+	if got == "/tmp/hive-iso/test.sock" {
+		t.Errorf("default leaked test override: %q", got)
+	}
+}

--- a/internal/registry/paths.go
+++ b/internal/registry/paths.go
@@ -12,8 +12,14 @@ import (
 //	Linux:   $XDG_STATE_HOME/hive  (default: ~/.local/state/hive)
 //	Windows: %LOCALAPPDATA%\Hive
 //
-// Tests can override by passing an explicit path to OpenAt.
+// Setting HIVE_STATE_DIR overrides the platform default — useful for
+// running an isolated dev daemon alongside a production one without
+// touching its registry. Tests can also override by passing an explicit
+// path to OpenAt.
 func StateDir() string {
+	if s := os.Getenv("HIVE_STATE_DIR"); s != "" {
+		return s
+	}
 	switch runtime.GOOS {
 	case "darwin":
 		if home, err := os.UserHomeDir(); err == nil {

--- a/internal/registry/paths_test.go
+++ b/internal/registry/paths_test.go
@@ -1,0 +1,21 @@
+package registry
+
+import "testing"
+
+func TestStateDirHIVEStateDirOverride(t *testing.T) {
+	t.Setenv("HIVE_STATE_DIR", "/tmp/hive-iso/state")
+	if got := StateDir(); got != "/tmp/hive-iso/state" {
+		t.Errorf("HIVE_STATE_DIR ignored: got %q", got)
+	}
+}
+
+func TestStateDirDefaultsWithoutOverride(t *testing.T) {
+	t.Setenv("HIVE_STATE_DIR", "")
+	got := StateDir()
+	if got == "" {
+		t.Error("default StateDir returned empty string")
+	}
+	if got == "/tmp/hive-iso/state" {
+		t.Errorf("default leaked test override: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `HIVE_SOCKET` overrides `daemon.SocketPath()` (where the daemon binds and the GUI dials).
- `HIVE_STATE_DIR` overrides `registry.StateDir()` (sessions index, projects, hived.log).
- Setting both lets a developer run an isolated dev daemon + dev GUI alongside a production daemon without touching its sessions or registry.
- Platform defaults are unchanged when the variables are unset.

## Usage

```sh
export HIVE_SOCKET=/tmp/hive-iso/hived.sock
export HIVE_STATE_DIR=/tmp/hive-iso/state
mkdir -p "$(dirname "$HIVE_SOCKET")" "$HIVE_STATE_DIR"
./hivegui   # launches an isolated daemon under those paths
```

## Test plan

- [x] `TestSocketPathHIVESocketOverride` / `TestSocketPathDefaultsWithoutOverride`
- [x] `TestStateDirHIVEStateDirOverride` / `TestStateDirDefaultsWithoutOverride`
- [x] `go test ./internal/...` — all packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)