### PR TITLE
fix(gui): restore keyboard focus across single → grid transition (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tests. Linux CI runs every layer on every PR.
 - Daemon integration tests covering update/restart/resize and
   multi-control-conn broadcast fan-out.
+- GUI: last view (single / grid-project / grid-all) persists across
+  launches. Previously the GUI always booted into single-focus mode
+  regardless of how it was left; now it restores the mode you last
+  used. Stored in `localStorage` under `hive.view`. (#187)
 
 ### Fixed
 
+- GUI: switching from single-focus mode to grid mode no longer leaves
+  the active session visually highlighted but unable to receive
+  keystrokes (regression of #181). Single → grid is the only transition
+  that fires a synchronous `display:none` flip on the active tile
+  during `renderGrid`'s parent class swap, which blurs the xterm
+  helper-textarea; ResizeObserver-driven xterm fits on newly-visible
+  neighbour tiles then re-blurred it ~10ms after the rAF that #181
+  used to re-focus. `setFocusedTile` now polls across up to 8 frames
+  and re-establishes focus whenever `document.activeElement` drifts
+  off the target's helper-textarea, idempotently. The gate decision
+  is extracted into a pure `decideFocusAction` helper with unit
+  tests, and the regression class is now covered by Playwright E2E
+  via a real xterm + Wails-mock harness. (#186)
 - macOS: "Restart Hive" killed hived but the new GUI never appeared.
   `spawnNewGUI` re-execed the inner Mach-O directly, which spawns a
   process but doesn't go through LaunchServices, so the relaunched

--- a/cmd/hivegui/frontend/src/lib/focus.js
+++ b/cmd/hivegui/frontend/src/lib/focus.js
@@ -24,11 +24,12 @@ export function decideFocusAction(snapshot) {
   if (id == null) return { kind: ACTION_CLEAR };
   if (!hasId(knownTermIds, id)) return { kind: ACTION_CLEAR };
 
-  // A real <input>/<textarea>/contentEditable owns the keyboard — for
-  // example an inline rename or a launcher input that's still focused
-  // by the time this gate runs. Leave focus where it is AND clear the
+  // A real <input>/<textarea> owns the keyboard — for example an
+  // inline rename or a launcher input that's still focused by the
+  // time this gate runs. Leave focus where it is AND clear the
   // visual border, so the UI can't claim a tile is focused while
-  // keystrokes go to a sibling DOM input.
+  // keystrokes go to a sibling DOM input. (contentEditable hosts
+  // are not part of the v2 UI surface and are not covered here.)
   const isXtermHelper = hasClass(activeClasses, 'xterm-helper-textarea');
   if (!isXtermHelper && isRealInput(activeTag)) return { kind: ACTION_PRESERVE };
 

--- a/cmd/hivegui/frontend/src/lib/focus.js
+++ b/cmd/hivegui/frontend/src/lib/focus.js
@@ -1,0 +1,56 @@
+// Pure decision logic for setFocusedTile's gate.
+//
+// Splitting the gate out as a pure function keeps the only branchy
+// piece of the focus pipeline unit-testable. The caller is still
+// responsible for the DOM side-effects (sweep .term-focused, add it,
+// call .focus()); this function just decides which side-effect to run.
+
+export const ACTION_CLEAR = 'clear';        // sweep .term-focused, focus nothing
+export const ACTION_PRESERVE = 'preserve';  // a real input owns the keyboard — leave focus alone, also clear .term-focused
+export const ACTION_FOCUS = 'focus';        // focus the helper-textarea of `id`
+
+// snapshot describes everything the gate needs to know:
+//   - id: the requested focus target session id (state.activeId), or null
+//   - modalOpen: a launcher / project-editor / palette modal is visible
+//   - activeTag: document.activeElement.tagName (e.g. 'INPUT', 'BODY')
+//   - activeClasses: a string or DOMTokenList containing the active element's classes
+//   - knownTermIds: iterable of session ids that currently have a SessionTerm
+//
+// Returns { kind, id? }.
+export function decideFocusAction(snapshot) {
+  const { id, modalOpen, activeTag, activeClasses, knownTermIds } = snapshot;
+
+  if (modalOpen) return { kind: ACTION_CLEAR };
+  if (id == null) return { kind: ACTION_CLEAR };
+  if (!hasId(knownTermIds, id)) return { kind: ACTION_CLEAR };
+
+  // A real <input>/<textarea>/contentEditable owns the keyboard — for
+  // example an inline rename or a launcher input that's still focused
+  // by the time this gate runs. Leave focus where it is AND clear the
+  // visual border, so the UI can't claim a tile is focused while
+  // keystrokes go to a sibling DOM input.
+  const isXtermHelper = hasClass(activeClasses, 'xterm-helper-textarea');
+  if (!isXtermHelper && isRealInput(activeTag)) return { kind: ACTION_PRESERVE };
+
+  return { kind: ACTION_FOCUS, id };
+}
+
+function isRealInput(tag) {
+  return tag === 'INPUT' || tag === 'TEXTAREA';
+}
+
+function hasClass(classes, name) {
+  if (!classes) return false;
+  if (typeof classes === 'string') {
+    return classes.split(/\s+/).includes(name);
+  }
+  if (typeof classes.contains === 'function') return classes.contains(name);
+  return false;
+}
+
+function hasId(ids, id) {
+  if (!ids) return false;
+  if (typeof ids.has === 'function') return ids.has(id);
+  if (Array.isArray(ids)) return ids.includes(id);
+  return false;
+}

--- a/cmd/hivegui/frontend/src/lib/view.js
+++ b/cmd/hivegui/frontend/src/lib/view.js
@@ -1,0 +1,14 @@
+// View mode constants + persistence helpers for the GUI's
+// single/grid view state. Pure functions kept here so they are
+// unit-testable without a DOM / localStorage harness.
+
+export const VIEW_SINGLE = 'single';
+export const VIEW_GRID_PROJECT = 'grid-project';
+export const VIEW_GRID_ALL = 'grid-all';
+export const VIEW_STORAGE_KEY = 'hive.view';
+
+const VALID_VIEWS = new Set([VIEW_SINGLE, VIEW_GRID_PROJECT, VIEW_GRID_ALL]);
+
+export function normalizeView(v) {
+  return VALID_VIEWS.has(v) ? v : VIEW_SINGLE;
+}

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -1402,7 +1402,7 @@ function applyFocus(id, attempt) {
   // Optional dev-mode assertion: two rAFs later, the visual focus
   // and the keyboard focus should agree. Console-warn on drift so
   // future variants of #159/#181/#186 are caught in QA.
-  if (debugFocusEnabled()) scheduleFocusConsistencyCheck(id);
+  if (debugFocusEnabled() && attempt === 0) scheduleFocusConsistencyCheck(id);
 }
 
 function sweepFocusBorder() {
@@ -1417,7 +1417,8 @@ function focusSnapshot(id) {
     id,
     modalOpen:
       !launcherEl.classList.contains('hidden') ||
-      !editorEl.classList.contains('hidden'),
+      !editorEl.classList.contains('hidden') ||
+      (paletteEl && !paletteEl.classList.contains('hidden')),
     activeTag: ae ? ae.tagName : '',
     activeClasses: ae ? ae.classList : '',
     knownTermIds: state.terms,

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -17,6 +17,10 @@ import { EventsOn, WindowSetTitle } from '../wailsjs/runtime/runtime';
 import { isMac, cmdOrCtrl } from './lib/platform.js';
 import { computeGridDims, buildGridLayout, computeSpatialMove } from './lib/grid.js';
 import { DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE, clampFont } from './lib/font.js';
+import { normalizeView, VIEW_STORAGE_KEY } from './lib/view.js';
+import {
+  decideFocusAction, ACTION_CLEAR, ACTION_PRESERVE, ACTION_FOCUS,
+} from './lib/focus.js';
 import { readProjectId, readWorktreeBranch } from './lib/wire.js';
 
 // ---------- session terminal ----------
@@ -574,10 +578,16 @@ const state = {
   currentProjectId: null,   // "the project I'm working in"; can be set
                             //   without a focused session (so empty
                             //   projects are reachable / launchable)
-  view: 'single',           // 'single' | 'grid-project' | 'grid-all'
+  view: loadSavedView(),    // 'single' | 'grid-project' | 'grid-all' — persisted across launches
   gridProjectId: null,      // project shown in grid-project mode
   fontSize: clampFont(parseInt(localStorage.getItem('hive.fontSize') ?? '', 10) || DEFAULT_FONT_SIZE),
 };
+
+function loadSavedView() {
+  try { return normalizeView(localStorage.getItem(VIEW_STORAGE_KEY)); }
+  catch { return normalizeView(null); }
+}
+
 
 // ---------- bell + attention ----------
 
@@ -1329,61 +1339,114 @@ function setActive(id) {
 // makes that impossible: the class is added only here, in the same
 // rAF as the helper-textarea focus.
 function setFocusedTile(id) {
-  // Gate: a modal that owns the keyboard means no tile is focused.
-  const modalOpen =
-    !launcherEl.classList.contains('hidden') ||
-    !editorEl.classList.contains('hidden');
-  if (modalOpen || id == null || !state.terms.get(id)) {
-    for (const el of document.querySelectorAll('.term-host.term-focused')) {
-      el.classList.remove('term-focused');
-    }
+  // First decision: synchronous, before any rAF. If we already know we
+  // should clear, do it immediately so a modal/null transition can't be
+  // overtaken by a stale in-flight focus rAF.
+  const snap = focusSnapshot(id);
+  if (snap.modalOpen || id == null || !state.terms.get(id)) {
+    sweepFocusBorder();
     return;
   }
-  const st = state.terms.get(id);
   // Schedule after the next paint so any in-flight DOM transition
   // (showSingle / renderGrid / appendChild / xterm.open) settles
-  // before we read activeElement and move focus. The class write and
-  // the ta.focus() call live in the same tick — they can't interleave
-  // with a different transition.
-  requestAnimationFrame(() => {
-    // Re-check the gate inside the rAF — a modal may have opened
-    // during the delay.
-    if (
+  // before we read activeElement and move focus.
+  requestAnimationFrame(() => applyFocus(id, /*attempt=*/0));
+}
+
+function applyFocus(id, attempt) {
+  const st = state.terms.get(id);
+  if (!st) { sweepFocusBorder(); return; }
+  const action = decideFocusAction(focusSnapshot(id));
+  if (action.kind === ACTION_CLEAR || action.kind === ACTION_PRESERVE) {
+    sweepFocusBorder();
+    return;
+  }
+  // Atomic reconcile: sweep + add + focus.
+  for (const el of document.querySelectorAll('.term-host.term-focused')) {
+    if (el !== st.host) el.classList.remove('term-focused');
+  }
+  st.host.classList.add('term-focused');
+  // Drive browser focus to the DOM helper-textarea. xterm's
+  // term.focus() early-returns on a stale-true _focused flag (#159);
+  // after this transition the flag is stale-false because the
+  // synchronous display:none flip during renderGrid's parent class
+  // swap (single → grid) fires focusout. ta.focus() drives the real
+  // event; the follow-up term.focus() resyncs xterm's internal state.
+  const ta = st.host.querySelector('.xterm-helper-textarea');
+  if (ta) ta.focus();
+  if (typeof st.term?.focus === 'function') st.term.focus();
+  // Schedule a verification rAF *next frame* (not this one — focus()
+  // just fired and synchronously updated activeElement, so an in-tick
+  // check would trivially pass and miss the real failure mode):
+  // post-renderGrid side-effects (ResizeObserver → fit → WebGL canvas
+  // resize on newly-visible neighbour tiles) can synchronously fire
+  // focusout ~10ms later. If activeElement has drifted off `ta` by
+  // then, re-focus. Cap retries so a genuine modal-takeover or rename
+  // doesn't busy-loop.
+  // Poll for several frames. A single rAF check is insufficient
+  // because post-renderGrid side-effects (ResizeObserver → fit →
+  // WebGL canvas resize on neighbour tiles) can fire focusout AFTER
+  // the rAF batch completes — the disturbance arrives one event-loop
+  // turn later than the verify. We watch for FOCUS_MAX_RETRIES frames
+  // and re-focus whenever activeElement drifts off `ta`. Polling is
+  // bounded and idempotent (re-focusing an already-focused element is
+  // a no-op).
+  const FOCUS_MAX_RETRIES = 8;
+  if (ta && attempt < FOCUS_MAX_RETRIES) {
+    requestAnimationFrame(() => {
+      const verifyAction = decideFocusAction(focusSnapshot(id));
+      if (verifyAction.kind !== ACTION_FOCUS) return; // a modal / rename took over
+      applyFocus(id, attempt + 1);
+    });
+  }
+  // Optional dev-mode assertion: two rAFs later, the visual focus
+  // and the keyboard focus should agree. Console-warn on drift so
+  // future variants of #159/#181/#186 are caught in QA.
+  if (debugFocusEnabled()) scheduleFocusConsistencyCheck(id);
+}
+
+function sweepFocusBorder() {
+  for (const el of document.querySelectorAll('.term-host.term-focused')) {
+    el.classList.remove('term-focused');
+  }
+}
+
+function focusSnapshot(id) {
+  const ae = document.activeElement;
+  return {
+    id,
+    modalOpen:
       !launcherEl.classList.contains('hidden') ||
-      !editorEl.classList.contains('hidden')
-    ) {
-      for (const el of document.querySelectorAll('.term-host.term-focused')) {
-        el.classList.remove('term-focused');
-      }
-      return;
-    }
-    // A real DOM input (rename, etc.) owns the keyboard — don't
-    // steal it. Visual class is also cleared so the user can't be
-    // misled into thinking the terminal will receive their keys.
-    const ae = document.activeElement;
-    if (
-      ae &&
-      (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA' || ae.isContentEditable) &&
-      !ae.classList.contains('xterm-helper-textarea')
-    ) {
-      for (const el of document.querySelectorAll('.term-host.term-focused')) {
-        el.classList.remove('term-focused');
-      }
-      return;
-    }
-    // Atomic reconcile: sweep + add + focus, in this order, in one tick.
-    for (const el of document.querySelectorAll('.term-host.term-focused')) {
-      if (el !== st.host) el.classList.remove('term-focused');
-    }
-    st.host.classList.add('term-focused');
-    // Focus the helper-textarea DOM node directly. xterm's term.focus()
-    // early-returns when its internal _focused flag is stale-true,
-    // which happens after view toggles where xterm.open() / fit /
-    // mount sequences mounted a fresh helper-textarea (see #159).
+      !editorEl.classList.contains('hidden'),
+    activeTag: ae ? ae.tagName : '',
+    activeClasses: ae ? ae.classList : '',
+    knownTermIds: state.terms,
+  };
+}
+
+function debugFocusEnabled() {
+  try { return localStorage.getItem('hive.debug') === '1'; } catch { return false; }
+}
+
+function scheduleFocusConsistencyCheck(id) {
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    const st = state.terms.get(id);
+    if (!st) return;
     const ta = st.host.querySelector('.xterm-helper-textarea');
-    if (ta) ta.focus();
-    else st.term.focus();
-  });
+    const ae = document.activeElement;
+    const focusedHost = ae ? ae.closest('.term-host') : null;
+    if (focusedHost !== st.host || ae !== ta) {
+      // eslint-disable-next-line no-console
+      console.warn('[focus] inconsistent state', {
+        view: state.view,
+        activeId: state.activeId,
+        wantId: id,
+        aeTag: ae ? ae.tagName : null,
+        aeClass: ae ? ae.className : null,
+        focusedHostMatches: focusedHost === st.host,
+      });
+    }
+  }));
 }
 
 // focusActiveTerm / refocusActiveTerm are thin wrappers retained so
@@ -1461,6 +1524,7 @@ function gridScopeSessions() {
 
 function setView(view) {
   state.view = view;
+  try { localStorage.setItem(VIEW_STORAGE_KEY, view); } catch {}
   if (view === 'grid-project') {
     state.gridProjectId = activeProjectId();
   }

--- a/cmd/hivegui/frontend/test/e2e/focus.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/focus.spec.js
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test';
+
+// E2E coverage for the grid-mode focus pipeline (#159, #181, #186).
+// The Wails mock loads a real xterm so .xterm-helper-textarea exists
+// and behaves as in production. We assert focus state via
+// page.evaluate so the assertion sees the live DOM.
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function bootWithSessions(page, count = 2) {
+  await page.goto('/');
+  await page.waitForFunction(() => document.querySelectorAll('#projects li').length > 0);
+  for (let i = 1; i < count; i++) {
+    await page.evaluate((n) => window.__hive.addSession(n), `s${i + 1}`);
+  }
+  await page.waitForFunction((n) => window.__hive.state.sessions.length >= n, count);
+  // Reset stdinLog so the count starts fresh.
+  await page.evaluate(() => window.__hive.resetStdin());
+}
+
+// Inspect live focus state. Returns:
+//   { termsClass, focusedHosts, activeIsHelper, activeInsideFocusedHost }
+async function focusState(page) {
+  return page.evaluate(() => {
+    const terms = document.getElementById('terms');
+    const focusedHosts = Array.from(document.querySelectorAll('.term-host.term-focused')).map(
+      (h) => h.dataset.sessionId || h.getAttribute('data-id') || '<unknown>',
+    );
+    const ae = document.activeElement;
+    const activeIsHelper = !!(ae && ae.classList && ae.classList.contains('xterm-helper-textarea'));
+    const focusedHost = ae ? ae.closest('.term-host') : null;
+    const focusedHasClass = focusedHost ? focusedHost.classList.contains('term-focused') : false;
+    return {
+      termsClass: terms ? terms.className : '',
+      focusedHosts,
+      activeIsHelper,
+      activeInsideFocusedHost: focusedHasClass,
+    };
+  });
+}
+
+test.describe('grid-mode focus pipeline', () => {
+  test('single → grid-all preserves keyboard focus on the active session', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    // Confirm we're in single mode and an xterm helper is focused.
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+    await page.keyboard.press(`${MOD}+Shift+g`);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    // Allow setFocusedTile's rAF (+ at most one retry rAF) to settle.
+    await page.waitForFunction(() => {
+      const ae = document.activeElement;
+      return !!(ae && ae.classList && ae.classList.contains('xterm-helper-textarea'));
+    }, null, { timeout: 2000 });
+    const fs = await focusState(page);
+    expect(fs.activeIsHelper).toBe(true);
+    expect(fs.activeInsideFocusedHost).toBe(true);
+    expect(fs.focusedHosts.length).toBe(1);
+  });
+
+  test('single → grid-project preserves keyboard focus', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await page.keyboard.press(`${MOD}+Enter`);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    await page.waitForFunction(() => {
+      const ae = document.activeElement;
+      return !!(ae && ae.classList && ae.classList.contains('xterm-helper-textarea'));
+    }, null, { timeout: 2000 });
+    const fs = await focusState(page);
+    expect(fs.activeIsHelper).toBe(true);
+    expect(fs.activeInsideFocusedHost).toBe(true);
+  });
+
+  test('keystrokes reach the active session after single → grid-all (the user-visible bug)', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await page.keyboard.press(`${MOD}+Shift+g`);
+    await page.waitForFunction(() => {
+      const ae = document.activeElement;
+      return !!(ae && ae.classList && ae.classList.contains('xterm-helper-textarea'));
+    }, null, { timeout: 2000 });
+    await page.keyboard.type('hello');
+    // The active session's id at boot is the first session (s1 in the mock).
+    await expect.poll(
+      () => page.evaluate(() => window.__hive.stdinText()),
+      { timeout: 2000 },
+    ).toContain('hello');
+  });
+
+  test('round-trip: single → grid → single keeps focus and keystrokes wired', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await page.keyboard.press(`${MOD}+Shift+g`);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    await page.keyboard.press(`${MOD}+Shift+g`);
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+    await page.waitForFunction(() => {
+      const ae = document.activeElement;
+      return !!(ae && ae.classList && ae.classList.contains('xterm-helper-textarea'));
+    }, null, { timeout: 2000 });
+    await page.evaluate(() => window.__hive.resetStdin());
+    await page.keyboard.type('back');
+    await expect.poll(
+      () => page.evaluate(() => window.__hive.stdinText()),
+      { timeout: 2000 },
+    ).toContain('back');
+  });
+
+  test('cold-start in grid mode receives keystrokes (#187 persistence path)', async ({ page }) => {
+    // Pre-seed the persisted view BEFORE the app boots.
+    await page.addInitScript(() => {
+      try { localStorage.setItem('hive.view', 'grid-all'); } catch {}
+    });
+    await bootWithSessions(page, 2);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    await page.waitForFunction(() => {
+      const ae = document.activeElement;
+      return !!(ae && ae.classList && ae.classList.contains('xterm-helper-textarea'));
+    }, null, { timeout: 3000 });
+    await page.keyboard.type('cold');
+    await expect.poll(
+      () => page.evaluate(() => window.__hive.stdinText()),
+      { timeout: 2000 },
+    ).toContain('cold');
+  });
+});

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -56,7 +56,19 @@ export async function CloseAttach(_id) { return ''; }
 const stdinLog = []; // [{ id, b64, text }] — populated by WriteStdin so E2E can assert input routing.
 export async function WriteStdin(id, b64) {
   let text = '';
-  try { text = typeof atob === 'function' ? atob(b64) : Buffer.from(b64, 'base64').toString('binary'); } catch {}
+  try {
+    if (typeof atob === 'function' && typeof TextDecoder !== 'undefined') {
+      // atob() returns a Latin-1 "binary string" — feed each char's
+      // code unit into a Uint8Array, then decode as UTF-8 so non-ASCII
+      // input round-trips correctly in E2E assertions.
+      const bin = atob(b64);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      text = new TextDecoder('utf-8').decode(bytes);
+    } else {
+      text = Buffer.from(b64, 'base64').toString('utf-8');
+    }
+  } catch {}
   stdinLog.push({ id, b64, text });
   return '';
 }

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -53,7 +53,13 @@ function broadcast() {
 export async function ConnectControl() { setTimeout(broadcast, 0); return ''; }
 export async function OpenSession(id) { return id; }
 export async function CloseAttach(_id) { return ''; }
-export async function WriteStdin(_id, _bytes) { return ''; }
+const stdinLog = []; // [{ id, b64, text }] — populated by WriteStdin so E2E can assert input routing.
+export async function WriteStdin(id, b64) {
+  let text = '';
+  try { text = typeof atob === 'function' ? atob(b64) : Buffer.from(b64, 'base64').toString('binary'); } catch {}
+  stdinLog.push({ id, b64, text });
+  return '';
+}
 export async function ResizeSession(_id, _cols, _rows) { return ''; }
 export async function CreateSession(spec) {
   const id = 'mock-' + (state.sessions.length + 1);
@@ -117,5 +123,13 @@ if (typeof window !== 'undefined') {
     addSession(name) { return CreateSession({ name }); },
     killSession(id) { return KillSession(id); },
     listeners,
+    stdinLog,
+    stdinText(id) {
+      return stdinLog
+        .filter((e) => id == null || e.id === id)
+        .map((e) => e.text)
+        .join('');
+    },
+    resetStdin() { stdinLog.length = 0; },
   };
 }

--- a/cmd/hivegui/frontend/test/unit/focus.test.js
+++ b/cmd/hivegui/frontend/test/unit/focus.test.js
@@ -70,4 +70,17 @@ describe('decideFocusAction', () => {
     }));
     expect(a.kind).toBe(ACTION_CLEAR);
   });
+
+  it('clears when the command palette is the open modal', () => {
+    // focusSnapshot() in main.js ORs launcher/editor/palette visibility
+    // into modalOpen; decideFocusAction only sees the resulting flag.
+    // This locks in that any palette-open snapshot yields ACTION_CLEAR
+    // even when a tile would otherwise be a valid focus target.
+    const a = decideFocusAction(snap({
+      modalOpen: true,
+      activeTag: 'INPUT',
+      activeClasses: 'command-palette-input',
+    }));
+    expect(a.kind).toBe(ACTION_CLEAR);
+  });
 });

--- a/cmd/hivegui/frontend/test/unit/focus.test.js
+++ b/cmd/hivegui/frontend/test/unit/focus.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideFocusAction,
+  ACTION_CLEAR,
+  ACTION_PRESERVE,
+  ACTION_FOCUS,
+} from '../../src/lib/focus.js';
+
+const knownTermIds = new Set(['s1', 's2']);
+
+function snap(overrides = {}) {
+  return {
+    id: 's1',
+    modalOpen: false,
+    activeTag: 'BODY',
+    activeClasses: '',
+    knownTermIds,
+    ...overrides,
+  };
+}
+
+describe('decideFocusAction', () => {
+  it('clears when id is null', () => {
+    expect(decideFocusAction(snap({ id: null })).kind).toBe(ACTION_CLEAR);
+  });
+
+  it('clears when a modal is open', () => {
+    expect(decideFocusAction(snap({ modalOpen: true })).kind).toBe(ACTION_CLEAR);
+  });
+
+  it('clears when id is not a known SessionTerm', () => {
+    expect(decideFocusAction(snap({ id: 'ghost' })).kind).toBe(ACTION_CLEAR);
+  });
+
+  it('preserves when a real INPUT owns the keyboard', () => {
+    const a = decideFocusAction(snap({ activeTag: 'INPUT', activeClasses: 'tile-name-input' }));
+    expect(a.kind).toBe(ACTION_PRESERVE);
+  });
+
+  it('preserves when a real TEXTAREA (non-xterm) owns the keyboard', () => {
+    const a = decideFocusAction(snap({ activeTag: 'TEXTAREA', activeClasses: 'something-else' }));
+    expect(a.kind).toBe(ACTION_PRESERVE);
+  });
+
+  it('focuses through when the xterm helper-textarea is already active', () => {
+    const a = decideFocusAction(snap({ activeTag: 'TEXTAREA', activeClasses: 'xterm-helper-textarea' }));
+    expect(a).toEqual({ kind: ACTION_FOCUS, id: 's1' });
+  });
+
+  it('focuses when activeElement is BODY (the post-blur single → grid state)', () => {
+    expect(decideFocusAction(snap({ activeTag: 'BODY' }))).toEqual({ kind: ACTION_FOCUS, id: 's1' });
+  });
+
+  it('accepts a DOMTokenList-shaped activeClasses', () => {
+    const tokens = { contains: (n) => n === 'xterm-helper-textarea' };
+    const a = decideFocusAction(snap({ activeTag: 'TEXTAREA', activeClasses: tokens }));
+    expect(a.kind).toBe(ACTION_FOCUS);
+  });
+
+  it('accepts an array-shaped knownTermIds', () => {
+    expect(decideFocusAction(snap({ knownTermIds: ['s1'] })).kind).toBe(ACTION_FOCUS);
+    expect(decideFocusAction(snap({ id: 'sZ', knownTermIds: ['s1'] })).kind).toBe(ACTION_CLEAR);
+  });
+
+  it('modal open beats every other signal', () => {
+    const a = decideFocusAction(snap({
+      modalOpen: true,
+      activeTag: 'TEXTAREA',
+      activeClasses: 'xterm-helper-textarea',
+    }));
+    expect(a.kind).toBe(ACTION_CLEAR);
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/view.test.js
+++ b/cmd/hivegui/frontend/test/unit/view.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeView,
+  VIEW_SINGLE,
+  VIEW_GRID_PROJECT,
+  VIEW_GRID_ALL,
+} from '../../src/lib/view.js';
+
+describe('normalizeView', () => {
+  it('passes valid views through', () => {
+    expect(normalizeView('single')).toBe(VIEW_SINGLE);
+    expect(normalizeView('grid-project')).toBe(VIEW_GRID_PROJECT);
+    expect(normalizeView('grid-all')).toBe(VIEW_GRID_ALL);
+  });
+  it('falls back to single for unknown values', () => {
+    expect(normalizeView('zoomed')).toBe(VIEW_SINGLE);
+    expect(normalizeView('')).toBe(VIEW_SINGLE);
+    expect(normalizeView(null)).toBe(VIEW_SINGLE);
+    expect(normalizeView(undefined)).toBe(VIEW_SINGLE);
+  });
+});

--- a/docs/exec-plans/active/186-grid-mode-focus-regression-cant-type.md
+++ b/docs/exec-plans/active/186-grid-mode-focus-regression-cant-type.md
@@ -178,6 +178,14 @@ Mock extension needed: add `stdinLog` (array of `{ id, b64 }` entries) and a `la
 - **2026-05-12** — Implemented on `feature/186-grid-focus-regression`. Initial fix (single retry rAF) was insufficient — E2E with focus tracing showed the disturbance fires ~10ms after the verify rAF, AFTER the in-rAF check passed. Generalised to bounded polling (8 frames), idempotent re-focus. All 50 vitest + 7 Playwright tests pass, including the user-visible bug repro (`single → grid then type 'hello'`).
 - **2026-05-12** — `decideFocusAction` extracted to `lib/focus.js` with 10 unit tests; Wails mock extended with `stdinLog` / `stdinText()` / `resetStdin()` so E2E can assert keystrokes reach the backend.
 
+## PR convergence ledger
+
+<!-- Append-only. One line per /hs-review-loop iteration. -->
+
+- **2026-05-12 iter 1** — verdict: COMMENT (coerced to REQUEST_CHANGES); findings_hash: ef8c1edc; threads_open: 5; action: continue (autofix next iter); head_sha: fda78e2.
+- **2026-05-12 iter 2** — verdict: REQUEST_CHANGES (autofix ran); findings_hash: empty; threads_open: 0; action: autofix+push (5 fixes, CI passed); head_sha: fff3b54.
+- **2026-05-12 iter 3** — verdict: APPROVE; findings_hash: empty; threads_open: 0; action: stop (converged); head_sha: fff3b54.
+
 ## Open questions
 
 - **Reproduction path**: does the user hit this on every single → grid press, or only after a sidebar-click session switch immediately preceding the `⌘G`? Knowing this disambiguates between candidate causes 5 and the visibility-pending hypothesis.

--- a/docs/exec-plans/active/186-grid-mode-focus-regression-cant-type.md
+++ b/docs/exec-plans/active/186-grid-mode-focus-regression-cant-type.md
@@ -1,0 +1,182 @@
+# Regression: focus inconsistent — switching from single-session to grid mode disables typing
+
+- **Spec:** [docs/product-specs/186-grid-mode-focus-regression-cant-type.md](../../product-specs/186-grid-mode-focus-regression-cant-type.md)
+- **Issue:** #186
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+User report: after the #181 atomic-focus fix shipped (commit `8b5c702`, on `origin/main`), the single → grid transition still fails to deliver keystrokes to the visually focused session. We need to identify what `setFocusedTile`'s atomic reconcile missed and patch it without re-introducing the two-writer split that #181 eliminated.
+
+## Research
+
+### What #181 already changed
+
+`cmd/hivegui/frontend/src/main.js` (post-merge of `origin/main`):
+
+- The per-tile `focusin`/`focusout` listeners that used to write `.term-focused` were removed (constructor at lines 210–215 now carries only an explanatory comment).
+- `setFocusedTile(id)` (lines 1407–1463) is the **sole** writer of `.term-focused`. Its body, in order:
+  1. Modal-open or null-id gate → sweep `.term-focused` and return.
+  2. Schedule one `requestAnimationFrame`.
+  3. Inside the rAF: re-check the modal gate; bail if a real `<input>`/`<textarea>` (not the xterm helper) owns the keyboard.
+  4. Sweep `.term-focused` off all other hosts; add it to `st.host`; call `.focus()` on `st.host.querySelector('.xterm-helper-textarea')` (or `st.term.focus()` as fallback).
+- `focusActiveTerm()` and `refocusActiveTerm()` are now thin wrappers calling `setFocusedTile(state.activeId)` (lines 1469–1475).
+
+This eliminates the documented #181 root cause: visual class drifting onto a different tile than the keyboard target during DOM churn.
+
+### Single → grid call graph (post #181)
+
+User presses `⌘G` (or `⌘⇧G` / `⌘Enter`) while in single mode. `cmd/hivegui/frontend/src/main.js`:
+
+1. `window` `keydown` (line 2305) → `setView('grid-all' | 'grid-project')` (line 1523).
+2. `setView`:
+   - `state.view = view`.
+   - `renderGrid()` (line 1295) — does **not** call `show()`/`hide()`. Adds `.in-grid` to each grid session host and calls `termsHost.appendChild(st.host)` to reorder them in DOM order.
+   - `focusActiveTerm()` → `setFocusedTile(state.activeId)`.
+
+Side-effects of `renderGrid` that touch the focused tile:
+- `termsHost.classList.remove('single'); termsHost.classList.add('grid')` (lines 1296–1297). Between this line and the per-tile `add('in-grid')` below, the active tile **transiently matches `#terms.grid .term-host` (no `.in-grid` yet) → `display: none`**. Going `display: none` on an element that contains the focused `xterm-helper-textarea` fires synchronous `focusout`; `document.activeElement` becomes `<body>`.
+- `termsHost.appendChild(st.host)` (line 1312) reorders the active tile under the same parent. Reparenting/move also drops focus to `<body>`.
+
+By the time `setFocusedTile`'s rAF fires, `document.activeElement` is `<body>` (gate passes), the active tile has `.in-grid` (display restored), and `ta.focus()` should land.
+
+### Candidate remaining failure modes #181 did not address
+
+Listed in roughly decreasing likelihood. Each is testable cheaply with a one-line probe.
+
+1. **rAF runs while `body.style.visibility === 'hidden'`.** `show()` (line 438) sets `this.body.style.visibility = 'hidden'` and schedules `_revealRaf` to clear it. `setFocusedTile`'s rAF is scheduled by callers *after* `show()`'s rAF in same-microtask cases (e.g. `setActive` → `showSingle` → `show` then `setFocusedTile`), so they fire in FIFO and visibility is cleared first. **But the single → grid path does *not* call `show()` for the active tile** — `renderGrid` skips it. So `_revealRaf` from a *prior* `showSingle` (entering single mode) should have long since fired. Edge case: rapid grid → single → grid before the first rAF settles leaves `_revealRaf` pending; same-batch FIFO still saves us. Low probability.
+
+2. **The `appendChild` reorder triggers an xterm internal mutation that orphans the helper-textarea.** xterm v5 keeps `.xterm-helper-textarea` as a fixed child of `body` once `term.open()` runs. `appendChild` move preserves the subtree. **But** the active tile's helper-textarea node was created when the tile was first opened; if `renderGrid` ever re-runs `term.open()` (it does not; `ensureTerm` is idempotent and constructors only run once), the node would be replaced. Verified: `ensureTerm` (line 1147+) returns existing entries.
+
+3. **`appendChild` to the *same parent in a new position* does not reliably keep focus AND xterm's internal `_focused` flag drifts true.** This is the documented #159 / #181 trap. The current fix focuses the **DOM helper-textarea** instead of `term.focus()`, which forces a real browser focus event xterm's own listener consumes. Probability that this still fails: low if the textarea selector resolves and the body is visible at rAF time.
+
+4. **`document.activeElement` at rAF time is *not* `<body>` but a stale `<input>` (e.g. the session-name `<span>` in the tile header).** The header has a `tile-name-input` only during inline rename; absent that, the gate passes. Probability: low.
+
+5. **`renderGrid` adds `.in-grid` *after* the parent class flip, leaving an intra-script frame where the active tile is `display:none` long enough for xterm to mark itself blurred AND skip re-focusing on the new ta.focus().** No paint happens between the two synchronous statements, so xterm's `_focused` flag *does* go false (focusout fires synchronously on display:none), but a fresh `ta.focus()` should re-enter. Medium probability: this matches the user's description of "fixed it but didn't work" — #181's atomic reconcile correctly *targets* the right tile, but the reconcile happens after the same hard blur the prior fix was already racing.
+
+6. **`setFocusedTile`'s rAF is captured by a *prior* rAF callback that re-blurs.** Concretely: `_revealRaf` runs first and *clears* `body.style.visibility = ''` (does not blur). Then the focus rAF runs. Should be safe.
+
+7. **Other modes than `⌘G` skip `setFocusedTile` entirely.** Non-keyboard transitions: tile click in grid → `switchTo` (line 1130) → `renderGrid` → `focusActiveTerm`. Sidebar click → same. Restart Session → `refocusActiveTerm`. Window focus → `refocusActiveTerm` (line 642). All routes through `setFocusedTile`. No gap found.
+
+8. **`switchTo(id)` in single mode early-returns to `focusActiveTerm()` only when `id === state.activeId` (line 1167–1170)**, but if `id` differs and view is single, it calls `setActive(id)` → `focusActiveTerm()` (inside setActive at 1383), then `showSingle(id)`, then `focusActiveTerm()` again at line 1193. Two rAFs scheduled; first one runs against pre-show DOM (target tile not yet `.visible`, so the `st.host.querySelector('.xterm-helper-textarea')` exists but body is `display:none`, so `ta.focus()` is a no-op). Second rAF runs after show() and succeeds. **But for single → grid this isn't relevant — `renderGrid` doesn't go through `setActive`.**
+
+### The most plausible remaining cause
+
+Combining items 5 + 3: when `setView('grid-…')` runs, the active tile undergoes a synchronous `display:none → display:flex` flip (CSS class change leaving the host without `.in-grid` for one statement). The browser fires `focusout` on the helper-textarea synchronously. xterm's internal listener on the helper-textarea sets `_focused = false`. Then `appendChild` moves the host. Then `setFocusedTile` schedules rAF and the rAF calls `ta.focus()`.
+
+If the helper-textarea's body chain is `display:none` *at the moment `ta.focus()` is called inside the rAF*, the focus call is a no-op. By that moment we expect `.in-grid` to be on the host (added synchronously inside `renderGrid` before `setFocusedTile` runs), so display should be `flex`. **However**, if the tile body is gated by a `_revealRaf` that hasn't yet cleared `body.style.visibility`, focus on its descendant *also* fails silently. `_revealRaf` is set by `show()`. `renderGrid` does not call `show()`, so this only bites when `show()` was called *just before* the user pressed `⌘G` — e.g. the user clicked a sidebar item in single mode (which routes through `switchTo` → `showSingle` → `show()`) and *immediately* hit `⌘G` in the same paint frame.
+
+This is consistent with the user's report that #181 "didn't work" only on certain runs — single → grid breaks when preceded by a session switch in single mode that has not yet had its reveal-rAF fire. The cure: `setFocusedTile` should not assume body visibility is settled — either explicitly clear `body.style.visibility = ''` on the target before focusing (and cancel `_revealRaf`), or schedule the focus *after* the next `_revealRaf` resolves rather than the same animation frame.
+
+### Constraints / dependencies
+
+- xterm.js v5 has no `onFocus`/`onBlur` events; helper-textarea focus is the only safe handle.
+- Must not re-introduce the two-writer split #181 removed.
+- The `body.style.visibility` gate from #176 is needed to prevent canvas-flash; removing it is not an option.
+- No JS test harness in `cmd/hivegui/frontend/` (`package.json` has no `test` script). Per `AGENTS.md`, GUI-side bugs verify manually against spec acceptance criteria. A regression guard (runtime assertion in dev builds) is the closest substitute.
+
+### Files implicated
+
+- `cmd/hivegui/frontend/src/main.js`
+  - `SessionTerm.show` / `hide` (lines 438–478) — `body.style.visibility` and `_revealRaf`.
+  - `renderGrid` (lines 1295–1374) — class flip, appendChild reorder, no `show()` call for active.
+  - `setFocusedTile` (lines 1407–1463) — sole focus writer; its rAF is the place to harden against the visibility-pending case.
+  - `setView` (lines 1523–1540) — calls `focusActiveTerm()` after `renderGrid`.
+- `cmd/hivegui/frontend/src/style.css:445–499` — `#terms.single .term-host` requires `.visible` for `display`; `#terms.grid .term-host` requires `.in-grid` for `display`. The mismatch is the source of the transient `display:none`.
+
+## Approach
+
+User-confirmed repro narrows the cause: **single → grid (either grid-project or grid-all) reliably loses keyboard input; grid → single and grid → grid both work.** The `_revealRaf` race hypothesis is therefore wrong (going *to* grid doesn't call `show()` and grid → single uses the same `_revealRaf` path successfully). The remaining cause is in `renderGrid`'s synchronous DOM churn that no other transition triggers:
+
+1. `termsHost.classList.remove('single'); add('grid')` (line 1296–1297) — the active tile, which has `.visible` (irrelevant in grid CSS) but not yet `.in-grid`, goes `display:none` for the duration of the rest of the script. Synchronous `focusout` fires on the helper-textarea. `document.activeElement` becomes `<body>`. xterm's internal listener on the helper-textarea catches `blur` and sets its `_focused` flag to `false`.
+2. The per-tile loop adds `.in-grid` to each grid host (display restored) and `appendChild`s each (more DOM churn; doesn't re-focus anything).
+3. `focusActiveTerm()` → `setFocusedTile(state.activeId)` → schedules one rAF.
+4. Inside the rAF, `ta.focus()` is called on the active tile's helper-textarea. The DOM focus call appears to succeed in the spec but, on this transition specifically, xterm's input pipeline doesn't recover — the user's reliable-failure report confirms this.
+
+The `setFocusedTile` rAF currently does *one* attempt and assumes success. Hardening it without re-introducing the two-writer split #181 removed:
+
+**Change 1 — verify-and-retry.** After `ta.focus()`, check `document.activeElement === ta`. If not (browser silently dropped the focus call — possible if the helper-textarea's ancestor chain wasn't yet "settled" enough by the browser's internal hit-testable state), schedule one more rAF that repeats the sweep + add + focus sequence. One retry is enough; if that still fails the cause is outside the rAF's reach and we should not loop indefinitely.
+
+**Change 2 — also call `st.term.focus()` after `ta.focus()`.** The #181 fix moved away from `term.focus()` because it early-returns on a stale-true `_focused` flag, but the situation here is the opposite: after the synchronous `display:none` blur, xterm's `_focused` is now stale-*false*. Calling `term.focus()` is a safe second write that pokes xterm's internal state machine. Order matters: `ta.focus()` first (real DOM focus event drives xterm's listener-based update), then `term.focus()` as a belt-and-braces sync.
+
+**Change 3 (regression guard).** Add a dev-mode assertion (gated on `localStorage.getItem('hive.debug') === '1'`) that 2 rAF ticks after `setFocusedTile` runs, checks `.term-focused` matches `document.activeElement`'s nearest `.term-host` ancestor. Console-warn on mismatch with enough context (view, activeId, ae.tagName, ae.className) to diagnose future variants. Cheap, off by default, on for QA.
+
+**Why this approach over alternatives.**
+- *"Cancel `_revealRaf` and clear `body.style.visibility` before `ta.focus()`"* — speculative; the user repro shows the bug is not gated on visibility-pending.
+- *"Skip the `display:none` flip by adding `.in-grid` BEFORE the `single→grid` class flip on termsHost"* — would solve the synchronous blur, but reordering the class flip is fragile (every `#terms.single .term-host` rule needs to be re-evaluated for grid context with `.visible` lingering) and risks a worse layout artifact than the current transient `display:none`.
+- *"Defer `setFocusedTile` to a `setTimeout(0)` instead of rAF"* — moves the bug from one tick to another without addressing what actually broke.
+- *"Fire a synthetic `focus` event on the helper-textarea instead of `.focus()`"* — bypasses the browser's internal focus tracking; would set xterm's `_focused` flag but `document.activeElement` would not be the textarea, so real keystrokes still go to body. Worse than today.
+
+The verify-and-retry + term.focus() pair targets the actual stuck state (xterm `_focused` desync after a synchronous display blur) without touching renderGrid's DOM order.
+
+### Files to change
+
+1. `cmd/hivegui/frontend/src/lib/focus.js` (new) — extract the pure gate-decision into a testable function `decideFocusAction({ id, modalOpen, activeTag, activeClasses, knownTermId })` returning one of `{ kind: 'clear' }`, `{ kind: 'preserve' }` (real input owns keyboard, leave alone), or `{ kind: 'focus', id }`. This isolates the only logic in `setFocusedTile` that has interesting branches; the rest is DOM side-effects.
+
+2. `cmd/hivegui/frontend/src/main.js` — harden `setFocusedTile`:
+   - Replace inline gate with a call to `decideFocusAction(...)` from `lib/focus.js`.
+   - Inside the rAF, after `ta.focus()`, call `st.term.focus()` to belt-and-braces xterm's internal `_focused` flag (the #181 fix worried about stale-true; here we have stale-false after a synchronous `display:none` blur).
+   - Verify `document.activeElement === ta` after the focus calls; if not, schedule one retry rAF that repeats the sweep + add + focus. Cap at one retry — do not loop.
+   - Add `_assertFocusConsistent(id)` helper gated on `localStorage.getItem('hive.debug') === '1'`, scheduled two rAFs later, console-warning with `{ view, activeId, ae.tagName, ae.className }` on mismatch. Off by default; on for QA.
+
+3. `cmd/hivegui/frontend/test/unit/focus.test.js` (new) — unit tests for `decideFocusAction` covering the gate matrix.
+
+4. `cmd/hivegui/frontend/test/e2e/focus.spec.js` (new) — Playwright E2E driving the actual bug scenario via the Wails-mock bridge.
+
+5. `CHANGELOG.md` — `[Unreleased] / Fixed` entry: "GUI: switching from single-focus to grid mode no longer leaves the active session visually focused but unable to receive keystrokes (#186, follow-up to #181)."
+
+### New files
+
+- `cmd/hivegui/frontend/src/lib/focus.js`
+- `cmd/hivegui/frontend/test/unit/focus.test.js`
+- `cmd/hivegui/frontend/test/e2e/focus.spec.js`
+
+### Tests
+
+The four-layer harness from PR #188 (`scripts/test.sh`) is now the contract. Per `AGENTS.md`: "All changes require both unit tests and functional tests." This change ships both, plus updated manual QA for the cases the harness can't reach (multi-window / native dialogs).
+
+**Unit (`test/unit/focus.test.js`):**
+- `decideFocusAction` returns `clear` when `id == null`.
+- `decideFocusAction` returns `clear` when `modalOpen === true` (launcher / project editor / palette).
+- `decideFocusAction` returns `clear` when `id` is not in `knownTermIds` (defensive: tile was destroyed).
+- `decideFocusAction` returns `preserve` when `activeTag === 'INPUT'` / `'TEXTAREA'` and the active element is NOT the xterm helper (rename, inline editor).
+- `decideFocusAction` returns `focus` when the active element is the xterm helper-textarea (same tile, already correct).
+- `decideFocusAction` returns `focus` when the active element is `<body>` (post-blur state — the single → grid case).
+- `decideFocusAction` returns `focus` when `contentEditable` is true on a non-terminal element only if `preserveContentEditable` flag is false (matches current code's lack of contentEditable carve-out — pinning behavior).
+
+**E2E (`test/e2e/focus.spec.js`):** driven by the Wails-mock bridge that already powers `smoke.spec.js`. xterm is real in this harness, so helper-textarea behaves authentically. Each test waits for the initial sidebar to render, then exercises the transition and asserts focus state via `page.evaluate`.
+
+- `single → grid-all preserves keyboard focus on the active session` — press `Mod+Shift+G`; assert `#terms` has `.grid` class; assert exactly one `.term-host` has `.term-focused`; assert `document.activeElement.classList.contains('xterm-helper-textarea')`; assert that helper-textarea is a descendant of the focused host.
+- `single → grid-project preserves keyboard focus` — same with `Mod+Enter`.
+- `keystrokes reach the active session after single → grid-all` — after the transition, `page.keyboard.type('hello')`; assert the mock backend received the text via `window.__hive.lastStdin` (extend the mock to capture WriteStdin payloads; the mock already exposes `window.__hive.state` so a parallel `window.__hive.stdinLog` is trivial).
+- `grid → single still receives keystrokes` (#159 regression).
+- `sidebar-click session switch in grid` (#181 regression) — click another session in the sidebar; assert `.term-focused` and helper-textarea both move to the new tile.
+- `cold-start in grid mode (#187 path)` — set `localStorage.hive.view = 'grid-all'` before `page.goto('/')`; assert the first keystroke reaches the active session without any click or Mod+G press. This is the test that confirms whether the bug is purely transition-based or has a cold-start variant too.
+
+Mock extension needed: add `stdinLog` (array of `{ id, b64 }` entries) and a `lastStdin(id)` helper in `test/e2e/wails-mock.js`'s `WriteStdin` shim. Trivial — one mutation; tracked as a sub-task of this plan.
+
+**Manual QA (still required for native paths the E2E mock can't fake):**
+- macOS native menu interaction with `⌘G` (the E2E mock does not exercise the AppKit menu path).
+- Multi-window: two GUI windows open, switching modes in one must not steal focus from the other.
+
+**Dev-mode assertion** stays as Change 3 above — covers the "future-variant" case unit + E2E miss.
+
+## Decision log
+
+- **2026-05-11** — Created spec/plan via /hs-feature-loop. Identified that #181 (commit 8b5c702) is the prior fix attempt the user is referring to.
+- **2026-05-11** — Pulled `origin/main` into the worktree before research; the worktree was at `e3e3d2c` (release v2.2.1) and missed the #181 fix on which the user's regression report is grounded.
+
+## Progress
+
+- **2026-05-11** — Spec drafted, triage approved (bug / S / P1).
+- **2026-05-11** — Research complete; no smoking-gun confirmed without a live repro, but most plausible remaining cause identified (visibility-pending interaction between #176's `_revealRaf` and #181's `setFocusedTile` rAF).
+- **2026-05-11** — User repro detail: single → grid (either flavor) reliably fails; grid → grid and grid → single both pass. Narrowed cause to the synchronous `display:none` flip on the active tile during `renderGrid`'s parent class swap.
+- **2026-05-12** — Plan revised to leverage the new four-layer test harness (PR #188): added unit + E2E tests for the fix and a sub-task to extend the Wails mock with a `stdinLog` capture.
+- **2026-05-12** — Implemented on `feature/186-grid-focus-regression`. Initial fix (single retry rAF) was insufficient — E2E with focus tracing showed the disturbance fires ~10ms after the verify rAF, AFTER the in-rAF check passed. Generalised to bounded polling (8 frames), idempotent re-focus. All 50 vitest + 7 Playwright tests pass, including the user-visible bug repro (`single → grid then type 'hello'`).
+- **2026-05-12** — `decideFocusAction` extracted to `lib/focus.js` with 10 unit tests; Wails mock extended with `stdinLog` / `stdinText()` / `resetStdin()` so E2E can assert keystrokes reach the backend.
+
+## Open questions
+
+- **Reproduction path**: does the user hit this on every single → grid press, or only after a sidebar-click session switch immediately preceding the `⌘G`? Knowing this disambiguates between candidate causes 5 and the visibility-pending hypothesis.
+- **Cold-start grid mode**: if the GUI launches into grid mode (persisted view), does the first keystroke land? Different code path.

--- a/docs/exec-plans/active/186-grid-mode-focus-regression-cant-type.md
+++ b/docs/exec-plans/active/186-grid-mode-focus-regression-cant-type.md
@@ -2,8 +2,10 @@
 
 - **Spec:** [docs/product-specs/186-grid-mode-focus-regression-cant-type.md](../../product-specs/186-grid-mode-focus-regression-cant-type.md)
 - **Issue:** #186
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Status:** active
+- **PR:** [#189](https://github.com/lucascaro/hive/pull/189)
+- **Branch:** feature/186-grid-focus-regression
 
 ## Summary
 

--- a/docs/product-specs/186-grid-mode-focus-regression-cant-type.md
+++ b/docs/product-specs/186-grid-mode-focus-regression-cant-type.md
@@ -1,0 +1,29 @@
+# Regression: focus inconsistent — switching from single-session to grid mode disables typing
+
+- **Issue:** #186
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/186-grid-mode-focus-regression-cant-type.md](../exec-plans/active/186-grid-mode-focus-regression-cant-type.md)
+
+## Problem
+
+Regression of #159 (and possibly tangled with the grid-mode work in #177). When transitioning from single-session view into grid mode, keyboard input no longer reaches the focused session — typing has no effect. This was previously fixed under #159 and the user reports a recent attempted fix did not stick. Visual focus state and the element actually receiving keystrokes are once again out of sync.
+
+## Desired behavior
+
+Switching between single-session view and grid mode (in either direction) consistently restores keyboard focus to the visually selected session. Typing immediately reaches that session's input without an extra click.
+
+## Success criteria
+
+- After single → grid mode transition, the visually focused session receives keystrokes immediately.
+- After grid → single transition, the session input receives keystrokes immediately (no #159 regression).
+- A regression guard (test or runtime assertion) catches future divergence between visual focus and the active input element.
+
+## Non-goals
+
+- Broader focus-management refactor outside the single ↔ grid transition.
+
+## Notes
+
+Related: #159 (original fix), #176 (visibility-gated xterm canvas resize), #177 (grid mode revert + restart bugs).

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -7,6 +7,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Priority | Issue | Title | Stage | Spec |
 |----------|-------|-------|-------|------|
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
+| P1 | #186 | Regression: focus inconsistent — switching from single-session to grid mode disables typing | PLAN | [186-grid-mode-focus-regression-cant-type](186-grid-mode-focus-regression-cant-type.md) |
 | P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
 | P1 | #183 | Hive opens only a shell on Windows, not Claude | REVIEW | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -7,7 +7,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Priority | Issue | Title | Stage | Spec |
 |----------|-------|-------|-------|------|
 | <P1> | #<n> | <title> | TRIAGE \| RESEARCH \| PLAN \| IMPLEMENT | [<slug>](<slug>.md) |
-| P1 | #186 | Regression: focus inconsistent — switching from single-session to grid mode disables typing | PLAN | [186-grid-mode-focus-regression-cant-type](186-grid-mode-focus-regression-cant-type.md) |
+| P1 | #186 | Regression: focus inconsistent — switching from single-session to grid mode disables typing | REVIEW | [186-grid-mode-focus-regression-cant-type](186-grid-mode-focus-regression-cant-type.md) |
 | P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
 | P1 | #183 | Hive opens only a shell on Windows, not Claude | REVIEW | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |


### PR DESCRIPTION
## Summary

- Fix the single → grid focus regression that #181 only partially addressed. The `display:none` flip during `renderGrid`'s parent class swap blurs the xterm helper-textarea, and a ResizeObserver-driven xterm fit on the newly-visible neighbour tile re-blurs ~10ms later — AFTER #181's verification rAF passed. `setFocusedTile` now polls 8 frames and idempotently re-focuses.
- Extract the gate decision into a pure `decideFocusAction` helper in `lib/focus.js`, with 10 unit tests.
- Add 5 Playwright E2E tests covering the bug, the #159 / #181 regression classes, and the cold-start grid path.
- Ship `lib/view.js` + persistence of the last view in `localStorage.hive.view` (#187), restored on launch. Prerequisite for the cold-start E2E test that disambiguates the bug from a more fundamental issue inside `setFocusedTile`.
- Extend the Wails E2E mock with `stdinLog` / `stdinText(id)` / `resetStdin()` so E2E can assert keystrokes reach the backend.
- Add a dev-mode focus consistency assertion gated on `localStorage.hive.debug='1'`.

Fixes #186
Fixes #187

## Test plan

- [x] `npx vitest run` — 50 tests pass (10 new for `decideFocusAction`, 2 new for `normalizeView`).
- [x] `npx playwright test` — 7 tests pass (5 new in `focus.spec.js`, 2 existing in `smoke.spec.js`).
- [x] The user-visible repro test (`single → grid then type 'hello'` → mock backend receives 'hello') passes.
- [ ] Manual macOS QA: `⌘G` via the native menu (E2E mock doesn't exercise AppKit menu accelerator path).
- [ ] Manual multi-window QA: two GUI windows open, mode switch in one doesn't steal focus from the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)