### PR TITLE
fix(gui): scrollback survives single↔grid resize; no overwrite mid-print (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GUI: scrollback no longer renders at the narrow grid width after a
+  single → grid → single transition, and live output no longer
+  overwrites already-scrolled lines. The daemon now keeps a per-session
+  raw-byte ring buffer (8 MiB) and re-streams it through a new
+  `REQUEST_REPLAY` wire frame whenever the GUI's column count changes
+  by ≥4 cols; the frontend `term.reset()`s on a `scrollback_replay_begin`
+  event so the replay paints onto a clean buffer. Initial attach uses
+  the same path, so reattach scrollback is no longer capped at the old
+  500-row vt10x history. (#200)
 - Worktrees: surface a log warning when `git fetch origin` fails or
   `origin/HEAD` is not configured, instead of silently falling back to
   local HEAD (or worse, silently basing a new worktree on a stale

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -697,15 +697,19 @@ func (a *App) ResizeSession(id string, cols, rows int) error {
 	return cs.writeJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
 }
 
-// RequestSnapshotReplay asks the daemon to re-stream the session's
-// scrollback ring buffer. The GUI uses this after a width-changing
+// RequestScrollbackReplay asks the daemon to re-stream the session's
+// scrollback byte ring. The GUI uses this after a width-changing
 // resize (single ↔ grid transitions) because xterm.js does not reflow
 // scrollback when its column count changes — replaying the raw bytes
 // into a freshly-reset terminal gets the history rendered at the new
 // width. The daemon serializes the replay against live PTY fanout, so
 // the client sees a clean Begin/bytes/Done sequence even under heavy
 // streaming.
-func (a *App) RequestSnapshotReplay(id string) error {
+//
+// Distinct from RenderSnapshot / SubscribeAtomicSnapshot — the bytes
+// streamed back are the raw PTY ring, not the vt10x-synthesized
+// repaint.
+func (a *App) RequestScrollbackReplay(id string) error {
 	cs, err := a.attachFor(id)
 	if err != nil {
 		return err

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -697,6 +697,22 @@ func (a *App) ResizeSession(id string, cols, rows int) error {
 	return cs.writeJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
 }
 
+// RequestSnapshotReplay asks the daemon to re-stream the session's
+// scrollback ring buffer. The GUI uses this after a width-changing
+// resize (single ↔ grid transitions) because xterm.js does not reflow
+// scrollback when its column count changes — replaying the raw bytes
+// into a freshly-reset terminal gets the history rendered at the new
+// width. The daemon serializes the replay against live PTY fanout, so
+// the client sees a clean Begin/bytes/Done sequence even under heavy
+// streaming.
+func (a *App) RequestSnapshotReplay(id string) error {
+	cs, err := a.attachFor(id)
+	if err != nil {
+		return err
+	}
+	return cs.writeFrame(wire.FrameRequestReplay, nil)
+}
+
 func (a *App) attachFor(id string) (*connState, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -20,3 +20,32 @@ export function shouldRequestReplay(prevCols, nextCols, threshold = REPLAY_COL_T
   if (!prevCols || !nextCols) return false;
   return Math.abs(nextCols - prevCols) >= threshold;
 }
+
+// Handle one EventScrollback{Begin,Done} payload by mutating the
+// session-term object accordingly. Extracted from main.js so the
+// state machine can be unit-tested against a mock term object
+// without dragging xterm.js + jsdom into the suite.
+//
+// Returns true if `kind` matched a known event, false otherwise.
+// On Begin we call `st.term.reset()` to wipe xterm's buffer so the
+// incoming replay bytes paint onto a clean slate, AND reset the
+// UTF-8 decoder so a partial multi-byte rune sitting across the
+// boundary doesn't corrupt the first replay character. On Done we
+// scroll to bottom so the user sees the cursor / newest output
+// rather than landing mid-history.
+export function handleScrollbackEvent(st, kind) {
+  if (!st || !st.term) return false;
+  switch (kind) {
+    case 'scrollback_replay_begin':
+      st.term.reset();
+      if (st.decoder) st.decoder = new TextDecoder('utf-8');
+      return true;
+    case 'scrollback_replay_done':
+      if (typeof st.term.scrollToBottom === 'function') {
+        st.term.scrollToBottom();
+      }
+      return true;
+    default:
+      return false;
+  }
+}

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -1,0 +1,22 @@
+// Scrollback-replay decision helpers. Pure functions so the resize-
+// driven replay logic in main.js can be unit-tested without dragging
+// xterm.js or the Wails bridge into jsdom.
+
+// Column-count change that warrants a fresh scrollback replay. Picked
+// to ignore minor font-kerning jitter while still firing on single ↔
+// grid transitions (which typically change cols by tens of columns).
+export const REPLAY_COL_THRESHOLD = 4;
+
+// Debounce window so dragging a divider doesn't spam replays — only
+// the final settled width sends a request.
+export const REPLAY_DEBOUNCE_MS = 100;
+
+// Returns true when a resize from prevCols → nextCols should trigger
+// a scrollback replay request. Encapsulates "first measurement"
+// (prevCols falsy) as well: an undefined / 0 prev means we haven't
+// measured yet, so suppress — the initial attach already sent a
+// replay.
+export function shouldRequestReplay(prevCols, nextCols, threshold = REPLAY_COL_THRESHOLD) {
+  if (!prevCols || !nextCols) return false;
+  return Math.abs(nextCols - prevCols) >= threshold;
+}

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -249,7 +249,6 @@ class SessionTerm {
     // ensureAttached so the new PTY's stream resumes without the user
     // having to switch sessions and back.
     this.needsReattach = false;
-    this.phase = 'replay';
 
     // Track the OSC-set window title from the running TUI (vim, htop,
     // claude code, etc.) so the app title bar can show it after the
@@ -1916,12 +1915,12 @@ EventsOn('pty:event', (id, jsonStr) => {
       // whatever's already rendered, producing the "live text overwrites
       // scrollback" symptom (the bug-2 path). The decoder is also
       // reset so a partial UTF-8 sequence across the boundary doesn't
-      // corrupt the first replay rune.
-      st.phase = 'replay';
+      // corrupt the first replay rune. Wire-order is what guarantees no
+      // live bytes land between Begin and Done — see daemon's
+      // SubscribeWithAtomicReplay / EmitAtomicReplay.
       st.term.reset();
       if (st.decoder) st.decoder = new TextDecoder('utf-8');
     } else if (ev.kind === 'scrollback_replay_done') {
-      st.phase = 'live';
       // After scrollback replay, snap the viewport to the latest line
       // so the user sees the cursor / newest output rather than landing
       // somewhere mid-history. Tile dims are already correct via the

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -6,7 +6,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 
 import {
   ConnectControl, OpenSession, CloseAttach,
-  WriteStdin, ResizeSession,
+  WriteStdin, ResizeSession, RequestSnapshotReplay,
   CreateSession, DuplicateSession, KillSession, RestartSession, UpdateSession, ListAgents,
   CreateProject, KillProject, UpdateProject,
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
@@ -28,6 +28,9 @@ import {
   recoverFromContextLoss,
   bindDprWatcher,
 } from './lib/renderer-recovery.js';
+import {
+  shouldRequestReplay, REPLAY_DEBOUNCE_MS,
+} from './lib/scrollback.js';
 
 // ---------- session terminal ----------
 
@@ -578,11 +581,31 @@ class SessionTerm {
     const wasAtBottom = buf ? (buf.baseY - buf.viewportY) <= STICKY_BOTTOM_LINES : true;
     // Swallow throw and continue: a transient FitAddon error (e.g. a
     // race against teardown) shouldn't drop the daemon-side resize.
+    const prevCols = this.term.cols;
     try { this.fit.fit(); } catch { /* keep going with last-known dims */ }
     if (this.attached) {
       ResizeSession(this.info.id, this.term.cols, this.term.rows);
     }
     if (wasAtBottom) this.term.scrollToBottom();
+
+    // If the column count changed materially (single ↔ grid transit,
+    // window resize across modes), xterm's scrollback is now stale —
+    // its rendered rows were baked at the old width and xterm.js does
+    // not reflow history on resize. Ask the daemon to re-stream the
+    // raw byte ring; the EventScrollbackReplayBegin handler will
+    // term.reset() before the bytes arrive, and the daemon serializes
+    // the replay against live fanout so nothing interleaves.
+    //
+    // Debounced so dragging a divider doesn't trigger N replays —
+    // only the final settled width does. Sub-threshold changes
+    // (1–3 cols, e.g. font kerning jitter) are ignored.
+    if (this.attached && shouldRequestReplay(prevCols, this.term.cols)) {
+      if (this._replayTimer) clearTimeout(this._replayTimer);
+      this._replayTimer = setTimeout(() => {
+        this._replayTimer = 0;
+        RequestSnapshotReplay(this.info.id).catch(() => { /* attach may have closed */ });
+      }, REPLAY_DEBOUNCE_MS);
+    }
   }
 
   async ensureAttached() {
@@ -1885,7 +1908,19 @@ EventsOn('pty:event', (id, jsonStr) => {
   try {
     const ev = JSON.parse(jsonStr);
     const st = state.terms.get(id);
-    if (st && ev.kind === 'scrollback_replay_done') {
+    if (!st) return;
+    if (ev.kind === 'scrollback_replay_begin') {
+      // Daemon is about to re-stream the byte ring. Wipe xterm's buffer
+      // (visible viewport + scrollback) so the replay paints onto a
+      // clean slate — otherwise the new bytes would land on top of
+      // whatever's already rendered, producing the "live text overwrites
+      // scrollback" symptom (the bug-2 path). The decoder is also
+      // reset so a partial UTF-8 sequence across the boundary doesn't
+      // corrupt the first replay rune.
+      st.phase = 'replay';
+      st.term.reset();
+      if (st.decoder) st.decoder = new TextDecoder('utf-8');
+    } else if (ev.kind === 'scrollback_replay_done') {
       st.phase = 'live';
       // After scrollback replay, snap the viewport to the latest line
       // so the user sees the cursor / newest output rather than landing

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -6,7 +6,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 
 import {
   ConnectControl, OpenSession, CloseAttach,
-  WriteStdin, ResizeSession, RequestSnapshotReplay,
+  WriteStdin, ResizeSession, RequestScrollbackReplay,
   CreateSession, DuplicateSession, KillSession, RestartSession, UpdateSession, ListAgents,
   CreateProject, KillProject, UpdateProject,
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
@@ -29,7 +29,7 @@ import {
   bindDprWatcher,
 } from './lib/renderer-recovery.js';
 import {
-  shouldRequestReplay, REPLAY_DEBOUNCE_MS,
+  shouldRequestReplay, REPLAY_DEBOUNCE_MS, handleScrollbackEvent,
 } from './lib/scrollback.js';
 
 // ---------- session terminal ----------
@@ -587,22 +587,36 @@ class SessionTerm {
     }
     if (wasAtBottom) this.term.scrollToBottom();
 
-    // If the column count changed materially (single ↔ grid transit,
-    // window resize across modes), xterm's scrollback is now stale —
-    // its rendered rows were baked at the old width and xterm.js does
-    // not reflow history on resize. Ask the daemon to re-stream the
-    // raw byte ring; the EventScrollbackReplayBegin handler will
-    // term.reset() before the bytes arrive, and the daemon serializes
-    // the replay against live fanout so nothing interleaves.
+    // If the column count changed materially relative to the
+    // *baseline* (the cols active at the last replay, or initial
+    // attach if no replay has fired yet), xterm's scrollback is
+    // stale — its rendered rows were baked at the old width and
+    // xterm.js does not reflow history on resize. Ask the daemon to
+    // re-stream the raw byte ring; the EventScrollbackReplayBegin
+    // handler will term.reset() before the bytes arrive, and the
+    // daemon serializes the replay against live fanout so nothing
+    // interleaves.
     //
-    // Debounced so dragging a divider doesn't trigger N replays —
-    // only the final settled width does. Sub-threshold changes
-    // (1–3 cols, e.g. font kerning jitter) are ignored.
-    if (this.attached && shouldRequestReplay(prevCols, this.term.cols)) {
-      if (this._replayTimer) clearTimeout(this._replayTimer);
+    // Comparing against a baseline (rather than the just-previous
+    // measurement) means a 80→84→83 sequence still triggers a replay
+    // — the final width is 3 cols off the baseline, even though
+    // neither single step crosses the threshold. We also unconditionally
+    // clear any pending timer on every resize, then re-arm only if
+    // the *current* delta still warrants a replay; otherwise an old
+    // measurement that briefly crossed the threshold would leave a
+    // stale timer armed.
+    if (this._replayBaselineCols === undefined) {
+      this._replayBaselineCols = prevCols || this.term.cols;
+    }
+    if (this._replayTimer) {
+      clearTimeout(this._replayTimer);
+      this._replayTimer = 0;
+    }
+    if (this.attached && shouldRequestReplay(this._replayBaselineCols, this.term.cols)) {
       this._replayTimer = setTimeout(() => {
         this._replayTimer = 0;
-        RequestSnapshotReplay(this.info.id).catch(() => { /* attach may have closed */ });
+        this._replayBaselineCols = this.term.cols;
+        RequestScrollbackReplay(this.info.id).catch(() => { /* attach may have closed */ });
       }, REPLAY_DEBOUNCE_MS);
     }
   }
@@ -1908,25 +1922,13 @@ EventsOn('pty:event', (id, jsonStr) => {
     const ev = JSON.parse(jsonStr);
     const st = state.terms.get(id);
     if (!st) return;
-    if (ev.kind === 'scrollback_replay_begin') {
-      // Daemon is about to re-stream the byte ring. Wipe xterm's buffer
-      // (visible viewport + scrollback) so the replay paints onto a
-      // clean slate — otherwise the new bytes would land on top of
-      // whatever's already rendered, producing the "live text overwrites
-      // scrollback" symptom (the bug-2 path). The decoder is also
-      // reset so a partial UTF-8 sequence across the boundary doesn't
-      // corrupt the first replay rune. Wire-order is what guarantees no
-      // live bytes land between Begin and Done — see daemon's
-      // SubscribeWithAtomicReplay / EmitAtomicReplay.
-      st.term.reset();
-      if (st.decoder) st.decoder = new TextDecoder('utf-8');
-    } else if (ev.kind === 'scrollback_replay_done') {
-      // After scrollback replay, snap the viewport to the latest line
-      // so the user sees the cursor / newest output rather than landing
-      // somewhere mid-history. Tile dims are already correct via the
-      // ResizeObserver-driven fit at attach time — no defensive refit.
-      st.term.scrollToBottom();
-    }
+    // Begin: wipe xterm so replay paints onto a clean slate (otherwise
+    // the new bytes would overlay whatever's already rendered — the
+    // bug-2 symptom). Done: scroll to bottom so the user lands at the
+    // cursor. Wire-order is what guarantees no live bytes land
+    // between Begin and Done — see daemon's SubscribeWithAtomicReplay
+    // and EmitAtomicReplay.
+    handleScrollbackEvent(st, ev.kind);
   } catch { /* ignore */ }
 });
 

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -73,6 +73,7 @@ export async function WriteStdin(id, b64) {
   return '';
 }
 export async function ResizeSession(_id, _cols, _rows) { return ''; }
+export async function RequestSnapshotReplay(_id) { return ''; }
 export async function CreateSession(spec) {
   const id = 'mock-' + (state.sessions.length + 1);
   const s = {

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -73,7 +73,7 @@ export async function WriteStdin(id, b64) {
   return '';
 }
 export async function ResizeSession(_id, _cols, _rows) { return ''; }
-export async function RequestSnapshotReplay(_id) { return ''; }
+export async function RequestScrollbackReplay(_id) { return ''; }
 export async function CreateSession(spec) {
   const id = 'mock-' + (state.sessions.length + 1);
   const s = {

--- a/cmd/hivegui/frontend/test/unit/scrollback.test.js
+++ b/cmd/hivegui/frontend/test/unit/scrollback.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shouldRequestReplay,
+  REPLAY_COL_THRESHOLD,
+  REPLAY_DEBOUNCE_MS,
+} from '../../src/lib/scrollback.js';
+
+describe('shouldRequestReplay', () => {
+  it('returns true on grid → single (large widen)', () => {
+    expect(shouldRequestReplay(40, 200)).toBe(true);
+  });
+
+  it('returns true on single → grid (large shrink)', () => {
+    expect(shouldRequestReplay(200, 40)).toBe(true);
+  });
+
+  it('returns true exactly at the threshold', () => {
+    expect(shouldRequestReplay(80, 80 + REPLAY_COL_THRESHOLD)).toBe(true);
+    expect(shouldRequestReplay(80, 80 - REPLAY_COL_THRESHOLD)).toBe(true);
+  });
+
+  it('returns false below the threshold (kerning jitter)', () => {
+    expect(shouldRequestReplay(80, 81)).toBe(false);
+    expect(shouldRequestReplay(80, 83)).toBe(false);
+    expect(shouldRequestReplay(80, 80)).toBe(false);
+  });
+
+  it('returns false when prevCols is missing (first measurement)', () => {
+    expect(shouldRequestReplay(undefined, 80)).toBe(false);
+    expect(shouldRequestReplay(0, 80)).toBe(false);
+  });
+
+  it('returns false when nextCols is zero (hidden tile)', () => {
+    expect(shouldRequestReplay(80, 0)).toBe(false);
+  });
+
+  it('accepts a custom threshold', () => {
+    expect(shouldRequestReplay(80, 82, 2)).toBe(true);
+    expect(shouldRequestReplay(80, 81, 2)).toBe(false);
+  });
+});
+
+describe('debounce timing constant', () => {
+  it('is small enough for live use', () => {
+    expect(REPLAY_DEBOUNCE_MS).toBeGreaterThan(0);
+    expect(REPLAY_DEBOUNCE_MS).toBeLessThan(1000);
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/scrollback.test.js
+++ b/cmd/hivegui/frontend/test/unit/scrollback.test.js
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   shouldRequestReplay,
   REPLAY_COL_THRESHOLD,
   REPLAY_DEBOUNCE_MS,
+  handleScrollbackEvent,
 } from '../../src/lib/scrollback.js';
 
 describe('shouldRequestReplay', () => {
@@ -44,5 +45,82 @@ describe('debounce timing constant', () => {
   it('is small enough for live use', () => {
     expect(REPLAY_DEBOUNCE_MS).toBeGreaterThan(0);
     expect(REPLAY_DEBOUNCE_MS).toBeLessThan(1000);
+  });
+});
+
+describe('handleScrollbackEvent', () => {
+  function makeSt() {
+    return {
+      term: {
+        reset: vi.fn(),
+        scrollToBottom: vi.fn(),
+      },
+      decoder: new TextDecoder('utf-8'),
+    };
+  }
+
+  it('begin event calls term.reset() and refreshes decoder', () => {
+    const st = makeSt();
+    const beforeDecoder = st.decoder;
+    const ok = handleScrollbackEvent(st, 'scrollback_replay_begin');
+    expect(ok).toBe(true);
+    expect(st.term.reset).toHaveBeenCalledTimes(1);
+    // decoder should be a fresh instance (not the same object)
+    expect(st.decoder).not.toBe(beforeDecoder);
+  });
+
+  it('done event scrolls to bottom', () => {
+    const st = makeSt();
+    const ok = handleScrollbackEvent(st, 'scrollback_replay_done');
+    expect(ok).toBe(true);
+    expect(st.term.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(st.term.reset).not.toHaveBeenCalled();
+  });
+
+  it('unknown event kinds are no-ops', () => {
+    const st = makeSt();
+    const ok = handleScrollbackEvent(st, 'something_else');
+    expect(ok).toBe(false);
+    expect(st.term.reset).not.toHaveBeenCalled();
+    expect(st.term.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('null / undefined st is a no-op (no throw)', () => {
+    expect(handleScrollbackEvent(null, 'scrollback_replay_begin')).toBe(false);
+    expect(handleScrollbackEvent(undefined, 'scrollback_replay_begin')).toBe(false);
+    expect(handleScrollbackEvent({}, 'scrollback_replay_begin')).toBe(false);
+  });
+
+  it('begin runs before any subsequent write would matter', () => {
+    // Document the ordering invariant: a caller doing
+    //   handleScrollbackEvent(st, 'scrollback_replay_begin')
+    //   st.term.write(replayBytes)
+    // observes reset() in call-1 before write() in call-2. Trivially
+    // true given JS is single-threaded; this test exists to lock the
+    // semantic in code so a future refactor that makes the handler
+    // async would have to update this test.
+    const st = makeSt();
+    st.term.write = vi.fn();
+    handleScrollbackEvent(st, 'scrollback_replay_begin');
+    st.term.write('hello');
+    expect(st.term.reset.mock.invocationCallOrder[0]).toBeLessThan(
+      st.term.write.mock.invocationCallOrder[0]
+    );
+  });
+});
+
+describe('shouldRequestReplay against baseline (debounce edge case)', () => {
+  // Simulates main.js's baseline-relative debounce: compare *current*
+  // cols against baseline-at-last-replay (not just-previous
+  // measurement). The reviewer flagged r614 — 80→84→83 should NOT
+  // trigger (final delta 3 < threshold 4). Conversely 80→90→89 SHOULD
+  // trigger (final delta 9), even though the single 90→89 step is
+  // sub-threshold.
+  it('baseline-relative threshold catches multi-step crossings', () => {
+    const baseline = 80;
+    expect(shouldRequestReplay(baseline, 90)).toBe(true);
+    expect(shouldRequestReplay(baseline, 89)).toBe(true);
+    expect(shouldRequestReplay(baseline, 83)).toBe(false);
+    expect(shouldRequestReplay(baseline, 84)).toBe(true);
   });
 });

--- a/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
+++ b/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
@@ -130,6 +130,7 @@ Frontend handles `ScrollbackReplayBegin` by calling `term.reset()` (via the extr
 
 - **2026-05-15 iter 1** — verdict: REQUEST_CHANGES; findings: 1 BLOCKING (replay snapshot race), 3 IMPORTANT (CSI-unsafe trim boundary; dead phase field; legacy history ring follow-up); action: autofix+push (manual, sub-agent did not invoke hivesmith skills); head_sha: fb1579e.
 - **2026-05-15 iter 2** — verdict: REQUEST_CHANGES (BLOCKING closed; 11 unresolved Copilot threads); action: manual autofix of 6 real findings (debounce baseline, binding rename, handler extract+test, plan drift in 3 places) and resolve-with-rationale of 11 threads; head_sha: de9dbe6.
+- **2026-05-15 iter 3** — verdict: APPROVE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 2b9cdb6.
 
 ## Progress
 

--- a/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
+++ b/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
@@ -59,31 +59,40 @@ Detail kept here under 200 lines; no separate design doc needed yet.
 
 ## Approach
 
+> **Note (post-implementation):** This approach was specified before the eng review surfaced that ripping out `historyRows` + `captureEvictions` would cascade through `RenderSnapshot`, the conformance corpus, `scripts/vtcapture`, and every snapshot-based test. The shipped implementation adds the byte ring *alongside* the legacy row-history ring rather than replacing it; `SubscribeAtomicSnapshot` and `RenderSnapshot` remain in place. Cleanup of the legacy path is tracked as a follow-up — see [Decision log](#decision-log).
+
 Two distinct bugs, two fixes, one shared piece of plumbing.
 
-**Fix 1 — narrow scrollback after resize.** Replace the Go VT's 500-row ANSI history ring (`internal/session/vt.go:31–50`) with a per-session **raw-byte ring buffer (default 8 MiB)** in the daemon. On overflow, drop oldest bytes at a safe CSI / UTF-8 boundary. The vt10x screen state stays — it still computes "what's on screen right now". The byte ring becomes the single source of truth for "everything that happened".
+**Fix 1 — narrow scrollback after resize.** Add a per-session **raw-byte ring buffer (default 8 MiB, hard-coded const `ringCap = 8<<20`)** in the Go VT alongside the existing row-history ring. On overflow, drop oldest bytes preferring a newline boundary, falling back to ESC, then to UTF-8 lead bytes verified to be outside any unterminated CSI / OSC sequence (`insideUnterminatedEscape` helper). The vt10x screen state stays — it still computes "what's on screen right now". The byte ring becomes the source of truth for "everything that happened".
 
-Add a new wire frame `FrameRequestReplay` (`internal/wire/control.go`). The daemon streams ring bytes back through the same chunked path as today's reattach snapshot, bracketed by two new events `ScrollbackReplayBegin` / `ScrollbackReplayDone` (introduced for fix 2, reused here). Initial attach uses this same path, replacing today's `RenderSnapshot`-based reattach — fixes cross-attach scrollback truncation as a free side-effect.
+Add a new wire frame `FrameRequestReplay` (`internal/wire/frame.go`). The daemon streams ring bytes back chunked at 16 KiB, bracketed by two new events `ScrollbackReplayBegin` / `ScrollbackReplayDone`. Initial attach uses this same path, replacing the old `RenderSnapshot`-based attach data write — fixes cross-attach scrollback truncation (previously capped at the 500-row vt10x history).
 
-Frontend: `_onBodyResize` (`cmd/hivegui/frontend/src/main.js:535–570`) sends a debounced (100 ms) `RequestReplay` when `cols` change crosses a ≥4-col threshold. The frontend stays a dumb pipe — no client-side buffer.
+Frontend: `_onBodyResize` (`cmd/hivegui/frontend/src/main.js`) sends a debounced (100 ms) `FrameRequestReplay` when `cols` change crosses a ≥4-col threshold **relative to the baseline at the last replay** — not relative to the previous measurement, so a 80→90→89 sequence still triggers a replay even though no single step is ≥4. The frontend stays a dumb pipe — no client-side buffer.
 
-**Fix 2 — live text overwriting scrollback.** Symptom is the snapshot+live race at `internal/daemon/daemon.go:420–429`: snapshot bytes and live PTY bytes interleave at xterm with no buffer reset between. Add per-sink `replayInFlight` gating in the daemon (live fanout buffers until `Done` ships). Frontend handles `ScrollbackReplayBegin` by calling `term.reset()` before accepting replay bytes. Defensive: also fix the `captureEvictions` heuristic (`vt.go:121–149`) — once we delete the row-history ring, this heuristic goes away entirely.
+**Fix 2 — live text overwriting scrollback.** Symptom is the snapshot+live race in the attach path: snapshot bytes and live PTY bytes interleaved at xterm with no buffer reset between. Two new Session methods serialize replay against fanout:
+
+- `SubscribeWithAtomicReplay(sink, writeFn)` — initial attach. Captures the ring, calls writeFn (which writes Begin → bytes → Done under the sink's f.mu), then registers the sink, all under s.mu. Deliver is blocked for the duration; live fanout to this sink starts strictly after Done.
+- `EmitAtomicReplay(writeFn)` — mid-session `FrameRequestReplay`. Sink already registered; s.mu blocks deliver while writeFn runs; queued live bytes deliver in order after Done.
+
+Frontend handles `ScrollbackReplayBegin` by calling `term.reset()` (via the extracted `handleScrollbackEvent` helper for unit-test access). Wire-order — not a JS-side phase flag — is what guarantees no live bytes land between Begin and Done.
 
 ### Why this design
 
 - **Single source of truth.** Bytes live only in the daemon ring. No client-side dup with xterm's cell scrollback.
 - **Composes.** Fix 2's gating events carry fix 1's replay traffic too.
 - **No cell-level reflow needed.** Replaying raw bytes lets xterm re-parse at the new width — sidesteps the "vt.go:166 says it's not worth the complexity" problem.
-- **Memory:** 8 MiB × typical 3–10 sessions = 24–80 MiB in the daemon. Old ANSI ring was ~50 KiB; net add is bounded and capped via env/config.
+- **Memory:** 8 MiB × typical 3–10 sessions = 24–80 MiB in the daemon. The cap is currently a Go `const`, not env/config-tunable; raising it requires a recompile.
 
 ### Files to change
 
-1. `internal/wire/control.go` — add `FrameRequestReplay` frame type; add `EventScrollbackReplayBegin` / `EventScrollbackReplayDone` event constants.
-2. `internal/session/vt.go` — replace `historyRows` ANSI ring (lines 31–50) with a raw-byte ring (cap configurable; default 8 MiB). Add `RingBytes() []byte` and `RingLen() int` accessors. Drop `captureEvictions` (121–149) and its callers — no longer needed. Keep the vt10x screen for current-state rendering. Add a `resizeInFlight` guard around `Resize` (166–177) for safety.
-3. `internal/session/session.go` — write every chunk to the new ring in `deliver` (around 204). Ensure `vt.Resize` and `vt.Write` ordering is unambiguous under `s.mu`.
-4. `internal/daemon/daemon.go` — handle the new `FrameRequestReplay`. Emit `Begin` → chunked ring bytes → `Done`. Gate per-sink live fanout via a `replayInFlight` boolean. Initial attach (around 420–429) uses this same path instead of `RenderSnapshot`.
-5. `cmd/hivegui/frontend/src/main.js` — in `_onBodyResize` (535–570) detect width-threshold crossing, debounce 100 ms, send `RequestReplay`. New event handler for `ScrollbackReplayBegin` → `term.reset()`. No client-side buffer.
-6. `cmd/hivegui/frontend/src/lib/` — if a small helper is warranted for the replay-state machine, factor it out for unit-testability.
+1. `internal/wire/frame.go` — add `FrameRequestReplay` frame type (0x14).
+2. `internal/wire/control.go` — add `EventScrollbackReplayBegin` / `EventScrollbackReplayDone` event constants.
+3. `internal/session/vt.go` — add a raw-byte ring (cap `ringCap = 8<<20`, hard-coded) alongside the existing `historyRows` ring. Add `RingBytes()` accessor and `appendRing` with newline-preferring, CSI-safe boundary trim. **Legacy `historyRows` ring and `captureEvictions` are retained** — load-bearing for `RenderSnapshot` and the conformance corpus. Cleanup tracked as follow-up.
+4. `internal/session/session.go` — add `SubscribeWithAtomicReplay` and `EmitAtomicReplay`. Both hold s.mu across snapshot+writeFn so deliver is serialized.
+5. `internal/daemon/daemon.go` — handle the new `FrameRequestReplay` via `EmitAtomicReplay`. Initial attach uses `SubscribeWithAtomicReplay`. `frameSink.writeReplay` writes Begin → chunked ring bytes → Done under f.mu (called from inside the s.mu-held writeFn, so lock order is s.mu → f.mu, matching deliver).
+6. `cmd/hivegui/app.go` — add `RequestScrollbackReplay(id)` Wails binding.
+7. `cmd/hivegui/frontend/src/main.js` — `_onBodyResize` tracks `_replayBaselineCols`; on every resize, clear pending timer; re-arm only if current cols are ≥4 off the baseline. On replay events, delegate to `handleScrollbackEvent`.
+8. `cmd/hivegui/frontend/src/lib/scrollback.js` — `shouldRequestReplay` and `handleScrollbackEvent` helpers, unit-testable.
 
 ### New files
 
@@ -114,7 +123,12 @@ Frontend: `_onBodyResize` (`cmd/hivegui/frontend/src/main.js:535–570`) sends a
 
 ## Decision log
 
+- **2026-05-15** — Plan called for replacing `historyRows` ANSI ring + dropping `captureEvictions`. During IMPLEMENT the cascade through `RenderSnapshot` → conformance tests → `scripts/vtcapture` was assessed as out-of-scope for this PR. Decision: add the byte ring alongside the legacy ring, leave `RenderSnapshot` and the snapshot-based reattach API intact (still used by `SubscribeAtomicSnapshot`). Follow-up to delete the legacy path when the conformance corpus is migrated. Why: keeps this PR focused on the two scrollback bugs without entangling a snapshot-format migration.
+- **2026-05-15** — `ringCap` is hard-coded at 8 MiB (`const ringCap = 8 << 20` in vt.go). Plan originally said "tunable via env/config" — that was aspirational and is not implemented. If operators need to tune, raise via a follow-up: read from `os.Getenv("HIVE_SCROLLBACK_RING_KB")` at `NewVT` time. Decision deferred because the 8 MiB default has not yet been observed to be too small or too large in practice.
+
 ## PR convergence ledger
+
+- **2026-05-15 iter 1** — verdict: REQUEST_CHANGES; findings: 1 BLOCKING (replay snapshot race), 3 IMPORTANT (CSI-unsafe trim boundary; dead phase field; legacy history ring follow-up); action: autofix+push (manual, sub-agent did not invoke hivesmith skills); head_sha: fb1579e.
 
 ## Progress
 

--- a/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
+++ b/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
@@ -2,8 +2,10 @@
 
 - **Spec:** [docs/product-specs/200-scrollback-corruption-after-grid-transitions.md](../../product-specs/200-scrollback-corruption-after-grid-transitions.md)
 - **Issue:** #200
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Status:** active
+- **PR:** https://github.com/lucascaro/hive/pull/203
+- **Branch:** feature/200-scrollback-corruption-after-grid-transitions
 
 ## Summary
 
@@ -117,6 +119,7 @@ Frontend: `_onBodyResize` (`cmd/hivegui/frontend/src/main.js:535–570`) sends a
 - **2026-05-15** — Spec created, issue #200 opened, triage: bug / L / P2. Stage → RESEARCH.
 - **2026-05-15** — Research complete. Stage → PLAN.
 - **2026-05-15** — Plan approved via interactive HTML review (3 revisions: v1 truncate-scrollback → v2 client-side ring → v3 daemon-side byte ring, approved). Approval flag: `~/.claude/plans/scrollback-corruption-after-grid-transitions.approved.json`. Stage → IMPLEMENT.
+- **2026-05-15** — Implementation landed on `feature/200-scrollback-corruption-after-grid-transitions`. All Go + Vitest tests pass (74/74 frontend, full Go suite). PR #203 open. Stage → REVIEW.
 
 ## Open questions
 

--- a/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
+++ b/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
@@ -114,6 +114,8 @@ Frontend: `_onBodyResize` (`cmd/hivegui/frontend/src/main.js:535–570`) sends a
 
 ## Decision log
 
+## PR convergence ledger
+
 ## Progress
 
 - **2026-05-15** — Spec created, issue #200 opened, triage: bug / L / P2. Stage → RESEARCH.

--- a/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
+++ b/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
@@ -1,0 +1,125 @@
+# GUI: scrollback corruption after single↔grid transitions; text overwrites mid-print
+
+- **Spec:** [docs/product-specs/200-scrollback-corruption-after-grid-transitions.md](../../product-specs/200-scrollback-corruption-after-grid-transitions.md)
+- **Issue:** #200
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Diagnose two scrollback symptoms in the GUI: (1) after single→grid→single, scrolling up shows prior output wrapped at the narrower grid column count; (2) live output sometimes overwrites lines that have already scrolled. Before proposing a fix, establish *who owns scrollback today* (in-house Go VT, xterm.js, or both) and lock the answer in with the four-layer test harness so iterations are safe.
+
+## Research
+
+### Who owns scrollback (the answer)
+
+**xterm.js owns the live scrollback. The Go VT owns a small parallel ring used only for snapshot-on-reattach.** They do not coordinate.
+
+- Frontend: `cmd/hivegui/frontend/src/main.js:81–98` instantiates `new Terminal({ scrollback: 5000, ... })`. Raw PTY bytes arrive as base64 from the daemon, decoded once, and handed to `term.write(...)` at `main.js:596–601`. **No custom scrollback code in the frontend.**
+- Backend: `internal/session/vt.go:31–50` keeps a 500-row ANSI-encoded history ring (`historyRows = 500`). `session.go:204` writes every PTY byte into the VT mirror; `session.go:252` renders a snapshot on reattach (`vt.RenderSnapshot()`); `session.go:272` calls `vt.Resize()` when the GUI resizes.
+- Two scrollback buffers exist simultaneously: xterm.js (5000 lines, lives) and Go VT (500 lines, snapshot only). They are not deduped, not aligned, and not reflowed.
+
+### Bug 1 — narrow scrollback after single → grid → single
+
+Smoking gun at `cmd/hivegui/frontend/src/main.js:1227–1238, 1325–1382` (single ↔ grid view) and `:535–570` (resize handler):
+- The same xterm.js Terminal instance is reused across modes. A ResizeObserver on each tile body fires `fit.fit()` which calls `term.resize(cols, rows)`.
+- xterm.js reflows only the *visible viewport* on resize. Hard-wrapped lines already pushed into scrollback stay at the old (grid) width.
+- The Go VT acknowledges the same limitation explicitly at `internal/session/vt.go:166–177`: "History rows captured at the old width remain in the ring as-is — re-laying them out is not worth the complexity since most users don't resize mid-session."
+
+Effect: spending any time in grid view bakes narrow lines into the xterm scrollback. Returning to single view shows them at the old narrow width forever.
+
+### Bug 2 — text overwrites already-scrolled lines during live print
+
+Two distinct mechanisms, both plausible — needs PLAN-stage confirmation via repro tests:
+
+1. **VT eviction race** at `internal/session/vt.go:121–149` (`captureEvictions`). The heuristic matches post-write rows back against the pre-write snapshot to detect how far the screen scrolled. If a `Resize()` interleaves with `deliver()` (or if the terminal contains repeated rows like blank lines), `rowsEqualTerm` can mis-match and lose / re-emit rows. The Go VT history isn't what the user sees on screen, but on reattach the snapshot replays from there.
+
+2. **Snapshot + live double-feed**. On reattach, `daemon.go:420–429` writes the full snapshot (history + visible grid) into the wire, then the live PTY stream resumes. There is no marker telling xterm.js "discard your existing buffer". If a tile was already attached during a transition, xterm.js can receive an overlapping prefix and stamp it over the cursor/last-line.
+
+The "live text overwrites scrollback while printing" symptom matches (2) more strongly because it does not require any resize event.
+
+### Existing test coverage
+
+- Go VT (`internal/session/vt_test.go`, `internal/session/conformance_*_test.go`): snapshot round-trip, scrollback cap at 500, clear-doesn't-leak, resize-with-non-empty-history. **No reflow-on-resize test, no scroll-while-printing test, no snapshot+live race test.**
+- Frontend Vitest + jsdom (`cmd/hivegui/frontend/test/unit,dom/`): focus, visibility, renderer recovery, view normalization, grid layout dims. **No reflow / scrollback / mode-transition tests.**
+- Playwright e2e (`cmd/hivegui/frontend/test/e2e/`): focus spec only. **Could host a real-xterm reflow regression test** (this is the layer where xterm.js scrollback width is observable).
+
+### Design doc
+
+Detail kept here under 200 lines; no separate design doc needed yet.
+
+### Open questions for PLAN
+
+1. xterm.js v5 does have a reflow API for *soft-wrapped* lines. Do we get soft-wraps or hard newlines from agents (claude / codex / etc.)? If hard newlines dominate, reflow won't help — we'd need to clear-and-replay scrollback on resize.
+2. Cheapest fix for bug 1: clear xterm scrollback (`term.clear()` + replay from Go VT snapshot) on mode transitions where width changes meaningfully — accepts losing some history at the cost of correct rendering.
+3. Cheapest fix for bug 2: gate snapshot delivery with an explicit "buffer reset" sentinel (xterm escape `\x1b[2J\x1b[3J\x1b[H` or a Hive-side `term.reset()` before snapshot replay), so live and snapshot can't interleave.
+4. Do we even need the Go VT's 500-row history for the v2 GUI? It's snapshot-only. If we move that to "let xterm.js own scrollback end to end" we delete a class of bugs (but lose snapshot fidelity if the GUI client connects fresh).
+
+## Approach
+
+Two distinct bugs, two fixes, one shared piece of plumbing.
+
+**Fix 1 — narrow scrollback after resize.** Replace the Go VT's 500-row ANSI history ring (`internal/session/vt.go:31–50`) with a per-session **raw-byte ring buffer (default 8 MiB)** in the daemon. On overflow, drop oldest bytes at a safe CSI / UTF-8 boundary. The vt10x screen state stays — it still computes "what's on screen right now". The byte ring becomes the single source of truth for "everything that happened".
+
+Add a new wire frame `FrameRequestReplay` (`internal/wire/control.go`). The daemon streams ring bytes back through the same chunked path as today's reattach snapshot, bracketed by two new events `ScrollbackReplayBegin` / `ScrollbackReplayDone` (introduced for fix 2, reused here). Initial attach uses this same path, replacing today's `RenderSnapshot`-based reattach — fixes cross-attach scrollback truncation as a free side-effect.
+
+Frontend: `_onBodyResize` (`cmd/hivegui/frontend/src/main.js:535–570`) sends a debounced (100 ms) `RequestReplay` when `cols` change crosses a ≥4-col threshold. The frontend stays a dumb pipe — no client-side buffer.
+
+**Fix 2 — live text overwriting scrollback.** Symptom is the snapshot+live race at `internal/daemon/daemon.go:420–429`: snapshot bytes and live PTY bytes interleave at xterm with no buffer reset between. Add per-sink `replayInFlight` gating in the daemon (live fanout buffers until `Done` ships). Frontend handles `ScrollbackReplayBegin` by calling `term.reset()` before accepting replay bytes. Defensive: also fix the `captureEvictions` heuristic (`vt.go:121–149`) — once we delete the row-history ring, this heuristic goes away entirely.
+
+### Why this design
+
+- **Single source of truth.** Bytes live only in the daemon ring. No client-side dup with xterm's cell scrollback.
+- **Composes.** Fix 2's gating events carry fix 1's replay traffic too.
+- **No cell-level reflow needed.** Replaying raw bytes lets xterm re-parse at the new width — sidesteps the "vt.go:166 says it's not worth the complexity" problem.
+- **Memory:** 8 MiB × typical 3–10 sessions = 24–80 MiB in the daemon. Old ANSI ring was ~50 KiB; net add is bounded and capped via env/config.
+
+### Files to change
+
+1. `internal/wire/control.go` — add `FrameRequestReplay` frame type; add `EventScrollbackReplayBegin` / `EventScrollbackReplayDone` event constants.
+2. `internal/session/vt.go` — replace `historyRows` ANSI ring (lines 31–50) with a raw-byte ring (cap configurable; default 8 MiB). Add `RingBytes() []byte` and `RingLen() int` accessors. Drop `captureEvictions` (121–149) and its callers — no longer needed. Keep the vt10x screen for current-state rendering. Add a `resizeInFlight` guard around `Resize` (166–177) for safety.
+3. `internal/session/session.go` — write every chunk to the new ring in `deliver` (around 204). Ensure `vt.Resize` and `vt.Write` ordering is unambiguous under `s.mu`.
+4. `internal/daemon/daemon.go` — handle the new `FrameRequestReplay`. Emit `Begin` → chunked ring bytes → `Done`. Gate per-sink live fanout via a `replayInFlight` boolean. Initial attach (around 420–429) uses this same path instead of `RenderSnapshot`.
+5. `cmd/hivegui/frontend/src/main.js` — in `_onBodyResize` (535–570) detect width-threshold crossing, debounce 100 ms, send `RequestReplay`. New event handler for `ScrollbackReplayBegin` → `term.reset()`. No client-side buffer.
+6. `cmd/hivegui/frontend/src/lib/` — if a small helper is warranted for the replay-state machine, factor it out for unit-testability.
+
+### New files
+
+- `cmd/hivegui/frontend/test/unit/scrollback.test.js` — Vitest, threshold + reset behavior.
+- `cmd/hivegui/frontend/test/e2e/scrollback.spec.js` — Playwright, real xterm reflow + streaming regression.
+
+### Tests
+
+**Go unit (`internal/session/vt_test.go`):**
+- `TestVT_RingCapturesAllBytes` — write N chunks, `RingBytes()` equals concat.
+- `TestVT_RingOverflowDropsAtSafeBoundary` — overflow a small ring, surviving prefix starts at `ESC` / UTF-8 lead.
+- `TestVT_ReplayReproducesScreen` — write, snapshot screen, reset vt10x, replay ring; screen equals snapshot.
+- `TestVT_ResizeWhileWriting_NoEvictionRace` — interleave `Write` and `Resize`; ring is correct.
+
+**Go integration (`internal/daemon/daemon_test.go`):**
+- `TestDaemon_ReplayGating_LiveBuffersUntilDone` — sink sees `Begin` → replay → `Done` → live, no interleave.
+- `TestDaemon_RequestReplay_StreamsRingBytes` — issue request, bytes equal `vt.RingBytes()`.
+- `TestDaemon_InitialAttachReplaysRing` — fresh attach receives full ring before live.
+
+**Vitest + jsdom (`cmd/hivegui/frontend/test/unit/scrollback.test.js` — new):**
+- `width-threshold resize sends RequestReplay` — fire resize obs with ≥4-col delta, assert one bridge message after 100 ms debounce.
+- `BeginScrollbackReplay resets xterm before replay` — fire event, assert `term.reset()` called before subsequent `term.write`.
+- `sub-threshold resizes do not request replay` — 1–2 col delta, no request.
+
+**Playwright e2e (`cmd/hivegui/frontend/test/e2e/scrollback.spec.js` — new):**
+- `single → grid → single keeps wide-column scrollback` — drive real xterm in Wails dev shell, scroll up after transit, assert row length ≥ wide-cols − 10 before any soft-wrap.
+- `rapid streaming never overwrites scrolled history` — feed `seq 1 10000`, scroll up mid-stream, assert visible row numbers are monotonically increasing — no overwrite.
+
+## Decision log
+
+## Progress
+
+- **2026-05-15** — Spec created, issue #200 opened, triage: bug / L / P2. Stage → RESEARCH.
+- **2026-05-15** — Research complete. Stage → PLAN.
+- **2026-05-15** — Plan approved via interactive HTML review (3 revisions: v1 truncate-scrollback → v2 client-side ring → v3 daemon-side byte ring, approved). Approval flag: `~/.claude/plans/scrollback-corruption-after-grid-transitions.approved.json`. Stage → IMPLEMENT.
+
+## Open questions
+
+- Does xterm.js's built-in scrollback (`scrollback` option) handle reflow on resize, or do we override it?
+- Does the in-house VT (`internal/session/vt.go`) maintain its own scrollback that competes with xterm.js's?
+- Is the data path "PTY → Go VT → snapshot → xterm.write" or "PTY → bytes → xterm.write" directly? The answer determines who reflows.

--- a/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
+++ b/docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md
@@ -129,6 +129,7 @@ Frontend handles `ScrollbackReplayBegin` by calling `term.reset()` (via the extr
 ## PR convergence ledger
 
 - **2026-05-15 iter 1** — verdict: REQUEST_CHANGES; findings: 1 BLOCKING (replay snapshot race), 3 IMPORTANT (CSI-unsafe trim boundary; dead phase field; legacy history ring follow-up); action: autofix+push (manual, sub-agent did not invoke hivesmith skills); head_sha: fb1579e.
+- **2026-05-15 iter 2** — verdict: REQUEST_CHANGES (BLOCKING closed; 11 unresolved Copilot threads); action: manual autofix of 6 real findings (debounce baseline, binding rename, handler extract+test, plan drift in 3 places) and resolve-with-rationale of 11 threads; head_sha: de9dbe6.
 
 ## Progress
 

--- a/docs/product-specs/200-scrollback-corruption-after-grid-transitions.md
+++ b/docs/product-specs/200-scrollback-corruption-after-grid-transitions.md
@@ -1,0 +1,39 @@
+# GUI: scrollback corruption after single↔grid transitions; text overwrites mid-print
+
+- **Issue:** #200
+- **Type:** bug
+- **Complexity:** L
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/200-scrollback-corruption-after-grid-transitions.md](../exec-plans/active/200-scrollback-corruption-after-grid-transitions.md)
+
+## Problem
+
+After switching from single-session view to grid view and back, scrolling up shows prior output rendered at the narrower grid width (text was reflowed/resized to the grid's column count rather than the current viewport's). Separately, while text is actively printing, lines that are scrolling up the screen sometimes overwrite text that was already there, producing a corrupted scrollback.
+
+Open research questions:
+- How are we managing scrollback today (in Hive, the in-house VT, or via xterm.js)?
+- Do agents / xterm.js / the virtual terminal already provide scrollback automatically, so we don't need to manage it ourselves?
+- What test coverage (Go VT-level + Vitest/jsdom + Playwright per the four-layer harness) can pin scroll/resize behavior down so we can iterate without regressions?
+
+## Desired behavior
+
+- Scrollback content is rendered at the current pane's column width regardless of intermediate resizes (single → grid → single).
+- Live output written near the bottom of the viewport scrolls cleanly upward without overwriting already-emitted lines.
+- Whichever layer owns scrollback (Hive's VT, xterm.js, the agent's PTY) is intentional and documented, and regressions in its reflow/scroll behavior are caught by automated tests.
+
+## Success criteria
+
+- Repro: open a session in single view, generate enough output to scroll, switch to grid and back, scroll up — prior output renders at the single-view column width.
+- Repro: stream rapid output in a session — no line emitted earlier ever gets overwritten by a later line.
+- New automated tests at the appropriate layer(s) of the four-layer harness cover both behaviors and fail on the current `main` (or document why a layer can't reach it).
+
+## Non-goals
+
+- Re-implementing the in-house VT emulator's scrollback from scratch (covered by the in-house-vt-emulator plan).
+- Changing visible scrollback length / config surface.
+
+## Notes
+
+- Related shipped spec: [143 — vt snapshot: scrollback above visible viewport not preserved](143-vt-snapshot-scrollback-above-visible-viewport.md).
+- Related in-flight specs touching xterm rendering: #190 (garbled glyphs), #195 (shared TextDecoder).
+- Four-layer test harness landed in 97dfa9a (Go + Vitest + jsdom + Playwright).

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -10,6 +10,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | P1 | #186 | Regression: focus inconsistent — switching from single-session to grid mode disables typing | REVIEW | [186-grid-mode-focus-regression-cant-type](186-grid-mode-focus-regression-cant-type.md) |
 | P1 | #172 | Pin/capture agent session id for Gemini and Copilot | IMPLEMENT | [172-agent-session-id-gemini-copilot](172-agent-session-id-gemini-copilot.md) |
 | P1 | #183 | Hive opens only a shell on Windows, not Claude | REVIEW | [183-windows-claude-opens-shell](183-windows-claude-opens-shell.md) |
+| P2 | #200 | GUI: scrollback corruption after single↔grid transitions; text overwrites mid-print | REVIEW | [200-scrollback-corruption-after-grid-transitions](200-scrollback-corruption-after-grid-transitions.md) |
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 | P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | REVIEW | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
 | P1 | #195 | GUI: shared TextDecoder across sessions produces garbled glyphs | IMPLEMENT | [195-shared-textdecoder-glyphs](195-shared-textdecoder-glyphs.md) |

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -417,18 +417,20 @@ func (d *Daemon) serveAttach(conn net.Conn, sessionID string) {
 	}
 
 	sink := &frameSink{conn: conn}
-	replay, unsub := sess.SubscribeAtomicReplay(sink)
-	defer unsub()
-
-	// Stream the byte-ring replay (or an empty replay for a fresh
-	// session) under the sink's write mutex so live PTY fanout blocks
-	// until the Begin/bytes/Done sequence is fully on the wire. No live
-	// bytes can land inside the replay window. The Begin event also
-	// tells the client to reset xterm.js's buffer before the bytes
-	// arrive, so the replay paints a clean slate.
-	if err := sink.writeReplay(replay, 16<<10); err != nil {
+	// SubscribeWithAtomicReplay holds s.mu across both the snapshot
+	// capture and the writeReplay call, so deliver cannot fanout to
+	// any sink (including this one before it's registered) while the
+	// Begin/replay/Done sequence is being written. The sink is
+	// registered for live fanout only after writeReplay returns
+	// successfully, so live bytes start arriving on the wire strictly
+	// after Done.
+	unsub, err := sess.SubscribeWithAtomicReplay(sink, func(replay []byte) error {
+		return sink.writeReplay(replay, 16<<10)
+	})
+	if err != nil {
 		return
 	}
+	defer unsub()
 
 	for {
 		ft, payload, err := wire.ReadFrame(conn)
@@ -451,10 +453,14 @@ func (d *Daemon) serveAttach(conn net.Conn, sessionID string) {
 			_ = sess.Resize(rz.Cols, rz.Rows)
 		case wire.FrameRequestReplay:
 			// Client (typically the GUI after a width-changing resize)
-			// asks us to re-stream the scrollback. Same atomic dance as
-			// the initial attach: hold the sink mutex from the Begin
-			// event through the Done event so live fanout queues on it.
-			if err := sink.writeReplay(sess.Replay(), 16<<10); err != nil {
+			// asks us to re-stream the scrollback. The sink is already
+			// registered for live fanout, so EmitAtomicReplay's hold of
+			// s.mu blocks deliver entirely until the Begin/replay/Done
+			// sequence is on the wire. After release, queued live data
+			// resumes in order.
+			if err := sess.EmitAtomicReplay(func(replay []byte) error {
+				return sink.writeReplay(replay, 16<<10)
+			}); err != nil {
 				return
 			}
 		default:
@@ -478,12 +484,18 @@ func (f *frameSink) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// writeReplay streams a scrollback replay to the client as
-// EventScrollbackReplayBegin → chunked FrameData → EventScrollbackReplayDone,
-// all under the sink's write mutex so any concurrent live PTY fanout
-// blocks until the replay finishes. That ordering is what prevents live
-// bytes from landing in the middle of (or before) the replay — which is
-// the proximate cause of the "live text overwriting scrollback" bug.
+// writeReplay streams Begin → chunked replay bytes → Done to the
+// client under f.mu, so any concurrent non-fanout writes to this sink
+// serialize behind us. The caller is expected to run this via the
+// session's atomic-replay helpers (SubscribeWithAtomicReplay /
+// EmitAtomicReplay) so that s.mu also serializes us against deliver
+// — without that outer serialization, a live fanout that started
+// before we acquired f.mu would write its byte to the wire BEFORE
+// the Begin event, get rendered by xterm in `live` phase, then get
+// wiped by term.reset() when Begin arrives. That is the exact
+// "live text overwriting scrollback" symptom the replay protocol
+// exists to eliminate.
+//
 // chunk is the max payload size per FrameData; pass 16<<10 to match
 // existing snapshot chunking.
 func (f *frameSink) writeReplay(replay []byte, chunk int) error {
@@ -495,10 +507,7 @@ func (f *frameSink) writeReplay(replay []byte, chunk int) error {
 		return err
 	}
 	for len(replay) > 0 {
-		n := chunk
-		if n > len(replay) {
-			n = len(replay)
-		}
+		n := min(chunk, len(replay))
 		if err := wire.WriteFrame(f.conn, wire.FrameData, replay[:n]); err != nil {
 			return err
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -417,15 +417,16 @@ func (d *Daemon) serveAttach(conn net.Conn, sessionID string) {
 	}
 
 	sink := &frameSink{conn: conn}
-	snapshot, unsub := sess.SubscribeAtomicSnapshot(sink)
+	replay, unsub := sess.SubscribeAtomicReplay(sink)
 	defer unsub()
 
-	if err := writeChunked(conn, wire.FrameData, snapshot, 16<<10); err != nil {
-		return
-	}
-	if err := wire.WriteJSON(conn, wire.FrameEvent, wire.Event{
-		Kind: wire.EventScrollbackReplayDone,
-	}); err != nil {
+	// Stream the byte-ring replay (or an empty replay for a fresh
+	// session) under the sink's write mutex so live PTY fanout blocks
+	// until the Begin/bytes/Done sequence is fully on the wire. No live
+	// bytes can land inside the replay window. The Begin event also
+	// tells the client to reset xterm.js's buffer before the bytes
+	// arrive, so the replay paints a clean slate.
+	if err := sink.writeReplay(replay, 16<<10); err != nil {
 		return
 	}
 
@@ -448,6 +449,14 @@ func (d *Daemon) serveAttach(conn net.Conn, sessionID string) {
 				continue
 			}
 			_ = sess.Resize(rz.Cols, rz.Rows)
+		case wire.FrameRequestReplay:
+			// Client (typically the GUI after a width-changing resize)
+			// asks us to re-stream the scrollback. Same atomic dance as
+			// the initial attach: hold the sink mutex from the Begin
+			// event through the Done event so live fanout queues on it.
+			if err := sink.writeReplay(sess.Replay(), 16<<10); err != nil {
+				return
+			}
 		default:
 			log.Printf("hived: unexpected attach frame: %s", ft)
 		}
@@ -469,6 +478,37 @@ func (f *frameSink) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// writeReplay streams a scrollback replay to the client as
+// EventScrollbackReplayBegin → chunked FrameData → EventScrollbackReplayDone,
+// all under the sink's write mutex so any concurrent live PTY fanout
+// blocks until the replay finishes. That ordering is what prevents live
+// bytes from landing in the middle of (or before) the replay — which is
+// the proximate cause of the "live text overwriting scrollback" bug.
+// chunk is the max payload size per FrameData; pass 16<<10 to match
+// existing snapshot chunking.
+func (f *frameSink) writeReplay(replay []byte, chunk int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := wire.WriteJSON(f.conn, wire.FrameEvent, wire.Event{
+		Kind: wire.EventScrollbackReplayBegin,
+	}); err != nil {
+		return err
+	}
+	for len(replay) > 0 {
+		n := chunk
+		if n > len(replay) {
+			n = len(replay)
+		}
+		if err := wire.WriteFrame(f.conn, wire.FrameData, replay[:n]); err != nil {
+			return err
+		}
+		replay = replay[n:]
+	}
+	return wire.WriteJSON(f.conn, wire.FrameEvent, wire.Event{
+		Kind: wire.EventScrollbackReplayDone,
+	})
+}
+
 func (f *frameSink) Close() error { return f.conn.Close() }
 
 // bootstrapWanted reports whether opts has any non-default field set.
@@ -477,16 +517,3 @@ func bootstrapWanted(opts session.Options) bool {
 	return opts.Shell != "" || opts.Cols != 0 || opts.Rows != 0 || len(opts.Env) > 0
 }
 
-func writeChunked(w io.Writer, t wire.FrameType, p []byte, chunk int) error {
-	for len(p) > 0 {
-		n := chunk
-		if n > len(p) {
-			n = len(p)
-		}
-		if err := wire.WriteFrame(w, t, p[:n]); err != nil {
-			return err
-		}
-		p = p[n:]
-	}
-	return nil
-}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net"
 	"os"
 	"os/exec"
@@ -94,7 +95,9 @@ func handshake(t *testing.T, conn net.Conn, hello wire.Hello) wire.Welcome {
 }
 
 // readUntilReplayDone consumes DATA frames into out until the
-// scrollback_replay_done event arrives.
+// scrollback_replay_done event arrives. The replay sequence is now
+// Begin event → DATA frames → Done event, so we tolerate (and skip)
+// the Begin marker — only Done terminates the read.
 func readUntilReplayDone(t *testing.T, conn net.Conn, out *bytes.Buffer) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -108,7 +111,18 @@ func readUntilReplayDone(t *testing.T, conn net.Conn, out *bytes.Buffer) {
 		case wire.FrameData:
 			out.Write(payload)
 		case wire.FrameEvent:
-			return
+			var ev wire.Event
+			if err := json.Unmarshal(payload, &ev); err != nil {
+				t.Fatalf("decode event: %v", err)
+			}
+			switch ev.Kind {
+			case wire.EventScrollbackReplayBegin:
+				// keep reading; Done is what ends the replay
+			case wire.EventScrollbackReplayDone:
+				return
+			default:
+				t.Fatalf("unexpected event kind during replay: %q", ev.Kind)
+			}
 		default:
 			t.Fatalf("unexpected frame during replay: %s", ft)
 		}
@@ -667,5 +681,77 @@ func TestStartup_NoOverride_ReapsOrphans(t *testing.T) {
 
 	if _, err := os.Stat(foreign); !os.IsNotExist(err) {
 		t.Fatalf("expected stale worktree to be reaped, got err=%v", err)
+	}
+}
+
+// TestRequestReplay verifies a client can issue FrameRequestReplay
+// mid-attach and receive the scrollback bytes between Begin/Done
+// markers, with the same atomicity guarantees as the initial replay
+// at attach time.
+func TestRequestReplay(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	id := firstSessionID(t, d)
+
+	conn := dial(t, d)
+	defer conn.Close()
+	_ = handshake(t, conn, wire.Hello{Mode: wire.ModeAttach, SessionID: id})
+
+	// Drain the initial replay.
+	var initial bytes.Buffer
+	readUntilReplayDone(t, conn, &initial)
+
+	// Generate distinctive output the daemon's byte ring will capture.
+	if err := wire.WriteFrame(conn, wire.FrameData, []byte("echo HIVE_REPLAY_MARK_77\n")); err != nil {
+		t.Fatalf("write data: %v", err)
+	}
+	// Drain live frames until the marker shows up.
+	var live bytes.Buffer
+	drainFor(conn, &live, 800*time.Millisecond)
+	if !strings.Contains(live.String(), "HIVE_REPLAY_MARK_77") {
+		t.Fatalf("marker did not arrive live: %q", live.String())
+	}
+
+	// Ask for a replay; expect Begin → DATA (containing marker) → Done.
+	if err := wire.WriteFrame(conn, wire.FrameRequestReplay, nil); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	var replay bytes.Buffer
+	sawBegin := false
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		_ = conn.SetReadDeadline(deadline)
+		ft, payload, err := wire.ReadFrame(conn)
+		if err != nil {
+			t.Fatalf("read frame: %v", err)
+		}
+		switch ft {
+		case wire.FrameData:
+			if !sawBegin {
+				t.Errorf("got DATA before Begin event")
+			}
+			replay.Write(payload)
+		case wire.FrameEvent:
+			var ev wire.Event
+			if err := json.Unmarshal(payload, &ev); err != nil {
+				t.Fatalf("decode event: %v", err)
+			}
+			switch ev.Kind {
+			case wire.EventScrollbackReplayBegin:
+				sawBegin = true
+			case wire.EventScrollbackReplayDone:
+				if !sawBegin {
+					t.Errorf("got Done without Begin")
+				}
+				if !strings.Contains(replay.String(), "HIVE_REPLAY_MARK_77") {
+					t.Errorf("replay missing marker: %q", replay.String())
+				}
+				return
+			default:
+				t.Fatalf("unexpected event: %q", ev.Kind)
+			}
+		default:
+			t.Fatalf("unexpected frame: %s", ft)
+		}
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -258,6 +258,43 @@ func (s *Session) SubscribeAtomicSnapshot(sink Sink) (snapshot []byte, unsubscri
 	}
 }
 
+// SubscribeAtomicReplay returns the raw-byte scrollback ring AND
+// registers the sink under a single lock acquisition. Sibling of
+// SubscribeAtomicSnapshot, but the caller writes the bytes verbatim to
+// the client (which has just been told to reset its terminal) rather
+// than a vt10x-synthesized repaint. Two advantages over snapshot:
+//
+//  1. Preserves the full byte stream (CSI sequences, alt-screen
+//     enter/leave, OSC titles) — the client gets exactly what the
+//     PTY produced, which xterm.js re-parses correctly at the new
+//     width. Snapshot bakes width into pre-rendered cells.
+//  2. Cross-attach scrollback is no longer limited to the 500-row
+//     vt10x history ring; the byte ring is sized by ringCap.
+//
+// To preserve "no live byte is dropped between replay and live", the
+// caller must serialize the replay write against fanout — typically
+// by holding the sink's write mutex from before this call returns
+// until after the last replay byte is written.
+func (s *Session) SubscribeAtomicReplay(sink Sink) (replay []byte, unsubscribe func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	replay = s.vt.RingBytes()
+	s.sinks[sink] = struct{}{}
+	return replay, func() {
+		s.mu.Lock()
+		delete(s.sinks, sink)
+		s.mu.Unlock()
+	}
+}
+
+// Replay returns the current raw-byte scrollback ring without
+// registering a sink. For client-initiated replay requests (e.g. the
+// GUI's width-changing resize trigger) the sink is already registered;
+// only the bytes are needed.
+func (s *Session) Replay() []byte {
+	return s.vt.RingBytes()
+}
+
 // Write forwards bytes from a client to the PTY (i.e. keystrokes).
 func (s *Session) Write(p []byte) (int, error) {
 	return s.ptmx.Write(p)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -258,41 +258,47 @@ func (s *Session) SubscribeAtomicSnapshot(sink Sink) (snapshot []byte, unsubscri
 	}
 }
 
-// SubscribeAtomicReplay returns the raw-byte scrollback ring AND
-// registers the sink under a single lock acquisition. Sibling of
-// SubscribeAtomicSnapshot, but the caller writes the bytes verbatim to
-// the client (which has just been told to reset its terminal) rather
-// than a vt10x-synthesized repaint. Two advantages over snapshot:
+// SubscribeWithAtomicReplay runs writeFn with the current ring
+// snapshot AND registers sink for future fanout, all under s.mu, so
+// no live PTY byte can land on writeFn's transport between the
+// snapshot capture and the writeFn return. After writeFn returns
+// (without error), the sink is registered and starts receiving live
+// fanout from the next deliver onward.
 //
-//  1. Preserves the full byte stream (CSI sequences, alt-screen
-//     enter/leave, OSC titles) — the client gets exactly what the
-//     PTY produced, which xterm.js re-parses correctly at the new
-//     width. Snapshot bakes width into pre-rendered cells.
-//  2. Cross-attach scrollback is no longer limited to the 500-row
-//     vt10x history ring; the byte ring is sized by ringCap.
+// writeFn is expected to write a Begin event, the replay bytes, and a
+// Done event to its underlying transport, ideally under the sink's
+// own write mutex so any concurrent non-fanout writer is also
+// serialized. While writeFn runs, deliver() is blocked on s.mu — the
+// PTY reader continues filling the kernel buffer, but no other write
+// reaches the wire. Keep writeFn quick: long replays mean longer
+// session pauses (PTY backpressure picks up at the kernel buffer
+// level, ~64 KiB on macOS, before the agent stalls).
 //
-// To preserve "no live byte is dropped between replay and live", the
-// caller must serialize the replay write against fanout — typically
-// by holding the sink's write mutex from before this call returns
-// until after the last replay byte is written.
-func (s *Session) SubscribeAtomicReplay(sink Sink) (replay []byte, unsubscribe func()) {
+// On writeFn error the sink is not registered and unsubscribe is nil.
+func (s *Session) SubscribeWithAtomicReplay(sink Sink, writeFn func(replay []byte) error) (unsubscribe func(), err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	replay = s.vt.RingBytes()
+	if err := writeFn(s.vt.RingBytes()); err != nil {
+		return nil, err
+	}
 	s.sinks[sink] = struct{}{}
-	return replay, func() {
+	return func() {
 		s.mu.Lock()
 		delete(s.sinks, sink)
 		s.mu.Unlock()
-	}
+	}, nil
 }
 
-// Replay returns the current raw-byte scrollback ring without
-// registering a sink. For client-initiated replay requests (e.g. the
-// GUI's width-changing resize trigger) the sink is already registered;
-// only the bytes are needed.
-func (s *Session) Replay() []byte {
-	return s.vt.RingBytes()
+// EmitAtomicReplay runs writeFn with the current ring snapshot under
+// s.mu, so no deliver runs while writeFn writes. Used by clients
+// asking for a re-replay mid-attach (FrameRequestReplay) where the
+// sink is already registered — we still need the snapshot to be
+// captured atomically with the wire write to prevent live bytes from
+// being interleaved between Begin and Done.
+func (s *Session) EmitAtomicReplay(writeFn func(replay []byte) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return writeFn(s.vt.RingBytes())
 }
 
 // Write forwards bytes from a client to the PTY (i.e. keystrokes).

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -32,6 +32,15 @@ const (
 // the snapshot. ~80 cols × 500 rows × ~100 bytes/row ≈ 50 KiB worst case.
 const historyRows = 500
 
+// ringCap is the default size of the raw-byte scrollback ring. 8 MiB ≈
+// tens of thousands of lines of typical agent output. The ring lets us
+// replay the entire session into a freshly-reset xterm.js on resize,
+// recovering scrollback that xterm baked at the wrong width — which
+// xterm itself does not reflow on resize. Larger than the row history
+// because it stores raw bytes (CSI sequences and all) rather than
+// pre-rendered rows.
+const ringCap = 8 << 20
+
 // VT is a goroutine-safe wrapper around a vt10x.Terminal. The emulator
 // itself takes a State lock internally on Write/Parse, but our own
 // Mutex serializes Write/Resize/RenderSnapshot against each other so we
@@ -47,6 +56,13 @@ type VT struct {
 	mu      sync.Mutex
 	term    vt10x.Terminal
 	history [][]byte
+
+	// ring holds the raw PTY bytes seen so far, capped at ringCap. On
+	// overflow we drop the oldest bytes but advance to a safe boundary
+	// (ESC or UTF-8 lead byte) so replay never starts mid-escape or
+	// mid-multibyte rune. Used by clients to repaint xterm.js from a
+	// clean slate after a width-changing resize.
+	ring []byte
 }
 
 // NewVT constructs a VT sized cols x rows. Falls back to 80x24 when
@@ -100,6 +116,7 @@ func (v *VT) Write(p []byte) (int, error) {
 	}
 
 	n, err := v.term.Write(p)
+	v.appendRing(p)
 
 	postAlt := v.term.Mode()&vt10x.ModeAltScreen != 0
 	if preRows != nil && !postAlt {
@@ -148,6 +165,58 @@ func (v *VT) captureEvictions(preRows [][]vt10x.Glyph, cols, rows int) {
 	}
 }
 
+// appendRing copies p onto the byte ring, trimming the oldest bytes
+// when the cap is exceeded. After trimming we scan forward to the
+// next CSI escape (ESC, 0x1B) or UTF-8 leading byte so a replay
+// from offset 0 doesn't begin in the middle of an escape sequence
+// or a multi-byte rune. The scan is bounded so worst-case truncation
+// loss is minor. Caller holds v.mu.
+func (v *VT) appendRing(p []byte) {
+	if len(p) == 0 {
+		return
+	}
+	v.ring = append(v.ring, p...)
+	if len(v.ring) <= ringCap {
+		return
+	}
+	drop := len(v.ring) - ringCap
+	// Find a safe boundary at or after `drop`. Scan up to 4 KiB beyond
+	// the cut to find an ESC (CSI/OSC start) or a UTF-8 leading byte
+	// (not a 10xxxxxx continuation). If nothing safe is in range, fall
+	// through and just drop exactly `drop` bytes — replay may emit one
+	// glitched cell but won't desync the parser long-term.
+	const scanWindow = 4 << 10
+	limit := drop + scanWindow
+	if limit > len(v.ring) {
+		limit = len(v.ring)
+	}
+	safe := drop
+	for i := drop; i < limit; i++ {
+		b := v.ring[i]
+		if b == 0x1B {
+			safe = i
+			break
+		}
+		// UTF-8: leading bytes are 0xxxxxxx (ASCII) or 11xxxxxx;
+		// continuation bytes are 10xxxxxx. Cut on a leading byte.
+		if b < 0x80 || (b&0xC0) == 0xC0 {
+			// Skip past raw CSI parameter / data bytes hidden inside an
+			// active escape — heuristic: if the previous byte is ESC we
+			// already took that boundary above; here we just accept any
+			// leading-byte position as a safe rune boundary.
+			safe = i
+			break
+		}
+	}
+	// Compact: a single copy keeps the slice small. Pre-allocate to the
+	// retained length so the underlying array doesn't keep the trimmed
+	// bytes pinned.
+	retained := len(v.ring) - safe
+	next := make([]byte, retained)
+	copy(next, v.ring[safe:])
+	v.ring = next
+}
+
 // pushHistory appends b to the ring, trimming the oldest entries when
 // over capacity. Caller holds v.mu.
 func (v *VT) pushHistory(b []byte) {
@@ -159,6 +228,20 @@ func (v *VT) pushHistory(b []byte) {
 		drop := len(v.history) - historyRows
 		v.history = append([][]byte(nil), v.history[drop:]...)
 	}
+}
+
+// RingBytes returns a defensive copy of the raw-byte scrollback ring.
+// Callers can stream the result to a client that wants to repaint
+// xterm.js from a clean slate after a width-changing resize.
+func (v *VT) RingBytes() []byte {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if len(v.ring) == 0 {
+		return nil
+	}
+	out := make([]byte, len(v.ring))
+	copy(out, v.ring)
+	return out
 }
 
 // Resize updates the emulator's grid dimensions. Returns nil for now;

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -166,11 +166,26 @@ func (v *VT) captureEvictions(preRows [][]vt10x.Glyph, cols, rows int) {
 }
 
 // appendRing copies p onto the byte ring, trimming the oldest bytes
-// when the cap is exceeded. After trimming we scan forward to the
-// next CSI escape (ESC, 0x1B) or UTF-8 leading byte so a replay
-// from offset 0 doesn't begin in the middle of an escape sequence
-// or a multi-byte rune. The scan is bounded so worst-case truncation
-// loss is minor. Caller holds v.mu.
+// when the cap is exceeded. After trimming, scan forward for a safe
+// replay boundary so a replay from offset 0 never begins in the
+// middle of a CSI/OSC sequence or a multi-byte UTF-8 rune — either
+// of which would surface as visible literal-text garbage at the top
+// of the user's scrollback after an overflow.
+//
+// Boundary preference, from most-preferred to least:
+//
+//  1. A LF or CR byte (0x0A / 0x0D). Newlines never appear inside CSI
+//     parameter sequences and are an unambiguous parser boundary.
+//  2. The byte immediately after a CSI/OSC final byte (the `m` of
+//     "[31m", the `BEL` of "]2;…\a"). We pick this up by tracking
+//     whether the scan position is inside an unterminated escape.
+//  3. An ESC byte (0x1B) — the start of a fresh sequence.
+//  4. A UTF-8 leading byte (ASCII or 0xC0+) that is not inside an
+//     active escape per the back-scan.
+//
+// If nothing safe is in `scanWindow`, fall through and drop exactly
+// `drop` bytes. Worst case: one glitched cell of literal text at the
+// top of replay. Caller holds v.mu.
 func (v *VT) appendRing(p []byte) {
 	if len(p) == 0 {
 		return
@@ -180,11 +195,6 @@ func (v *VT) appendRing(p []byte) {
 		return
 	}
 	drop := len(v.ring) - ringCap
-	// Find a safe boundary at or after `drop`. Scan up to 4 KiB beyond
-	// the cut to find an ESC (CSI/OSC start) or a UTF-8 leading byte
-	// (not a 10xxxxxx continuation). If nothing safe is in range, fall
-	// through and just drop exactly `drop` bytes — replay may emit one
-	// glitched cell but won't desync the parser long-term.
 	const scanWindow = 4 << 10
 	limit := drop + scanWindow
 	if limit > len(v.ring) {
@@ -193,28 +203,92 @@ func (v *VT) appendRing(p []byte) {
 	safe := drop
 	for i := drop; i < limit; i++ {
 		b := v.ring[i]
-		if b == 0x1B {
-			safe = i
-			break
-		}
-		// UTF-8: leading bytes are 0xxxxxxx (ASCII) or 11xxxxxx;
-		// continuation bytes are 10xxxxxx. Cut on a leading byte.
-		if b < 0x80 || (b&0xC0) == 0xC0 {
-			// Skip past raw CSI parameter / data bytes hidden inside an
-			// active escape — heuristic: if the previous byte is ESC we
-			// already took that boundary above; here we just accept any
-			// leading-byte position as a safe rune boundary.
+		// Newlines are the gold-standard boundary: never inside CSI.
+		if b == 0x0A || b == 0x0D {
 			safe = i
 			break
 		}
 	}
-	// Compact: a single copy keeps the slice small. Pre-allocate to the
-	// retained length so the underlying array doesn't keep the trimmed
-	// bytes pinned.
+	// If we didn't find a newline, fall back to ESC / UTF-8 leading
+	// byte, but verify the candidate is NOT inside an unterminated
+	// escape by back-scanning up to backScan bytes for an unmatched
+	// ESC.
+	if safe == drop {
+		const backScan = 64
+		for i := drop; i < limit; i++ {
+			b := v.ring[i]
+			if b == 0x1B {
+				safe = i
+				break
+			}
+			if b < 0x80 || (b&0xC0) == 0xC0 {
+				if !insideUnterminatedEscape(v.ring, i, backScan) {
+					safe = i
+					break
+				}
+			}
+		}
+	}
 	retained := len(v.ring) - safe
 	next := make([]byte, retained)
 	copy(next, v.ring[safe:])
 	v.ring = next
+}
+
+// insideUnterminatedEscape reports whether position `pos` in `b` is
+// in the middle of a CSI / OSC sequence — i.e. there's an ESC in the
+// preceding `back` bytes that has not yet seen a terminating byte.
+// Walks each sequence explicitly:
+//
+//   CSI: ESC [ <params 0x30–0x3F | intermediates 0x20–0x2F>*
+//        <final 0x40–0x7E>      — '[' itself is a final-range byte
+//                                  but only the FIRST byte after ESC.
+//   OSC: ESC ] <data>* <BEL | ESC \>
+//   short: ESC <single byte>   — e.g. ESC 7 (DECSC). One-byte tail.
+//
+// "Back" caps how far we look backwards; CSI sequences are typically
+// under 16 bytes, OSC titles can be longer (terminal title up to
+// ~256 bytes), so 256 is a safe upper bound.
+func insideUnterminatedEscape(b []byte, pos int, back int) bool {
+	start := pos - back
+	if start < 0 {
+		start = 0
+	}
+	// Find the most recent ESC before pos.
+	escAt := -1
+	for i := pos - 1; i >= start; i-- {
+		if b[i] == 0x1B {
+			escAt = i
+			break
+		}
+	}
+	if escAt < 0 || escAt+1 >= pos {
+		return false
+	}
+	switch b[escAt+1] {
+	case '[':
+		// CSI: scan from escAt+2 to pos-1 looking for a final byte.
+		for i := escAt + 2; i < pos; i++ {
+			c := b[i]
+			if c >= 0x40 && c <= 0x7E {
+				return false
+			}
+		}
+		return true
+	case ']':
+		// OSC: scan for BEL or a subsequent ESC (start of ST).
+		for i := escAt + 2; i < pos; i++ {
+			c := b[i]
+			if c == 0x07 || c == 0x1B {
+				return false
+			}
+		}
+		return true
+	default:
+		// Short escape: ESC <X>. Terminated at escAt+2. If pos is
+		// past escAt+2 we're not inside any escape anymore.
+		return pos < escAt+2
+	}
 }
 
 // pushHistory appends b to the ring, trimming the oldest entries when

--- a/internal/session/vt_test.go
+++ b/internal/session/vt_test.go
@@ -482,3 +482,127 @@ func TestVTSnapshotScrollbackResize(t *testing.T) {
 		t.Errorf("snapshot missing post-resize content: %q", snap)
 	}
 }
+
+// TestVT_RingCapturesAllBytes verifies that the byte ring buffer
+// retains every byte handed to Write, in order, until it fills the
+// cap. The ring is what powers the GUI's resize-replay path — if it
+// loses bytes, replay produces a corrupted xterm state.
+func TestVT_RingCapturesAllBytes(t *testing.T) {
+	v := NewVT(80, 24)
+	chunks := [][]byte{
+		[]byte("hello "),
+		[]byte("\x1b[31mred\x1b[m "),
+		[]byte("world\r\n"),
+		[]byte("second line\r\n"),
+	}
+	var want bytes.Buffer
+	for _, c := range chunks {
+		if _, err := v.Write(c); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		want.Write(c)
+	}
+	got := v.RingBytes()
+	if !bytes.Equal(got, want.Bytes()) {
+		t.Errorf("ring mismatch:\n  got  %q\n  want %q", got, want.Bytes())
+	}
+}
+
+// TestVT_RingOverflowDropsAtSafeBoundary verifies that when the ring
+// trims to stay under cap, the surviving prefix starts at an ESC byte
+// or a UTF-8 leading byte — not a multibyte continuation byte or a
+// raw parameter byte inside an active CSI. Otherwise the first replay
+// frame would be parsed as garbage by xterm.js.
+func TestVT_RingOverflowDropsAtSafeBoundary(t *testing.T) {
+	v := NewVT(80, 24)
+	// Build a stream that, when trimmed mid-byte, would land inside a
+	// UTF-8 multibyte run. Interleave plain ASCII + CSI + a UTF-8 rune.
+	var stream bytes.Buffer
+	for i := 0; i < (ringCap/16)+128; i++ {
+		stream.WriteString("\x1b[32mAB\xe2\x9c\x93\x1b[m ") // CSI + "AB" + ✓ + reset + space
+	}
+	if _, err := v.Write(stream.Bytes()); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := v.RingBytes()
+	if len(got) == 0 {
+		t.Fatalf("ring empty after overflowing write")
+	}
+	if len(got) > ringCap {
+		t.Errorf("ring exceeds cap: got %d, cap %d", len(got), ringCap)
+	}
+	first := got[0]
+	// Acceptable: ESC, ASCII byte (<0x80), or UTF-8 lead (>=0xC0).
+	// Forbidden: UTF-8 continuation byte (0x80–0xBF, mask 0x80=set & 0x40=clear).
+	if first&0xC0 == 0x80 {
+		t.Errorf("ring starts inside multibyte sequence: first byte %#x", first)
+	}
+}
+
+// TestVT_ReplayReproducesScreen replays the byte ring into a fresh VT
+// and asserts the resulting visible screen matches the original. This
+// is the property the GUI's resize-replay path depends on: replaying
+// the ring into a freshly-reset xterm.js produces the same visible
+// state as the live session.
+func TestVT_ReplayReproducesScreen(t *testing.T) {
+	src := NewVT(40, 10)
+	script := []string{
+		"first line\r\n",
+		"\x1b[1mbold here\x1b[m\r\n",
+		"\x1b[31mred\x1b[m and \x1b[32mgreen\x1b[m\r\n",
+		"  indented\r\n",
+		"final\r\n",
+	}
+	for _, s := range script {
+		if _, err := src.Write([]byte(s)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	ring := src.RingBytes()
+	if len(ring) == 0 {
+		t.Fatal("ring empty")
+	}
+
+	dst := NewVT(40, 10)
+	if _, err := dst.Write(ring); err != nil {
+		t.Fatalf("replay write: %v", err)
+	}
+
+	// Compare visible cells (chars only).
+	src.mu.Lock()
+	dst.mu.Lock()
+	defer src.mu.Unlock()
+	defer dst.mu.Unlock()
+	cols, rows := src.term.Size()
+	for y := 0; y < rows; y++ {
+		var s, d strings.Builder
+		for x := 0; x < cols; x++ {
+			cs := src.term.Cell(x, y)
+			cd := dst.term.Cell(x, y)
+			cc := cs.Char
+			if cc == 0 {
+				cc = ' '
+			}
+			dc := cd.Char
+			if dc == 0 {
+				dc = ' '
+			}
+			s.WriteRune(cc)
+			d.WriteRune(dc)
+		}
+		got := strings.TrimRight(d.String(), " ")
+		want := strings.TrimRight(s.String(), " ")
+		if got != want {
+			t.Errorf("row %d mismatch:\n  src: %q\n  dst: %q", y, want, got)
+		}
+	}
+
+	// vt10x's Cursor() doesn't have stable equality semantics across
+	// instances (offsets vary), but x/y should match.
+	if src.term.Cursor().X != dst.term.Cursor().X ||
+		src.term.Cursor().Y != dst.term.Cursor().Y {
+		t.Errorf("cursor mismatch: src=(%d,%d) dst=(%d,%d)",
+			src.term.Cursor().X, src.term.Cursor().Y,
+			dst.term.Cursor().X, dst.term.Cursor().Y)
+	}
+}

--- a/internal/session/vt_test.go
+++ b/internal/session/vt_test.go
@@ -606,3 +606,53 @@ func TestVT_ReplayReproducesScreen(t *testing.T) {
 			dst.term.Cursor().X, dst.term.Cursor().Y)
 	}
 }
+
+// TestVT_RingOverflowPrefersNewlineBoundary verifies that the
+// overflow-trim path prefers a newline as its replay boundary over
+// CSI / UTF-8 candidates. Newlines never appear inside CSI sequences,
+// so a replay starting on `\n` is guaranteed not to emit literal CSI
+// parameter bytes as visible text.
+func TestVT_RingOverflowPrefersNewlineBoundary(t *testing.T) {
+	v := NewVT(80, 24)
+	// Stream with explicit newlines + CSI; overflow once.
+	var stream bytes.Buffer
+	for i := 0; i < (ringCap/8)+200; i++ {
+		stream.WriteString("\x1b[31mhi\x1b[m\r\n")
+	}
+	if _, err := v.Write(stream.Bytes()); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := v.RingBytes()
+	if len(got) == 0 {
+		t.Fatalf("ring empty")
+	}
+	// First byte should be a newline or an ESC — NOT a CSI parameter
+	// digit / 'm' / 'h' / 'i' which would render as literal text.
+	first := got[0]
+	if first != 0x0A && first != 0x0D && first != 0x1B {
+		t.Errorf("ring starts at unsafe byte %#x (%q); expected newline or ESC", first, string([]byte{first}))
+	}
+}
+
+// TestVT_InsideUnterminatedEscape exercises the helper directly.
+func TestVT_InsideUnterminatedEscape(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  string
+		pos  int
+		want bool
+	}{
+		{"plain text", "hello world", 5, false},
+		{"after CSI terminator", "\x1b[31mhi", 5, false}, // pos=5 is the 'h' after 'm'
+		{"inside CSI param", "\x1b[31mhi", 3, true},      // pos=3 is the '1' inside [31m
+		{"inside OSC", "\x1b]2;title", 4, true},
+		{"after OSC BEL", "\x1b]2;title\x07more", 10, false},
+		{"no ESC nearby", "abcdefghij\x1b[mlater", 5, false},
+	}
+	for _, c := range cases {
+		got := insideUnterminatedEscape([]byte(c.buf), c.pos, 64)
+		if got != c.want {
+			t.Errorf("%s: pos=%d got %v want %v", c.name, c.pos, got, c.want)
+		}
+	}
+}

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -212,8 +212,13 @@ type Event struct {
 
 // Well-known event kinds.
 const (
-	EventScrollbackReplayDone = "scrollback_replay_done"
-	EventSessionExit          = "session_exit"
+	// EventScrollbackReplayBegin precedes a replay (initial attach or a
+	// client-requested replay). The client should reset its terminal
+	// buffer on receipt so the incoming bytes paint a clean slate
+	// instead of overlaying whatever's already on screen.
+	EventScrollbackReplayBegin = "scrollback_replay_begin"
+	EventScrollbackReplayDone  = "scrollback_replay_done"
+	EventSessionExit           = "session_exit"
 )
 
 // Error is sent by the server when something goes wrong.

--- a/internal/wire/frame.go
+++ b/internal/wire/frame.go
@@ -61,6 +61,14 @@ const (
 	FrameProjectEvent  FrameType = 0x12 // S → C, JSON, control
 
 	FrameRestartSession FrameType = 0x13 // C → S, JSON, control
+
+	// FrameRequestReplay asks the daemon to re-stream the session's
+	// scrollback ring buffer into the attach connection. The daemon
+	// responds with EventScrollbackReplayBegin, a sequence of FrameData
+	// frames carrying the ring bytes, and EventScrollbackReplayDone —
+	// all written atomically with respect to live PTY fanout, so the
+	// client sees a clean buffer-reset boundary.
+	FrameRequestReplay FrameType = 0x14 // C → S, empty payload, attach
 )
 
 func (t FrameType) String() string {
@@ -103,6 +111,8 @@ func (t FrameType) String() string {
 		return "PROJECT_EVENT"
 	case FrameRestartSession:
 		return "RESTART_SESSION"
+	case FrameRequestReplay:
+		return "REQUEST_REPLAY"
 	default:
 		return fmt.Sprintf("UNKNOWN(0x%02x)", byte(t))
 	}


### PR DESCRIPTION
## Summary

- Fixes two GUI scrollback bugs reported in #200: (1) prior output rendered at the narrow grid column width after a single → grid → single transition; (2) live output overwriting already-scrolled lines.
- New per-session raw-byte ring buffer (8 MiB, with ESC / UTF-8-safe boundary trimming on overflow) on the daemon side, plus a new `FrameRequestReplay` wire frame and `EventScrollbackReplayBegin` event so the frontend can `term.reset()` before the replay paints.
- Replay is serialized against live fanout under the sink's write mutex, so live PTY bytes never land in the middle of a replay — fixing bug 2 mechanically rather than via heuristics.
- Initial attach uses the same replay path, so reattach scrollback is no longer capped at the old 500-row vt10x history.
- The `RenderSnapshot` path is left intact so existing snapshot tests and any other consumers continue to work — this change is purely additive on the protocol surface (one new frame type, one new event kind).

## Approach

- `internal/session/vt.go` — add an 8 MiB byte ring next to the existing row history. On overflow, scan forward for `ESC` or a UTF-8 leading byte so replay never starts mid-escape.
- `internal/session/session.go` — `SubscribeAtomicReplay` returns the ring atomically with sink registration; `Replay()` returns it for mid-attach refreshes.
- `internal/daemon/daemon.go` — `frameSink.writeReplay` brackets the replay with Begin/Done events under `sink.mu`; attach path uses it; new `FrameRequestReplay` handler does the same on demand.
- `cmd/hivegui/app.go` — `RequestSnapshotReplay(id)` Wails binding sends the new frame.
- `cmd/hivegui/frontend/src/main.js` + `lib/scrollback.js` — `_onBodyResize` fires a debounced (100 ms) replay request when the column count crosses a ≥4-col threshold; `pty:event` handler `term.reset()`s on Begin.

## Test plan

- [x] `go test ./...` — all green; new tests `TestVT_RingCapturesAllBytes`, `TestVT_RingOverflowDropsAtSafeBoundary`, `TestVT_ReplayReproducesScreen`, `TestRequestReplay`.
- [x] `cd cmd/hivegui/frontend && npm test` — 74/74 (8 new in `scrollback.test.js`).
- [x] `VITE_WAILS_MOCK=1 npm run build` and `go build ./...` both clean.
- [ ] Manual smoke: open a session, generate output (`seq 1 10000`), switch to grid, switch back, scroll up. Confirm history renders at wide-column width.
- [ ] Manual smoke: rapid stream of output while toggling single/grid. Confirm no overwrite of scrolled lines.

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)