### PR TITLE
experiment(gui): periodic atlas clear + window.focus trigger for matrix-glyph regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on DPR changes and on becoming visible again. The GL context is also
   disposed explicitly when a tile is destroyed to reduce pressure on
   the per-process context cap. (#190)
+- GUI: extend the matrix-glyph mitigation to long-lived sessions with
+  heavy unique-glyph output (Claude, syntax-highlighted diffs, 24-bit
+  colors) where the xterm WebGL atlas overflows over time even without
+  a context-loss, DPR, or visibility trigger. Each tile now also
+  refreshes the renderer when the window regains focus (covers
+  cross-monitor focus shifts on macOS where `visibilitychange` may not
+  fire) and on a 90s visible-document interval that breaks the
+  atlas-accumulation pattern. Decision logic and binding live in
+  `lib/renderer-recovery.js` with unit-test coverage. (#198)
 
 ## [2.2.1] — 2026-05-10
 

--- a/cmd/hivegui/frontend/src/lib/renderer-recovery.js
+++ b/cmd/hivegui/frontend/src/lib/renderer-recovery.js
@@ -55,6 +55,74 @@ export function recoverFromContextLoss(deps) {
 // listener at destruction. Returns `null` when the platform doesn't
 // support matchMedia or the initial bind throws — callers can skip the
 // DPR path silently.
+// Decide whether a periodic atlas refresh tick should fire. Long-lived
+// sessions with heavy unique-glyph output (Claude, syntax-highlighted
+// diffs, 24-bit colors) overflow xterm's fixed WebGL atlas; eviction
+// makes new glyphs sample stale UVs (the "matrix characters" symptom).
+// A periodic clear breaks the accumulation, but only when the document
+// is actually visible — refreshing a hidden tab is wasted GPU work and
+// can defeat browser throttling.
+export function shouldRunAtlasTick(visibilityState) {
+  return visibilityState === 'visible';
+}
+
+// Bind a `window.focus` listener that calls `onRefresh` whenever the
+// user tabs back to the app. Covers the cross-monitor focus-shift case
+// on macOS where `visibilitychange` may not fire (document stays
+// 'visible'). `deps`:
+//   - addEventListener(evt, fn):    window's addEventListener.
+//   - removeEventListener(evt, fn): window's removeEventListener.
+//   - onRefresh():                  called on focus.
+// Returns `{ teardown() }` so callers can remove the listener at
+// destruction. Symmetric with bindDprWatcher.
+export function bindFocusRefresh(deps) {
+  let handler = () => {
+    try { deps.onRefresh(); } catch { /* host handles its own errors */ }
+  };
+  try {
+    deps.addEventListener('focus', handler);
+  } catch {
+    handler = null;
+    return null;
+  }
+  return {
+    teardown() {
+      if (!handler) return;
+      try { deps.removeEventListener('focus', handler); } catch { /* ignore */ }
+      handler = null;
+    },
+  };
+}
+
+// Bind a periodic atlas-refresh interval. Fires `onRefresh` every
+// `intervalMs` ticks, but only when `getVisibilityState()` reports the
+// document is visible — see `shouldRunAtlasTick` for the rationale.
+// `deps`:
+//   - setInterval(fn, ms):    timer factory (injectable for fake-timer tests).
+//   - clearInterval(id):      timer teardown.
+//   - getVisibilityState():   returns the current `document.visibilityState`.
+//   - onRefresh():            called on each visible tick.
+// Returns `{ teardown() }`. Symmetric with bindDprWatcher.
+export function bindAtlasInterval(deps, intervalMs) {
+  let id = null;
+  try {
+    id = deps.setInterval(() => {
+      if (!shouldRunAtlasTick(deps.getVisibilityState())) return;
+      try { deps.onRefresh(); } catch { /* host handles its own errors */ }
+    }, intervalMs);
+  } catch {
+    id = null;
+    return null;
+  }
+  return {
+    teardown() {
+      if (id === null) return;
+      try { deps.clearInterval(id); } catch { /* ignore */ }
+      id = null;
+    },
+  };
+}
+
 export function bindDprWatcher(deps) {
   let mql = null;
   let handler = null;

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -424,6 +424,23 @@ class SessionTerm {
       if (shouldRefreshOnVisibility(document.visibilityState)) this._refreshRenderer();
     };
     document.addEventListener('visibilitychange', this._onVisibility);
+
+    // Window focus: covers the user-noticeable "I tabbed back to Hive"
+    // case where visibilitychange may not fire (e.g. cross-monitor focus
+    // shifts on macOS with the window still 'visible').
+    this._onFocus = () => this._refreshRenderer();
+    window.addEventListener('focus', this._onFocus);
+
+    // Long-running sessions with heavy unique-glyph output (Claude,
+    // syntax-highlighted diffs, 24-bit colors) overflow xterm's fixed
+    // WebGL atlas. Eviction makes new glyphs sample stale UVs — the
+    // "matrix characters" symptom. The user's known workaround is to
+    // resize. Periodically clear the atlas while the document is
+    // visible; one frame's cost, breaks the accumulation.
+    this._atlasInterval = setInterval(() => {
+      if (document.visibilityState !== 'visible') return;
+      this._refreshRenderer();
+    }, 90_000);
   }
 
   setInfo(info) {
@@ -610,6 +627,14 @@ class SessionTerm {
     }
     if (this._onVisibility) {
       document.removeEventListener('visibilitychange', this._onVisibility);
+    }
+    if (this._onFocus) {
+      window.removeEventListener('focus', this._onFocus);
+      this._onFocus = null;
+    }
+    if (this._atlasInterval) {
+      clearInterval(this._atlasInterval);
+      this._atlasInterval = null;
     }
     // Release the GL context proactively so a many-tile session doesn't
     // sit on it until GC and push another tile over the browser cap.

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -26,7 +26,15 @@ import {
   shouldRefreshOnVisibility,
   recoverFromContextLoss,
   bindDprWatcher,
+  bindFocusRefresh,
+  bindAtlasInterval,
 } from './lib/renderer-recovery.js';
+
+// Long-running sessions with heavy unique-glyph output (Claude,
+// syntax-highlighted diffs, 24-bit colors) overflow xterm's fixed WebGL
+// atlas; eviction makes new glyphs sample stale UVs — the "matrix
+// characters" symptom. Periodically clear the atlas while visible.
+const ATLAS_REFRESH_INTERVAL_MS = 90_000;
 
 // ---------- session terminal ----------
 
@@ -427,20 +435,22 @@ class SessionTerm {
 
     // Window focus: covers the user-noticeable "I tabbed back to Hive"
     // case where visibilitychange may not fire (e.g. cross-monitor focus
-    // shifts on macOS with the window still 'visible').
-    this._onFocus = () => this._refreshRenderer();
-    window.addEventListener('focus', this._onFocus);
+    // shifts on macOS with the window still 'visible'). Decision +
+    // binding live in lib/renderer-recovery.js so they're testable.
+    this._focusWatcher = bindFocusRefresh({
+      addEventListener: (evt, fn) => window.addEventListener(evt, fn),
+      removeEventListener: (evt, fn) => window.removeEventListener(evt, fn),
+      onRefresh: () => this._refreshRenderer(),
+    });
 
-    // Long-running sessions with heavy unique-glyph output (Claude,
-    // syntax-highlighted diffs, 24-bit colors) overflow xterm's fixed
-    // WebGL atlas. Eviction makes new glyphs sample stale UVs — the
-    // "matrix characters" symptom. The user's known workaround is to
-    // resize. Periodically clear the atlas while the document is
-    // visible; one frame's cost, breaks the accumulation.
-    this._atlasInterval = setInterval(() => {
-      if (document.visibilityState !== 'visible') return;
-      this._refreshRenderer();
-    }, 90_000);
+    // Periodic atlas clear while visible — see ATLAS_REFRESH_INTERVAL_MS
+    // and lib/renderer-recovery.js for the WebGL-atlas-overflow rationale.
+    this._atlasWatcher = bindAtlasInterval({
+      setInterval: (fn, ms) => setInterval(fn, ms),
+      clearInterval: (id) => clearInterval(id),
+      getVisibilityState: () => document.visibilityState,
+      onRefresh: () => this._refreshRenderer(),
+    }, ATLAS_REFRESH_INTERVAL_MS);
   }
 
   setInfo(info) {
@@ -628,13 +638,13 @@ class SessionTerm {
     if (this._onVisibility) {
       document.removeEventListener('visibilitychange', this._onVisibility);
     }
-    if (this._onFocus) {
-      window.removeEventListener('focus', this._onFocus);
-      this._onFocus = null;
+    if (this._focusWatcher) {
+      this._focusWatcher.teardown();
+      this._focusWatcher = null;
     }
-    if (this._atlasInterval) {
-      clearInterval(this._atlasInterval);
-      this._atlasInterval = null;
+    if (this._atlasWatcher) {
+      this._atlasWatcher.teardown();
+      this._atlasWatcher = null;
     }
     // Release the GL context proactively so a many-tile session doesn't
     // sit on it until GC and push another tile over the browser cap.

--- a/cmd/hivegui/frontend/test/unit/renderer-recovery.test.js
+++ b/cmd/hivegui/frontend/test/unit/renderer-recovery.test.js
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   shouldRefreshOnVisibility,
+  shouldRunAtlasTick,
   recoverFromContextLoss,
   bindDprWatcher,
+  bindFocusRefresh,
+  bindAtlasInterval,
 } from '../../src/lib/renderer-recovery.js';
 
 function makeFakeMql() {
@@ -194,5 +197,162 @@ describe('bindDprWatcher', () => {
     // Rebind still happened despite onChange throwing.
     expect(mqls[1].listenerCount()).toBe(1);
     watcher.teardown();
+  });
+});
+
+describe('shouldRunAtlasTick', () => {
+  it('only ticks when the document is visible', () => {
+    expect(shouldRunAtlasTick('visible')).toBe(true);
+    expect(shouldRunAtlasTick('hidden')).toBe(false);
+    expect(shouldRunAtlasTick('prerender')).toBe(false);
+    expect(shouldRunAtlasTick(undefined)).toBe(false);
+  });
+});
+
+function makeFakeWindow() {
+  const listeners = new Map(); // evt -> Set<fn>
+  return {
+    addEventListener: vi.fn((evt, fn) => {
+      if (!listeners.has(evt)) listeners.set(evt, new Set());
+      listeners.get(evt).add(fn);
+    }),
+    removeEventListener: vi.fn((evt, fn) => {
+      listeners.get(evt)?.delete(fn);
+    }),
+    fire(evt) { for (const fn of [...(listeners.get(evt) || [])]) fn(); },
+    listenerCount(evt) { return listeners.get(evt)?.size || 0; },
+  };
+}
+
+describe('bindFocusRefresh', () => {
+  it('invokes onRefresh on window focus events', () => {
+    const win = makeFakeWindow();
+    const onRefresh = vi.fn();
+    const watcher = bindFocusRefresh({
+      addEventListener: win.addEventListener,
+      removeEventListener: win.removeEventListener,
+      onRefresh,
+    });
+    expect(watcher).not.toBeNull();
+    expect(win.listenerCount('focus')).toBe(1);
+    expect(onRefresh).not.toHaveBeenCalled();
+    win.fire('focus');
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    win.fire('focus');
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('teardown removes the focus listener and is idempotent', () => {
+    const win = makeFakeWindow();
+    const watcher = bindFocusRefresh({
+      addEventListener: win.addEventListener,
+      removeEventListener: win.removeEventListener,
+      onRefresh: () => {},
+    });
+    expect(win.listenerCount('focus')).toBe(1);
+    watcher.teardown();
+    expect(win.listenerCount('focus')).toBe(0);
+    expect(() => watcher.teardown()).not.toThrow();
+    expect(win.listenerCount('focus')).toBe(0);
+  });
+
+  it('swallows a throwing onRefresh so future focus events still fire', () => {
+    const win = makeFakeWindow();
+    const onRefresh = vi.fn(() => { throw new Error('host blew up'); });
+    const watcher = bindFocusRefresh({
+      addEventListener: win.addEventListener,
+      removeEventListener: win.removeEventListener,
+      onRefresh,
+    });
+    expect(() => win.fire('focus')).not.toThrow();
+    expect(() => win.fire('focus')).not.toThrow();
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+    watcher.teardown();
+  });
+
+  it('returns null when addEventListener throws (unsupported platform)', () => {
+    const watcher = bindFocusRefresh({
+      addEventListener: () => { throw new Error('not supported'); },
+      removeEventListener: () => {},
+      onRefresh: () => {},
+    });
+    expect(watcher).toBeNull();
+  });
+});
+
+describe('bindAtlasInterval', () => {
+  it('schedules an interval and fires onRefresh only when visible', () => {
+    let tick = null;
+    const setIntervalFake = vi.fn((fn, _ms) => { tick = fn; return 42; });
+    const clearIntervalFake = vi.fn();
+    let state = 'visible';
+    const onRefresh = vi.fn();
+    const watcher = bindAtlasInterval({
+      setInterval: setIntervalFake,
+      clearInterval: clearIntervalFake,
+      getVisibilityState: () => state,
+      onRefresh,
+    }, 90_000);
+    expect(watcher).not.toBeNull();
+    expect(setIntervalFake).toHaveBeenCalledWith(expect.any(Function), 90_000);
+
+    // Visible tick: fires.
+    tick();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    // Hidden tick: skipped — refreshing a hidden tab wastes GPU and
+    // fights browser throttling.
+    state = 'hidden';
+    tick();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    // Prerender tick: skipped.
+    state = 'prerender';
+    tick();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+
+    // Back to visible: fires again.
+    state = 'visible';
+    tick();
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('teardown clears the interval and is idempotent', () => {
+    const clearIntervalFake = vi.fn();
+    const watcher = bindAtlasInterval({
+      setInterval: () => 99,
+      clearInterval: clearIntervalFake,
+      getVisibilityState: () => 'visible',
+      onRefresh: () => {},
+    }, 1_000);
+    watcher.teardown();
+    expect(clearIntervalFake).toHaveBeenCalledWith(99);
+    // Idempotent: teardown a second time is a no-op.
+    watcher.teardown();
+    expect(clearIntervalFake).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a throwing onRefresh so future ticks still fire', () => {
+    let tick = null;
+    const onRefresh = vi.fn(() => { throw new Error('refresh blew up'); });
+    bindAtlasInterval({
+      setInterval: (fn) => { tick = fn; return 1; },
+      clearInterval: () => {},
+      getVisibilityState: () => 'visible',
+      onRefresh,
+    }, 1_000);
+    expect(() => tick()).not.toThrow();
+    expect(() => tick()).not.toThrow();
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when setInterval throws', () => {
+    const watcher = bindAtlasInterval({
+      setInterval: () => { throw new Error('no timers'); },
+      clearInterval: () => {},
+      getVisibilityState: () => 'visible',
+      onRefresh: () => {},
+    }, 1_000);
+    expect(watcher).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Targets the recurring \"matrix characters\" regression: in long-lived sessions with rich unique-glyph output (Claude, syntax-highlighted diffs, 24-bit colors) the xterm WebGL atlas overflows, evicts pages, and new glyphs end up sampling stale UV coordinates — rendering as garbage characters. User's known workaround is to resize, which xterm uses as an atlas-clear signal.

Same family as #190 (renderer atlas corruption). #190 covered three triggers — context loss, DPR change, visibility→visible — none of which fire from \"lots of output over time.\"

## Change

`cmd/hivegui/frontend/src/main.js`:
- Add `window.focus` listener → clears atlas when the user tabs back to Hive (covers cross-monitor focus shifts where `visibilitychange` may not fire).
- Add a 90s interval (only fires when document is visible) → atlas clear during continuous output, breaking the accumulation pattern.
- Both reuse the existing `_refreshRenderer` from #190 (`clearTextureAtlas()` + `term.refresh(0, rows-1)`).
- Teardown wired up in `destroy()`.

Distinct from #195 (per-session TextDecoder): that was UTF-8 decode contamination across sessions; this is GPU-side atlas eviction within one session.

## Status

**Experimental** — author cannot reproduce locally. Branch was opened as a PR so a reproducer machine can test the merged-into-main artifact end-to-end before we ceremony it (spec + exec plan + dedicated issue). If this fixes the regression, I'll backfill docs and treat the merged commit as the implementation.

Two outcomes to look for after rebuilding `hivegui`:
- Garbage clears at the 90s tick → atlas overflow confirmed; we may tune the interval or add a write-threshold trigger.
- Garbage persists between ticks → atlas isn't the cause (or not the only one); back to investigating.

If the timer causes visible flicker on a real workload, the strategy can change to \"clear when output rate drops\" instead of fixed interval.

## Test plan

- [x] Vitest: 66/66 pass (no new tests yet — this is the experimental cut; regression test arrives with the productized PR).
- [ ] Manual on repro machine: run multiple concurrent Claude sessions, observe whether matrix glyphs still appear and whether timer ticks clear them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)