### PR TITLE
fix(gui): recover xterm renderer from context loss, DPR, visibility (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for fnm/nvm/asdf PATH setup); Windows uses `%ComSpec% /C <line>`
   with cmd.exe-aware quoting, which also correctly handles `.cmd`
   shims like `claude.cmd`. (#183)
+- GUI: terminal text no longer gets stuck displaying garbled glyphs in
+  long-lived sessions until the user resizes the window. The xterm.js
+  WebGL renderer can lose its GL context (browsers cap simultaneous
+  contexts process-wide, so many-tile sessions can trigger this) or
+  silently invalidate its glyph atlas on device-pixel-ratio changes
+  and visibility transitions. Each session tile now recovers from
+  context loss by re-attaching the WebGL addon (or falling back to the
+  DOM renderer) and forcing a full repaint, and clears the glyph atlas
+  on DPR changes and on becoming visible again. The GL context is also
+  disposed explicitly when a tile is destroyed to reduce pressure on
+  the per-process context cap. (#190)
 
 ## [2.2.1] — 2026-05-10
 

--- a/cmd/hivegui/frontend/src/lib/renderer-recovery.js
+++ b/cmd/hivegui/frontend/src/lib/renderer-recovery.js
@@ -1,0 +1,41 @@
+// Pure helpers for the xterm WebGL renderer recovery flow (#190).
+//
+// The renderer can land in a state where the glyph atlas / GPU
+// backbuffer are stale — context loss (browsers cap simultaneous WebGL
+// contexts), DPR change, or post-visibility GPU sleep — and the canvas
+// keeps displaying corrupted glyphs until something forces a repaint.
+// SessionTerm wires these helpers up; the helpers themselves take no
+// terminal or DOM dependencies so they're trivially unit-testable.
+
+// Decide whether a visibilitychange should trigger a renderer refresh.
+// We only repaint when the document is becoming visible (the stale
+// backbuffer is irrelevant while we're hidden, and we don't want to
+// thrash GPU on the way down).
+export function shouldRefreshOnVisibility(visibilityState) {
+  return visibilityState === 'visible';
+}
+
+// Drive a single context-loss recovery cycle. `deps` is an injectable
+// surface for the three side-effects so the cycle can be tested in
+// isolation:
+//   - dispose():  best-effort teardown of the dead WebGL addon.
+//   - reattach(): try to bring up a fresh WebGL addon. Returns true on
+//                 success, false when the GL context can't be acquired
+//                 (e.g. the per-process cap is still saturated).
+//   - refresh():  force a full terminal repaint so stale pixels don't
+//                 survive into the next user-visible frame.
+//
+// Returns { reattached } so callers can null out their addon handle
+// when reattach failed.
+export function recoverFromContextLoss(deps) {
+  try { deps.dispose(); } catch { /* dispose is best-effort */ }
+  let reattached = false;
+  try { reattached = deps.reattach() === true; } catch { reattached = false; }
+  if (!reattached) {
+    // Reattach failed → we're on the DOM renderer now (or no renderer
+    // at all). Force a refresh so the canvas's stale pixels are
+    // overwritten without waiting for the next resize.
+    try { deps.refresh(); } catch { /* nothing else to do */ }
+  }
+  return { reattached };
+}

--- a/cmd/hivegui/frontend/src/lib/renderer-recovery.js
+++ b/cmd/hivegui/frontend/src/lib/renderer-recovery.js
@@ -39,3 +39,52 @@ export function recoverFromContextLoss(deps) {
   }
   return { reattached };
 }
+
+// Build a self-rebinding DPR change watcher. A `(resolution: Xdppx)`
+// MediaQueryList only fires `change` on the single transition away from
+// X — after that, `matches` stays false and further DPR shifts are
+// silent. We work around this by re-creating the MQL against the
+// *current* `window.devicePixelRatio` inside each `change` handler.
+//
+// `deps`:
+//   - matchMedia(query):  factory for MediaQueryList instances.
+//   - getDpr():           returns the current device pixel ratio.
+//   - onChange():         called after each successful DPR change.
+//
+// Returns `{ teardown() }` so callers can remove the currently-bound
+// listener at destruction. Returns `null` when the platform doesn't
+// support matchMedia or the initial bind throws — callers can skip the
+// DPR path silently.
+export function bindDprWatcher(deps) {
+  let mql = null;
+  let handler = null;
+  const bind = () => {
+    try {
+      const dpr = deps.getDpr();
+      mql = deps.matchMedia(`(resolution: ${dpr}dppx)`);
+      handler = () => {
+        // Tear down the now-stale MQL and rebind against the new DPR
+        // before notifying, so further transitions keep firing.
+        try { mql.removeEventListener('change', handler); } catch { /* ignore */ }
+        bind();
+        try { deps.onChange(); } catch { /* host handles its own errors */ }
+      };
+      mql.addEventListener('change', handler);
+      return true;
+    } catch {
+      mql = null;
+      handler = null;
+      return false;
+    }
+  };
+  if (!bind()) return null;
+  return {
+    teardown() {
+      if (mql && handler) {
+        try { mql.removeEventListener('change', handler); } catch { /* ignore */ }
+      }
+      mql = null;
+      handler = null;
+    },
+  };
+}

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -22,6 +22,7 @@ import {
   decideFocusAction, ACTION_CLEAR, ACTION_PRESERVE, ACTION_FOCUS,
 } from './lib/focus.js';
 import { readProjectId, readWorktreeBranch } from './lib/wire.js';
+import { shouldRefreshOnVisibility, recoverFromContextLoss } from './lib/renderer-recovery.js';
 
 // ---------- session terminal ----------
 
@@ -375,14 +376,16 @@ class SessionTerm {
 
   _onWebglContextLoss() {
     // The current addon's context died (commonly: too many WebGL
-    // contexts process-wide). Dispose it and try once to re-attach.
-    // If that fails, leave the terminal on the DOM renderer and still
-    // force a refresh so stale glyphs don't survive on the canvas.
-    try { this.webgl?.dispose(); } catch {}
+    // contexts process-wide). Recovery logic — dispose, reattach, fall
+    // back to refresh — lives in lib/renderer-recovery.js so it can be
+    // unit-tested without xterm or a real WebGL context.
+    const dead = this.webgl;
     this.webgl = null;
-    if (!this._attachWebgl()) {
-      try { this.term.refresh(0, this.term.rows - 1); } catch {}
-    }
+    recoverFromContextLoss({
+      dispose: () => dead?.dispose(),
+      reattach: () => this._attachWebgl(),
+      refresh: () => this.term.refresh(0, this.term.rows - 1),
+    });
   }
 
   _installRendererRecoveryListeners() {
@@ -409,7 +412,7 @@ class SessionTerm {
     // Visibility transitions: occlusion / GPU sleep can invalidate the
     // backbuffer without firing context-loss. Repaint on return.
     this._onVisibility = () => {
-      if (document.visibilityState === 'visible') this._refreshRenderer();
+      if (shouldRefreshOnVisibility(document.visibilityState)) this._refreshRenderer();
     };
     document.addEventListener('visibilitychange', this._onVisibility);
   }

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -99,15 +99,20 @@ class SessionTerm {
     // WebGL renderer is dramatically faster than the default DOM
     // renderer on older machines (VS Code uses the same approach).
     // Load it lazily after open() and silently fall back to DOM if
-    // the GPU / driver doesn't support it.
-    try {
-      const webgl = new WebglAddon();
-      webgl.onContextLoss(() => webgl.dispose());
-      this.term.loadAddon(webgl);
-      this.webgl = webgl;
-    } catch (err) {
-      // GPU lacks WebGL2 — keep DOM renderer. No user-visible message.
-    }
+    // the GPU / driver doesn't support it. On context loss (e.g. the
+    // browser caps simultaneous WebGL contexts and kills ours when too
+    // many tiles exist), dispose the dead addon and try to re-attach;
+    // if re-attach fails, fall back to DOM and force a full repaint so
+    // we don't leave stale glyphs frozen on the canvas.
+    this._attachWebgl();
+
+    // Recover the renderer from the silent triggers that leave a stale
+    // backbuffer until the next resize: device-pixel-ratio changes
+    // (window dragged between displays with different scale, OS zoom)
+    // and visibility transitions (occlusion, GPU sleep). Both are cheap:
+    // clearTextureAtlas() rebuilds the glyph cache; term.refresh()
+    // forces a full repaint so the stale pixels are overwritten.
+    this._installRendererRecoveryListeners();
 
     // Detect URLs in terminal output and route activation through
     // the OS default browser. Hover underlines the URL; click (or
@@ -350,6 +355,65 @@ class SessionTerm {
     }, { capture: true, passive: false });
   }
 
+  _attachWebgl() {
+    // Build / re-build the WebGL addon. Called at init and on
+    // context-loss recovery. After a fresh attach the renderer's atlas
+    // is empty, so force a full repaint to overwrite whatever stale
+    // pixels were left behind by the lost context.
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => this._onWebglContextLoss());
+      this.term.loadAddon(webgl);
+      this.webgl = webgl;
+      try { this.term.refresh(0, this.term.rows - 1); } catch {}
+      return true;
+    } catch {
+      this.webgl = null;
+      return false;
+    }
+  }
+
+  _onWebglContextLoss() {
+    // The current addon's context died (commonly: too many WebGL
+    // contexts process-wide). Dispose it and try once to re-attach.
+    // If that fails, leave the terminal on the DOM renderer and still
+    // force a refresh so stale glyphs don't survive on the canvas.
+    try { this.webgl?.dispose(); } catch {}
+    this.webgl = null;
+    if (!this._attachWebgl()) {
+      try { this.term.refresh(0, this.term.rows - 1); } catch {}
+    }
+  }
+
+  _installRendererRecoveryListeners() {
+    // Clear the glyph atlas and force a full repaint. Cheap; safe to
+    // call when no WebGL addon is loaded (DOM renderer ignores the
+    // atlas hint and still benefits from the refresh).
+    this._refreshRenderer = () => {
+      try { this.webgl?.clearTextureAtlas(); } catch {}
+      try { this.term.refresh(0, this.term.rows - 1); } catch {}
+    };
+
+    // DPR change: move-to-different-display or OS zoom. matchMedia
+    // syntax / availability varies across Chromium-CEF builds; feature-
+    // detect and skip silently if unsupported.
+    try {
+      const dpr = window.devicePixelRatio || 1;
+      this._dprMql = window.matchMedia(`(resolution: ${dpr}dppx)`);
+      this._onDprChange = () => this._refreshRenderer();
+      this._dprMql.addEventListener('change', this._onDprChange);
+    } catch {
+      this._dprMql = null;
+    }
+
+    // Visibility transitions: occlusion / GPU sleep can invalidate the
+    // backbuffer without firing context-loss. Repaint on return.
+    this._onVisibility = () => {
+      if (document.visibilityState === 'visible') this._refreshRenderer();
+    };
+    document.addEventListener('visibilitychange', this._onVisibility);
+  }
+
   setInfo(info) {
     this.info = info;
     this.host.style.setProperty('--session-color', info.color || '#888');
@@ -528,6 +592,16 @@ class SessionTerm {
     CloseAttach(this.info.id).catch(() => {});
     if (this._revealRaf) cancelAnimationFrame(this._revealRaf);
     this.ro.disconnect();
+    if (this._dprMql && this._onDprChange) {
+      try { this._dprMql.removeEventListener('change', this._onDprChange); } catch {}
+    }
+    if (this._onVisibility) {
+      document.removeEventListener('visibilitychange', this._onVisibility);
+    }
+    // Release the GL context proactively so a many-tile session doesn't
+    // sit on it until GC and push another tile over the browser cap.
+    try { this.webgl?.dispose(); } catch {}
+    this.webgl = null;
     this.term.dispose();
     this.host.remove();
   }

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -22,7 +22,11 @@ import {
   decideFocusAction, ACTION_CLEAR, ACTION_PRESERVE, ACTION_FOCUS,
 } from './lib/focus.js';
 import { readProjectId, readWorktreeBranch } from './lib/wire.js';
-import { shouldRefreshOnVisibility, recoverFromContextLoss } from './lib/renderer-recovery.js';
+import {
+  shouldRefreshOnVisibility,
+  recoverFromContextLoss,
+  bindDprWatcher,
+} from './lib/renderer-recovery.js';
 
 // ---------- session terminal ----------
 
@@ -397,17 +401,16 @@ class SessionTerm {
       try { this.term.refresh(0, this.term.rows - 1); } catch {}
     };
 
-    // DPR change: move-to-different-display or OS zoom. matchMedia
-    // syntax / availability varies across Chromium-CEF builds; feature-
-    // detect and skip silently if unsupported.
-    try {
-      const dpr = window.devicePixelRatio || 1;
-      this._dprMql = window.matchMedia(`(resolution: ${dpr}dppx)`);
-      this._onDprChange = () => this._refreshRenderer();
-      this._dprMql.addEventListener('change', this._onDprChange);
-    } catch {
-      this._dprMql = null;
-    }
+    // DPR change: move-to-different-display or OS zoom. A
+    // `(resolution: Xdppx)` MQL only fires `change` on the single
+    // transition away from X, so the helper rebinds against the new
+    // DPR inside each handler — feature-detected and self-teardown so
+    // it's safe on Chromium-CEF builds that don't expose matchMedia.
+    this._dprWatcher = bindDprWatcher({
+      matchMedia: (q) => window.matchMedia(q),
+      getDpr: () => window.devicePixelRatio || 1,
+      onChange: () => this._refreshRenderer(),
+    });
 
     // Visibility transitions: occlusion / GPU sleep can invalidate the
     // backbuffer without firing context-loss. Repaint on return.
@@ -595,8 +598,9 @@ class SessionTerm {
     CloseAttach(this.info.id).catch(() => {});
     if (this._revealRaf) cancelAnimationFrame(this._revealRaf);
     this.ro.disconnect();
-    if (this._dprMql && this._onDprChange) {
-      try { this._dprMql.removeEventListener('change', this._onDprChange); } catch {}
+    if (this._dprWatcher) {
+      try { this._dprWatcher.teardown(); } catch {}
+      this._dprWatcher = null;
     }
     if (this._onVisibility) {
       document.removeEventListener('visibilitychange', this._onVisibility);

--- a/cmd/hivegui/frontend/test/unit/renderer-recovery.test.js
+++ b/cmd/hivegui/frontend/test/unit/renderer-recovery.test.js
@@ -2,7 +2,18 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   shouldRefreshOnVisibility,
   recoverFromContextLoss,
+  bindDprWatcher,
 } from '../../src/lib/renderer-recovery.js';
+
+function makeFakeMql() {
+  const listeners = new Set();
+  return {
+    addEventListener: vi.fn((evt, fn) => { if (evt === 'change') listeners.add(fn); }),
+    removeEventListener: vi.fn((evt, fn) => { if (evt === 'change') listeners.delete(fn); }),
+    fire() { for (const fn of [...listeners]) fn(); },
+    listenerCount() { return listeners.size; },
+  };
+}
 
 describe('shouldRefreshOnVisibility', () => {
   it('refreshes only when becoming visible', () => {
@@ -89,5 +100,99 @@ describe('recoverFromContextLoss', () => {
     const result = recoverFromContextLoss(deps);
     expect(result.reattached).toBe(false);
     expect(deps.refresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bindDprWatcher', () => {
+  it('binds an initial change listener against the current DPR', () => {
+    const mql = makeFakeMql();
+    const matchMedia = vi.fn(() => mql);
+    const onChange = vi.fn();
+    const watcher = bindDprWatcher({
+      matchMedia,
+      getDpr: () => 2,
+      onChange,
+    });
+    expect(watcher).not.toBeNull();
+    expect(matchMedia).toHaveBeenCalledWith('(resolution: 2dppx)');
+    expect(mql.listenerCount()).toBe(1);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('rebinds against the new DPR on each change and keeps firing onChange', () => {
+    // A `(resolution: Xdppx)` MQL only fires once when DPR moves away
+    // from X. The watcher must rebind so subsequent DPR transitions
+    // continue to trigger renderer refreshes.
+    const mqls = [makeFakeMql(), makeFakeMql(), makeFakeMql()];
+    let i = 0;
+    const matchMedia = vi.fn(() => mqls[i++]);
+    let dpr = 1;
+    const onChange = vi.fn();
+    const watcher = bindDprWatcher({
+      matchMedia,
+      getDpr: () => dpr,
+      onChange,
+    });
+    expect(matchMedia).toHaveBeenNthCalledWith(1, '(resolution: 1dppx)');
+
+    // First DPR transition: 1 → 2.
+    dpr = 2;
+    mqls[0].fire();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(matchMedia).toHaveBeenNthCalledWith(2, '(resolution: 2dppx)');
+    // The stale MQL must be removed so it doesn't leak listeners.
+    expect(mqls[0].listenerCount()).toBe(0);
+    expect(mqls[1].listenerCount()).toBe(1);
+
+    // Second DPR transition: 2 → 3. This is the regression case —
+    // before the rebind fix, no further events fired here.
+    dpr = 3;
+    mqls[1].fire();
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(matchMedia).toHaveBeenNthCalledWith(3, '(resolution: 3dppx)');
+    expect(mqls[1].listenerCount()).toBe(0);
+    expect(mqls[2].listenerCount()).toBe(1);
+
+    watcher.teardown();
+    expect(mqls[2].listenerCount()).toBe(0);
+  });
+
+  it('teardown removes the currently-bound listener', () => {
+    const mql = makeFakeMql();
+    const watcher = bindDprWatcher({
+      matchMedia: () => mql,
+      getDpr: () => 1,
+      onChange: () => {},
+    });
+    expect(mql.listenerCount()).toBe(1);
+    watcher.teardown();
+    expect(mql.listenerCount()).toBe(0);
+    // Idempotent.
+    expect(() => watcher.teardown()).not.toThrow();
+  });
+
+  it('returns null when matchMedia throws (unsupported platform)', () => {
+    const watcher = bindDprWatcher({
+      matchMedia: () => { throw new Error('not supported'); },
+      getDpr: () => 1,
+      onChange: () => {},
+    });
+    expect(watcher).toBeNull();
+  });
+
+  it('swallows a throwing onChange so the listener chain keeps working', () => {
+    const mqls = [makeFakeMql(), makeFakeMql()];
+    let i = 0;
+    const onChange = vi.fn(() => { throw new Error('host blew up'); });
+    const watcher = bindDprWatcher({
+      matchMedia: () => mqls[i++],
+      getDpr: () => 1,
+      onChange,
+    });
+    expect(() => mqls[0].fire()).not.toThrow();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    // Rebind still happened despite onChange throwing.
+    expect(mqls[1].listenerCount()).toBe(1);
+    watcher.teardown();
   });
 });

--- a/cmd/hivegui/frontend/test/unit/renderer-recovery.test.js
+++ b/cmd/hivegui/frontend/test/unit/renderer-recovery.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  shouldRefreshOnVisibility,
+  recoverFromContextLoss,
+} from '../../src/lib/renderer-recovery.js';
+
+describe('shouldRefreshOnVisibility', () => {
+  it('refreshes only when becoming visible', () => {
+    expect(shouldRefreshOnVisibility('visible')).toBe(true);
+  });
+  it('does not refresh while hidden / prerendering', () => {
+    expect(shouldRefreshOnVisibility('hidden')).toBe(false);
+    expect(shouldRefreshOnVisibility('prerender')).toBe(false);
+    expect(shouldRefreshOnVisibility(undefined)).toBe(false);
+  });
+});
+
+describe('recoverFromContextLoss', () => {
+  it('disposes, reattaches, and skips refresh when reattach succeeds', () => {
+    const deps = {
+      dispose: vi.fn(),
+      reattach: vi.fn(() => true),
+      refresh: vi.fn(),
+    };
+    const result = recoverFromContextLoss(deps);
+    expect(deps.dispose).toHaveBeenCalledTimes(1);
+    expect(deps.reattach).toHaveBeenCalledTimes(1);
+    expect(deps.refresh).not.toHaveBeenCalled();
+    expect(result).toEqual({ reattached: true });
+  });
+
+  it('falls back to refresh when reattach returns false', () => {
+    // Reattach failure means the GL context cap is still saturated and
+    // we land on the DOM renderer; force a repaint so stale pixels
+    // from the lost context aren't left frozen on the canvas.
+    const deps = {
+      dispose: vi.fn(),
+      reattach: vi.fn(() => false),
+      refresh: vi.fn(),
+    };
+    const result = recoverFromContextLoss(deps);
+    expect(deps.refresh).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ reattached: false });
+  });
+
+  it('treats a throwing reattach as a failed reattach', () => {
+    const deps = {
+      dispose: vi.fn(),
+      reattach: vi.fn(() => { throw new Error('no WebGL2'); }),
+      refresh: vi.fn(),
+    };
+    const result = recoverFromContextLoss(deps);
+    expect(deps.refresh).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ reattached: false });
+  });
+
+  it('swallows a throwing dispose so reattach is still attempted', () => {
+    // Dispose can throw on an already-disposed addon (xterm.js raises
+    // on double-dispose). The recovery path must keep going.
+    const deps = {
+      dispose: vi.fn(() => { throw new Error('already disposed'); }),
+      reattach: vi.fn(() => true),
+      refresh: vi.fn(),
+    };
+    const result = recoverFromContextLoss(deps);
+    expect(deps.reattach).toHaveBeenCalledTimes(1);
+    expect(result.reattached).toBe(true);
+  });
+
+  it('swallows a throwing refresh on the fallback path', () => {
+    // Refresh can throw if the terminal was disposed mid-recovery.
+    // Recovery must not propagate that into the event handler.
+    const deps = {
+      dispose: vi.fn(),
+      reattach: vi.fn(() => false),
+      refresh: vi.fn(() => { throw new Error('disposed'); }),
+    };
+    expect(() => recoverFromContextLoss(deps)).not.toThrow();
+  });
+
+  it('coerces non-boolean reattach return to reattached: false', () => {
+    // Defends against a future reattach() that accidentally returns
+    // the addon instance instead of true/false.
+    const deps = {
+      dispose: vi.fn(),
+      reattach: vi.fn(() => ({ some: 'addon' })),
+      refresh: vi.fn(),
+    };
+    const result = recoverFromContextLoss(deps);
+    expect(result.reattached).toBe(false);
+    expect(deps.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
+++ b/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
@@ -1,0 +1,89 @@
+# GUI: session terminal text gets replaced by garbled glyphs over time
+
+- **Spec:** [docs/product-specs/190-gui-text-replaced-with-garbled-glyphs.md](../../product-specs/190-gui-text-replaced-with-garbled-glyphs.md)
+- **Issue:** #190
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Long-lived GUI sessions render corrupted glyphs in the xterm.js WebGL renderer; a window resize triggers a renderer rebuild and fixes the display. Root cause is the WebGL texture-atlas getting into a stale/invalidated state — most commonly when the WebGL context is lost (browser caps on simultaneous contexts), when the device pixel ratio changes, or after long sessions accumulate atlas pressure. This plan teaches each `SessionTerm` to detect those triggers and recover without user action.
+
+## Research
+
+### Relevant code
+
+- `cmd/hivegui/frontend/src/main.js:80-120` — `SessionTerm` constructor. Each tile creates its own `Terminal` and loads `WebglAddon`. The only context-loss handling is `webgl.onContextLoss(() => webgl.dispose())` (line 115), which tears down the addon but leaves the terminal mounted with no working renderer. Nothing reloads the addon, nothing falls back to the DOM renderer, and nothing forces a `term.refresh()`. The stale pixels survive until the next layout-driven `fit.fit()`.
+- `cmd/hivegui/frontend/src/main.js:484-515` — `_onBodyResize` is the single resize path; it calls `fit.fit()` and (when attached) `ResizeSession(...)`. This is also the implicit "fix" the user discovered: any geometry change causes the WebGL renderer to rebuild its atlas, which masks the bug. It is *not* called for DPR-only changes (e.g. moving the window to a different-DPI display, OS zoom).
+- `cmd/hivegui/frontend/src/main.js:548-554` — `destroy()` disposes the terminal but does not explicitly dispose the WebGL addon, so on tab close the GL context lingers until GC. With many sessions this contributes to context-limit pressure.
+- `cmd/hivegui/frontend/package.json` — pins `@xterm/xterm ^5.5.0` and `@xterm/addon-webgl ^0.18.0`. Both versions are current; this is not a stale-dep issue. `WebglAddon` exposes `clearTextureAtlas()` (public since 0.16) and emits `onContextLoss` / `onChangeTextureAtlas`.
+
+### Constraints / dependencies
+
+- **WebGL contexts are a finite resource.** Browsers cap simultaneous WebGL contexts (Chromium ≈ 16). The grid-mode GUI creates one context per tile, so a user with many sessions reliably blows past this limit; older contexts get killed by the browser and fire `webglcontextlost`. xterm.js surfaces this via `WebglAddon.onContextLoss`. Our handler disposes the addon but does not re-create it or fall back to the DOM renderer, leaving the term visually frozen with stale glyphs.
+- **Atlas corruption without context loss.** Even within one context, the WebGL renderer caches glyph pages keyed by (char, fg, bg, bold, italic, underline). Long Claude sessions cycle through many color/attr combos (syntax-highlighted output, tool diffs), evicting pages. xterm.js's atlas LRU has had several bugs across the 0.16–0.18 line that manifest as "wrong char drawn"; `clearTextureAtlas()` is the documented escape hatch.
+- **DPR changes.** Moving the Wails window between displays with different scale factors changes `devicePixelRatio`. xterm's WebGL renderer reads DPR at addon-load time and at resize. If the window isn't resized at the same instant DPR changes, the atlas is rendered at the old DPR and looks garbled on the new display — until the next resize.
+- **Visibility & GPU sleep.** When the Wails window is occluded or the GPU sleeps (laptop lid close/open), some Chromium/CEF builds invalidate the GL backbuffer without firing context-loss. The canvas then displays whatever was last drawn until something triggers a `term.refresh()`.
+- **Conventions.** Backend is Go (`go build ./...` / `go test ./...`); the GUI frontend has no JS test harness today — manual / functional verification in the running Wails app is the project's pattern for renderer changes (mirrors how #176 and #178 were validated).
+
+### Hypotheses, ranked by likelihood
+
+1. **WebGL context loss in many-tile setups (highest).** Our `onContextLoss` handler disposes but never recovers. Reproduces by opening enough sessions to exceed the per-process WebGL context cap.
+2. **Atlas LRU eviction bug in `@xterm/addon-webgl@0.18`.** Long Claude sessions emit enough unique (glyph × attr) combos to thrash the LRU. Documented fix: call `clearTextureAtlas()` periodically or on `onChangeTextureAtlas`.
+3. **DPR desync after display-switch or OS-zoom change.** No `window` listener for DPR change today.
+4. **Stale backbuffer after window occlusion / GPU sleep.** No `visibilitychange` handler today.
+
+## Approach
+
+Two-layered fix in `SessionTerm`:
+
+1. **Recover from context loss instead of swallowing it.** Replace the current `onContextLoss(() => webgl.dispose())` with a handler that disposes the addon *and* either re-creates the WebGL addon (preferred, fast path) or, if re-creation fails, leaves the terminal on the DOM renderer with an explicit `term.refresh(0, term.rows-1)`. Either branch must call `term.refresh` after re-creation/fallback so the stale backbuffer is overwritten without waiting for a resize.
+
+   Chosen over the alternative of "fall back to DOM renderer unconditionally" because the WebGL renderer is performance-critical (see comment at main.js:109-111: "dramatically faster than the default DOM renderer on older machines, VS Code uses the same approach"); permanent DOM fallback would regress the use case the WebGL renderer was added for.
+
+2. **Forced atlas-clear on the known silent triggers.** Add three lightweight listeners per `SessionTerm`:
+   - `window.matchMedia('(resolution: ...)')` change → `webgl.clearTextureAtlas(); term.refresh(0, term.rows-1)`. Cheaper than the alternative of disposing+reloading the addon on every DPR change, and recommended in the xterm.js docs.
+   - `document.addEventListener('visibilitychange', …)` → on becoming visible, `term.refresh(0, term.rows-1)`. Covers backbuffer-stale-after-occlusion.
+   - A periodic `clearTextureAtlas()` is **deliberately not added** — it would mask underlying bugs and waste GPU on the fast path. We rely on the loss-recovery and DPR/visibility hooks; if reports persist we can add an idle-time atlas clear as a follow-up.
+
+   Chosen over "dispose+reload the WebglAddon on every trigger" because `clearTextureAtlas()` is the documented minimal-cost reset; full addon re-creation is reserved for the context-loss path where it is actually required.
+
+3. **Tidy disposal.** In `destroy()`, explicitly call `this.webgl?.dispose()` before `this.term.dispose()` so the GL context is released proactively. Reduces context-cap pressure when users close tiles in a many-tile session.
+
+### Files to change
+
+1. `cmd/hivegui/frontend/src/main.js`
+   - **lines ~109-120** (WebGL addon init): factor addon construction into a small helper `_attachWebgl()` so the same code path is used at init and after context loss. The helper stores the addon on `this.webgl`, wires `onContextLoss` to (a) dispose the current addon, (b) attempt re-attach via `_attachWebgl`, (c) on re-attach failure null `this.webgl` and call `this.term.refresh(0, this.term.rows-1)`. After successful (re)attach, also call `term.refresh(...)` so the freshly-built atlas is painted immediately.
+   - **constructor tail (~line 230)**: register a DPR `matchMedia` listener and a `document.visibilitychange` listener; in both, call `this.webgl?.clearTextureAtlas()` then `this.term.refresh(0, this.term.rows-1)`. Bind the listeners through `this._dprMql.addEventListener` / `document.addEventListener` and store the bound handlers on `this` so `destroy()` can remove them.
+   - **`destroy()` (~lines 548-554)**: remove the listeners added above, then `this.webgl?.dispose()`, then existing `this.term.dispose()`.
+
+### New files
+
+None.
+
+### Tests
+
+No JS test harness exists in the GUI frontend (see AGENTS.md; renderer changes have historically been validated manually — e.g. PR #176, #178). Coverage plan:
+
+- **Manual repro & verification matrix** captured in the PR description: (a) trigger context loss by opening >16 session tiles in grid mode; expected: no glyph corruption, smooth painting; (b) drag the window across two displays of different DPR; expected: atlas refreshes within one frame, no garbled text; (c) ⌘-tab away for >30s on a laptop with discrete-GPU sleep; expected: on return the terminal repaints cleanly. Each case checked before and after the fix; screenshots attached.
+- **Add a Go unit test only if** we touch any Go-side resize/PTY code; this plan is JS-only so there is no Go test to add. `go test ./...` must still pass.
+- **Regression checks:** confirm `internal/tui/...` flow tests still pass (`go test ./...`), and that the existing #176 "huge-text flash" path (main.js:449-467) still behaves correctly after the new listeners are attached.
+
+### Open questions / risks
+
+- **Risk: re-attaching `WebglAddon` after context loss can itself fail repeatedly in a context-exhausted process.** Mitigation: the recovery helper attempts re-attach at most once; on failure it leaves the terminal on the DOM renderer and logs nothing user-visible (matching today's silent fallback at main.js:118-120). A subsequent successful re-attach can happen the next time the user closes another tile (freeing a context) and the visibilitychange handler fires.
+- **Risk: `matchMedia('(resolution: ...)')` syntax varies across Chromium versions / Wails-CEF builds.** Mitigation: feature-detect — if `matchMedia` is unavailable or throws, skip the DPR listener; the visibilitychange + context-loss paths still cover the dominant cases.
+- **Open question: is grid mode the only repro vector, or do users hit this with a single tile after very long sessions?** If only grid mode reproduces, the context-loss fix alone is likely sufficient and the DPR/visibility hooks are belt-and-braces. If single-tile sessions also reproduce, hypothesis #2 (atlas LRU) is implicated and we may need a follow-up `clearTextureAtlas()` cadence.
+
+## Decision log
+
+- **2026-05-12** — Picked targeted listeners + context-loss recovery over a periodic atlas-clear timer. Why: a timer would mask whichever underlying trigger is real and waste GPU on the fast path; targeted listeners give us a clean signal for follow-up if reports persist.
+
+## Progress
+
+- **2026-05-12** — Spec drafted (#190), triage = bug/M/P1, research complete, plan drafted; awaiting Gate 4.
+- **2026-05-12** — Implemented: `_attachWebgl()` / `_onWebglContextLoss()` recovery, DPR + `visibilitychange` listeners that call `clearTextureAtlas()` + `term.refresh()`, explicit `webgl.dispose()` in `destroy()`. `go build ./...` + `go test ./...` pass. JS syntax checked with `node --check` (full `vite build` requires Wails-generated bindings not in repo).
+
+## Open questions
+
+- See "Open questions / risks" in Approach.

--- a/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
+++ b/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
@@ -87,6 +87,10 @@ No JS test harness exists in the GUI frontend (see AGENTS.md; renderer changes h
 - **2026-05-12** — Implemented: `_attachWebgl()` / `_onWebglContextLoss()` recovery, DPR + `visibilitychange` listeners that call `clearTextureAtlas()` + `term.refresh()`, explicit `webgl.dispose()` in `destroy()`. `go build ./...` + `go test ./...` pass. JS syntax checked with `node --check` (full `vite build` requires Wails-generated bindings not in repo).
 - **2026-05-13** — Rebased onto `origin/main` (was days stale; resolved CHANGELOG conflict, main.js auto-merged cleanly). Extracted pure helpers into `cmd/hivegui/frontend/src/lib/renderer-recovery.js` and added 8 vitest unit cases covering context-loss recovery + visibility predicate. Full `scripts/test.sh go unit dom` passes (e2e skipped — requires Wails-built `frontend/dist`).
 
+## PR convergence ledger
+
+- **2026-05-13 iter 1** — verdict: REQUEST_CHANGES; findings_hash: c4864cd91a268b7facb5a18f1fa5697c785db449fb0fa31d82a2827f230a55a9; threads_open: 0; action: autofix+push (DPR matchMedia rebind helper + tests); head_sha: ad1fe80. CI failure (focus.spec.js stdinText='llo' not 'hello') flagged as flake — retry pending.
+
 ## Open questions
 
 - See "Open questions / risks" in Approach.

--- a/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
+++ b/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
@@ -85,6 +85,7 @@ No JS test harness exists in the GUI frontend (see AGENTS.md; renderer changes h
 
 - **2026-05-12** — Spec drafted (#190), triage = bug/M/P1, research complete, plan drafted; awaiting Gate 4.
 - **2026-05-12** — Implemented: `_attachWebgl()` / `_onWebglContextLoss()` recovery, DPR + `visibilitychange` listeners that call `clearTextureAtlas()` + `term.refresh()`, explicit `webgl.dispose()` in `destroy()`. `go build ./...` + `go test ./...` pass. JS syntax checked with `node --check` (full `vite build` requires Wails-generated bindings not in repo).
+- **2026-05-13** — Rebased onto `origin/main` (was days stale; resolved CHANGELOG conflict, main.js auto-merged cleanly). Extracted pure helpers into `cmd/hivegui/frontend/src/lib/renderer-recovery.js` and added 8 vitest unit cases covering context-loss recovery + visibility predicate. Full `scripts/test.sh go unit dom` passes (e2e skipped — requires Wails-built `frontend/dist`).
 
 ## Open questions
 

--- a/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
+++ b/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
@@ -2,8 +2,10 @@
 
 - **Spec:** [docs/product-specs/190-gui-text-replaced-with-garbled-glyphs.md](../../product-specs/190-gui-text-replaced-with-garbled-glyphs.md)
 - **Issue:** #190
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Status:** active
+- **PR:** #191
+- **Branch:** feature/190-gui-glyph-corruption-recovery
 
 ## Summary
 

--- a/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
+++ b/docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md
@@ -89,7 +89,8 @@ No JS test harness exists in the GUI frontend (see AGENTS.md; renderer changes h
 
 ## PR convergence ledger
 
-- **2026-05-13 iter 1** — verdict: REQUEST_CHANGES; findings_hash: c4864cd91a268b7facb5a18f1fa5697c785db449fb0fa31d82a2827f230a55a9; threads_open: 0; action: autofix+push (DPR matchMedia rebind helper + tests); head_sha: ad1fe80. CI failure (focus.spec.js stdinText='llo' not 'hello') flagged as flake — retry pending.
+- **2026-05-13 iter 1** — verdict: REQUEST_CHANGES; findings_hash: c4864cd91a268b7facb5a18f1fa5697c785db449fb0fa31d82a2827f230a55a9; threads_open: 0; action: autofix+push (DPR matchMedia rebind helper + tests); head_sha: ad1fe80. CI failure (focus.spec.js stdinText='llo' not 'hello') confirmed flake — manual rerun of Linux job passed, and full CI on fe9ca21 also green.
+- **2026-05-13 iter 2** — verdict: APPROVE; findings_hash: empty; threads_open: 0; action: stop; head_sha: fe9ca21.
 
 ## Open questions
 

--- a/docs/product-specs/190-gui-text-replaced-with-garbled-glyphs.md
+++ b/docs/product-specs/190-gui-text-replaced-with-garbled-glyphs.md
@@ -1,0 +1,32 @@
+# GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it
+
+- **Issue:** #190
+- **Type:** bug
+- **Complexity:** M
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md](../exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md)
+
+## Problem
+
+After working in a session for some time (observed with Claude at least), the rendered terminal text starts being replaced by weird/garbled glyphs. Sometimes only a few glyphs are affected, other times nearly the whole visible buffer is corrupted. The underlying text is intact — resizing the window forces a re-render and the text comes back correctly.
+
+Likely a renderer / canvas / atlas issue in xterm.js (stale glyph atlas, font texture corruption, or DPR/zoom desync). Reproduces in long-lived sessions; resize is the known workaround.
+
+## Desired behavior
+
+Session text remains correctly rendered for the lifetime of the session. No manual resize needed to recover from corrupted glyphs.
+
+## Success criteria
+
+- Long-lived sessions (multi-hour, with sustained output like a Claude conversation) render text correctly without visible glyph corruption.
+- No regression in rendering performance or memory.
+
+## Non-goals
+
+- Changes to non-GUI surfaces (CLI, headless).
+- Switching the renderer engine away from xterm.js.
+
+## Notes
+
+- Reproduced with Claude sessions; likely renderer-agnostic but worth testing both webgl and canvas addons.
+- Resize workaround suggests an atlas/cache issue (full re-layout flushes it).

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -12,7 +12,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | P1 | #183 | Hive opens only a shell on Windows, not Claude | REVIEW | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
 | P2 | #192 | Worktrees should branch from origin/main, not local HEAD | REVIEW | [192-worktrees-branch-from-origin-main](192-worktrees-branch-from-origin-main.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
-| P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | IMPLEMENT | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
+| P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | REVIEW | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
 
 ## Completed
 

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -12,6 +12,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | P1 | #183 | Hive opens only a shell on Windows, not Claude | REVIEW | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
 | P2 | #192 | Worktrees should branch from origin/main, not local HEAD | REVIEW | [192-worktrees-branch-from-origin-main](192-worktrees-branch-from-origin-main.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
+| P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | IMPLEMENT | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
 
 ## Completed
 


### PR DESCRIPTION
## Summary

- Long-lived GUI sessions could display garbled glyphs until the user resized the window. The xterm.js WebGL renderer can silently lose its GL context (browsers cap simultaneous contexts process-wide, so many-tile sessions can trigger this) or invalidate its glyph atlas on device-pixel-ratio changes and visibility transitions.
- The old code disposed the addon on context loss but never re-attached and never forced a repaint, so stale pixels survived on the canvas until the next resize triggered a renderer rebuild.
- Each `SessionTerm` now recovers from context loss (re-attach WebGL, fall back to DOM if that fails, always `term.refresh()`), clears the glyph atlas + repaints on DPR and visibility-return, and disposes its WebGL addon explicitly in `destroy()` to reduce pressure on the per-process context cap.

Spec: `docs/product-specs/190-gui-text-replaced-with-garbled-glyphs.md`
Exec plan: `docs/exec-plans/active/190-gui-text-replaced-with-garbled-glyphs.md`

Fixes #190

## Test plan

JS renderer-only change; matches the manual-verification pattern used for #176 / #178 (no GUI test harness in repo).

- [ ] `go build ./...` and `go test ./...` pass (verified locally).
- [ ] Open >16 tiles in grid mode, run sustained output in each (e.g. `yes`). Expected: no garbled glyphs; if context loss fires, the affected tile recovers within one frame.
- [ ] Drag the Wails window between two displays at different scale factors (e.g. retina ↔ external 1×). Expected: text repaints cleanly on arrival, no stuck glyphs.
- [ ] On a laptop, close the lid for ~30s then reopen. Expected: terminals repaint immediately on becoming visible, no stale backbuffer.
- [ ] Long Claude session (multi-hour, with tool diffs / colored output): no glyph corruption accumulates over time.
- [ ] Close many tiles in succession: GL contexts release promptly (no slow drift toward context-cap exhaustion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)