### PR TITLE
fix(gui): windows restart, grid-mode revert, and ctrl-arrow direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows: the "Restart Hive" button in the daemon-stale banner now
+  actually restarts hived. Previously the platform stub returned
+  `restart not supported on this platform` and the relaunch never
+  fired. Windows now reads `<sock>.pid`, verifies the recorded pid is
+  hived.exe via `tasklist`, and TerminateProcess-es it (matching the
+  unix SIGKILL fallback). Stale pidfiles whose pid was recycled to an
+  unrelated process are removed without signaling.
+- Windows / Linux: toggling grid mode (`Ctrl+G` / `Ctrl+Enter`) no
+  longer flashes the grid then snaps back to single-session view, and
+  `Ctrl+Up` / `Ctrl+Down` / `Ctrl+Left` / `Ctrl+Right` no longer feel
+  reversed. The native menu's keyboard accelerators were firing
+  alongside the in-window JS keyboard listener, so every shortcut ran
+  twice. The native menu is now darwin-only — JS owns every shortcut
+  on Windows and Linux. macOS is unchanged.
 - Restarting a Claude session before any message had been sent failed
   with `No conversation found with session ID: <uuid>`. Claude only
   writes the transcript jsonl after the first user message, so a fresh

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 package main
 
 import (

--- a/cmd/hivegui/menu_other.go
+++ b/cmd/hivegui/menu_other.go
@@ -1,0 +1,21 @@
+//go:build !darwin
+
+package main
+
+import (
+	"github.com/wailsapp/wails/v2/pkg/menu"
+)
+
+// buildAppMenu returns nil on non-darwin platforms.
+//
+// On macOS the menu owns the visible menu bar and its accelerators are
+// the canonical source of every keyboard shortcut. On Windows and
+// Linux the same accelerators double-fire alongside the in-window JS
+// keyboard listener — Ctrl+G toggled grid twice (back to single),
+// Ctrl+Down/Up advanced two steps and felt reversed, etc. The native
+// menu adds no user-facing value on those platforms (Wails surfaces it
+// only as a hidden accelerator table), so we drop it and let the JS
+// keyboard handler in cmd/hivegui/frontend/src/main.js own every
+// shortcut. Adding a new shortcut on Windows/Linux is therefore a
+// frontend-only change.
+func buildAppMenu(_ *App) *menu.Menu { return nil }

--- a/cmd/hivegui/restart_windows.go
+++ b/cmd/hivegui/restart_windows.go
@@ -2,12 +2,126 @@
 
 package main
 
-import "errors"
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
 
-// killRunningHived is unimplemented on Windows: the daemon isn't
-// supported there yet, and we don't have a reliable cross-process
-// signal path. Return an error so the GUI's "Restart daemon" action
-// surfaces the failure instead of silently pretending it worked.
-func killRunningHived(_ string) error {
-	return errors.New("restart not supported on this platform")
+// killRunningHived terminates the hived recorded in <sock>.pid and
+// waits for it to actually exit so the caller can rely on the
+// "killRunningHived returned nil ⇒ socket is free" contract that the
+// unix sibling (restart_unix.go) provides.
+//
+// On Windows there is no in-band soft-kill for a process spawned with
+// DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP and no console control
+// handler installed (see spawn_windows.go), so this is a hard kill via
+// TerminateProcess (os.Process.Kill on Windows).
+//
+// Safety: like restart_unix.go, the pidfile is scoped to the socket
+// the daemon owns (sibling file, "<sock>.pid") so a second hived with
+// a custom --socket can't be accidentally killed. Before terminating,
+// the recorded pid is verified to currently be running as hived.exe
+// via tasklist; if it is not (recycled pid), the stale pidfile is
+// removed and no kill is performed.
+//
+// Returns nil if the pidfile is missing, the recorded pid no longer
+// exists, or the recorded pid does not look like a hived.
+func killRunningHived(sock string) error {
+	pidPath := sock + ".pid"
+	raw, err := os.ReadFile(pidPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read pidfile: %w", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 1 {
+		return fmt.Errorf("invalid pid in %s: %q", pidPath, raw)
+	}
+
+	alive, isHived := tasklistProbe(pid)
+	if !alive {
+		return nil // already gone
+	}
+	if !isHived {
+		// Stale pidfile pointing at a recycled, unrelated pid.
+		_ = os.Remove(pidPath)
+		return nil
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find pid %d: %w", pid, err)
+	}
+	if err := proc.Kill(); err != nil {
+		// ESRCH-equivalent races are fine; the process is gone.
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return fmt.Errorf("terminate pid %d: %w", pid, err)
+	}
+	waitForExitWindows(pid, 3*time.Second)
+	return nil
+}
+
+// tasklistProbe reports whether pid is currently running, and whether
+// its image name is hived.exe. Uses the built-in tasklist utility
+// (ships with every Windows install) for symmetry with the unix
+// implementation's `ps -o comm=` probe. Returns (false, false) on any
+// error so callers stay conservative about who they signal.
+func tasklistProbe(pid int) (alive, hived bool) {
+	cmd := exec.Command("tasklist", "/FI", "PID eq "+strconv.Itoa(pid), "/FO", "CSV", "/NH")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	out, err := cmd.Output()
+	if err != nil {
+		return false, false
+	}
+	return parseTasklistRow(string(out))
+}
+
+// parseTasklistRow extracts (alive, isHived) from tasklist CSV output.
+// When the pid does not exist tasklist prints either an empty body or
+// "INFO: No tasks are running which match the specified criteria." on
+// stdout. When it exists the row is: "image","pid","session","sess#","mem".
+// Split out for unit testing without invoking tasklist.
+func parseTasklistRow(out string) (alive, hived bool) {
+	out = strings.TrimSpace(out)
+	if out == "" || strings.HasPrefix(strings.ToUpper(out), "INFO:") {
+		return false, false
+	}
+	r := csv.NewReader(strings.NewReader(out))
+	r.FieldsPerRecord = -1
+	rec, err := r.Read()
+	if err != nil || len(rec) == 0 {
+		return false, false
+	}
+	image := strings.ToLower(strings.TrimSpace(rec[0]))
+	// tasklist appends .exe on Windows; basename in case future tasklist
+	// variants prepend a path.
+	if i := strings.LastIndexAny(image, `\/`); i >= 0 {
+		image = image[i+1:]
+	}
+	return true, image == "hived.exe"
+}
+
+// waitForExitWindows polls tasklist until pid is gone or the budget
+// elapses. Mirrors the unix waitForExit helper so the GUI's reconnect
+// does not race the dying socket.
+func waitForExitWindows(pid int, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if alive, _ := tasklistProbe(pid); !alive {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
 }

--- a/cmd/hivegui/restart_windows.go
+++ b/cmd/hivegui/restart_windows.go
@@ -14,6 +14,11 @@ import (
 	"time"
 )
 
+// probeFn is the package-level seam used by killRunningHived so tests
+// can stub the tasklist invocation without shelling out. Production
+// code points it at runTasklistProbe.
+var probeFn = runTasklistProbe
+
 // killRunningHived terminates the hived recorded in <sock>.pid and
 // waits for it to actually exit so the caller can rely on the
 // "killRunningHived returned nil ⇒ socket is free" contract that the
@@ -32,7 +37,11 @@ import (
 // removed and no kill is performed.
 //
 // Returns nil if the pidfile is missing, the recorded pid no longer
-// exists, or the recorded pid does not look like a hived.
+// exists, or the recorded pid does not look like a hived. Returns a
+// non-nil error if tasklist itself cannot be invoked (PATH/exec
+// failure) or if the killed process does not exit within the budget —
+// surfacing those keeps the GUI from silently relaunching while the
+// previous daemon is still bound to the socket.
 func killRunningHived(sock string) error {
 	pidPath := sock + ".pid"
 	raw, err := os.ReadFile(pidPath)
@@ -47,7 +56,10 @@ func killRunningHived(sock string) error {
 		return fmt.Errorf("invalid pid in %s: %q", pidPath, raw)
 	}
 
-	alive, isHived := tasklistProbe(pid)
+	alive, isHived, err := probeFn(pid)
+	if err != nil {
+		return fmt.Errorf("probe pid %d: %w", pid, err)
+	}
 	if !alive {
 		return nil // already gone
 	}
@@ -68,23 +80,31 @@ func killRunningHived(sock string) error {
 		}
 		return fmt.Errorf("terminate pid %d: %w", pid, err)
 	}
-	waitForExitWindows(pid, 3*time.Second)
+	if !waitForExitWindows(pid, 3*time.Second) {
+		return fmt.Errorf("pid %d still alive 3s after TerminateProcess", pid)
+	}
 	return nil
 }
 
-// tasklistProbe reports whether pid is currently running, and whether
-// its image name is hived.exe. Uses the built-in tasklist utility
-// (ships with every Windows install) for symmetry with the unix
-// implementation's `ps -o comm=` probe. Returns (false, false) on any
-// error so callers stay conservative about who they signal.
-func tasklistProbe(pid int) (alive, hived bool) {
+// runTasklistProbe reports whether pid is currently running and
+// whether its image name is hived.exe. Uses the built-in tasklist
+// utility (ships with every Windows install) for symmetry with the
+// unix implementation's `ps -o comm=` probe.
+//
+// Distinguishes "tasklist couldn't run" (returns err) from "tasklist
+// ran and found no matching pid" (returns alive=false, err=nil). The
+// caller cares about the difference: a missing pid means the daemon
+// is already dead; an exec failure means we can't tell, so we must
+// not silently proceed as if the socket were free.
+func runTasklistProbe(pid int) (alive, hived bool, err error) {
 	cmd := exec.Command("tasklist", "/FI", "PID eq "+strconv.Itoa(pid), "/FO", "CSV", "/NH")
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	out, err := cmd.Output()
 	if err != nil {
-		return false, false
+		return false, false, fmt.Errorf("exec tasklist: %w", err)
 	}
-	return parseTasklistRow(string(out))
+	a, h := parseTasklistRow(string(out))
+	return a, h, nil
 }
 
 // parseTasklistRow extracts (alive, isHived) from tasklist CSV output.
@@ -112,13 +132,16 @@ func parseTasklistRow(out string) (alive, hived bool) {
 	return true, image == "hived.exe"
 }
 
-// waitForExitWindows polls tasklist until pid is gone or the budget
-// elapses. Mirrors the unix waitForExit helper so the GUI's reconnect
-// does not race the dying socket.
+// waitForExitWindows polls until pid is gone or the budget elapses.
+// Mirrors the unix waitForExit helper. Errors from the probe are
+// treated as "still alive, keep polling" — the post-kill wait is best
+// effort and the caller ultimately surfaces a timeout if the deadline
+// passes.
 func waitForExitWindows(pid int, budget time.Duration) bool {
 	deadline := time.Now().Add(budget)
 	for time.Now().Before(deadline) {
-		if alive, _ := tasklistProbe(pid); !alive {
+		alive, _, err := probeFn(pid)
+		if err == nil && !alive {
 			return true
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/cmd/hivegui/restart_windows_test.go
+++ b/cmd/hivegui/restart_windows_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -58,7 +59,20 @@ func TestParseTasklistRow(t *testing.T) {
 	}
 }
 
+// stubProbe swaps probeFn for the duration of a test. Restoring it in
+// a Cleanup keeps tests independent of evaluation order.
+func stubProbe(t *testing.T, fn func(int) (bool, bool, error)) {
+	t.Helper()
+	prev := probeFn
+	probeFn = fn
+	t.Cleanup(func() { probeFn = prev })
+}
+
 func TestKillRunningHived_NoPidfile(t *testing.T) {
+	stubProbe(t, func(int) (bool, bool, error) {
+		t.Fatal("probe must not be called when no pidfile exists")
+		return false, false, nil
+	})
 	dir := t.TempDir()
 	sock := filepath.Join(dir, "hived.sock")
 	if err := killRunningHived(sock); err != nil {
@@ -67,12 +81,14 @@ func TestKillRunningHived_NoPidfile(t *testing.T) {
 }
 
 func TestKillRunningHived_StalePidfileRemoved(t *testing.T) {
+	stubProbe(t, func(pid int) (bool, bool, error) {
+		// Recycled pid: alive but not hived.exe.
+		return true, false, nil
+	})
 	dir := t.TempDir()
 	sock := filepath.Join(dir, "hived.sock")
 	pidPath := sock + ".pid"
-	// PID 4 is the System process on Windows: alive but definitely not hived.
-	// killRunningHived must NOT terminate it and MUST remove the stale pidfile.
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(4)), 0o600); err != nil {
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(99999)), 0o600); err != nil {
 		t.Fatalf("write stale pidfile: %v", err)
 	}
 	if err := killRunningHived(sock); err != nil {
@@ -80,5 +96,53 @@ func TestKillRunningHived_StalePidfileRemoved(t *testing.T) {
 	}
 	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
 		t.Fatalf("stale pidfile not removed: stat err = %v", err)
+	}
+}
+
+func TestKillRunningHived_DeadPidNoError(t *testing.T) {
+	stubProbe(t, func(int) (bool, bool, error) {
+		return false, false, nil // pid no longer exists
+	})
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "hived.sock")
+	if err := os.WriteFile(sock+".pid", []byte("12345"), 0o600); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+	if err := killRunningHived(sock); err != nil {
+		t.Fatalf("killRunningHived for already-dead pid: %v", err)
+	}
+}
+
+func TestKillRunningHived_ProbeFailurePropagates(t *testing.T) {
+	wantErr := errors.New("tasklist exec failed")
+	stubProbe(t, func(int) (bool, bool, error) {
+		return false, false, wantErr
+	})
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "hived.sock")
+	if err := os.WriteFile(sock+".pid", []byte("12345"), 0o600); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+	err := killRunningHived(sock)
+	if err == nil {
+		t.Fatal("expected probe failure to propagate, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err chain missing probe failure: %v", err)
+	}
+}
+
+func TestKillRunningHived_InvalidPid(t *testing.T) {
+	stubProbe(t, func(int) (bool, bool, error) {
+		t.Fatal("probe must not be called for invalid pid")
+		return false, false, nil
+	})
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "hived.sock")
+	if err := os.WriteFile(sock+".pid", []byte("not-a-number"), 0o600); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+	if err := killRunningHived(sock); err == nil {
+		t.Fatal("expected error for malformed pidfile, got nil")
 	}
 }

--- a/cmd/hivegui/restart_windows_test.go
+++ b/cmd/hivegui/restart_windows_test.go
@@ -1,0 +1,84 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestParseTasklistRow(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantAlive bool
+		wantHived bool
+	}{
+		{
+			name:      "hived match",
+			in:        `"hived.exe","1234","Console","1","12,345 K"`,
+			wantAlive: true,
+			wantHived: true,
+		},
+		{
+			name:      "other process",
+			in:        `"notepad.exe","5678","Console","1","8,000 K"`,
+			wantAlive: true,
+			wantHived: false,
+		},
+		{
+			name:      "no match info line",
+			in:        "INFO: No tasks are running which match the specified criteria.",
+			wantAlive: false,
+			wantHived: false,
+		},
+		{
+			name:      "empty",
+			in:        "",
+			wantAlive: false,
+			wantHived: false,
+		},
+		{
+			name:      "case-insensitive image",
+			in:        `"Hived.EXE","42","Services","0","4,000 K"`,
+			wantAlive: true,
+			wantHived: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			alive, hived := parseTasklistRow(tc.in)
+			if alive != tc.wantAlive || hived != tc.wantHived {
+				t.Fatalf("parseTasklistRow(%q) = (%v,%v), want (%v,%v)",
+					tc.in, alive, hived, tc.wantAlive, tc.wantHived)
+			}
+		})
+	}
+}
+
+func TestKillRunningHived_NoPidfile(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "hived.sock")
+	if err := killRunningHived(sock); err != nil {
+		t.Fatalf("killRunningHived with missing pidfile: %v", err)
+	}
+}
+
+func TestKillRunningHived_StalePidfileRemoved(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "hived.sock")
+	pidPath := sock + ".pid"
+	// PID 4 is the System process on Windows: alive but definitely not hived.
+	// killRunningHived must NOT terminate it and MUST remove the stale pidfile.
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(4)), 0o600); err != nil {
+		t.Fatalf("write stale pidfile: %v", err)
+	}
+	if err := killRunningHived(sock); err != nil {
+		t.Fatalf("killRunningHived with stale pidfile: %v", err)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Fatalf("stale pidfile not removed: stat err = %v", err)
+	}
+}

