### PR TITLE
fix(worktree): warn on unreachable upstream instead of silent stale-HEAD fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Worktrees: surface a log warning when `git fetch origin` fails or
+  `origin/HEAD` is not configured, instead of silently falling back to
+  local HEAD (or worse, silently basing a new worktree on a stale
+  cached `origin/HEAD`). Closes the spec gap in #192's "remote
+  unreachable" success criterion.
 - Worktrees now branch from `origin/<default-branch>` (typically
   `origin/main`) instead of local HEAD. Previously, creating a
   session-backed worktree from a stale checkout produced a worktree

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,15 +125,20 @@ func upstreamBaseRef(repoDir string) string {
 
 	// Best-effort fetch (10s). Network or auth failures fall through:
 	// we'll still resolve whatever `origin/HEAD` already points at locally.
+	// Warn so a stale cached origin/HEAD doesn't silently base new
+	// worktrees on outdated upstream — the very failure mode #192 fixed.
 	fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer fetchCancel()
-	_ = exec.CommandContext(fetchCtx, "git", "-C", repoDir, "fetch", "--quiet", "origin").Run()
+	if fetchOut, fetchErr := exec.CommandContext(fetchCtx, "git", "-C", repoDir, "fetch", "--quiet", "origin").CombinedOutput(); fetchErr != nil {
+		log.Printf("worktree: fetch origin failed (%v); new worktree may be based on stale origin/HEAD: %s", fetchErr, strings.TrimSpace(string(fetchOut)))
+	}
 
 	// Resolve origin/HEAD -> origin/<default-branch>.
 	resolveCtx, resolveCancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer resolveCancel()
 	out, err := exec.CommandContext(resolveCtx, "git", "-C", repoDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD").Output()
 	if err != nil {
+		log.Printf("worktree: origin/HEAD not set in %s; falling back to local HEAD for new worktree", repoDir)
 		return ""
 	}
 	return strings.TrimSpace(string(out))

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,6 +1,8 @@
 package worktree
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -199,6 +201,41 @@ func TestCreateWorktree_NoRemoteFallsBackToHEAD(t *testing.T) {
 	got := revParse(t, wtPath, "HEAD")
 	if got != headBefore {
 		t.Errorf("worktree HEAD = %s, want local HEAD %s", got, headBefore)
+	}
+}
+
+func TestCreateWorktree_UnreachableRemoteWarnsAndFallsBack(t *testing.T) {
+	skipNoGit(t)
+	repo := initRepo(t)
+	// Point origin at a path that does not exist. `git fetch` will fail;
+	// `symbolic-ref refs/remotes/origin/HEAD` will also fail (never set).
+	bogus := filepath.Join(t.TempDir(), "does-not-exist.git")
+	mustGit(t, repo, "remote", "add", "origin", bogus)
+
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(origOut) })
+
+	headBefore := revParse(t, repo, "HEAD")
+	branch := "offline-feature"
+	wtPath := WorktreePath(repo, branch)
+	if err := CreateWorktree(repo, branch, wtPath); err != nil {
+		t.Fatalf("CreateWorktree with unreachable remote: %v", err)
+	}
+	defer Cleanup(repo, wtPath)
+
+	if got := revParse(t, wtPath, "HEAD"); got != headBefore {
+		t.Errorf("worktree HEAD = %s, want local HEAD %s (fallback path)", got, headBefore)
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "worktree:") {
+		t.Errorf("expected worktree warning in logs when remote is unreachable; got: %q", logs)
+	}
+	// Must mention either the fetch failure or the missing origin/HEAD so
+	// the operator can diagnose stale-upstream risk.
+	if !strings.Contains(logs, "fetch origin failed") && !strings.Contains(logs, "origin/HEAD not set") {
+		t.Errorf("expected log to mention fetch failure or missing origin/HEAD; got: %q", logs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the gap in #192's success criterion #2 ("when the remote is unreachable, worktree creation falls back to local HEAD **and surfaces a warning to the user / logs**"). The original fix did the fallback but silently discarded the fetch error and silently returned \"\" on missing \`origin/HEAD\`. Worst case: \`git fetch\` fails but a stale cached \`origin/HEAD\` still resolves locally — the new worktree is then silently based on outdated upstream, the exact failure mode #192 set out to prevent.

\`upstreamBaseRef\` now \`log.Printf\`s when:
- \`git fetch origin\` returns a non-nil error (combined output included for diagnostics)
- \`symbolic-ref refs/remotes/origin/HEAD\` fails

Adds \`TestCreateWorktree_UnreachableRemoteWarnsAndFallsBack\` covering the unreachable-remote path: pointing \`origin\` at a bogus path, asserting \`CreateWorktree\` still succeeds with HEAD-based fallback, and verifying a \`worktree:\` warning lands in the log buffer.

Spotted while reviewing #194's QA verdict — the verdict claimed all three spec criteria were covered, but neither test exercised the warning subclause and the implementation didn't emit one. #194 has been rebased separately with a corrected (PASS-WITH-GAP) verdict.

## Test plan

- [x] \`go test ./internal/worktree/...\` — all 4 \`TestCreateWorktree_*\` cases pass, including the new one
- [ ] Manual smoke: \`git remote set-url origin file:///nonexistent\` in a real checkout, create a Hive session, confirm warning lands in stderr and worktree HEAD == local HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)