### PR TITLE
fix(session): launch agent via cmd.exe /C on Windows, not POSIX flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (xterm helper-textarea) are now reconciled atomically through a
   single state-driven writer, so they can no longer drift across view
   transitions, modal open/close, or rename input. (#181)
+- Windows: starting a session with an agent (Claude, Gemini, Copilot,
+  …) opened a bare `cmd.exe` prompt instead of running the agent. The
+  session spawner unconditionally invoked `<shell> -l -i -c <line>`,
+  but on Windows the shell falls back to `cmd.exe`, which treats
+  `-l -i -c` as garbage and drops the command. The spawn path now
+  branches on GOOS: Unix keeps `<shell> -l -i -c <line>` (load-bearing
+  for fnm/nvm/asdf PATH setup); Windows uses `%ComSpec% /C <line>`
+  with cmd.exe-aware quoting, which also correctly handles `.cmd`
+  shims like `claude.cmd`. (#183)
 
 ## [2.2.1] — 2026-05-10
 

--- a/docs/exec-plans/active/183-windows-claude-opens-shell.md
+++ b/docs/exec-plans/active/183-windows-claude-opens-shell.md
@@ -78,6 +78,8 @@ Build `hivegui` on Windows, create a session with the Claude agent profile, conf
 
 <!-- Append-only. One line per ralph-loop iteration. -->
 
+- **2026-05-10 iter 1** — verdict: REQUEST_CHANGES; findings_hash: f2e3855b; threads_open: 0 (all 4 resolved by autofix); action: escalated:windows-ci-unfired; head_sha: cced798. Autofix pushed 5 commits (410ed63, 492746d, 8bb60f6, 29e5837, cced798) attempting to fix the Windows quoting via cmd.exe `/S /C` wrapping + `SysProcAttr.CmdLine` bypass of go-pty's `ComposeCommandLine`. Windows CI ran for `ec1927d`, `410ed63`, `492746d` — all FAILED with `'\"cmd.exe\"' is not recognized` because the test argv `["cmd.exe", "/C", "echo hivetest"]` triggers a double-wrap (spawner adds its own `cmd.exe /C` around it). Windows CI did NOT fire for `8bb60f6`, `29e5837`, `cced798` (the actual fix commits) — GitHub Actions silently skipped them. Linux/macOS CI passed throughout. Threads were correctness/consistency nits from review-pr; autofix cleared them all.
+
 ## Open questions
 
 - Should we keep `cmd.exe` as the wrapper, or detect PowerShell and prefer it? Recommendation: `cmd.exe` for simplicity and ubiquity.

--- a/docs/exec-plans/active/183-windows-claude-opens-shell.md
+++ b/docs/exec-plans/active/183-windows-claude-opens-shell.md
@@ -1,0 +1,77 @@
+# Hive opens only a shell on Windows, not Claude
+
+- **Spec:** [docs/product-specs/183-windows-claude-opens-shell.md](../../product-specs/183-windows-claude-opens-shell.md)
+- **Issue:** #183
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+On Windows, sessions configured with an agent command (e.g. `claude`) drop into a bare shell instead of running the agent. The session spawner unconditionally wraps the command in Unix login-interactive shell flags (`-l -i -c`) that `cmd.exe` doesn't understand. Fix: branch on platform when building the spawn args.
+
+## Research
+
+### Relevant code
+
+- `internal/session/session.go:107-121` — sole spawn site. When `opts.Cmd` is non-empty, builds `ptmx.Command(shell, "-l", "-i", "-c", line)` for **all** platforms. The comment above it (lines 109-114) only makes sense for zsh/bash login + interactive — it explicitly references `.zprofile`, `.zshrc`, `fnm`, `nvm`, `asdf`.
+- `internal/session/session.go:311-322` — `defaultShell()` falls back to `$ComSpec` or `cmd.exe` on Windows when `$SHELL` is unset. So on a fresh Windows box, `shell = cmd.exe` and the command line becomes `cmd.exe -l -i -c "claude"`. `cmd.exe` treats `-l -i -c` as args/garbage and ends up presenting its prompt — exactly the reported symptom.
+- `internal/session/session.go:267-300` — `shellEscape` is POSIX-style quoting (single quotes, `'\''` escape). Not safe for `cmd.exe`, which uses different quoting rules. Needs a Windows-aware sibling.
+- `internal/session/session.go:13` — uses `github.com/aymanbagabas/go-pty`, which supports ConPTY on Windows, so the underlying spawn primitive is fine.
+- `internal/agent/agent.go:63-69` — uses `exec.LookPath` for agent binary detection. On Windows that already includes `PATHEXT` (`.cmd`, `.exe`, …), so `claude.cmd` will be found. The lookup itself is not the bug.
+- `internal/session/session_test.go:13` — existing test already skips on Windows for the default-shell path. Cmd-driven path has no Windows coverage today.
+- Prior Windows fixes for context: PR #179 (restart/grid/ctrl-arrow), PR #176/#178 (xterm canvas resize). No prior change to the agent spawn path.
+
+### Constraints / dependencies
+
+- `claude` on Windows is normally a `claude.cmd` shim. CreateProcessW can't `exec` a `.cmd` directly — it must go through `cmd.exe /C`. So the Windows fix path is naturally "use cmd.exe as the wrapper", not "spawn the binary directly".
+- We don't want to regress the macOS/Linux behavior, which relies on login+interactive rc sourcing for PATH (fnm/nvm/asdf).
+- PowerShell is available on modern Windows but is not guaranteed; `cmd.exe` is. Stick with `cmd.exe` to minimize variability.
+- Argument quoting: cmd.exe needs `"..."` quoting with `^` escaping for metacharacters (`&`, `|`, `<`, `>`, `^`, `%`). Agent argv is typically simple (`claude` plus a few flags) but the escape helper must be Windows-correct.
+
+## Approach
+
+Branch the agent-command spawn on `runtime.GOOS` inside `Session.New`. On Unix, keep the current `<shell> -l -i -c <line>` behavior — it's load-bearing for fnm/nvm/asdf PATH setup. On Windows, build the command line as `cmd.exe /C <line>` with cmd.exe-aware quoting. Prefer `$ComSpec` when set; fall back to `cmd.exe`.
+
+This is the smallest correct fix. Alternatives considered and rejected:
+
+- **Spawn the binary directly via `LookPath` on Windows.** Rejected: `claude` ships as `claude.cmd` (a batch shim). CreateProcessW cannot exec `.cmd` files directly — it requires `cmd.exe /C`. So going through `cmd.exe` is mandatory anyway.
+- **Use PowerShell.** Rejected: not guaranteed on all Windows installs; cmd.exe is. PS adds startup latency and extra quoting rules with no benefit for the simple "run this command" case.
+- **Build-tag split into `spawn_unix.go` / `spawn_windows.go`.** Reasonable but overkill for ~15 lines. A `runtime.GOOS` switch keeps the spawn logic in one readable block. Revisit if Windows handling grows.
+
+The current `shellEscape` (POSIX single-quote) is unchanged. A new `cmdExeEscape` helper handles cmd.exe quoting: wrap each argv element in `"..."`, double-up embedded `"`, and prefix cmd metacharacters (`& | < > ^ %`) with `^` outside quotes — but since we're inside quotes, only `"` and `\` near a `"` need care. For typical agent argv (`claude`, plus simple flags) plain `"arg"` wrapping is sufficient; the helper covers the general case so future agents with metacharacters in args don't break.
+
+`defaultShell()` is left alone — its `cmd.exe` fallback is still the right wrapper; the bug was in how it was invoked, not which shell was picked.
+
+### Files to change
+
+1. `internal/session/session.go` — at the `len(opts.Cmd) > 0` branch (lines 107-121), switch on `runtime.GOOS`. On Windows, build `wrapper := os.Getenv("ComSpec")` (fallback `"cmd.exe"`) and invoke `ptmx.Command(wrapper, "/C", cmdExeLine(opts.Cmd))`. Adjust the log line to record the actual argv used. Add `cmdExeEscape(argv []string) string` near `shellEscape`. Import `runtime`.
+
+### New files
+
+None.
+
+### Tests
+
+- `internal/session/session_test.go` — add `TestCmdExeEscape` (runs on all platforms) covering: simple argv `[]string{"claude"}` → `"claude"`; argv with spaces `[]string{"claude", "--model", "claude opus 4.7"}` → `"claude" "--model" "claude opus 4.7"`; argv with embedded `"` → escaped via doubled quotes; argv with cmd metacharacters (`&`, `|`, `%`) → safely quoted; empty string argv → `""`.
+- `internal/session/session_test.go` — add `TestNewSpawnsCmdOnWindows`, gated by `runtime.GOOS == "windows"` (skip elsewhere). Calls `Session.New` with `Cmd: []string{"cmd.exe", "/C", "echo hivetest"}` (something self-contained that doesn't require a third-party CLI), waits for the read loop to capture output via `SubscribeAtomicSnapshot`, asserts `hivetest` appears in the snapshot.
+- `internal/session/session_test.go` — add `TestNewSpawnsCmdOnUnix` symmetric counterpart (skip on Windows) using `echo hivetest` so the Unix path stays covered too.
+
+### Manual verification
+
+Build `hivegui` on Windows, create a session with the Claude agent profile, confirm the `claude` REPL launches inside the terminal (not a cmd.exe prompt). Repeat for gemini and copilot agents if their CLIs are installed.
+
+## Decision log
+
+- **2026-05-10** — Triage: bug / S / P1. Why: Windows is a supported platform, this breaks the primary agent flow, single-file fix.
+- **2026-05-10** — Used CommandLineToArgvW backslash-quoting rules in `cmdExeEscape`, not the simpler "double quotes only" approach. Why: keeps future agents that include paths like `C:\foo\bar.exe` correct without a follow-up fix.
+
+## Progress
+
+- **2026-05-10** — Spec + exec plan created. Stage TRIAGE → RESEARCH.
+- **2026-05-10** — Research done; root cause confirmed at session.go:116. Stage RESEARCH → PLAN.
+- **2026-05-10** — Plan approved. Stage PLAN → IMPLEMENT.
+- **2026-05-10** — Implemented GOOS branch + `cmdExeEscape` in session.go; added 3 tests in session_test.go; CHANGELOG `[Unreleased]` entry added. All session package tests pass; full suite green except pre-existing `cmd/hivegui` frontend embed (unrelated).
+
+## Open questions
+
+- Should we keep `cmd.exe` as the wrapper, or detect PowerShell and prefer it? Recommendation: `cmd.exe` for simplicity and ubiquity.

--- a/docs/exec-plans/active/183-windows-claude-opens-shell.md
+++ b/docs/exec-plans/active/183-windows-claude-opens-shell.md
@@ -32,7 +32,7 @@ On Windows, sessions configured with an agent command (e.g. `claude`) drop into 
 
 ## Approach
 
-Branch the agent-command spawn on `runtime.GOOS` inside `Session.Start`. On Unix, keep the current `<shell> -l -i -c <line>` behavior — it's load-bearing for fnm/nvm/asdf PATH setup. On Windows, build the command line as `cmd.exe /S /C "<line>"` with cmd.exe-aware quoting. Prefer `$ComSpec` when set; fall back to `cmd.exe`.
+Branch the agent-command spawn on `runtime.GOOS` inside `Session.Start`. On Unix, keep the current `<shell> -l -i -c <line>` behavior — it's load-bearing for fnm/nvm/asdf PATH setup. On Windows, build the command line as `cmd.exe /C <line>` with cmd.exe-aware quoting. Prefer `$ComSpec` when set; fall back to `cmd.exe`.
 
 This is the smallest correct fix. Alternatives considered and rejected:
 

--- a/docs/exec-plans/active/183-windows-claude-opens-shell.md
+++ b/docs/exec-plans/active/183-windows-claude-opens-shell.md
@@ -79,6 +79,7 @@ Build `hivegui` on Windows, create a session with the Claude agent profile, conf
 <!-- Append-only. One line per ralph-loop iteration. -->
 
 - **2026-05-10 iter 1** — verdict: REQUEST_CHANGES; findings_hash: f2e3855b; threads_open: 0 (all 4 resolved by autofix); action: escalated:windows-ci-unfired; head_sha: cced798. Autofix pushed 5 commits (410ed63, 492746d, 8bb60f6, 29e5837, cced798) attempting to fix the Windows quoting via cmd.exe `/S /C` wrapping + `SysProcAttr.CmdLine` bypass of go-pty's `ComposeCommandLine`. Windows CI ran for `ec1927d`, `410ed63`, `492746d` — all FAILED with `'\"cmd.exe\"' is not recognized` because the test argv `["cmd.exe", "/C", "echo hivetest"]` triggers a double-wrap (spawner adds its own `cmd.exe /C` around it). Windows CI did NOT fire for `8bb60f6`, `29e5837`, `cced798` (the actual fix commits) — GitHub Actions silently skipped them. Linux/macOS CI passed throughout. Threads were correctness/consistency nits from review-pr; autofix cleared them all.
+- **2026-05-11 iter 2** — verdict: APPROVE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 9c43bd6. Rebased onto current main + simplified test argv to `["echo", "hivetest"]` (commit 9c43bd6). All CI green: Linux/macOS/Windows + CodeQL + Analyze. review-pr returned no BLOCKING / IMPORTANT / MINOR findings. Loop converged.
 
 ## Open questions
 

--- a/docs/exec-plans/active/183-windows-claude-opens-shell.md
+++ b/docs/exec-plans/active/183-windows-claude-opens-shell.md
@@ -2,7 +2,9 @@
 
 - **Spec:** [docs/product-specs/183-windows-claude-opens-shell.md](../../product-specs/183-windows-claude-opens-shell.md)
 - **Issue:** #183
-- **Stage:** IMPLEMENT
+- **PR:** #184
+- **Branch:** feature/183-windows-claude-opens-shell
+- **Stage:** REVIEW
 - **Status:** active
 
 ## Summary
@@ -30,7 +32,7 @@ On Windows, sessions configured with an agent command (e.g. `claude`) drop into 
 
 ## Approach
 
-Branch the agent-command spawn on `runtime.GOOS` inside `Session.New`. On Unix, keep the current `<shell> -l -i -c <line>` behavior — it's load-bearing for fnm/nvm/asdf PATH setup. On Windows, build the command line as `cmd.exe /C <line>` with cmd.exe-aware quoting. Prefer `$ComSpec` when set; fall back to `cmd.exe`.
+Branch the agent-command spawn on `runtime.GOOS` inside `Session.Start`. On Unix, keep the current `<shell> -l -i -c <line>` behavior — it's load-bearing for fnm/nvm/asdf PATH setup. On Windows, build the command line as `cmd.exe /S /C "<line>"` with cmd.exe-aware quoting. Prefer `$ComSpec` when set; fall back to `cmd.exe`.
 
 This is the smallest correct fix. Alternatives considered and rejected:
 
@@ -53,7 +55,7 @@ None.
 ### Tests
 
 - `internal/session/session_test.go` — add `TestCmdExeEscape` (runs on all platforms) covering: simple argv `[]string{"claude"}` → `"claude"`; argv with spaces `[]string{"claude", "--model", "claude opus 4.7"}` → `"claude" "--model" "claude opus 4.7"`; argv with embedded `"` → escaped via doubled quotes; argv with cmd metacharacters (`&`, `|`, `%`) → safely quoted; empty string argv → `""`.
-- `internal/session/session_test.go` — add `TestNewSpawnsCmdOnWindows`, gated by `runtime.GOOS == "windows"` (skip elsewhere). Calls `Session.New` with `Cmd: []string{"cmd.exe", "/C", "echo hivetest"}` (something self-contained that doesn't require a third-party CLI), waits for the read loop to capture output via `SubscribeAtomicSnapshot`, asserts `hivetest` appears in the snapshot.
+- `internal/session/session_test.go` — add `TestStartSpawnsCmdOnWindows`, gated by `runtime.GOOS == "windows"` (skip elsewhere). Calls `Start` with `Cmd: []string{"cmd.exe", "/C", "echo hivetest"}` (something self-contained that doesn't require a third-party CLI), waits for the read loop to capture output via `SubscribeAtomicSnapshot`, asserts `hivetest` appears in the snapshot.
 - `internal/session/session_test.go` — add `TestNewSpawnsCmdOnUnix` symmetric counterpart (skip on Windows) using `echo hivetest` so the Unix path stays covered too.
 
 ### Manual verification
@@ -71,6 +73,10 @@ Build `hivegui` on Windows, create a session with the Claude agent profile, conf
 - **2026-05-10** — Research done; root cause confirmed at session.go:116. Stage RESEARCH → PLAN.
 - **2026-05-10** — Plan approved. Stage PLAN → IMPLEMENT.
 - **2026-05-10** — Implemented GOOS branch + `cmdExeEscape` in session.go; added 3 tests in session_test.go; CHANGELOG `[Unreleased]` entry added. All session package tests pass; full suite green except pre-existing `cmd/hivegui` frontend embed (unrelated).
+
+## PR convergence ledger
+
+<!-- Append-only. One line per ralph-loop iteration. -->
 
 ## Open questions
 

--- a/docs/product-specs/183-windows-claude-opens-shell.md
+++ b/docs/product-specs/183-windows-claude-opens-shell.md
@@ -1,0 +1,30 @@
+# Hive opens only a shell on Windows, not Claude
+
+- **Issue:** #183
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/183-windows-claude-opens-shell.md](../exec-plans/active/183-windows-claude-opens-shell.md)
+
+## Problem
+
+On Windows, launching a session in Hive that should start Claude (the `claude` CLI) opens a plain shell instead. The expected behavior — matching macOS/Linux — is for the configured agent command (`claude`) to launch directly inside the session terminal.
+
+This appears to be a platform-specific spawning issue: the command resolution, shell wrapping, or PATH handling on Windows is producing a shell rather than executing the agent binary.
+
+## Desired behavior
+
+On Windows, starting a Hive session whose agent is `claude` launches the `claude` CLI inside the session terminal, matching macOS/Linux behavior. Other agents (gemini, copilot, etc.) should also launch correctly on Windows.
+
+## Success criteria
+
+- On Windows, creating a new session with the Claude agent results in the `claude` CLI running, not a bare shell prompt.
+- No regression on macOS or Linux for any agent.
+
+## Non-goals
+
+- Installing or configuring the `claude` CLI itself on Windows — assume it is already on PATH.
+
+## Notes
+
+Related to recent Windows fixes (#177, #179).

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -8,6 +8,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 |----------|-------|-------|-------|------|
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
 | P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
+| P1 | #183 | Hive opens only a shell on Windows, not Claude | IMPLEMENT | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 
 ## Completed

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -8,7 +8,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 |----------|-------|-------|-------|------|
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
 | P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
-| P1 | #183 | Hive opens only a shell on Windows, not Claude | IMPLEMENT | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
+| P1 | #183 | Hive opens only a shell on Windows, not Claude | REVIEW | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 
 ## Completed

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"sync"
 
 	"github.com/aymanbagabas/go-pty"
@@ -106,15 +107,31 @@ func Start(opts Options) (*Session, error) {
 
 	var cmd *pty.Cmd
 	if len(opts.Cmd) > 0 {
-		// Run the command via the user's login + interactive shell so
-		// PATH/aliases/functions set up in *either* .zprofile (login)
-		// or .zshrc (interactive) apply. fnm, nvm, asdf, etc. land in
-		// different rc files depending on the install instructions —
-		// covering both is the safe default. Same model Terminal.app
-		// uses for new windows.
-		line := shellEscape(opts.Cmd)
-		cmd = ptmx.Command(shell, "-l", "-i", "-c", line)
-		log.Printf("session: spawn %s -l -i -c %q (cwd=%s)", shell, line, opts.Cwd)
+		if runtime.GOOS == "windows" {
+			// cmd.exe doesn't understand `-l -i -c`. Windows installs
+			// `claude` (and most npm-shipped CLIs) as a `.cmd` shim that
+			// CreateProcessW can't exec directly — so wrapping via
+			// `cmd.exe /C` is both correct and required. PATH inherits
+			// from the parent process; there's no Windows analogue to
+			// login+interactive rc sourcing to preserve.
+			wrapper := os.Getenv("ComSpec")
+			if wrapper == "" {
+				wrapper = "cmd.exe"
+			}
+			line := cmdExeEscape(opts.Cmd)
+			cmd = ptmx.Command(wrapper, "/C", line)
+			log.Printf("session: spawn %s /C %q (cwd=%s)", wrapper, line, opts.Cwd)
+		} else {
+			// Run the command via the user's login + interactive shell so
+			// PATH/aliases/functions set up in *either* .zprofile (login)
+			// or .zshrc (interactive) apply. fnm, nvm, asdf, etc. land in
+			// different rc files depending on the install instructions —
+			// covering both is the safe default. Same model Terminal.app
+			// uses for new windows.
+			line := shellEscape(opts.Cmd)
+			cmd = ptmx.Command(shell, "-l", "-i", "-c", line)
+			log.Printf("session: spawn %s -l -i -c %q (cwd=%s)", shell, line, opts.Cwd)
+		}
 	} else {
 		cmd = ptmx.Command(shell)
 		log.Printf("session: spawn %s (cwd=%s)", shell, opts.Cwd)
@@ -295,6 +312,51 @@ func shellEscape(argv []string) string {
 			}
 		}
 		out = append(out, '\'')
+	}
+	return string(out)
+}
+
+// cmdExeEscape joins argv into a single command line for `cmd.exe /C`.
+// Each element is wrapped in double quotes; embedded `"` is escaped by
+// preceding backslashes per the standard CommandLineToArgvW rules, and
+// cmd.exe metacharacters (`& | < > ^ %`) inside quotes are passed
+// through literally — cmd.exe only treats them as special outside
+// quotes, so quoting the whole arg neutralizes them.
+func cmdExeEscape(argv []string) string {
+	out := make([]byte, 0, 32)
+	for i, a := range argv {
+		if i > 0 {
+			out = append(out, ' ')
+		}
+		out = append(out, '"')
+		// CommandLineToArgvW rules: a run of N backslashes followed by
+		// `"` becomes 2N backslashes plus an escaped quote; a run
+		// followed by end-of-arg becomes 2N backslashes (so the closing
+		// `"` isn't escaped); otherwise backslashes pass through.
+		bs := 0
+		for j := 0; j < len(a); j++ {
+			c := a[j]
+			switch c {
+			case '\\':
+				bs++
+			case '"':
+				for k := 0; k < bs*2+1; k++ {
+					out = append(out, '\\')
+				}
+				out = append(out, '"')
+				bs = 0
+			default:
+				for k := 0; k < bs; k++ {
+					out = append(out, '\\')
+				}
+				bs = 0
+				out = append(out, c)
+			}
+		}
+		for k := 0; k < bs*2; k++ {
+			out = append(out, '\\')
+		}
+		out = append(out, '"')
 	}
 	return string(out)
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -111,31 +111,23 @@ func Start(opts Options) (*Session, error) {
 			// cmd.exe doesn't understand `-l -i -c`. Windows installs
 			// `claude` (and most npm-shipped CLIs) as a `.cmd` shim that
 			// CreateProcessW can't exec directly — so wrapping via
-			// `cmd.exe /C` is both correct and required. PATH inherits
-			// from the parent process; there's no Windows analogue to
-			// login+interactive rc sourcing to preserve.
+			// `cmd.exe /S /C "<line>"` is both correct and required.
+			// PATH inherits from the parent process; there's no Windows
+			// analogue to login+interactive rc sourcing to preserve.
+			//
+			// Implementation note: Go's Windows exec layer re-quotes
+			// every argv element via `windows.ComposeCommandLine`,
+			// which would mangle the precisely-quoted line produced by
+			// `cmdExeEscape`. We bypass that by setting
+			// `SysProcAttr.CmdLine` directly — see
+			// `newWindowsCmd` in spawn_windows.go.
 			wrapper := os.Getenv("ComSpec")
 			if wrapper == "" {
 				wrapper = "cmd.exe"
 			}
-			// Note on cmd.exe `/C` argument-quote stripping: cmd's
-			// documented rule strips the leading and trailing quote of
-			// the rest of the command line when (a) there is exactly
-			// one quoted token, (b) it has no special chars, and (c) it
-			// names an executable. The single-token case (e.g.
-			// `cmdExeEscape(["claude"])` → `"claude"`) hits this rule —
-			// cmd strips both quotes and resolves `claude` via PATHEXT,
-			// which works for `.exe`/`.cmd` shims. Multi-token cases
-			// have >2 quotes and the rule does not fire, so per-arg
-			// quoting survives intact. We deliberately do NOT pre-wrap
-			// the line in extra outer quotes with `/S` because Go's
-			// Windows `exec` package re-applies its own argv quoting
-			// (`syscall.EscapeArg`) to each argv element passed to
-			// `ptmx.Command`, which double-escapes embedded quotes and
-			// produces a malformed command line.
 			line := cmdExeEscape(opts.Cmd)
-			cmd = ptmx.Command(wrapper, "/C", line)
-			log.Printf("session: spawn %s /C %q (cwd=%s)", wrapper, line, opts.Cwd)
+			cmd = newWindowsCmd(ptmx, wrapper, line)
+			log.Printf("session: spawn %s /S /C %q (cwd=%s)", wrapper, `"`+line+`"`, opts.Cwd)
 		} else {
 			// Run the command via the user's login + interactive shell so
 			// PATH/aliases/functions set up in *either* .zprofile (login)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -118,17 +118,24 @@ func Start(opts Options) (*Session, error) {
 			if wrapper == "" {
 				wrapper = "cmd.exe"
 			}
-			// Use `/S /C "<line>"`: cmd.exe's documented `/C` parsing
-			// strips the leading and trailing quote of the rest of the
-			// command line when certain conditions hold (single quoted
-			// token naming an executable, no special chars between).
-			// `/S` makes that strip deterministic — cmd always removes
-			// exactly one outer pair — so the per-arg quoting produced
-			// by cmdExeEscape survives intact for every argv shape.
+			// Note on cmd.exe `/C` argument-quote stripping: cmd's
+			// documented rule strips the leading and trailing quote of
+			// the rest of the command line when (a) there is exactly
+			// one quoted token, (b) it has no special chars, and (c) it
+			// names an executable. The single-token case (e.g.
+			// `cmdExeEscape(["claude"])` → `"claude"`) hits this rule —
+			// cmd strips both quotes and resolves `claude` via PATHEXT,
+			// which works for `.exe`/`.cmd` shims. Multi-token cases
+			// have >2 quotes and the rule does not fire, so per-arg
+			// quoting survives intact. We deliberately do NOT pre-wrap
+			// the line in extra outer quotes with `/S` because Go's
+			// Windows `exec` package re-applies its own argv quoting
+			// (`syscall.EscapeArg`) to each argv element passed to
+			// `ptmx.Command`, which double-escapes embedded quotes and
+			// produces a malformed command line.
 			line := cmdExeEscape(opts.Cmd)
-			wrapped := `"` + line + `"`
-			cmd = ptmx.Command(wrapper, "/S", "/C", wrapped)
-			log.Printf("session: spawn %s /S /C %q (cwd=%s)", wrapper, wrapped, opts.Cwd)
+			cmd = ptmx.Command(wrapper, "/C", line)
+			log.Printf("session: spawn %s /C %q (cwd=%s)", wrapper, line, opts.Cwd)
 		} else {
 			// Run the command via the user's login + interactive shell so
 			// PATH/aliases/functions set up in *either* .zprofile (login)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -118,9 +118,17 @@ func Start(opts Options) (*Session, error) {
 			if wrapper == "" {
 				wrapper = "cmd.exe"
 			}
+			// Use `/S /C "<line>"`: cmd.exe's documented `/C` parsing
+			// strips the leading and trailing quote of the rest of the
+			// command line when certain conditions hold (single quoted
+			// token naming an executable, no special chars between).
+			// `/S` makes that strip deterministic — cmd always removes
+			// exactly one outer pair — so the per-arg quoting produced
+			// by cmdExeEscape survives intact for every argv shape.
 			line := cmdExeEscape(opts.Cmd)
-			cmd = ptmx.Command(wrapper, "/C", line)
-			log.Printf("session: spawn %s /C %q (cwd=%s)", wrapper, line, opts.Cwd)
+			wrapped := `"` + line + `"`
+			cmd = ptmx.Command(wrapper, "/S", "/C", wrapped)
+			log.Printf("session: spawn %s /S /C %q (cwd=%s)", wrapper, wrapped, opts.Cwd)
 		} else {
 			// Run the command via the user's login + interactive shell so
 			// PATH/aliases/functions set up in *either* .zprofile (login)
@@ -318,10 +326,18 @@ func shellEscape(argv []string) string {
 
 // cmdExeEscape joins argv into a single command line for `cmd.exe /C`.
 // Each element is wrapped in double quotes; embedded `"` is escaped by
-// preceding backslashes per the standard CommandLineToArgvW rules, and
-// cmd.exe metacharacters (`& | < > ^ %`) inside quotes are passed
-// through literally — cmd.exe only treats them as special outside
-// quotes, so quoting the whole arg neutralizes them.
+// preceding backslashes per the standard CommandLineToArgvW rules.
+// cmd.exe metacharacters (`& | < > ^`) inside quotes are passed through
+// literally — cmd.exe only treats them as special outside quotes, so
+// quoting the whole arg neutralizes them.
+//
+// Caveat: `%` is NOT neutralized by quoting — cmd.exe performs `%VAR%`
+// environment-variable expansion even inside double quotes. Callers
+// must not pass user-controlled `%` characters expecting them to
+// survive verbatim. For agent argv (`claude`, flag-value pairs) this
+// is fine because `%` is not used; if a future caller needs `%`,
+// disable expansion by invoking cmd.exe with `/V:OFF` and `/D`, or
+// pre-escape outside this helper.
 func cmdExeEscape(argv []string) string {
 	out := make([]byte, 0, 32)
 	for i, a := range argv {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -99,7 +99,16 @@ func TestCmdExeEscape(t *testing.T) {
 		{"flag with value", []string{"claude", "--model", "opus"}, `"claude" "--model" "opus"`},
 		{"arg with space", []string{"claude", "--name", "claude opus"}, `"claude" "--name" "claude opus"`},
 		{"empty string preserved", []string{"foo", ""}, `"foo" ""`},
-		{"cmd metacharacters inside quotes", []string{"echo", "a&b|c^d>e<f%g"}, `"echo" "a&b|c^d>e<f%g"`},
+		// cmd.exe leaves `& | < > ^` alone inside double quotes, so the
+		// helper merely wraps them. `%` is intentionally excluded — cmd
+		// expands `%VAR%` even inside quotes, so quoting alone does not
+		// neutralize it. See the doc comment on cmdExeEscape.
+		{"cmd metacharacters inside quotes", []string{"echo", "a&b|c^d>e<f"}, `"echo" "a&b|c^d>e<f"`},
+		// Pin actual behavior for `%`: the helper does not escape it.
+		// The quoted output is verbatim; cmd.exe will perform variable
+		// expansion at spawn time. Callers must not pass `%` expecting
+		// it to survive.
+		{"percent passes through verbatim (not escaped)", []string{"echo", "100%done"}, `"echo" "100%done"`},
 		{"embedded double quote", []string{"echo", `she said "hi"`}, `"echo" "she said \"hi\""`},
 		{"trailing backslashes get doubled before closing quote", []string{"x", `c:\path\`}, `"x" "c:\path\\"`},
 		{"backslash before quote", []string{"x", `a\"b`}, `"x" "a\\\"b"`},

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -127,7 +127,10 @@ func TestStartSpawnsCmdOnWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("windows-only spawn path")
 	}
-	sess, err := Start(Options{Cmd: []string{"cmd.exe", "/C", "echo hivetest"}, Cols: 80, Rows: 24})
+	// The spawner already wraps Cmd in `cmd.exe /S /C "..."`; using
+	// cmd.exe's built-in `echo` directly verifies that wrapping without
+	// the double-cmd-wrap that would confuse cmd.exe's quote parser.
+	sess, err := Start(Options{Cmd: []string{"echo", "hivetest"}, Cols: 80, Rows: 24})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -89,6 +89,63 @@ func TestSessionEchoAndPersistsState(t *testing.T) {
 	}
 }
 
+func TestCmdExeEscape(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"single plain word", []string{"claude"}, `"claude"`},
+		{"flag with value", []string{"claude", "--model", "opus"}, `"claude" "--model" "opus"`},
+		{"arg with space", []string{"claude", "--name", "claude opus"}, `"claude" "--name" "claude opus"`},
+		{"empty string preserved", []string{"foo", ""}, `"foo" ""`},
+		{"cmd metacharacters inside quotes", []string{"echo", "a&b|c^d>e<f%g"}, `"echo" "a&b|c^d>e<f%g"`},
+		{"embedded double quote", []string{"echo", `she said "hi"`}, `"echo" "she said \"hi\""`},
+		{"trailing backslashes get doubled before closing quote", []string{"x", `c:\path\`}, `"x" "c:\path\\"`},
+		{"backslash before quote", []string{"x", `a\"b`}, `"x" "a\\\"b"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := cmdExeEscape(c.in)
+			if got != c.want {
+				t.Fatalf("cmdExeEscape(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestStartSpawnsCmdOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only spawn path")
+	}
+	sess, err := Start(Options{Cmd: []string{"cmd.exe", "/C", "echo hivetest"}, Cols: 80, Rows: 24})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer sess.Close()
+	sink := &bufSinkMu{}
+	_, unsub := sess.SubscribeAtomicSnapshot(sink)
+	defer unsub()
+	if !drainUntil(func() bool { return strings.Contains(sink.String(), "hivetest") }, 5*time.Second) {
+		t.Fatalf("expected hivetest in output, got %q", sink.String())
+	}
+}
+
+func TestStartSpawnsCmdOnUnix(t *testing.T) {
+	skipOnWindows(t)
+	sess, err := Start(Options{Shell: "/bin/bash", Cmd: []string{"echo", "hivetest"}, Cols: 80, Rows: 24})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer sess.Close()
+	sink := &bufSinkMu{}
+	_, unsub := sess.SubscribeAtomicSnapshot(sink)
+	defer unsub()
+	if !drainUntil(func() bool { return strings.Contains(sink.String(), "hivetest") }, 5*time.Second) {
+		t.Fatalf("expected hivetest in output, got %q", sink.String())
+	}
+}
+
 func TestSessionResize(t *testing.T) {
 	skipOnWindows(t)
 	sess, err := Start(Options{Shell: "/bin/bash", Cols: 80, Rows: 24})

--- a/internal/session/spawn_other.go
+++ b/internal/session/spawn_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package session
+
+import (
+	"github.com/aymanbagabas/go-pty"
+)
+
+// newWindowsCmd is a non-Windows stub. It exists so the call site in
+// session.go can compile cross-platform; on non-Windows builds the
+// Windows branch is gated behind `runtime.GOOS == "windows"` and this
+// function is never invoked.
+func newWindowsCmd(ptmx pty.Pty, wrapper, line string) *pty.Cmd {
+	_ = line
+	return ptmx.Command(wrapper)
+}

--- a/internal/session/spawn_windows.go
+++ b/internal/session/spawn_windows.go
@@ -31,8 +31,11 @@ func newWindowsCmd(ptmx pty.Pty, wrapper, line string) *pty.Cmd {
 	// Path is set by ptmx.Command via lookExtensions; preserve it.
 	// Args[0] is also wrapper. Replace the command-line entirely so
 	// neither EscapeArg nor ComposeCommandLine touches our quoting.
+	// Quote the wrapper path in case ComSpec lives under a path with
+	// spaces (rare for cmd.exe — Windows installs it under
+	// %SystemRoot%\System32 — but cheap insurance).
 	c.SysProcAttr = &syscall.SysProcAttr{
-		CmdLine: wrapper + ` /S /C "` + line + `"`,
+		CmdLine: `"` + wrapper + `" /S /C "` + line + `"`,
 	}
 	return c
 }

--- a/internal/session/spawn_windows.go
+++ b/internal/session/spawn_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package session
+
+import (
+	"syscall"
+
+	"github.com/aymanbagabas/go-pty"
+)
+
+// newWindowsCmd builds a `*pty.Cmd` that spawns `wrapper` (cmd.exe) with
+// the command-line `wrapper /S /C "<line>"`, bypassing Go's automatic
+// argv re-quoting. We need the bypass because:
+//
+//   - The PTY backend (`go-pty`) on Windows runs each argv element through
+//     `windows.ComposeCommandLine` → `EscapeArg`, which wraps any arg
+//     containing whitespace in additional quotes and backslash-escapes any
+//     embedded `"`. The precisely-quoted line produced by `cmdExeEscape`
+//     contains both, so without the bypass we end up with mangled output
+//     like `\"cmd.exe\" \"/C\" \"echo hivetest\"` reaching cmd.exe.
+//
+//   - `syscall.SysProcAttr.CmdLine`, when non-empty, is used verbatim as
+//     `lpCommandLine` for CreateProcessW — exactly what we want.
+//
+// The `/S /C "<line>"` shape is the canonical safe pattern: `/S` makes
+// cmd.exe deterministically strip exactly one outer pair of quotes,
+// leaving the per-argument quoting in `<line>` intact for every argv
+// shape (single token, multi token, args with metacharacters).
+func newWindowsCmd(ptmx pty.Pty, wrapper, line string) *pty.Cmd {
+	c := ptmx.Command(wrapper)
+	// Path is set by ptmx.Command via lookExtensions; preserve it.
+	// Args[0] is also wrapper. Replace the command-line entirely so
+	// neither EscapeArg nor ComposeCommandLine touches our quoting.
+	c.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine: wrapper + ` /S /C "` + line + `"`,
+	}
+	return c
+}


### PR DESCRIPTION
## Summary

- On Windows, agent sessions opened a bare `cmd.exe` prompt instead of running `claude` (or any other agent). The spawner unconditionally wrapped commands in `<shell> -l -i -c <line>`, which `cmd.exe` (the Windows fallback shell) doesn't understand — the agent command was silently dropped.
- Fix: branch on `runtime.GOOS` in `Session.Start`. Unix keeps the existing `<shell> -l -i -c <line>` (load-bearing for fnm/nvm/asdf PATH setup). Windows uses `%ComSpec% /C <line>` with a new `cmdExeEscape` helper quoting argv per `CommandLineToArgvW` rules. Going through `cmd.exe` is also required for `claude.cmd` shims, which `CreateProcessW` cannot exec directly.
- Spec: `docs/product-specs/183-windows-claude-opens-shell.md`. Exec plan: `docs/exec-plans/active/183-windows-claude-opens-shell.md`.

## Test plan

- [x] `TestCmdExeEscape` — cross-platform unit test for the quoter (spaces, embedded quotes, trailing backslashes, cmd metacharacters).
- [x] `TestStartSpawnsCmdOnUnix` — verifies the Unix `Cmd` path still works.
- [ ] `TestStartSpawnsCmdOnWindows` — gated to `GOOS=windows`; needs a Windows runner / Windows dev box.
- [ ] Manual: on Windows, create a Hive session with the Claude agent and confirm `claude` launches inside the terminal (not a `cmd.exe` prompt). Repeat for `gemini` / `copilot` agents.
- [x] `go test ./internal/...` green locally (macOS).

Fixes #183