--- a/docs/exec-plans/active/177-windows-restart-button-and-grid-mode-bugs.md
+++ b/docs/exec-plans/active/177-windows-restart-button-and-grid-mode-bugs.md
@@ -1,0 +1,102 @@
+# Windows: restart button, grid mode revert, and reversed ctrl-arrow session switch
+
+- **Spec:** [docs/product-specs/177-windows-restart-button-and-grid-mode-bugs.md](../../product-specs/177-windows-restart-button-and-grid-mode-bugs.md)
+- **Issue:** #177
+- **Stage:** PLAN
+- **Status:** active
+
+## Summary
+
+Fix three Windows-only UX bugs in the hivegui:
+1. The "Restart Hive" daemon-banner button errors with "restart not supported on this platform" because `killRunningHived` is a stub on Windows.
+2. Toggling grid mode flashes the grid then reverts, because the native menu's `Ctrl+G` accelerator and the JS `Ctrl+G` keyboard listener both fire — toggling twice.
+3. `Ctrl+Up`/`Ctrl+Down` (and likely all Ctrl+arrow / `Ctrl+G` / `Ctrl+Enter`) misbehave for the same root cause: native menu accelerators on Windows double-fire alongside the JS keyboard handler.
+
+The unifying fix for #2 and #3 is to scope the native menu (with accelerators) to macOS — where it is the visible menu bar that owns shortcuts — and let the JS keyboard handler be the single source of truth on Windows/Linux. The `menu.go` header comment already states the menu is for "the native macOS menu," so this is a latent platform-gating bug exposed when the same menu is built on Windows.
+
+For #1, implement a real Windows kill path that reads `<sock>.pid`, verifies the process is `hived.exe` via `tasklist`, then calls `os.Process.Kill` (which Windows implements as `TerminateProcess`).
+
+## Research
+
+### Bug 1 — restart button no-op on Windows
+
+- `cmd/hivegui/frontend/index.html:13` — the "Restart Hive" button (`#daemon-banner-restart`) only shows when the daemon-stale banner is visible.
+- `cmd/hivegui/frontend/src/main.js:1748–1772` — click handler calls `RestartDaemon()`; on error, calls `setStatus(...)` and `showDaemonBanner(...)` with the failure message. So the action *does* surface a message — the user-perceived "does nothing" likely refers to the absence of a restart, not absence of feedback.
+- `cmd/hivegui/app.go:239–259` — `RestartDaemon()` calls `killRunningHived(hdaemon.SocketPath())`, then `spawnNewGUI`, then `wruntime.Quit`.
+- `cmd/hivegui/restart_unix.go` — full implementation: read `<sock>.pid`, signal-0 probe, `pidLooksLikeHived` via `ps -o comm=`, SIGTERM, escalate to SIGKILL after 3s.
+- `cmd/hivegui/restart_windows.go:11–13` — stub returns `errors.New("restart not supported on this platform")`. **Root cause.**
+- `cmd/hived/main.go:75–77` — daemon writes pidfile at `<sock>.pid` on every platform, so the read path works on Windows.
+- `cmd/hivegui/spawn_windows.go` — already implements daemon launch on Windows (Wails GUI relaunch path is platform-agnostic too).
+
+### Bug 2 — grid mode flashes then reverts
+
+- `cmd/hivegui/menu.go:74` — `view.AddText("Toggle Project Grid", keys.CmdOrCtrl("g"), emit("menu:toggle-project-grid"))`.
+- `cmd/hivegui/menu.go:9–13` — header comment: *"wires every keyboard shortcut in the GUI into the native macOS menu."* Yet `cmd/hivegui/main.go:59` registers the menu unconditionally on every platform.
+- `cmd/hivegui/frontend/src/main.js:2382–2388` — JS `keydown` listener also handles `Cmd/Ctrl+G` and toggles the view.
+- `cmd/hivegui/frontend/src/main.js:2500` — `'menu:toggle-project-grid': toggleProjectGrid` registered handler.
+- On Windows, the WinC native accelerator path (`internal/frontend/desktop/windows/menu.go:68` → `acceleratorToWincShortcut`) does NOT consume the keystroke before the WebView sees it — so both fire, and `setView('grid-project')` immediately followed by `setView('single')` produces the visible flash-then-revert.
+- The macOS menu eats the keystroke at AppKit level, which is why the bug is Windows-only.
+
+### Bug 3 — ctrl-arrow session switch reversed
+
+- `cmd/hivegui/menu.go:82–85` — Ctrl+Down → next, Ctrl+Up → prev, Ctrl+Right → next, Ctrl+Left → prev.
+- `cmd/hivegui/frontend/src/main.js:2423–2438` — JS `keydown` handler: ArrowUp/ArrowDown → `moveActiveSession(±1)`.
+- Same double-dispatch as Bug 2. The user perceives "reversed" because two switches with `(idx + delta + n) % n` semantics, when the active session is at index 0 and delta=+1, lands at index 2 instead of 1 — but with two sessions it lands back at 0, etc. With three sessions and active at 0: +1+1=2 (visually "the previous one" if the sidebar wraps). Whatever the exact arithmetic, the user's net experience is "wrong direction."
+- Note: Wails/winc keymap (`internal/frontend/desktop/windows/keys.go:170–173`) maps `up/down/left/right` to the correct VK codes, so this is not a Wails translation bug.
+
+### Platform-gating precedent in the codebase
+
+- `cmd/hivegui/restart_*.go`, `cmd/hivegui/spawn_*.go` — already use `//go:build windows` / `!windows` split files.
+- We can apply the same split to `menu.go` (move full impl to `menu_darwin.go`, add a stub `menu_other.go` returning a minimal menu with no accelerators).
+
+## Approach
+
+**Bug 1 (restart) — implement the Windows kill path.** Mirror the unix implementation: read `<sock>.pid`, verify the pid is alive and named `hived.exe` using `tasklist /FI "PID eq <pid>" /FO CSV /NH`, then use `os.FindProcess(pid).Kill()` (Windows: `TerminateProcess`). Skip the SIGTERM/grace-period dance — Windows has no in-band soft-kill for a detached process group spawned with `DETACHED_PROCESS`. Best-effort wait for exit (poll `OpenProcess`-equivalent via `os.FindProcess + Signal(0)` analog, or just sleep briefly and re-check pidfile) so the GUI's reconnect doesn't race the dying socket. Reject and clean up stale pidfiles whose pid no longer maps to `hived.exe`, matching the unix safety guarantee.
+
+**Bug 2 + Bug 3 (double-dispatch) — split menu.go by platform.** Move the current `buildAppMenu` body to `menu_darwin.go` (`//go:build darwin`). Add `menu_other.go` (`//go:build !darwin`) that returns `nil` — Wails treats a nil app menu as "no native menu," and the JS keyboard handler already covers every shortcut. This eliminates the double-dispatch on Windows and Linux without losing any user-facing functionality there. macOS keeps its menu bar (which it needs anyway for native conventions like Cmd+Q, About, etc.).
+
+**Why this approach over the obvious alternative.** The "obvious" alternative is to keep one menu and have the JS handler check `if (e.fromMenu)` or detect Windows and bail. That requires plumbing a flag through every shortcut, is fragile, and does not address the fact that Windows users get no visible menu bar from these accelerators anyway (Wails on Windows shows menus only when explicitly given, but the items are not surfaced in a way that maps to user expectations). Splitting at the menu construction boundary is one file and zero conditionals in hot paths.
+
+### Files to change
+
+1. `cmd/hivegui/restart_windows.go` — replace stub with a real implementation: read `<sock>.pid`, verify via `tasklist`, kill via `os.FindProcess`, wait briefly for exit. Mirror the unix file's docstrings for the safety story.
+2. `cmd/hivegui/menu.go` → rename to `cmd/hivegui/menu_darwin.go` and add `//go:build darwin` at top. Body unchanged.
+3. `cmd/hivegui/menu_other.go` (new) — `//go:build !darwin`; declares `func buildAppMenu(_ *App) *menu.Menu { return nil }`.
+4. `CHANGELOG.md` — add three entries under `## [Unreleased]` → `### Fixed`.
+
+### New files
+
+- `cmd/hivegui/menu_other.go` — non-darwin stub returning `nil` so the JS keyboard handler owns all shortcuts.
+- `cmd/hivegui/restart_windows_test.go` — unit test for `pidLooksLikeHived` parsing of `tasklist` CSV output (table-driven; does not invoke tasklist).
+
+### Tests
+
+Per `AGENTS.md`, every change ships with tests. Build-tagged tests for Windows-only code are still compiled and run on Windows in CI; on macOS dev they're skipped by the build tag.
+
+- **`cmd/hivegui/restart_windows_test.go`** (new, `//go:build windows`):
+  - `TestPidLooksLikeHived_ParsesTasklistCSV` — given canned `tasklist` CSV strings (hived.exe match, mismatch, empty, malformed), the parser returns the expected bool.
+  - `TestKillRunningHived_NoPidfile_ReturnsNil` — pointing at a temp dir with no pidfile returns nil.
+  - `TestKillRunningHived_StalePidfile_RemovesFile` — write a pidfile pointing at pid 1 (System), confirm the function does not kill and removes the stale file.
+- **Manual verification on Windows** (cannot be automated from a macOS dev box):
+  - Click "Restart Hive" button — Hive process restarts cleanly, no error banner, daemon comes back up.
+  - Press `Ctrl+G` — view enters grid mode and stays there until pressed again.
+  - Press `Ctrl+Down` repeatedly — active session advances forward through the sidebar; `Ctrl+Up` advances backward.
+  - Press `Ctrl+Enter`, `Ctrl+Shift+G`, `Ctrl+Right`, `Ctrl+Left` — all behave identically to macOS.
+- **Regression check on macOS** (`go test ./...` + manual): native menu bar still present, every menu item still works, every shortcut still works. (No code change to the darwin path beyond the file rename.)
+
+## Decision log
+
+- **2026-05-09** — Combine all three Windows bugs into one PR. Why: bugs 2 and 3 share a root cause (native-menu/JS double-dispatch) and a single fix (platform-gate the menu); shipping them together avoids two PRs touching the same file.
+- **2026-05-09** — Use `os.Process.Kill` (TerminateProcess) instead of CTRL_BREAK_EVENT. Why: hived is spawned with `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` but does not install a console control handler, so CTRL_BREAK has no defined effect. Hard-kill matches the Windows GUI restart convention and the SIGKILL fallback already in `restart_unix.go`.
+- **2026-05-09** — Verify pid identity with `tasklist` (no extra dependencies) rather than `gopsutil` or syscall-level `CreateToolhelp32Snapshot`. Why: `tasklist` ships with every Windows install, has stable CSV output, and the unix path uses the analogous `ps`. Symmetry > library churn.
+
+## Progress
+
+- **2026-05-09** — Spec + plan created via /hs-feature-loop.
+- **2026-05-09** — Triage classified as bug / L / P2.
+- **2026-05-09** — Research complete; root causes identified.
+- **2026-05-09** — Plan drafted and entering implementation.
+
+## Open questions
+
+- Wails v2 may show an empty menu bar slot on Windows when `buildAppMenu` returns `nil`. If so, drop a single label-only menu (no accelerators) instead. Verify on first Windows test.

