### PR TITLE
feat(agent): pin/capture session id for Gemini and Copilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,19 +33,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   native menu accelerators. Conversely, Ctrl+\` (open OS terminal)
   is now Ctrl-only on every platform — on macOS ⌘\` is reserved for
   native window cycling, so it's no longer swallowed by the app.
-- Restart: Restarting a Claude or Codex session no longer reattaches
-  to a sibling's conversation when multiple sessions share a worktree
-  or cwd. For Claude, Hive pins each session to its entry id at first
-  launch (`--session-id <uuid>`) and resumes via
-  `claude --resume <uuid>`. For Codex (which has no flag to inject an
-  id at launch), Hive captures the codex-generated session UUID from
-  `~/.codex/sessions/.../rollout-*.jsonl` shortly after spawn and
-  resumes via `codex resume <uuid>`. The pinned id is persisted on the
-  session metadata so daemon restart respawns each session against its
-  own conversation rather than collapsing back to "most recent in
-  cwd". Restart is now unambiguous regardless of how many siblings
-  live in the same directory. Gemini/Copilot retain today's
-  path-scoped resume. (#165)
+- Restart: Restarting a Claude, Codex, Gemini, or Copilot session no
+  longer reattaches to a sibling's conversation when multiple sessions
+  share a worktree or cwd. For Claude and Gemini, Hive pins each
+  session to its entry id at first launch (`--session-id <uuid>`) and
+  resumes via `<agent> --resume <uuid>`. For Codex and Copilot (which
+  have no flag to inject an id at launch), Hive captures the
+  agent-generated session UUID from
+  `~/.codex/sessions/.../rollout-*.jsonl` (codex) or
+  `~/.copilot/session-state/<uuid>/workspace.yaml` (copilot) shortly
+  after spawn, matching the spawn cwd to disambiguate concurrent
+  sessions. The pinned id is persisted on the session metadata so
+  daemon restart respawns each session against its own conversation
+  rather than collapsing back to "most recent in cwd". Restart is now
+  unambiguous regardless of how many siblings live in the same
+  directory. Aider retains today's behavior (no resume command
+  available). (#165, #172)
 - GUI: Toggling between grid and single view (⌘\, ⌘[) now reliably
   returns keyboard focus to the active session. Previously the
   sidebar still showed the session as selected but keystrokes were

--- a/docs/exec-plans/active/172-agent-session-id-gemini-copilot.md
+++ b/docs/exec-plans/active/172-agent-session-id-gemini-copilot.md
@@ -1,0 +1,151 @@
+# Pin/capture agent session id for Gemini and Copilot
+
+- **Spec:** [docs/product-specs/172-agent-session-id-gemini-copilot.md](../../product-specs/172-agent-session-id-gemini-copilot.md)
+- **Issue:** #172
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Extend the session-id pinning/capture infrastructure introduced in
+#166 to Gemini (pin, mirroring Claude) and Copilot (capture, mirroring
+Codex). Aider stays unsupported. The registry-side plumbing is already
+in place; this plan adds two small per-agent additions.
+
+## Research
+
+- `internal/agent/agent.go:28-55` — `Def` already exposes
+  `SessionIDFlag`, `ResumeArgs(id)`, and `CaptureSessionIDFn` (added
+  by #166). Generic infrastructure; no Registry changes needed.
+- `internal/agent/agent.go:80-100` — `IDClaude` Def shows the pin
+  pattern: `SessionIDFlag: "--session-id"` + `ResumeArgs:
+  func(id) []string { return []string{"claude", "--resume", id} }`.
+- `internal/agent/agent.go:101-120` — `IDCodex` Def shows the capture
+  pattern: `ResumeArgs` + `CaptureSessionIDFn: codexCaptureSessionID`.
+- `internal/agent/codex.go` — full capture implementation. Polls
+  `~/.codex/sessions/`, regex-matches rollout filenames for the UUID,
+  reads first JSONL line to verify cwd. Mtime cutoff is `spawnedAt-1s`.
+  This file is the structural template for `copilot.go`.
+- `internal/agent/codex_test.go` — fixtures + concurrent-spawn test;
+  template for `copilot_test.go`.
+
+### CLI capability matrix (verified)
+
+| Agent | `--session-id <UUID>` at launch | Resume by UUID | On-disk store |
+|---|---|---|---|
+| Gemini | ✅ `--session-id <UUID>` (arbitrary UUID accepted) | ✅ `gemini --resume <UUID>` | `~/.gemini/tmp/<project>/chats/session-...-<short-uuid>.jsonl` |
+| Copilot | ❌ no flag | ✅ `copilot --resume=<UUID>` (note `=` form) | `~/.copilot/session-state/<UUID>/workspace.yaml` (UUID = dir name; `cwd:` field present) |
+
+Empirically verified via:
+
+```
+gemini --skip-trust --session-id 11111111-2222-3333-4444-555555555555 -p "say hi"
+gemini --skip-trust --resume    11111111-2222-3333-4444-555555555555 -p "what did i say"
+# ⇒ "You said \"say hi briefly\"."
+```
+
+## Approach
+
+Two parallel slices, both shipped in one PR.
+
+### Slice G — Gemini (pin)
+
+Mirror Claude exactly. Two-line addition to `IDGemini` Def:
+
+```go
+SessionIDFlag: "--session-id",
+ResumeArgs: func(id string) []string {
+    return []string{"gemini", "--resume", id}
+},
+```
+
+The existing `Registry.Create` infrastructure appends `--session-id
+<entry-id>` to the spawn cmd whenever `SessionIDFlag` is set; that
+already handles Gemini once these two lines land.
+
+### Slice C — Copilot (capture)
+
+Mirror Codex. New `internal/agent/copilot.go` with
+`copilotCaptureSessionID(ctx, cwd, spawnedAt) (string, error)`:
+
+- Resolve `~/.copilot/session-state/` (override-able for tests, same
+  pattern as `codexSessionsDir`).
+- Poll every 200ms (same cadence as codex). Each poll:
+  - List immediate subdirectories of session-state.
+  - Skip names that are not valid UUIDs.
+  - Skip dirs whose mtime < `spawnedAt-1s` (cutoff slack).
+  - Skip dirs we've already inspected and rejected (negative cache).
+  - Read `<dir>/workspace.yaml`, look for the `cwd:` line, compare
+    against the spawn cwd. First match wins.
+- Returns the UUID (= dir name) or "" + error on ctx done.
+
+Wire to `IDCopilot` Def:
+
+```go
+ResumeArgs: func(id string) []string {
+    return []string{"copilot", "--resume=" + id}
+},
+CaptureSessionIDFn: copilotCaptureSessionID,
+```
+
+Use `--resume=<UUID>` (with `=`) per copilot's documented usage; the
+space-separated form is not in the help and may not be supported.
+
+### Files to change
+
+- `internal/agent/agent.go` — add SessionIDFlag/ResumeArgs to
+  `IDGemini`; add ResumeArgs/CaptureSessionIDFn to `IDCopilot`.
+- `internal/agent/agent_test.go` — extend the existing per-agent
+  Def-shape tests to assert Gemini and Copilot now have the new
+  fields populated correctly.
+
+### New files
+
+- `internal/agent/copilot.go` — capture implementation.
+- `internal/agent/copilot_test.go` — fixture-based capture tests
+  (mirrors `codex_test.go`).
+
+### Tests
+
+- `TestGeminiDef_HasSessionIDPinning` — Def has SessionIDFlag set
+  and ResumeArgs returns `[gemini, --resume, <id>]`.
+- `TestCopilotDef_HasCaptureAndResume` — Def has CaptureSessionIDFn
+  and ResumeArgs returns `[copilot, --resume=<id>]`.
+- `TestCopilotCaptureSessionID_HappyPath` — fixture: drop
+  `<UUID>/workspace.yaml` with matching cwd, capture returns UUID.
+- `TestCopilotCaptureSessionID_SkipsWrongCwd` — workspace.yaml has
+  wrong cwd, capture continues until match or ctx done.
+- `TestCopilotCaptureSessionID_SkipsPreexistingByMtime` — old dir
+  with matching cwd but mtime before cutoff is skipped (the codex
+  test pattern).
+- `TestCopilotCaptureSessionID_NegativeCache` — same wrong-cwd dir
+  is not re-read on later polls.
+- `TestCopilotCaptureSessionID_ConcurrentSpawns` — two captures with
+  different cwds pick the correct UUIDs.
+- `TestCopilotCaptureSessionID_ContextCancel` — ctx cancel returns
+  promptly with empty id, no error noise.
+
+## Decision log
+
+- **2026-05-09** — Use `--resume=<UUID>` (with `=`) for copilot, not
+  `--resume <UUID>` (space). Why: `=` form is the only one in
+  `copilot --help`; space form is undocumented and may not work.
+- **2026-05-09** — Mtime cutoff `spawnedAt-1s`, same as codex. Why:
+  filesystem mtime resolution + the gap between `time.Now()` and
+  the agent's first write are both imprecise; 1s slack matches the
+  cutoff already validated in `codex.go`.
+
+## Progress
+
+- **2026-05-09** — Spec + plan written; CLI capabilities verified
+  empirically.
+- **2026-05-09** — Implementation complete. `internal/agent/agent.go`
+  wires Gemini pinning + Copilot capture; `internal/agent/copilot.go`
+  is the capture impl; `internal/agent/copilot_test.go` adds 6 tests
+  (capture happy path, wrong-cwd skip, ctx cancel, preexisting-by-
+  mtime, non-UUID dir skip, Def shape). `go test ./internal/...
+  ./cmd/hived/...` passes.
+
+## Open questions
+
+None.

--- a/docs/product-specs/172-agent-session-id-gemini-copilot.md
+++ b/docs/product-specs/172-agent-session-id-gemini-copilot.md
@@ -1,0 +1,61 @@
+# Pin/capture agent session id for Gemini and Copilot
+
+- **Issue:** #172
+- **Type:** enhancement
+- **Complexity:** S
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/172-agent-session-id-gemini-copilot.md](../exec-plans/active/172-agent-session-id-gemini-copilot.md)
+
+## Problem
+
+#166 fixed the duplicate-cwd Restart collision for Claude (pin via
+`--session-id`) and Codex (capture from rollout file), but explicitly
+deferred Gemini and Copilot. Hive sessions sharing a cwd or worktree
+that run Gemini or Copilot still collide on Restart: clicking Restart
+on session B runs `gemini --continue` / `copilot --resume` in the
+shared cwd, and the agent CLI picks "most recent in cwd" — usually
+the sibling, not session B.
+
+⌘P duplicate (#149) makes this a real-day-one collision for users
+running multiple Gemini or Copilot sessions in one project.
+
+## Desired behavior
+
+- Restart on a Gemini or Copilot session that shares a cwd with another
+  Hive session reattaches to *that* session's conversation, not a
+  sibling's.
+- Daemon restart (`hived` reboot) revives each Gemini/Copilot session
+  against its own conversation.
+- Non-duplicated sessions are unaffected.
+
+## Success criteria
+
+- Two Gemini sessions in the same project: type "alpha" in one, "beta"
+  in the other, restart each, each agent reports back its own word.
+- Same for two Copilot sessions.
+- `gemini --session-id <UUID>` (caller-pinned) and `copilot
+  --resume=<UUID>` (post-capture) round-trip across daemon restart.
+
+## Non-goals
+
+- Aider: no `--resume` command exists; stays on plain `Cmd`.
+- Cross-machine session sync.
+- Backfilling pre-existing Gemini/Copilot sessions whose ids were
+  never captured (they retain today's path-scoped resume; collision
+  risk only goes away on next Create).
+
+## Notes
+
+- Verified empirically: `gemini --session-id <UUID>` accepts an
+  arbitrary caller UUID, and `gemini --resume <UUID>` resumes by full
+  UUID. (Smoke test: pinned session under `/tmp/gemini-test`, resumed
+  successfully.)
+- Verified via `copilot --help`: `--resume=<session-id>` resumes by
+  id; no `--session-id`-style flag for caller pinning. Inspection of
+  `~/.copilot/session-state/<UUID>/workspace.yaml` shows a `cwd:`
+  field — matches the cwd-disambiguation strategy already used in
+  `codex.go`.
+- This finishes the work scoped out of #166. The "track Gemini/
+  Copilot/Codex as a follow-up issue" decision-log line in
+  `docs/exec-plans/completed/165-restart-session-wrong-session.md`
+  closes when this lands.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -7,6 +7,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Priority | Issue | Title | Stage | Spec |
 |----------|-------|-------|-------|------|
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
+| P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 
 ## Completed

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -97,12 +97,16 @@ var (
 			CaptureSessionIDFn: codexCaptureSessionID,
 		},
 		IDGemini: {
-			ID:         IDGemini,
-			Name:       "Gemini",
-			Cmd:        []string{"gemini"},
-			ResumeCmd:  []string{"gemini", "--continue"},
-			Color:      "#3b82f6",
-			InstallCmd: []string{"npm", "install", "-g", "@google/gemini-cli"},
+			ID:            IDGemini,
+			Name:          "Gemini",
+			Cmd:           []string{"gemini"},
+			ResumeCmd:     []string{"gemini", "--continue"},
+			Color:         "#3b82f6",
+			InstallCmd:    []string{"npm", "install", "-g", "@google/gemini-cli"},
+			SessionIDFlag: "--session-id",
+			ResumeArgs: func(id string) []string {
+				return []string{"gemini", "--resume", id}
+			},
 		},
 		IDCopilot: {
 			ID:         IDCopilot,
@@ -111,6 +115,10 @@ var (
 			ResumeCmd:  []string{"copilot", "--resume"},
 			Color:      "#8b5cf6",
 			InstallCmd: []string{"npm", "install", "-g", "@github/copilot"},
+			ResumeArgs: func(id string) []string {
+				return []string{"copilot", "--resume=" + id}
+			},
+			CaptureSessionIDFn: copilotCaptureSessionID,
 		},
 		IDAider: {
 			ID:         IDAider,

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// copilotSessionStateDir is the directory copilot writes its
+// per-session state under. Tests swap this to a t.TempDir() to avoid
+// touching the real filesystem. Default resolves to
+// "$HOME/.copilot/session-state".
+var copilotSessionStateDir = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".copilot", "session-state")
+}()
+
+// copilotUUIDPattern matches the canonical 8-4-4-4-12 hex layout that
+// copilot uses for its session-state directory names.
+var copilotUUIDPattern = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
+)
+
+// copilotCapturePollInterval mirrors codex's cadence: 200ms keeps
+// capture latency low while not thrashing the disk.
+var copilotCapturePollInterval = 200 * time.Millisecond
+
+// copilotCaptureSessionID polls copilot's session-state directory for
+// a `<UUID>/` subdirectory whose `workspace.yaml` records the spawn
+// cwd and whose mtime is at or after spawnedAt-1s. Returns the UUID
+// (= directory name).
+//
+// Strategy mirrors codexCaptureSessionID: poll every
+// copilotCapturePollInterval until ctx is done. Per poll, list
+// session-state subdirectories, skip names that aren't valid UUIDs,
+// skip dirs whose workspace.yaml mtime is before the cutoff, skip
+// dirs we've already inspected and rejected (negative cache), read
+// workspace.yaml and confirm the `cwd:` field. First cwd-match wins.
+//
+// We do not snapshot "dirs seen on the first poll" as preexisting
+// (same reasoning as codex): copilot creates the session-state dir
+// very early in the run, often before our first poll tick. The
+// mtime-cutoff plus cwd-match disambiguates: a prior copilot run in
+// the same cwd has an mtime well before spawnedAt-1s.
+func copilotCaptureSessionID(ctx context.Context, cwd string, spawnedAt time.Time) (string, error) {
+	if copilotSessionStateDir == "" {
+		return "", errors.New("copilot session-state dir unresolved (no HOME)")
+	}
+	cutoff := spawnedAt.Add(-time.Second)
+	rejected := map[string]struct{}{}
+
+	ticker := time.NewTicker(copilotCapturePollInterval)
+	defer ticker.Stop()
+
+	for {
+		for _, m := range scanCopilotSessionDirs(copilotSessionStateDir, cutoff) {
+			if _, seen := rejected[m.path]; seen {
+				continue
+			}
+			if id, ok := readCopilotWorkspaceCwd(m.path, m.uuid, cwd); ok {
+				return id, nil
+			}
+			rejected[m.path] = struct{}{}
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+type copilotSessionMatch struct {
+	path    string // <session-state>/<UUID>
+	uuid    string // directory basename, validated as UUID
+	modTime time.Time
+}
+
+// scanCopilotSessionDirs lists immediate subdirectories of root and
+// returns every <UUID> dir whose workspace.yaml mtime is at or after
+// cutoff. Missing workspace.yaml is treated as "not yet ready" and
+// skipped (no error).
+func scanCopilotSessionDirs(root string, cutoff time.Time) []copilotSessionMatch {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var out []copilotSessionMatch
+	for _, d := range entries {
+		if !d.IsDir() {
+			continue
+		}
+		name := d.Name()
+		if !copilotUUIDPattern.MatchString(name) {
+			continue
+		}
+		dirPath := filepath.Join(root, name)
+		wsPath := filepath.Join(dirPath, "workspace.yaml")
+		info, ierr := os.Stat(wsPath)
+		if ierr != nil {
+			continue // workspace.yaml not written yet
+		}
+		if info.ModTime().Before(cutoff) {
+			continue
+		}
+		out = append(out, copilotSessionMatch{path: dirPath, uuid: name, modTime: info.ModTime()})
+	}
+	return out
+}
+
+// readCopilotWorkspaceCwd reads <path>/workspace.yaml and returns
+// (uuid, true) when its `cwd:` field matches wantCwd. The uuid is
+// passed in by the scanner (= directory basename, already validated).
+//
+// We parse manually instead of pulling in a YAML dependency: the
+// file is small (always the same handful of top-level keys) and we
+// only care about one field.
+func readCopilotWorkspaceCwd(dirPath, uuid, wantCwd string) (string, bool) {
+	wsPath := filepath.Join(dirPath, "workspace.yaml")
+	f, err := os.Open(wsPath)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	// Cap line length so a malformed/binary file can't spike memory.
+	scanner.Buffer(make([]byte, 0, 8*1024), 64*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Top-level keys only — copilot's workspace.yaml has cwd at
+		// the document root. Indented lines are nested objects and
+		// not what we want.
+		if len(line) == 0 || line[0] == ' ' || line[0] == '\t' || line[0] == '#' {
+			continue
+		}
+		const key = "cwd:"
+		if !strings.HasPrefix(line, key) {
+			continue
+		}
+		val := strings.TrimSpace(line[len(key):])
+		// Strip quotes (YAML allows both single and double quoted
+		// strings; copilot writes unquoted, but be defensive).
+		val = strings.Trim(val, `"'`)
+		if val == wantCwd {
+			return uuid, true
+		}
+		return "", false
+	}
+	return "", false
+}

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -65,10 +65,19 @@ func copilotCaptureSessionID(ctx context.Context, cwd string, spawnedAt time.Tim
 			if _, seen := rejected[m.path]; seen {
 				continue
 			}
-			if id, ok := readCopilotWorkspaceCwd(m.path, m.uuid, cwd); ok {
-				return id, nil
+			switch readCopilotWorkspaceCwd(m.path, cwd) {
+			case copilotCwdMatch:
+				return m.uuid, nil
+			case copilotCwdMismatch:
+				// Definitive mismatch — this dir's `cwd:` field is
+				// present and not ours. Negative-cache so we don't
+				// re-read it on every poll.
+				rejected[m.path] = struct{}{}
+			case copilotCwdNotReady:
+				// File exists but `cwd:` not yet written, or a
+				// transient read/scan error. Leave uncached so the
+				// next poll re-reads.
 			}
-			rejected[m.path] = struct{}{}
 		}
 
 		select {
@@ -117,18 +126,31 @@ func scanCopilotSessionDirs(root string, cutoff time.Time) []copilotSessionMatch
 	return out
 }
 
-// readCopilotWorkspaceCwd reads <path>/workspace.yaml and returns
-// (uuid, true) when its `cwd:` field matches wantCwd. The uuid is
-// passed in by the scanner (= directory basename, already validated).
+// copilotCwdResult is a tri-state for readCopilotWorkspaceCwd so the
+// caller can distinguish a definitive mismatch (negative-cache it)
+// from a transient "not ready / read error" (re-try next poll).
+type copilotCwdResult int
+
+const (
+	copilotCwdNotReady copilotCwdResult = iota // open/read/scan error or `cwd:` not yet written
+	copilotCwdMatch                            // `cwd:` present and equals wantCwd
+	copilotCwdMismatch                         // `cwd:` present and different from wantCwd
+)
+
+// readCopilotWorkspaceCwd reads <path>/workspace.yaml and reports
+// whether its top-level `cwd:` field matches wantCwd. Returns
+// copilotCwdNotReady for I/O errors, scan errors, or a file that
+// doesn't yet contain a `cwd:` line — caller must NOT negative-cache
+// these, since the file may still be partially written.
 //
 // We parse manually instead of pulling in a YAML dependency: the
 // file is small (always the same handful of top-level keys) and we
 // only care about one field.
-func readCopilotWorkspaceCwd(dirPath, uuid, wantCwd string) (string, bool) {
+func readCopilotWorkspaceCwd(dirPath, wantCwd string) copilotCwdResult {
 	wsPath := filepath.Join(dirPath, "workspace.yaml")
 	f, err := os.Open(wsPath)
 	if err != nil {
-		return "", false
+		return copilotCwdNotReady
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
@@ -151,9 +173,13 @@ func readCopilotWorkspaceCwd(dirPath, uuid, wantCwd string) (string, bool) {
 		// strings; copilot writes unquoted, but be defensive).
 		val = strings.Trim(val, `"'`)
 		if val == wantCwd {
-			return uuid, true
+			return copilotCwdMatch
 		}
-		return "", false
+		return copilotCwdMismatch
 	}
-	return "", false
+	// Scan error or EOF without finding `cwd:`. Either way the file
+	// isn't (yet) authoritative — treat as not-ready so the caller
+	// retries on the next poll instead of permanently rejecting it.
+	_ = scanner.Err()
+	return copilotCwdNotReady
 }

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func swapCopilotSessionStateDir(t *testing.T, dir string) {
+	t.Helper()
+	prev := copilotSessionStateDir
+	copilotSessionStateDir = dir
+	t.Cleanup(func() { copilotSessionStateDir = prev })
+}
+
+func swapCopilotPollInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := copilotCapturePollInterval
+	copilotCapturePollInterval = d
+	t.Cleanup(func() { copilotCapturePollInterval = prev })
+}
+
+// writeCopilotSession plants a fake copilot session-state directory
+// `<root>/<uuid>/workspace.yaml` containing `cwd: <cwd>` and forces
+// the workspace.yaml mtime. Returns the dir path.
+func writeCopilotSession(t *testing.T, root, uuid, cwd string, modTime time.Time) string {
+	t.Helper()
+	dir := filepath.Join(root, uuid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	wsPath := filepath.Join(dir, "workspace.yaml")
+	body := "id: " + uuid + "\ncwd: " + cwd + "\nsummary: test\n"
+	if err := os.WriteFile(wsPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write workspace.yaml: %v", err)
+	}
+	if err := os.Chtimes(wsPath, modTime, modTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return dir
+}
+
+func TestCopilotCaptureReadsWorkspaceUUID(t *testing.T) {
+	root := t.TempDir()
+	swapCopilotSessionStateDir(t, root)
+	swapCopilotPollInterval(t, 20*time.Millisecond)
+
+	cwd := "/tmp/proj-a"
+	wantUUID := "03cab944-0fea-4f86-b3be-989a00303876"
+
+	spawnedAt := time.Now()
+	// Write the session dir slightly in the future to simulate
+	// copilot creating workspace.yaml just after spawn.
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		writeCopilotSession(t, root, wantUUID, cwd, time.Now())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	got, err := copilotCaptureSessionID(ctx, cwd, spawnedAt)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if got != wantUUID {
+		t.Errorf("got uuid %q, want %q", got, wantUUID)
+	}
+}
+
+func TestCopilotCaptureSkipsMismatchedCwd(t *testing.T) {
+	root := t.TempDir()
+	swapCopilotSessionStateDir(t, root)
+	swapCopilotPollInterval(t, 20*time.Millisecond)
+
+	wantCwd := "/tmp/proj-a"
+	otherCwd := "/tmp/proj-b"
+	writeCopilotSession(t, root, "03cab944-0fea-4f86-b3be-989a00303876", otherCwd, time.Now())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := copilotCaptureSessionID(ctx, wantCwd, time.Now().Add(-2*time.Second))
+	if err == nil {
+		t.Fatalf("expected ctx-deadline error when no session matches cwd")
+	}
+}
+
+func TestCopilotCaptureRespectsContextCancel(t *testing.T) {
+	root := t.TempDir()
+	swapCopilotSessionStateDir(t, root)
+	swapCopilotPollInterval(t, 20*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := copilotCaptureSessionID(ctx, "/tmp/never", time.Now())
+		done <- err
+	}()
+	time.Sleep(40 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("capture did not return after context cancel")
+	}
+}
+
+func TestCopilotCaptureIgnoresPreexistingSessionsInSameCwd(t *testing.T) {
+	root := t.TempDir()
+	swapCopilotSessionStateDir(t, root)
+	swapCopilotPollInterval(t, 20*time.Millisecond)
+
+	cwd := "/tmp/proj-a"
+	older := "03cab944-0000-7000-8000-000000000001"
+	newer := "03cab944-0000-7000-8000-000000000002"
+
+	// Pre-existing session-state dir in the same cwd — must not match.
+	// mtime well before spawnedAt-1s mirrors a previous copilot run.
+	writeCopilotSession(t, root, older, cwd, time.Now().Add(-1*time.Hour))
+
+	spawnedAt := time.Now()
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		writeCopilotSession(t, root, newer, cwd, time.Now())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	got, err := copilotCaptureSessionID(ctx, cwd, spawnedAt)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if got != newer {
+		t.Errorf("got uuid %q, want %q (the post-spawn one)", got, newer)
+	}
+}
+
+func TestCopilotCaptureSkipsNonUUIDDirNames(t *testing.T) {
+	root := t.TempDir()
+	swapCopilotSessionStateDir(t, root)
+	swapCopilotPollInterval(t, 20*time.Millisecond)
+
+	cwd := "/tmp/proj-a"
+	// A non-UUID-named dir with a matching workspace.yaml — must be
+	// ignored regardless of cwd match.
+	if err := os.MkdirAll(filepath.Join(root, "not-a-uuid"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "not-a-uuid", "workspace.yaml"),
+		[]byte("cwd: "+cwd+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := copilotCaptureSessionID(ctx, cwd, time.Now().Add(-2*time.Second))
+	if err == nil {
+		t.Fatalf("expected ctx-deadline error; non-UUID dir should be ignored")
+	}
+}
+
+func TestCopilotDefHasResumeArgsAndCapture(t *testing.T) {
+	d, ok := Get(IDCopilot)
+	if !ok {
+		t.Fatalf("copilot not registered")
+	}
+	if d.ResumeArgs == nil {
+		t.Errorf("copilot ResumeArgs is nil")
+	} else {
+		got := d.ResumeArgs("xyz")
+		want := []string{"copilot", "--resume=xyz"}
+		if !slices.Equal(got, want) {
+			t.Errorf("ResumeArgs = %v, want %v", got, want)
+		}
+	}
+	if d.CaptureSessionIDFn == nil {
+		t.Errorf("copilot CaptureSessionIDFn is nil")
+	}
+	// Copilot has no caller-pinning flag.
+	if d.SessionIDFlag != "" {
+		t.Errorf("copilot SessionIDFlag = %q, want empty (no --session-id support)", d.SessionIDFlag)
+	}
+}
+
+func TestGeminiDefHasSessionIDPinning(t *testing.T) {
+	d, ok := Get(IDGemini)
+	if !ok {
+		t.Fatalf("gemini not registered")
+	}
+	if d.SessionIDFlag != "--session-id" {
+		t.Errorf("gemini SessionIDFlag = %q, want --session-id", d.SessionIDFlag)
+	}
+	if d.ResumeArgs == nil {
+		t.Errorf("gemini ResumeArgs is nil")
+	} else {
+		got := d.ResumeArgs("xyz")
+		want := []string{"gemini", "--resume", "xyz"}
+		if !slices.Equal(got, want) {
+			t.Errorf("ResumeArgs = %v, want %v", got, want)
+		}
+	}
+	// Gemini pins at launch — no capture goroutine needed.
+	if d.CaptureSessionIDFn != nil {
+		t.Errorf("gemini CaptureSessionIDFn should be nil (uses pinning instead)")
+	}
+}

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -137,6 +137,53 @@ func TestCopilotCaptureIgnoresPreexistingSessionsInSameCwd(t *testing.T) {
 	}
 }
 
+// Regression test: a session dir whose workspace.yaml is initially
+// missing the `cwd:` field (e.g. partially written) must NOT be
+// permanently negative-cached. Once the writer flushes the full file,
+// the next poll has to re-read and match.
+func TestCopilotCaptureRetriesPartiallyWrittenWorkspace(t *testing.T) {
+	root := t.TempDir()
+	swapCopilotSessionStateDir(t, root)
+	swapCopilotPollInterval(t, 20*time.Millisecond)
+
+	cwd := "/tmp/proj-a"
+	uuid := "03cab944-0fea-4f86-b3be-989a00303876"
+	dir := filepath.Join(root, uuid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wsPath := filepath.Join(dir, "workspace.yaml")
+	// Phase 1: workspace.yaml exists with a valid mtime but lacks
+	// `cwd:`. The capture loop must treat this as not-ready and keep
+	// polling rather than rejecting the dir for good.
+	if err := os.WriteFile(wsPath, []byte("id: "+uuid+"\nsummary: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	if err := os.Chtimes(wsPath, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	spawnedAt := time.Now()
+	go func() {
+		// Phase 2: writer finishes the file with cwd:.
+		time.Sleep(80 * time.Millisecond)
+		body := "id: " + uuid + "\ncwd: " + cwd + "\nsummary: test\n"
+		_ = os.WriteFile(wsPath, []byte(body), 0o644)
+		_ = os.Chtimes(wsPath, time.Now(), time.Now())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	got, err := copilotCaptureSessionID(ctx, cwd, spawnedAt)
+	if err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+	if got != uuid {
+		t.Errorf("got uuid %q, want %q (capture must not permanently reject not-ready dirs)", got, uuid)
+	}
+}
+
 func TestCopilotCaptureSkipsNonUUIDDirNames(t *testing.T) {
 	root := t.TempDir()
 	swapCopilotSessionStateDir(t, root)

--- a/scripts/dev-iso.sh
+++ b/scripts/dev-iso.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# dev-iso.sh — Build and launch an isolated dev Hive that doesn't
+# touch your prod daemon, sessions, or registry. Uses the
+# HIVE_SOCKET / HIVE_STATE_DIR env-var overrides.
+#
+# Usage:
+#   scripts/dev-iso.sh           # build + run
+#   scripts/dev-iso.sh --reset   # also wipe the iso state dir first
+#   scripts/dev-iso.sh --no-build  # skip ./build.sh, just relaunch
+#   scripts/dev-iso.sh --dir /tmp/foo  # use a custom iso dir
+#
+# Run the binary directly (not via `open`) so the env vars survive —
+# launchctl strips most env from .app bundles opened with `open`.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+iso_dir=/tmp/hive-iso
+do_build=1
+do_reset=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)      iso_dir="$2"; shift 2 ;;
+    --reset)    do_reset=1; shift ;;
+    --no-build) do_build=0; shift ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ $do_reset -eq 1 ]]; then
+  echo "==> Wiping $iso_dir"
+  rm -rf "$iso_dir"
+fi
+mkdir -p "$iso_dir/state"
+
+if [[ $do_build -eq 1 ]]; then
+  ./build.sh
+fi
+
+app="cmd/hivegui/build/bin/hivegui.app/Contents/MacOS/hivegui"
+if [[ ! -x "$app" ]]; then
+  echo "error: $app not found — run ./build.sh first or omit --no-build" >&2
+  exit 1
+fi
+
+echo "==> Launching isolated Hive"
+echo "    HIVE_SOCKET=$iso_dir/hived.sock"
+echo "    HIVE_STATE_DIR=$iso_dir/state"
+HIVE_SOCKET="$iso_dir/hived.sock" \
+HIVE_STATE_DIR="$iso_dir/state" \
+  "$app"

--- a/scripts/dev-iso.sh
+++ b/scripts/dev-iso.sh
@@ -32,8 +32,45 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $do_reset -eq 1 ]]; then
-  echo "==> Wiping $iso_dir"
-  rm -rf "$iso_dir"
+  # Guard against catastrophic --dir values. --reset must only ever
+  # wipe a scratch dir under /tmp or /var/folders.
+  # Reject any `..` in the raw input first — defeats prefix bypass
+  # like `/tmp/../etc` even before canonicalization.
+  case "/$iso_dir/" in
+    */../*|*/..*|*../*)
+      echo "refusing: --dir must not contain '..' segments ($iso_dir)" >&2
+      exit 2 ;;
+  esac
+  # Canonicalize. macOS realpath has no -m, so fall back via the
+  # parent dir if iso_dir doesn't exist yet.
+  if [[ -e "$iso_dir" ]]; then
+    abs_iso_dir=$(realpath "$iso_dir")
+  else
+    parent=$(dirname "$iso_dir")
+    base=$(basename "$iso_dir")
+    if [[ -d "$parent" ]]; then
+      abs_iso_dir="$(cd "$parent" && pwd -P)/$base"
+    else
+      echo "refusing: parent of --dir does not exist: $parent" >&2
+      exit 2
+    fi
+  fi
+  # Strip trailing slashes for the comparison so `/tmp/` and `/tmp`
+  # both reject as "the prefix itself, no subpath".
+  abs_iso_dir="${abs_iso_dir%/}"
+  case "$abs_iso_dir" in
+    ""|/|/Users|/home|/tmp|/var|/var/folders|/private|/private/tmp|/private/var|/private/var/folders|"$HOME")
+      echo "refusing to wipe $abs_iso_dir — must be a subpath under /tmp or /var/folders" >&2
+      exit 2 ;;
+  esac
+  case "$abs_iso_dir" in
+    /tmp/*|/var/folders/*|/private/tmp/*|/private/var/folders/*) ;;
+    *)
+      echo "refusing to wipe $abs_iso_dir — --reset only operates under /tmp or /var/folders" >&2
+      exit 2 ;;
+  esac
+  echo "==> Wiping $abs_iso_dir"
+  rm -rf "$abs_iso_dir"
 fi
 mkdir -p "$iso_dir/state"
 


### PR DESCRIPTION
## Summary

Closes #172. Extends #166's session-id pinning/capture infrastructure to the remaining agents:

- **Gemini** (pin, mirroring Claude): `IDGemini` gets `SessionIDFlag: "--session-id"` + `ResumeArgs(id) → [gemini, --resume, id]`. Verified empirically that `gemini --session-id <UUID>` + `gemini --resume <UUID>` round-trips a full UUID.
- **Copilot** (capture, mirroring Codex): new `internal/agent/copilot.go` polls `~/.copilot/session-state/` for a new `<UUID>/workspace.yaml` whose `cwd:` field matches the spawn cwd. `IDCopilot` gets `ResumeArgs(id) → [copilot, --resume=id]` (note `=` form per `copilot --help`) and `CaptureSessionIDFn`.

Aider remains unsupported (no `--resume` command).

## Architecture

Falls cleanly into the two patterns #166 established:

```
PIN PATTERN (Claude, Gemini)
Registry.Create
  → resolved cmd: [agent, ..., --session-id, <hive-entry-id>]
  → AgentSessionID = entry.ID at first launch
Restart/Revive
  → ResumeArgs(AgentSessionID) → [agent, --resume, <id>]

CAPTURE PATTERN (Codex, Copilot)
Registry.Create
  → spawn agent (no flag injection)
  → goroutine: poll agent's on-disk store every 200ms,
    match by cwd + spawnedAt-1s mtime cutoff,
    persist AgentSessionID on first match
Restart/Revive
  → ResumeArgs(AgentSessionID) → [agent, resume, <id>]
                              or [agent, --resume=<id>]
```

The new `copilotCaptureSessionID` follows codex's logic exactly, with two adjustments specific to copilot's layout:
- Storage is `~/.copilot/session-state/<UUID>/workspace.yaml`, so we list immediate subdirectories (vs codex's nested `YYYY/MM/DD/`) and validate names against a UUID regex.
- The `cwd:` field is in YAML rather than JSON, parsed manually at top level (no YAML dependency added).

## Test plan

- [x] `internal/agent/copilot_test.go` — 7 tests mirroring `codex_test.go`:
  - `TestCopilotCaptureReadsWorkspaceUUID` — happy path
  - `TestCopilotCaptureSkipsMismatchedCwd` — wrong cwd
  - `TestCopilotCaptureRespectsContextCancel` — ctx cancel
  - `TestCopilotCaptureIgnoresPreexistingSessionsInSameCwd` — mtime cutoff
  - `TestCopilotCaptureSkipsNonUUIDDirNames` — defensive against junk dirs
  - `TestCopilotDefHasResumeArgsAndCapture` — Def shape, including \`SessionIDFlag == ""\` (no caller-pinning support)
  - `TestGeminiDefHasSessionIDPinning` — Def shape, including \`CaptureSessionIDFn == nil\` (uses pin, not capture)
- [x] `go test ./internal/... ./cmd/hived/... -count=1` clean
- [x] `go vet ./internal/... ./cmd/hived/...` clean
- [x] Empirical: `gemini --session-id 11111111-2222-3333-4444-555555555555 -p "say hi"` → resumed via `gemini --resume <same-uuid>` recovered the conversation
- [ ] Manual: ⌘P-duplicate two Gemini sessions in one cwd, type into each, restart, verify each restarts to its own conversation
- [ ] Manual: same for two Copilot sessions
- [ ] Manual: kill `hived`, restart, verify both Gemini and Copilot sessions revive against their own conversations

## Verified CLI capabilities

| Agent | `--session-id <UUID>` at launch | Resume by UUID |
|---|---|---|
| Gemini | ✅ (any caller UUID accepted) | ✅ `gemini --resume <UUID>` |
| Copilot | ❌ no flag | ✅ `copilot --resume=<UUID>` (\`=\` form, per \`--help\`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)