### PR TITLE
fix(gui): relaunch macOS GUI via `open -n` on Restart Hive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- macOS: "Restart Hive" killed hived but the new GUI never appeared.
+  `spawnNewGUI` re-execed the inner Mach-O directly, which spawns a
+  process but doesn't go through LaunchServices, so the relaunched
+  Wails/WebKit window never gained focus (often never rendered). When
+  running inside a `.app` bundle we now relaunch via `open -n
+  <bundle.app>`; `-n` forces a fresh instance even while the dying
+  parent is still around. Dev builds (binary outside a bundle) keep
+  the existing re-exec path.
+
 ## [2.2.1] — 2026-05-10
 
 ### Fixed

--- a/cmd/hivegui/main.go
+++ b/cmd/hivegui/main.go
@@ -19,11 +19,17 @@ var assets embed.FS
 // cwd "/" regardless of how they were invoked (open, Finder, even
 // running Contents/MacOS/<bin> directly), so os.Getwd alone is not
 // reliable. We try, in order:
-//  1. os.Getwd() if it isn't "" or "/"
-//  2. $PWD env var (preserved when the user ran the binary directly
+//  1. $HIVE_LAUNCH_DIR — explicitly propagated across `open -n` by
+//     spawnNewGUI so Restart Hive preserves the original launchDir
+//     even though LaunchServices resets the bundle's cwd to "/"
+//  2. os.Getwd() if it isn't "" or "/"
+//  3. $PWD env var (preserved when the user ran the binary directly
 //     from a shell that exports PWD)