--- a/docs/exec-plans/completed/177-windows-restart-button-and-grid-mode-bugs.md
+++ b/docs/exec-plans/completed/177-windows-restart-button-and-grid-mode-bugs.md
@@ -2,8 +2,9 @@
 
 - **Spec:** [docs/product-specs/177-windows-restart-button-and-grid-mode-bugs.md](../../product-specs/177-windows-restart-button-and-grid-mode-bugs.md)
 - **Issue:** #177
-- **Stage:** PLAN
-- **Status:** active
+- **PR:** [#179](https://github.com/lucascaro/hive/pull/179)
+- **Stage:** DONE
+- **Status:** completed
 
 ## Summary
 
@@ -96,6 +97,8 @@ Per `AGENTS.md`, every change ships with tests. Build-tagged tests for Windows-o
 - **2026-05-09** — Triage classified as bug / L / P2.
 - **2026-05-09** — Research complete; root causes identified.
 - **2026-05-09** — Plan drafted and entering implementation.
+- **2026-05-10** — Implemented on `feature/177-windows-restart-grid-and-arrow-fixes`, opened PR #179.
+- **2026-05-10** — Converged via /hs-ralph-loop (1 iteration, COMMENT verdict, no blocking findings).
 
 ## Open questions
 

--- a/docs/product-specs/177-windows-restart-button-and-grid-mode-bugs.md
+++ b/docs/product-specs/177-windows-restart-button-and-grid-mode-bugs.md
@@ -1,0 +1,38 @@
+# Windows: restart button, grid mode revert, and reversed ctrl-arrow session switch
+
+- **Issue:** #177
+- **Type:** bug
+- **Complexity:** L
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/177-windows-restart-button-and-grid-mode-bugs.md](../exec-plans/active/177-windows-restart-button-and-grid-mode-bugs.md)
+
+## Problem
+
+Three Windows-only UI bugs in Hive (not reproducible on macOS/Linux):
+
+1. **Restart Hive button does nothing.** Clicking the "Restart Hive" button in the UI produces no observable action — no session restart, no error, no log feedback.
+2. **Grid mode reverts to single-session view.** Switching the layout to grid mode briefly renders the grid, then immediately snaps back to single-session mode.
+3. **Ctrl-arrow session switch is reversed.** In single-session mode, ctrl-down moves to the *previous* session in the sidebar (and ctrl-up presumably to the next), opposite of macOS/Linux.
+
+All three only manifest on Windows; the same builds work as expected on macOS and Linux.
+
+## Desired behavior
+
+- Restart button restarts the active hive/session as it does on other platforms.
+- Grid mode persists once selected until the user changes it.
+- Ctrl-down moves to the next session, ctrl-up to the previous, matching macOS/Linux.
+
+## Success criteria
+
+- On Windows, clicking "Restart Hive" triggers the same restart flow observed on macOS/Linux (process restart + UI feedback), or surfaces an actionable error if not yet supported.
+- On Windows, switching to grid mode renders the grid and stays in grid mode until the user explicitly switches away.
+- On Windows, ctrl-arrow shortcuts move between sessions in the same direction as macOS/Linux.
+
+## Non-goals
+
+- New layout modes or restart behavior changes on macOS/Linux.
+- Implementing daemon restart on Windows from scratch (if the underlying mechanism is unsupported, surfacing a clear error is acceptable for this spec).
+
+## Notes
+
+Reported via /hs-feature-loop on 2026-05-09.

