### PR TITLE
fix(registry): re-pin claude session id when restart predates first message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restarting a Claude session before any message had been sent failed
+  with `No conversation found with session ID: <uuid>`. Claude only
+  writes the transcript jsonl after the first user message, so a fresh
+  pinned session has no on-disk record for `claude --resume <id>` to
+  find. Restart/Revive now stat the expected transcript path
+  (`~/.claude/projects/<encoded-cwd>/<id>.jsonl`) and re-pin the same
+  id via `claude --session-id <id>` when it doesn't exist, preserving
+  the Hive entry id ↔ claude conversation id mapping.
 - An isolated dev daemon (`HIVE_STATE_DIR` set) no longer reaps
   worktrees owned by the canonical/prod daemon at startup. The
   on-disk `<project>/.worktrees/` namespace is shared across daemon

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -39,10 +39,15 @@ type Def struct {
 	// caller-chosen id. Required for unambiguous Restart when multiple
 	// sessions share a cwd/worktree.
 	SessionIDFlag string
-	// ResumeArgs builds the resume argv for a specific session id. When
-	// nil, Restart falls back to ResumeCmd (path-scoped, ambiguous when
-	// sessions share cwd) and then to Cmd.
-	ResumeArgs func(sessionID string) []string
+	// ResumeArgs builds the resume argv for a specific session id. cwd
+	// is the directory the session will be respawned in; agents that
+	// only have an on-disk transcript after the first user message
+	// (Claude) use it to detect the "restarted before any message"
+	// case and re-pin under the same id instead of failing with
+	// "No conversation found". When nil, Restart falls back to
+	// ResumeCmd (path-scoped, ambiguous when sessions share cwd) and
+	// then to Cmd.
+	ResumeArgs func(sessionID, cwd string) []string
 	// CaptureSessionIDFn, when non-nil, is invoked from a goroutine
 	// after the agent process is spawned. It returns the agent CLI's
 	// session id (e.g. parsed from a rollout file) so future Restart
@@ -80,9 +85,7 @@ var (
 			Color:         "#f59e0b",
 			InstallCmd:    []string{"npm", "install", "-g", "@anthropic-ai/claude-code"},
 			SessionIDFlag: "--session-id",
-			ResumeArgs: func(id string) []string {
-				return []string{"claude", "--resume", id}
-			},
+			ResumeArgs:    claudeResumeArgs,
 		},
 		IDCodex: {
 			ID:         IDCodex,
@@ -91,7 +94,7 @@ var (
 			ResumeCmd:  []string{"codex", "resume", "--last"},
 			Color:      "#10b981",
 			InstallCmd: []string{"npm", "install", "-g", "@openai/codex"},
-			ResumeArgs: func(id string) []string {
+			ResumeArgs: func(id, _ string) []string {
 				return []string{"codex", "resume", id}
 			},
 			CaptureSessionIDFn: codexCaptureSessionID,
@@ -104,7 +107,7 @@ var (
 			Color:         "#3b82f6",
 			InstallCmd:    []string{"npm", "install", "-g", "@google/gemini-cli"},
 			SessionIDFlag: "--session-id",
-			ResumeArgs: func(id string) []string {
+			ResumeArgs: func(id, _ string) []string {
 				return []string{"gemini", "--resume", id}
 			},
 		},
@@ -115,7 +118,7 @@ var (
 			ResumeCmd:  []string{"copilot", "--resume"},
 			Color:      "#8b5cf6",
 			InstallCmd: []string{"npm", "install", "-g", "@github/copilot"},
-			ResumeArgs: func(id string) []string {
+			ResumeArgs: func(id, _ string) []string {
 				return []string{"copilot", "--resume=" + id}
 			},
 			CaptureSessionIDFn: copilotCaptureSessionID,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -43,7 +43,10 @@ func TestClaudeDefSupportsSessionID(t *testing.T) {
 	if d.ResumeArgs == nil {
 		t.Fatalf("claude ResumeArgs is nil; expected per-id resume support")
 	}
-	got := d.ResumeArgs("abc123")
+	prev := claudeSessionExists
+	claudeSessionExists = func(id, cwd string) bool { return true }
+	t.Cleanup(func() { claudeSessionExists = prev })
+	got := d.ResumeArgs("abc123", "/tmp/some/cwd")
 	want := []string{"claude", "--resume", "abc123"}
 	if len(got) != len(want) {
 		t.Fatalf("ResumeArgs len = %d, want %d (got %v)", len(got), len(want), got)

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// claudeSessionExists reports whether claude has persisted a transcript
+// for sessionID under cwd. Claude only writes the JSONL after the first
+// user message, so a session started but never used has no on-disk
+// record and `claude --resume <id>` exits with "No conversation found
+// with session ID". The Hive Restart flow has to detect that and re-pin
+// the same id with --session-id instead.
+//
+// Layout: ~/.claude/projects/<encoded-cwd>/<id>.jsonl, where the
+// encoding replaces every "/" with "-".
+var claudeSessionExists = func(sessionID, cwd string) bool {
+	if sessionID == "" || cwd == "" {
+		return false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	encoded := strings.ReplaceAll(cwd, "/", "-")
+	_, err = os.Stat(filepath.Join(home, ".claude", "projects", encoded, sessionID+".jsonl"))
+	return err == nil
+}
+
+// SetClaudeSessionExistsForTest replaces the on-disk transcript probe
+// with a stub. Returns a restore function to defer in tests. Lives in
+// a regular .go file (not _test.go) so it's reachable from other
+// packages' tests, e.g. registry_test.go.
+func SetClaudeSessionExistsForTest(fn func(sessionID, cwd string) bool) (restore func()) {
+	prev := claudeSessionExists
+	claudeSessionExists = fn
+	return func() { claudeSessionExists = prev }
+}
+
+func claudeResumeArgs(sessionID, cwd string) []string {
+	if claudeSessionExists(sessionID, cwd) {
+		return []string{"claude", "--resume", sessionID}
+	}
+	return []string{"claude", "--session-id", sessionID}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -6,6 +6,21 @@ import (
 	"strings"
 )
 
+// encodeClaudeProjectDir mirrors claude's on-disk encoding for the
+// per-cwd transcript directory under ~/.claude/projects/. Claude
+// replaces both path separators and the "." in dotted segments (e.g.
+// .worktrees) with "-", so /Users/u/repo/.worktrees/x becomes
+// "-Users-u-repo--worktrees-x". On Windows we normalize backslashes
+// to forward slashes first and replace the drive colon so the probe
+// has a chance of matching whatever path-flavor claude itself wrote.
+func encodeClaudeProjectDir(cwd string) string {
+	s := filepath.ToSlash(filepath.Clean(cwd))
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.ReplaceAll(s, ".", "-")
+	s = strings.ReplaceAll(s, ":", "-")
+	return s
+}
+
 // claudeSessionExists reports whether claude has persisted a transcript
 // for sessionID under cwd. Claude only writes the JSONL after the first
 // user message, so a session started but never used has no on-disk
@@ -13,8 +28,8 @@ import (
 // with session ID". The Hive Restart flow has to detect that and re-pin
 // the same id with --session-id instead.
 //
-// Layout: ~/.claude/projects/<encoded-cwd>/<id>.jsonl, where the
-// encoding replaces every "/" with "-".
+// Layout: ~/.claude/projects/<encoded-cwd>/<id>.jsonl. See
+// encodeClaudeProjectDir for the encoding.
 var claudeSessionExists = func(sessionID, cwd string) bool {
 	if sessionID == "" || cwd == "" {
 		return false
@@ -23,7 +38,7 @@ var claudeSessionExists = func(sessionID, cwd string) bool {
 	if err != nil {
 		return false
 	}
-	encoded := strings.ReplaceAll(cwd, "/", "-")
+	encoded := encodeClaudeProjectDir(cwd)
 	_, err = os.Stat(filepath.Join(home, ".claude", "projects", encoded, sessionID+".jsonl"))
 	return err == nil
 }
@@ -32,7 +47,15 @@ var claudeSessionExists = func(sessionID, cwd string) bool {
 // with a stub. Returns a restore function to defer in tests. Lives in
 // a regular .go file (not _test.go) so it's reachable from other
 // packages' tests, e.g. registry_test.go.
+//
+// Callers must not run with t.Parallel() while the override is
+// installed: the hook is package-global and concurrent overrides will
+// race. fn must be non-nil; passing nil panics rather than deferring
+// the failure to the next claudeResumeArgs call.
 func SetClaudeSessionExistsForTest(fn func(sessionID, cwd string) bool) (restore func()) {
+	if fn == nil {
+		panic("agent.SetClaudeSessionExistsForTest: nil fn")
+	}
 	prev := claudeSessionExists
 	claudeSessionExists = fn
 	return func() { claudeSessionExists = prev }

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import "testing"
+
+func TestEncodeClaudeProjectDir(t *testing.T) {
+	cases := []struct {
+		name string
+		cwd  string
+		want string
+	}{
+		{
+			name: "plain posix path",
+			cwd:  "/Users/u/checkout/repo",
+			want: "-Users-u-checkout-repo",
+		},
+		{
+			name: "worktree dotted segment",
+			cwd:  "/Users/u/checkout/hive/.worktrees/green-anchor",
+			want: "-Users-u-checkout-hive--worktrees-green-anchor",
+		},
+		{
+			name: "trailing slash is cleaned",
+			cwd:  "/Users/u/checkout/repo/",
+			want: "-Users-u-checkout-repo",
+		},
+		{
+			name: "dotfile component",
+			cwd:  "/home/u/.config/x",
+			want: "-home-u--config-x",
+		},
+		{
+			name: "windows-shaped path with drive and backslashes",
+			cwd:  `C:\Users\u\repo`,
+			// filepath.Clean on linux leaves backslashes alone, so
+			// we just verify the colon and any forward slashes flip
+			// to dashes; the test is mainly a smoke for the Windows
+			// path of the encoder, and the no-data-loss fallback
+			// (`--session-id`) keeps it safe regardless.
+			want: `C-\Users\u\repo`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodeClaudeProjectDir(tc.cwd)
+			if got != tc.want {
+				t.Errorf("encodeClaudeProjectDir(%q) = %q, want %q", tc.cwd, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeResumeArgsFallsBackWhenTranscriptMissing(t *testing.T) {
+	t.Cleanup(SetClaudeSessionExistsForTest(func(_, _ string) bool { return false }))
+	got := claudeResumeArgs("abc", "/some/cwd")
+	want := []string{"claude", "--session-id", "abc"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestClaudeResumeArgsResumesWhenTranscriptExists(t *testing.T) {
+	t.Cleanup(SetClaudeSessionExistsForTest(func(_, _ string) bool { return true }))
+	got := claudeResumeArgs("abc", "/some/cwd")
+	want := []string{"claude", "--resume", "abc"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSetClaudeSessionExistsForTestRejectsNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic when passing nil fn")
+		}
+	}()
+	SetClaudeSessionExistsForTest(nil)
+}

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -29,14 +29,15 @@ func TestEncodeClaudeProjectDir(t *testing.T) {
 			want: "-home-u--config-x",
 		},
 		{
-			name: "windows-shaped path with drive and backslashes",
-			cwd:  `C:\Users\u\repo`,
-			// filepath.Clean on linux leaves backslashes alone, so
-			// we just verify the colon and any forward slashes flip
-			// to dashes; the test is mainly a smoke for the Windows
-			// path of the encoder, and the no-data-loss fallback
-			// (`--session-id`) keeps it safe regardless.
-			want: `C-\Users\u\repo`,
+			// Pre-normalized Windows-style input (already
+			// ToSlash'd) — covers the drive-colon branch in a
+			// platform-independent way. filepath.Clean's
+			// backslash handling differs between GOOS=windows
+			// and POSIX, so we feed the encoder slash form
+			// directly to keep the assertion deterministic.
+			name: "windows drive with forward slashes",
+			cwd:  "C:/Users/u/repo",
+			want: "C--Users-u-repo",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -146,7 +146,7 @@ func TestCodexDefHasResumeArgsAndCapture(t *testing.T) {
 	if d.ResumeArgs == nil {
 		t.Errorf("codex ResumeArgs is nil")
 	} else {
-		got := d.ResumeArgs("xyz")
+		got := d.ResumeArgs("xyz", "")
 		want := []string{"codex", "resume", "xyz"}
 		if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 			t.Errorf("ResumeArgs = %v, want %v", got, want)

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -216,7 +216,7 @@ func TestCopilotDefHasResumeArgsAndCapture(t *testing.T) {
 	if d.ResumeArgs == nil {
 		t.Errorf("copilot ResumeArgs is nil")
 	} else {
-		got := d.ResumeArgs("xyz")
+		got := d.ResumeArgs("xyz", "")
 		want := []string{"copilot", "--resume=xyz"}
 		if !slices.Equal(got, want) {
 			t.Errorf("ResumeArgs = %v, want %v", got, want)
@@ -242,7 +242,7 @@ func TestGeminiDefHasSessionIDPinning(t *testing.T) {
 	if d.ResumeArgs == nil {
 		t.Errorf("gemini ResumeArgs is nil")
 	} else {
-		got := d.ResumeArgs("xyz")
+		got := d.ResumeArgs("xyz", "")
 		want := []string{"gemini", "--resume", "xyz"}
 		if !slices.Equal(got, want) {
 			t.Errorf("ResumeArgs = %v, want %v", got, want)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -584,22 +584,6 @@ func (r *Registry) Revive(id string, opts session.Options) error {
 	}
 	r.mu.Unlock()
 
-	if agentID != "" && len(opts.Cmd) == 0 {
-		if def, ok := agent.Get(agent.ID(agentID)); ok && len(def.Cmd) > 0 {
-			// If we previously pinned this entry to an agent
-			// conversation id (Claude --session-id at first launch,
-			// or codex post-spawn capture), resume that exact
-			// conversation. Otherwise the daemon-startup respawn
-			// runs a bare agent in the cwd and re-introduces the
-			// path-scoped ambiguity #165 fixed.
-			if agentSessionID != "" && def.ResumeArgs != nil {
-				opts.Cmd = def.ResumeArgs(agentSessionID)
-			} else {
-				opts.Cmd = def.Cmd
-			}
-		}
-	}
-
 	if projectCwd != "" {
 		opts.Cwd = projectCwd
 	}
@@ -621,6 +605,22 @@ func (r *Registry) Revive(id string, opts session.Options) error {
 			info := e.Info()
 			r.mu.Unlock()
 			r.broadcast(wire.SessionEventUpdated, info)
+		}
+	}
+
+	if agentID != "" && len(opts.Cmd) == 0 {
+		if def, ok := agent.Get(agent.ID(agentID)); ok && len(def.Cmd) > 0 {
+			// If we previously pinned this entry to an agent
+			// conversation id (Claude --session-id at first launch,
+			// or codex post-spawn capture), resume that exact
+			// conversation. Otherwise the daemon-startup respawn
+			// runs a bare agent in the cwd and re-introduces the
+			// path-scoped ambiguity #165 fixed.
+			if agentSessionID != "" && def.ResumeArgs != nil {
+				opts.Cmd = def.ResumeArgs(agentSessionID, opts.Cwd)
+			} else {
+				opts.Cmd = def.Cmd
+			}
 		}
 	}
 
@@ -666,6 +666,7 @@ func (r *Registry) Restart(id string) error {
 	}
 	sess := e.sess
 	agentID := e.Agent
+	wtPath := e.WorktreePath
 	projectCwd := ""
 	if p, ok := r.projects[e.ProjectID]; ok {
 		projectCwd = p.Cwd
@@ -695,6 +696,17 @@ func (r *Registry) Restart(id string) error {
 	}
 	r.mu.Unlock()
 
+	// Resolve the cwd we expect the resume to spawn under, so
+	// ResumeArgs (Claude) can stat the agent's session file at the
+	// right project hash. Revive will redo this same promotion; we
+	// only compute it here to drive the resume-argv decision.
+	resumeCwd := projectCwd
+	if wtPath != "" {
+		if _, err := os.Stat(wtPath); err == nil {
+			resumeCwd = wtPath
+		}
+	}
+
 	var opts session.Options
 	if def, ok := agent.Get(agent.ID(agentID)); ok {
 		switch {
@@ -704,7 +716,7 @@ func (r *Registry) Restart(id string) error {
 			// a cwd. resumeID is the Hive entry id for Claude
 			// (pre-pinned via --session-id) and the codex-generated
 			// UUID captured post-spawn for Codex.
-			opts.Cmd = def.ResumeArgs(resumeID)
+			opts.Cmd = def.ResumeArgs(resumeID, resumeCwd)
 		case len(def.ResumeCmd) > 0:
 			opts.Cmd = def.ResumeCmd
 		default:

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lucascaro/hive/internal/agent"
 	"github.com/lucascaro/hive/internal/session"
 	"github.com/lucascaro/hive/internal/wire"
 )
@@ -368,6 +369,10 @@ func TestRestartUsesResumeArgsForClaude(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
+	// Simulate the post-first-message state: claude has written a
+	// transcript jsonl for the pinned id. Restart must use --resume.
+	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return true }))
+
 	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -488,6 +493,7 @@ func TestTwoClaudeSessionsRestartUseDistinctIDs(t *testing.T) {
 	skipOnWindows(t)
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
+	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return true }))
 
 	a, err := r.Create(wire.CreateSpec{Name: "a", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
@@ -573,6 +579,7 @@ func TestReviveUsesResumeArgsForPinnedClaude(t *testing.T) {
 	skipOnWindows(t)
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
+	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return true }))
 
 	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
@@ -603,6 +610,42 @@ func TestReviveUsesResumeArgsForPinnedClaude(t *testing.T) {
 	for i := range want {
 		if got[i] != want[i] {
 			t.Errorf("Revive cmd[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRestartEmptyClaudeSessionRepinsBySessionID covers the case
+// where the user clicks Restart before sending any prompt: claude
+// writes the transcript jsonl only after the first user message, so
+// `claude --resume <id>` would fail with "No conversation found with
+// session ID". Hive must instead re-pin the same id via
+// `claude --session-id <id>` so the restarted process keeps the
+// same Hive entry id ↔ claude conversation id mapping.
+func TestRestartEmptyClaudeSessionRepinsBySessionID(t *testing.T) {
+	skipOnWindows(t)
+	rec := captureStartSession(t)
+	r := freshRegistry(t)
+	// No transcript on disk: the session was never used.
+	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return false }))
+
+	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := r.Restart(a.ID); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	want := []string{"claude", "--session-id", a.ID}
+	got := rec.opts[len(rec.opts)-1].Cmd
+	if len(got) != len(want) {
+		t.Fatalf("Restart cmd = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Restart cmd[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Restarting a Claude session before any prompt has been sent failed with `No conversation found with session ID: <uuid>`. Claude writes the transcript jsonl only after the first user message, so a pinned-but-empty session has no on-disk record for `claude --resume <id>` to find.
- Restart/Revive now stat `~/.claude/projects/<encoded-cwd>/<id>.jsonl` and fall back to `claude --session-id <id>` when no transcript exists, re-pinning the same id so the entry-id ↔ conversation-id mapping from #166 survives the empty-restart case.
- `agent.Def.ResumeArgs` gains a `cwd` arg so Claude can probe the right project hash; Codex/Gemini/Copilot ignore it.

## Test plan

- [x] `go vet ./internal/...`
- [x] `go test ./internal/...`
- [x] New regression test `TestRestartEmptyClaudeSessionRepinsBySessionID` (probe → false → argv is `claude --session-id <id>`)
- [x] Existing `--resume` tests adapted to stub the probe to true
- [x] Manual repro confirmed: `claude --session-id <U>` then kill before any input → no jsonl created → `claude --resume <U>` exits 1 with the documented error
- [ ] Smoke test in the GUI: create a Claude session, immediately Restart Session, verify it stays alive
- [ ] Smoke test in the GUI: send a message, Restart Session, verify the conversation is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)