-//  3. $HOME
+//  4. $HOME
 func resolveLaunchDir() string {
+	if dir := os.Getenv("HIVE_LAUNCH_DIR"); dir != "" && dir != "/" {
+		return dir
+	}
 	if cwd, err := os.Getwd(); err == nil && cwd != "" && cwd != "/" {
 		return cwd
 	}

--- a/cmd/hivegui/window_unix.go
+++ b/cmd/hivegui/window_unix.go
@@ -32,13 +32,26 @@ func spawnNewGUI(cwd string) error {
 	if runtime.GOOS == "darwin" {
 		if app := enclosingAppBundle(self); app != "" {
 			cmd := exec.Command("open", "-n", app)
+			// LaunchServices resets the bundle's cwd to "/", so
+			// cmd.Dir doesn't reach the relaunched GUI. Propagate
+			// the desired launch dir via an env var that
+			// resolveLaunchDir() picks up on startup. `open`
+			// inherits env to the launched bundle on macOS.
 			if cwd != "" {
-				cmd.Dir = cwd
+				cmd.Env = append(os.Environ(), "HIVE_LAUNCH_DIR="+cwd)
 			}
-			return cmd.Start()
+			return startDetached(cmd, cwd)
 		}
 	}
 	cmd := exec.Command(self)
+	return startDetached(cmd, cwd)
+}
+
+// startDetached applies the shared detachment + stdio nulling so the
+// child process is independent of this (about-to-quit) parent. Both
+// the `open -n <bundle>` branch and the dev re-exec branch route
+// through here to keep the contract consistent.
+func startDetached(cmd *exec.Cmd, cwd string) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if cwd != "" {
 		cmd.Dir = cwd
@@ -49,9 +62,10 @@ func spawnNewGUI(cwd string) error {
 	return cmd.Start()
 }
 
-// enclosingAppBundle walks up from a Mach-O path looking for an
-// ".app" ancestor whose Contents/MacOS contains it. Returns "" when
-// the binary isn't inside a bundle (dev builds).
+// enclosingAppBundle walks up from a Mach-O path and returns the
+// first ancestor directory whose name ends in ".app". Returns "" when
+// no such ancestor exists within a few levels (dev builds where the
+// binary lives outside a bundle).
 func enclosingAppBundle(exe string) string {
 	dir := filepath.Dir(exe)
 	for i := 0; i < 6 && dir != "/" && dir != "."; i++ {

--- a/cmd/hivegui/window_unix.go
+++ b/cmd/hivegui/window_unix.go
@@ -5,18 +5,38 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"syscall"
 )
 
-// spawnNewGUI launches another instance of the GUI binary as a
-// detached child so the two processes have independent windows. We
-// re-exec ourselves rather than `open -n /path/to/Hive.app` because
-// the user might have launched the binary directly during dev; both
-// paths land at the same .app/Contents/MacOS/hivegui executable.
+// spawnNewGUI launches another instance of the GUI as a detached
+// child so the relaunched window is independent of this (about-to-
+// quit) process.
+//
+// On darwin, when we're running inside a .app bundle we relaunch via
+// `open -n <bundle.app>`. Re-execing the inner Mach-O directly works
+// for spawning a process but doesn't go through LaunchServices, so
+// the new instance doesn't get proper activation: no Dock focus, and
+// in practice the Wails/WebKit window never appears. `-n` forces a
+// new instance even if LS still sees the dying parent.
+//
+// For dev builds (binary outside a .app, e.g. `wails dev` or `go
+// run`) we fall back to re-execing the binary directly.
 func spawnNewGUI(cwd string) error {
 	self, err := os.Executable()
 	if err != nil {
 		return err
+	}
+	if runtime.GOOS == "darwin" {
+		if app := enclosingAppBundle(self); app != "" {
+			cmd := exec.Command("open", "-n", app)
+			if cwd != "" {
+				cmd.Dir = cwd
+			}
+			return cmd.Start()
+		}
 	}
 	cmd := exec.Command(self)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
@@ -27,4 +47,18 @@ func spawnNewGUI(cwd string) error {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Start()
+}
+
+// enclosingAppBundle walks up from a Mach-O path looking for an
+// ".app" ancestor whose Contents/MacOS contains it. Returns "" when
+// the binary isn't inside a bundle (dev builds).
+func enclosingAppBundle(exe string) string {
+	dir := filepath.Dir(exe)
+	for i := 0; i < 6 && dir != "/" && dir != "."; i++ {
+		if strings.HasSuffix(dir, ".app") {
+			return dir
+		}
+		dir = filepath.Dir(dir)
+	}
+	return ""
 }

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -25,6 +25,14 @@ func swapCodexPollInterval(t *testing.T, d time.Duration) {
 // writeRollout writes a fake codex rollout file with the given cwd and
 // returns the full path. The filename UUID is taken from the wantUUID
 // argument so tests assert against a known id.
+//
+// Writes to a staging path inside the same directory, applies Chtimes,
+// then renames into place so the file only becomes visible to a
+// concurrent watcher after mtime is set. Without this, the capture
+// goroutine could observe the file between WriteFile and Chtimes,
+// return early, end the test, and trigger t.TempDir cleanup — leaving
+// the still-running writer's Chtimes to fail with ENOENT and Fatalf
+// after the test had already completed.
 func writeRollout(t *testing.T, root, day, cwd, uuid string, modTime time.Time) string {
 	t.Helper()
 	dir := filepath.Join(root, day)
@@ -32,12 +40,16 @@ func writeRollout(t *testing.T, root, day, cwd, uuid string, modTime time.Time) 
 		t.Fatalf("mkdir: %v", err)
 	}
 	path := filepath.Join(dir, "rollout-2026-05-08T12-00-00-"+uuid+".jsonl")
+	staging := path + ".tmp"
 	body := `{"timestamp":"2026-05-08T12:00:00.000Z","type":"session_meta","payload":{"id":"` + uuid + `","cwd":"` + cwd + `","timestamp":"2026-05-08T12:00:00.000Z"}}` + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+	if err := os.WriteFile(staging, []byte(body), 0o644); err != nil {
 		t.Fatalf("write rollout: %v", err)
 	}
-	if err := os.Chtimes(path, modTime, modTime); err != nil {
+	if err := os.Chtimes(staging, modTime, modTime); err != nil {
 		t.Fatalf("chtimes: %v", err)
+	}
+	if err := os.Rename(staging, path); err != nil {
+		t.Fatalf("rename rollout: %v", err)
 	}
 	return path
 }


### PR DESCRIPTION
## Summary

- Restart Hive killed hived but the new GUI window never appeared on macOS. `spawnNewGUI` re-execed the inner Mach-O at `Hive.app/Contents/MacOS/hivegui`, which spawns a process but bypasses LaunchServices — the relaunched Wails/WebKit window never got proper activation.
- When running inside a `.app` bundle, walk up from `os.Executable()` to find the enclosing `.app` and relaunch via `open -n <bundle>`. `-n` forces a fresh instance regardless of the dying parent, and LS gives the new process Dock focus + an active run loop.
- Dev builds (binary outside a bundle, e.g. `wails dev` / `go run`) keep the existing re-exec fallback.

## Test plan

- [ ] Build the macOS `.app`, click "Restart Hive" from the daemon-stale banner — confirm hived dies and a fresh GUI window appears, focused.
- [ ] Run via `wails dev` and trigger restart — confirm fallback re-exec path still spawns a new process (dev case).
- [ ] Verify no regression on Linux (`runtime.GOOS != "darwin"` branch unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)