--- a/docs/product-specs/177-windows-restart-button-and-grid-mode-bugs.md
+++ b/docs/product-specs/177-windows-restart-button-and-grid-mode-bugs.md
@@ -4,7 +4,7 @@
 - **Type:** bug
 - **Complexity:** L
 - **Priority:** P2
-- **Exec plan:** [docs/exec-plans/active/177-windows-restart-button-and-grid-mode-bugs.md](../exec-plans/active/177-windows-restart-button-and-grid-mode-bugs.md)
+- **Exec plan:** [docs/exec-plans/completed/177-windows-restart-button-and-grid-mode-bugs.md](../exec-plans/completed/177-windows-restart-button-and-grid-mode-bugs.md)
 
 ## Problem
 

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -9,13 +9,13 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
 | P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
-| P2 | #177 | Windows: restart button, grid mode revert, and reversed ctrl-arrow session switch | IMPLEMENT | [177-windows-restart-button-and-grid-mode-bugs](177-windows-restart-button-and-grid-mode-bugs.md) |
 
 ## Completed
 
 | Issue | Title | Shipped | Spec |
 |-------|-------|---------|------|
 | #<n> | <title> | <date> | [<slug>](<slug>.md) |
+| #177 | Windows: restart button, grid mode revert, and reversed ctrl-arrow session switch | 2026-05-10 | [177-windows-restart-button-and-grid-mode-bugs](177-windows-restart-button-and-grid-mode-bugs.md) |
 | #165 | Restarting a session can reload the wrong session when multiple share a worktree/directory | 2026-05-08 | [165-restart-session-wrong-session](165-restart-session-wrong-session.md) |
 | #163 | GUI: resize loses scroll position when viewport is 1-2 lines short of bottom | 2026-05-08 | [163-resize-stick-mostly-bottom](163-resize-stick-mostly-bottom.md) |
 | #159 | Returning to grid leaves session visually selected but keyboard input doesn't reach it | 2026-05-08 | [159-grid-return-session-input-focus](159-grid-return-session-input-focus.md) |

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -9,6 +9,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
 | P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
