### PR TITLE
docs(195): mark stage QA after merge of #196

### DIFF
--- a/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
+++ b/docs/exec-plans/active/195-shared-textdecoder-glyphs.md
@@ -2,7 +2,7 @@
 
 - **Spec:** [docs/product-specs/195-shared-textdecoder-glyphs.md](../../product-specs/195-shared-textdecoder-glyphs.md)
 - **Issue:** #195
-- **Stage:** REVIEW
+- **Stage:** QA
 - **Status:** active
 
 ## Summary

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -12,7 +12,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | P1 | #183 | Hive opens only a shell on Windows, not Claude | REVIEW | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 | P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | REVIEW | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
-| P1 | #195 | GUI: shared TextDecoder across sessions produces garbled glyphs | IMPLEMENT | [195-shared-textdecoder-glyphs](195-shared-textdecoder-glyphs.md) |
+| P1 | #195 | GUI: shared TextDecoder across sessions produces garbled glyphs | QA | [195-shared-textdecoder-glyphs](195-shared-textdecoder-glyphs.md) |
 | P2 | #202 | GUI: minimize sessions to remove from grid view; restore from a tray | REVIEW | [202-minimize-session-from-grid](202-minimize-session-from-grid.md) |
 
 ## Completed


### PR DESCRIPTION
Post-merge marker: advance #195 Stage REVIEW → QA in both the exec plan and the spec index.

Per the /hs-review-loop post-merge hook.