### PR TITLE
fix(daemon): skip orphan-worktree reclaim when HIVE_STATE_DIR is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An isolated dev daemon (`HIVE_STATE_DIR` set) no longer reaps
+  worktrees owned by the canonical/prod daemon at startup. The
+  on-disk `<project>/.worktrees/` namespace is shared across daemon
+  instances even when registries are isolated, so the orphan-worktree
+  reclaim now runs only when `HIVE_STATE_DIR` is unset. Iso runs that
+  leak their own worktrees on SIGKILL still get reaped on the next
+  prod-daemon startup, matching the existing orphan contract.
 - GUI: Keyboard shortcuts no longer accept both ⌘ and Ctrl on macOS.
   Platform-adaptive bindings (⌘T, ⌘N, ⌘W, ⌘1–9, etc.) now require
   ⌘ on macOS and Ctrl on Windows/Linux exclusively, matching the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -81,8 +81,15 @@ func New(cfg Config) (*Daemon, error) {
 	}
 	reg.MigrateOrphanSessions()
 	// Reclaim worktree directories whose owning session no longer
-	// exists (e.g. previous daemon was SIGKILL'd mid-Kill).
-	reg.ReclaimOrphanWorktrees()
+	// exists (e.g. previous daemon was SIGKILL'd mid-Kill). Only the
+	// canonical daemon owns the on-disk <project>/.worktrees/ namespace;
+	// an isolated dev daemon (HIVE_STATE_DIR set) shares that directory
+	// with prod and would otherwise reap prod's worktrees as orphans.
+	if registry.StateDirOverridden() {
+		log.Printf("hived: HIVE_STATE_DIR set; skipping orphan-worktree reclaim to protect foreign worktrees")
+	} else {
+		reg.ReclaimOrphanWorktrees()
+	}
 
 	// Revive any persisted sessions that have no live PTY (i.e. every
 	// entry loaded from disk on this run). Metadata is preserved; the

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -554,3 +554,118 @@ func TestAttachUnknownSession(t *testing.T) {
 		t.Errorf("expected ERROR for missing session, got %s", ft)
 	}
 }
