### PR TITLE
fix(gui): per-session TextDecoder so multi-byte glyphs don't corrupt across sessions (#195)

### DIFF
--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -33,6 +33,12 @@ import {
 class SessionTerm {
   constructor(info) {
     this.info = info;
+    // Per-session UTF-8 decoder. Streaming mode buffers partial multi-byte
+    // sequences at chunk boundaries; sharing one decoder across sessions
+    // contaminates session B's bytes with session A's pending tail bytes,
+    // producing garbled glyphs — most visible with multi-byte-heavy output
+    // (emojis, box-drawing, Powerline glyphs from Claude, etc.).
+    this.decoder = new TextDecoder('utf-8', { fatal: false });
     this.host = document.createElement('div');
     this.host.className = 'term-host';
     this.host.dataset.sid = info.id;
@@ -591,7 +597,7 @@ class SessionTerm {
     const bin = atob(b64);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    this.term.write(decoder.decode(bytes, { stream: true }));
+    this.term.write(this.decoder.decode(bytes, { stream: true }));
   }
 
   destroy() {
@@ -642,8 +648,6 @@ class SessionTerm {
     refocusActiveTerm();
   }
 }
-
-const decoder = new TextDecoder('utf-8', { fatal: false });
 
 // ---------- app state ----------
 

--- a/cmd/hivegui/frontend/test/unit/decoder.test.js
+++ b/cmd/hivegui/frontend/test/unit/decoder.test.js
@@ -1,0 +1,71 @@
+// Regression: each SessionTerm must own its TextDecoder. A shared,
+// streaming decoder buffers a partial multi-byte sequence from one
+// session's chunk into the next session's decode, producing U+FFFD or
+// wrong glyphs. See docs/product-specs/195-shared-textdecoder-glyphs.md.
+
+import { describe, it, expect } from 'vitest';
+
+const REPLACEMENT = '�';
+
+// Encode `s` and split it at byte index `cut`. The first slice is
+// guaranteed to end mid-rune for any non-ASCII `s` with cut between 1
+// and bytes.length-1 chosen to land inside a multi-byte sequence.
+function splitMidRune(s) {
+  const bytes = new TextEncoder().encode(s);
+  // Find a byte index that sits inside a multi-byte sequence.
+  for (let i = 1; i < bytes.length; i++) {
+    // Continuation bytes match 10xxxxxx.
+    if ((bytes[i] & 0xc0) === 0x80) {
+      return [bytes.slice(0, i), bytes.slice(i)];
+    }
+  }
+  throw new Error(`no multi-byte boundary in ${JSON.stringify(s)}`);
+}
+
+describe('per-session UTF-8 decoder', () => {
+  // Strings exercised: CJK, Powerline/spinner glyph from Claude, box-drawing.
+  const samples = ['こんにちは世界', '✻ Working', '┌─┬─┐'];
+
+  it('decodes each session independently when chunks split mid-rune', () => {
+    for (const s of samples) {
+      const [head, tail] = splitMidRune(s);
+      const decA = new TextDecoder('utf-8', { fatal: false });
+      const decB = new TextDecoder('utf-8', { fatal: false });
+
+      // Interleave: A sends head, B sends head, A sends tail, B sends tail.
+      let outA = decA.decode(head, { stream: true });
+      let outB = decB.decode(head, { stream: true });
+      outA += decA.decode(tail, { stream: true });
+      outB += decB.decode(tail, { stream: true });
+      // Flush any trailing state.
+      outA += decA.decode();
+      outB += decB.decode();
+
+      expect(outA).toBe(s);
+      expect(outB).toBe(s);
+      expect(outA.includes(REPLACEMENT)).toBe(false);
+      expect(outB.includes(REPLACEMENT)).toBe(false);
+    }
+  });
+
+  it('pins the bug: a shared streaming decoder corrupts interleaved sessions', () => {
+    // This test documents the failure mode the fix prevents. If
+    // someone reverts to a shared decoder, the per-session test above
+    // would still pass — this one demonstrates *why* sharing is wrong.
+    const s = 'こんにちは';
+    const [head, tail] = splitMidRune(s);
+    const shared = new TextDecoder('utf-8', { fatal: false });
+
+    let outA = shared.decode(head, { stream: true });
+    // Session B's "head" is decoded against A's buffered continuation
+    // bytes — corrupting both streams.
+    let outB = shared.decode(head, { stream: true });
+    outA += shared.decode(tail, { stream: true });
+    outB += shared.decode(tail, { stream: true });
+    outA += shared.decode();
+    outB += shared.decode();
+
+    const combined = outA + outB;
+    expect(combined.includes(REPLACEMENT)).toBe(true);
+  });
+});

--- a/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
+++ b/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
@@ -1,0 +1,53 @@
+# Per-session TextDecoder
+
+- **Spec:** [docs/product-specs/195-shared-textdecoder-glyphs.md](../../product-specs/195-shared-textdecoder-glyphs.md)
+- **Issue:** #195
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Move the streaming UTF-8 decoder from module scope into `SessionTerm` so each session has its own state. Eliminates cross-session contamination of partial multi-byte sequences. Add a unit test that exercises the interleave-at-rune-boundary case.
+
+## Research
+
+- `cmd/hivegui/frontend/src/main.js`
+  - Module-level `const decoder = new TextDecoder('utf-8', { fatal: false });` — single instance shared by every session.
+  - `SessionTerm.writeData(b64)` calls `decoder.decode(bytes, { stream: true })`. `stream: true` buffers any incomplete multi-byte sequence at the tail of the input until the next call.
+  - `writeData` is invoked from the Wails `data` event router. Events from different sessions can arrive arbitrarily interleaved.
+- `cmd/hivegui/frontend/test/unit/` — existing Vitest unit tests; the harness already proven on `wire.test.js`, `focus.test.js`, etc.
+
+## Approach
+
+Give `SessionTerm` its own decoder. Each instance owns its streaming state; concurrent sessions cannot corrupt each other. The fix is mechanical (one field + one reference rename + remove the module-level decoder) and matches the rest of the per-session state already on the class (xterm instance, fit addon, ResizeObserver, etc.).
+
+Considered alternative: drop `stream: true` and accept that a chunk ending mid-rune produces one U+FFFD. Rejected — Claude's spinner emits frequent small writes; mid-rune chunks would be common and visibly broken.
+
+### Files to change
+
+- `cmd/hivegui/frontend/src/main.js`
+  - `SessionTerm` constructor: assign `this.decoder = new TextDecoder('utf-8', { fatal: false });`.
+  - `SessionTerm.writeData`: use `this.decoder` instead of the module-level `decoder`.
+  - Remove the module-level `const decoder = ...`.
+
+### New files
+
+- `cmd/hivegui/frontend/test/unit/decoder.test.js` — regression test for per-session decode isolation.
+
+### Tests
+
+- `decoder.test.js`:
+  - Two independent `TextDecoder` instances (modeling two `SessionTerm`s) each receive a stream split mid-rune for a multi-byte UTF-8 string (e.g. `'こんにちは'`, `'✻ Working'`, `'┌─┐'`). Assert each reconstructs its original string with no `U+FFFD`.
+  - A single shared decoder, fed the same interleaved bytes, *does* produce `U+FFFD` — pinning the bug to verify the test would have caught it.
+
+## Decision log
+
+- **2026-05-14** — Per-session decoder over dropping `stream: true`. Why: Claude's spinner writes are small and frequent; mid-rune chunks are the common case, not the edge case.
+
+## Progress
+
+- **2026-05-14** — Diagnosed root cause, implemented fix, removed global decoder, added regression test, opened PR.
+
+## Open questions
+
+None.

--- a/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
+++ b/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
@@ -2,7 +2,7 @@
 
 - **Spec:** [docs/product-specs/195-shared-textdecoder-glyphs.md](../../product-specs/195-shared-textdecoder-glyphs.md)
 - **Issue:** #195
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Status:** active
 
 ## Summary
@@ -51,3 +51,8 @@ Considered alternative: drop `stream: true` and accept that a chunk ending mid-r
 ## Open questions
 
 None.
+
+## PR convergence ledger
+
+<!-- Append-only. One line per review-loop iteration. -->
+

--- a/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
+++ b/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
@@ -55,4 +55,5 @@ None.
 ## PR convergence ledger
 
 <!-- Append-only. One line per review-loop iteration. -->
+- **2026-05-14 iter 1** — verdict: APPROVE; findings_hash: empty; threads_open: 0; action: stop; head_sha: a03203a.
 

--- a/docs/product-specs/195-shared-textdecoder-glyphs.md
+++ b/docs/product-specs/195-shared-textdecoder-glyphs.md
@@ -1,0 +1,31 @@
+# GUI: shared TextDecoder across sessions produces garbled glyphs
+
+- **Issue:** #195
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/195-shared-textdecoder-glyphs.md](../exec-plans/active/195-shared-textdecoder-glyphs.md)
+
+## Problem
+
+Users see replacement characters and garbled multi-byte glyphs in session terminals, most visibly when running Claude (emoji, box-drawing, Powerline `✻`, spinner runes). The frontend uses one module-level streaming `TextDecoder` shared across every `SessionTerm`; partial multi-byte byte sequences buffered at the end of one session's chunk leak into the next session's decode, corrupting both. Claude amplifies the bug because its output is unusually dense in multi-byte UTF-8, so chunk boundaries land mid-rune frequently.
+
+## Desired behavior
+
+Each session's output is decoded independently. Multi-byte glyphs from Claude (and any other TUI) render correctly even when multiple sessions stream concurrently. No spontaneous U+FFFD characters appear in well-formed UTF-8 output.
+
+## Success criteria
+
+- A unit test interleaves PTY chunks from two sessions where each chunk splits a multi-byte rune at the boundary, and the decoded output contains no `U+FFFD` and matches the original strings exactly.
+- Manual: running `claude` in two concurrent sessions for several minutes shows clean glyph rendering — no replacement characters, no drifting box-drawing.
+
+## Non-goals
+
+- Fixing CJK / wide-char column misalignment in the vt10x snapshot (tracked in #142). That is a separate column-width problem, not a decode problem.
+- Switching the wire format from base64 to binary frames.
+
+## Notes
+
+- Bug surface: `cmd/hivegui/frontend/src/main.js` — module-level `decoder` and `SessionTerm.writeData`.
+- Related: #190 (xterm renderer atlas corruption, fixed by PR #191) — same symptom ("garbled glyphs over time, worse with Claude") but a different mechanism. #190 was renderer/atlas; this is decoder-state contamination across sessions. After #191 shipped, users still reported glyphs — that residue is what this issue addresses.
+- Related: #142 (wide-char snapshot column misalignment) — same neighborhood of code, different root cause.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -13,6 +13,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | P2 | #192 | Worktrees should branch from origin/main, not local HEAD | REVIEW | [192-worktrees-branch-from-origin-main](192-worktrees-branch-from-origin-main.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 | P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | REVIEW | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
+| P1 | #195 | GUI: shared TextDecoder across sessions produces garbled glyphs | IMPLEMENT | [195-shared-textdecoder-glyphs](195-shared-textdecoder-glyphs.md) |
 
 ## Completed
 


### PR DESCRIPTION
## Summary

- Single shared streaming `TextDecoder` in `main.js` was leaking partial multi-byte UTF-8 sequences between concurrent sessions, producing U+FFFD and wrong glyphs — most visibly when running Claude (emoji, box-drawing, Powerline, spinner runes).
- Moved the decoder onto `SessionTerm` so each session owns its streaming state.
- Added `test/unit/decoder.test.js` covering the interleave-at-rune-boundary case and pinning the shared-decoder failure mode.

Distinct from #190 (xterm renderer atlas corruption, fixed by #191): same symptom, different mechanism. After #191 shipped, glyphs returned — this is the residual cause.

Closes #195.

## Test plan

- [x] `npx vitest run` — 66/66 pass (was 64; +2 new)
- [ ] Manual: run two concurrent sessions with `claude`, watch for glyph stability over multi-minute output bursts
- [ ] Manual: run a CJK-heavy session (`echo こんにちは世界`) alongside a Claude session; no replacement chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)