### PR TITLE
fix(gui): eliminate huge-text flash on grid → zoom → switch

### DIFF
--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -426,9 +426,15 @@ class SessionTerm {
 
   show() {
     this.host.classList.add('visible');
-    // Becoming visible flips display from none → block, which makes the
-    // body's box appear with non-zero size. ResizeObserver fires next
-    // tick and runs _onBodyResize for us.
+    // Becoming visible flips display from none → block. ResizeObserver
+    // would fit on its next callback, but xterm's WebGL renderer
+    // schedules its canvas resize on rAF — one paint frame slips in
+    // first, stretching the stale grid-sized canvas into the new full-
+    // sized body (huge-text flash on grid → zoom → switch). Force
+    // layout now and fit synchronously so the next paint already has
+    // the right canvas dims; the trailing RO callback becomes a no-op.
+    void this.body.clientWidth;
+    this._onBodyResize();
   }
 
   hide() {


### PR DESCRIPTION
## Summary
- `show()` forces a synchronous layout and fits immediately instead of waiting for ResizeObserver.
- ResizeObserver fires between layout and paint, but xterm's WebGL renderer schedules its canvas resize on rAF — one paint frame slips through with the stale grid-sized canvas stretched by CSS into the new full-sized body, visible as a huge-text flash on grid → zoom → switch.
- Fitting synchronously in `show()` ensures the canvas is at the right dims by the next paint; the trailing RO callback becomes a no-op (dims unchanged).

## Test plan
- [ ] Open multiple sessions, enter grid view (⌘G), zoom into one (⌘Enter), then switch to another session — confirm no huge-text flash on the new tile.
- [ ] Repeat with grid-project (⌘⇧G) → zoom → switch.
- [ ] Window resize, sidebar drag, font-size bumps still work (RO path unchanged).
- [ ] First-attach path: create a new session — initial fit/attach still works (covered by `_pendingAttach` guard inside `_onBodyResize`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)