+
+// initGitRepoAt initializes a git repo at dir with one empty commit.
+func initGitRepoAt(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-q", "-m", "init"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+}
+
+// TestStartup_HIVEStateDir_SkipsOrphanReap is the regression test for
+// the "dev-iso daemon kills foreign worktrees" bug: when the daemon
+// boots with HIVE_STATE_DIR set (i.e. an isolated dev daemon sharing
+// the on-disk <repo>/.worktrees/ namespace with prod), the orphan
+// reaper must NOT delete worktree dirs whose owning sessions live in
+// the prod registry — those would all look unclaimed in iso's empty
+// registry and get force-removed.
+func TestStartup_HIVEStateDir_SkipsOrphanReap(t *testing.T) {
+	skipOnWindows(t)
+	tmp := shortTempDir(t)
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, repo)
+	foreign := filepath.Join(repo, ".worktrees", "foreign-abc")
+	if err := os.MkdirAll(foreign, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(foreign, "MARKER")
+	if err := os.WriteFile(marker, []byte("prod-owned"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := filepath.Join(tmp, "state")
+	t.Setenv("HIVE_STATE_DIR", stateDir)
+
+	d, err := New(Config{
+		SocketPath: filepath.Join(tmp, "s"),
+		StateDir:   stateDir,
+		// Repo as bootstrap cwd → EnsureDefaultProject registers it,
+		// so ReclaimOrphanWorktrees would scan repo/.worktrees/ if the
+		// gate let it.
+		BootstrapSession: session.Options{
+			Shell: "/bin/bash",
+			Cols:  80,
+			Rows:  24,
+			Cwd:   repo,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		_ = d.Close()
+	})
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("foreign worktree was reaped despite HIVE_STATE_DIR override: %v", err)
+	}
+}
+
+// TestStartup_NoOverride_ReapsOrphans is the companion: without the
+// env override, the canonical daemon still reaps unclaimed worktree
+// dirs (this is the original, intended behavior of the reaper — the
+// fix only changes the iso case).
+func TestStartup_NoOverride_ReapsOrphans(t *testing.T) {
+	skipOnWindows(t)
+	t.Setenv("HIVE_STATE_DIR", "")
+	tmp := shortTempDir(t)
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, repo)
+	foreign := filepath.Join(repo, ".worktrees", "stale-xyz")
+	if err := os.MkdirAll(foreign, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := New(Config{
+		SocketPath: filepath.Join(tmp, "s"),
+		StateDir:   filepath.Join(tmp, "state"),
+		BootstrapSession: session.Options{
+			Shell: "/bin/bash",
+			Cols:  80,
+			Rows:  24,
+			Cwd:   repo,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { _ = d.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		_ = d.Close()
+	})
+
+	if _, err := os.Stat(foreign); !os.IsNotExist(err) {
+		t.Fatalf("expected stale worktree to be reaped, got err=%v", err)
+	}
+}

--- a/internal/registry/paths.go
+++ b/internal/registry/paths.go
@@ -40,6 +40,15 @@ func StateDir() string {
 	return filepath.Join(os.TempDir(), "hive")
 }
 
+// StateDirOverridden reports whether HIVE_STATE_DIR is set, i.e. the
+// caller is running with an isolated (non-canonical) state directory.
+// Code that touches state shared across daemon instances — like the
+// on-disk worktree namespace under <project>/.worktrees/ — should
+// refuse to garbage-collect when this is true.
+func StateDirOverridden() bool {
+	return os.Getenv("HIVE_STATE_DIR") != ""
+}
+
 // SessionsDir is the directory that holds per-session subdirectories
 // and the index file.
 func SessionsDir(stateDir string) string {

--- a/internal/registry/paths_test.go
+++ b/internal/registry/paths_test.go
@@ -19,3 +19,14 @@ func TestStateDirDefaultsWithoutOverride(t *testing.T) {
 		t.Errorf("default leaked test override: %q", got)
 	}
 }
+
+func TestStateDirOverridden(t *testing.T) {
+	t.Setenv("HIVE_STATE_DIR", "")
+	if StateDirOverridden() {
+		t.Error("StateDirOverridden() = true with empty HIVE_STATE_DIR; want false")
+	}
+	t.Setenv("HIVE_STATE_DIR", "/tmp/hive-iso/state")
+	if !StateDirOverridden() {
+		t.Error("StateDirOverridden() = false with HIVE_STATE_DIR set; want true")
+	}
+}

--- a/internal/registry/projects.go
+++ b/internal/registry/projects.go
@@ -56,6 +56,14 @@ func (r *Registry) EnsureDefaultProject(cwd string) (*Project, error) {
 // directory and runs worktree.Cleanup on any subdirectory whose path
 // is not claimed by some live registry entry. Idempotent. Run once at
 // daemon startup so a SIGKILL'd previous process doesn't leak.
+//
+// Caller contract: only the canonical daemon may call this. The
+// on-disk <project>/.worktrees/ namespace is shared across daemon
+// instances (it lives under the project cwd, not under the state
+// dir), so an isolated dev daemon — HIVE_STATE_DIR set — must not
+// reap: every prod-owned worktree would look unclaimed in its
+// registry and get force-removed. Daemon startup gates this call on
+// registry.StateDirOverridden().
 func (r *Registry) ReclaimOrphanWorktrees() {
 	r.mu.Lock()
 	claimed := make(map[string]bool, len(r.entries))


### PR DESCRIPTION
## Summary

- An isolated dev daemon (`HIVE_STATE_DIR` set, e.g. via `scripts/dev-iso.sh`) was reaping the **prod** daemon's worktrees on startup. The on-disk `<project>/.worktrees/` namespace is shared across daemon instances even when their registries are isolated, so prod's worktrees all looked unclaimed in iso and got `git worktree remove --force`'d + `rm -rf`'d — destroying any uncommitted work in those trees.
- Gate `ReclaimOrphanWorktrees` on a new `registry.StateDirOverridden()` predicate (returns true iff `HIVE_STATE_DIR` is set). Daemon startup logs `HIVE_STATE_DIR set; skipping orphan-worktree reclaim` so the behavior is discoverable in dev-iso runs.
- Iso daemons that leak their own worktrees on SIGKILL still get reaped by the next prod-daemon startup, matching the existing orphan contract.

## Test plan

- [x] `TestStateDirOverridden` — predicate returns false when env unset/empty, true when set.
- [x] `TestStartup_HIVEStateDir_SkipsOrphanReap` — boots a daemon with `HIVE_STATE_DIR` set against a temp git repo containing a foreign `.worktrees/foreign-abc/MARKER`; asserts the marker survives. Logs confirm the gate engages.
- [x] `TestStartup_NoOverride_ReapsOrphans` — companion test: without the override, a stale `.worktrees/stale-xyz` is still reaped.
- [x] `go test ./internal/registry/... ./internal/daemon/...` green.
- [ ] Manual repro: run prod Hive with a worktree session, then `scripts/dev-iso.sh` opening the same repo, then quit + relaunch dev-iso. Prior to this fix, prod's worktree dir disappears; after this fix it survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)