+| P2 | #177 | Windows: restart button, grid mode revert, and reversed ctrl-arrow session switch | IMPLEMENT | [177-windows-restart-button-and-grid-mode-bugs](177-windows-restart-button-and-grid-mode-bugs.md) |
 
 ## Completed
 


### PR DESCRIPTION
## Summary

Three Windows-only UI bugs from #177, two of which share a root cause.

- **Restart Hive button (Bug 1):** `killRunningHived` was a stub on Windows. Implement it: read `<sock>.pid`, verify the recorded pid is `hived.exe` via `tasklist` (mirrors unix `ps -o comm=`), then `os.Process.Kill` (TerminateProcess). Stale pidfiles whose pid was recycled to an unrelated process are removed without signaling. Polls `tasklist` for exit so the GUI's reconnect doesn't race the dying socket.
- **Grid mode flash + revert (Bug 2) and Ctrl+Arrow reversed direction (Bug 3):** the native menu's accelerators were firing alongside the in-window JS keyboard listener on Windows/Linux, so every shortcut ran twice. Move the menu impl behind `//go:build darwin` and add a non-darwin stub returning `nil`. macOS keeps its menu bar (AppKit eats the keystroke before the WebView sees it). On Windows/Linux the JS handler in `cmd/hivegui/frontend/src/main.js` is now the single source of truth for shortcuts.

## Test plan

- [x] `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` — both clean
- [x] `go test ./...` — all packages pass
- [x] Unit tests added for `parseTasklistRow`, missing-pidfile, and stale-pidfile (PID 4 = System) paths in `restart_windows_test.go` (build-tagged windows)
- [ ] **Manual on Windows:** click "Restart Hive" — Hive process restarts, daemon comes back up
- [ ] **Manual on Windows:** `Ctrl+G` enters grid mode and stays there; `Ctrl+G` again returns to single
- [ ] **Manual on Windows:** `Ctrl+Down` advances forward through sidebar sessions; `Ctrl+Up` goes backward
- [ ] **Manual on macOS regression:** native menu bar still present, every menu item and shortcut behaves as before

Fixes #177