### PR TITLE
feat(gui): minimize sessions to hide from grid; restore from a tray (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- GUI: minimize sessions to hide them from grid views. Each tile in
+  the project-grid and all-sessions-grid now has a small minimize
+  button on the right of its header (`–`). Minimized sessions are
+  removed from the grid and appear as chips in a tray below the
+  terminals; clicking a chip restores the session to the grid and
+  switches to it. Minimized sessions stay alive (output keeps
+  buffering) and remain reachable in single-session mode via the
+  sidebar, command palette, and `⌘[/]` cycling. State is per-app-run
+  (not persisted across launches). (#202)
 - Frontend test harness. `scripts/test.sh` runs four layers: Go
   (existing), Vitest unit tests for the new `cmd/hivegui/frontend/src/lib/`
   pure modules, jsdom DOM tests, and a Playwright E2E suite that

--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -62,6 +62,7 @@
     <div id="command-palette-list" role="listbox"></div>
   </div>
   <main id="terms"></main>
+  <div id="minimized-tray" class="hidden" role="toolbar" aria-label="Minimized sessions"></div>
   <div id="status">connecting…</div>
 </div>
 <script src="./src/main.js" type="module"></script>

--- a/cmd/hivegui/frontend/src/lib/minimized.js
+++ b/cmd/hivegui/frontend/src/lib/minimized.js
@@ -1,0 +1,7 @@
+// filterMinimized returns sessions whose id is NOT in minimizedSet.
+// Pure helper: extracted so the grid filter can be unit-tested without
+// the DOM. minimizedSet is any object with .has(id); usually a Set.
+export function filterMinimized(sessions, minimizedSet) {
+  if (!minimizedSet || typeof minimizedSet.has !== 'function') return sessions;
+  return sessions.filter((s) => !minimizedSet.has(s.id));
+}

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -18,6 +18,7 @@ import { isMac, cmdOrCtrl } from './lib/platform.js';
 import { computeGridDims, buildGridLayout, computeSpatialMove } from './lib/grid.js';
 import { DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE, clampFont } from './lib/font.js';
 import { normalizeView, VIEW_STORAGE_KEY } from './lib/view.js';
+import { filterMinimized } from './lib/minimized.js';
 import {
   decideFocusAction, ACTION_CLEAR, ACTION_PRESERVE, ACTION_FOCUS,
 } from './lib/focus.js';
@@ -70,7 +71,22 @@ class SessionTerm {
     // user can tell at a glance what each tile is currently doing.
     this.tileTermTitle = document.createElement('span');
     this.tileTermTitle.className = 'tile-term-title';
-    this.header.append(this.tileColor, this.tileName, this.tileWorktree, this.tileTermTitle, this.tileProject);
+    this.tileMinimize = document.createElement('button');
+    this.tileMinimize.className = 'tile-minimize';
+    this.tileMinimize.type = 'button';
+    this.tileMinimize.title = 'Minimize (hide from grid)';
+    this.tileMinimize.setAttribute('aria-label', 'Minimize session');
+    this.tileMinimize.textContent = '–';
+    this.tileMinimize.addEventListener('mousedown', (e) => {
+      // Block the surrounding tile mousedown so minimizing doesn't
+      // also select / switch to this tile.
+      e.stopPropagation();
+    });
+    this.tileMinimize.addEventListener('click', (e) => {
+      e.stopPropagation();
+      minimizeSession(this.info.id);
+    });
+    this.header.append(this.tileColor, this.tileName, this.tileWorktree, this.tileTermTitle, this.tileProject, this.tileMinimize);
 
     this.body = document.createElement('div');
     this.body.className = 'term-body';
@@ -656,6 +672,7 @@ const state = {
   sessions: [],             // SessionInfo[] in display order
   collapsed: new Set(),     // project ids that are collapsed
   attention: new Set(),     // session ids that have unread bells
+  minimized: new Set(),     // session ids hidden from grid views; restored via tray
   aliveById: new Map(),     // session id -> last-seen Alive bool (for transition detection)
   dismissedDead: new Set(), // session ids whose dead overlay user dismissed
   terms: new Map(),         // session id -> SessionTerm
@@ -1598,14 +1615,93 @@ function shiftActiveProject(delta) {
 // gridScopeSessions returns the list of sessions that should be tiled
 // in the current grid view.
 function gridScopeSessions() {
-  if (state.view === 'grid-all') return orderedSessions();
+  if (state.view === 'grid-all') {
+    return filterMinimized(orderedSessions(), state.minimized);
+  }
   if (state.view === 'grid-project') {
     const pid = state.gridProjectId || activeProjectId();
-    return state.sessions
+    const scoped = state.sessions
       .filter((s) => (s.projectId ?? s.project_id) === pid)
       .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    return filterMinimized(scoped, state.minimized);
   }
   return [];
+}
+
+// minimizeSession hides a session from grid views by adding its id to
+// state.minimized. The session stays alive; its tile is removed on the
+// next renderGrid(). Single-session mode is unaffected — the user can
+// still switch to a minimized session via the sidebar / palette / ⌘[/].
+function minimizeSession(id) {
+  if (!id || state.minimized.has(id)) return;
+  state.minimized.add(id);
+  // If the active session is the one being minimized while in grid
+  // mode, hand focus to the next still-visible session so the focus
+  // ring doesn't vanish onto an offscreen tile.
+  if (state.activeId === id && state.view !== 'single') {
+    const next = gridScopeSessions().find((s) => s.id !== id);
+    if (next) setActive(next.id);
+  }
+  if (state.view !== 'single') renderGrid();
+  renderMinimizedTray();
+}
+
+// restoreSession removes a session from state.minimized and switches
+// to it. Works from any view — switchTo handles the view-aware repaint.
+function restoreSession(id) {
+  if (!id) return;
+  state.minimized.delete(id);
+  renderMinimizedTray();
+  switchTo(id);
+}
+
+// renderMinimizedTray rebuilds the #minimized-tray chip row from
+// state.minimized. Hidden when the set is empty.
+function renderMinimizedTray() {
+  const tray = document.getElementById('minimized-tray');
+  if (!tray) return;
+  tray.innerHTML = '';
+  const ids = Array.from(state.minimized);
+  if (ids.length === 0) {
+    tray.classList.add('hidden');
+    return;
+  }
+  tray.classList.remove('hidden');
+  // Preserve display order so the chip row reads top-to-bottom like
+  // the sidebar / grid would.
+  const ord = orderedSessions().filter((s) => state.minimized.has(s.id));
+  for (const info of ord) {
+    const chip = document.createElement('button');
+    chip.className = 'min-chip';
+    chip.type = 'button';
+    chip.dataset.sid = info.id;
+    chip.title = `Restore ${info.name}`;
+    chip.style.setProperty('--session-color', info.color || '#888');
+
+    const dot = document.createElement('span');
+    dot.className = 'min-chip-color';
+    chip.append(dot);
+
+    const name = document.createElement('span');
+    name.className = 'min-chip-name';
+    name.textContent = info.name;
+    chip.append(name);
+
+    const pid = info.projectId ?? info.project_id;
+    const proj = state.projects.find((p) => p.id === pid);
+    if (proj?.name) {
+      const projLabel = document.createElement('span');
+      projLabel.className = 'min-chip-project';
+      projLabel.textContent = proj.name;
+      chip.append(projLabel);
+    }
+
+    chip.addEventListener('click', (e) => {
+      e.stopPropagation();
+      restoreSession(info.id);
+    });
+    tray.append(chip);
+  }
 }
 
 function setView(view) {
@@ -1699,7 +1795,14 @@ EventsOn('session:list', (jsonStr) => {
   const { sessions } = JSON.parse(jsonStr);
   state.sessions = sessions || [];
   for (const s of state.sessions) processAliveTransition(s);
+  // Drop any minimized ids whose sessions no longer exist (e.g. after
+  // a daemon restart or list reset) so the tray doesn't leak stale chips.
+  const liveIds = new Set(state.sessions.map((s) => s.id));
+  for (const id of Array.from(state.minimized)) {
+    if (!liveIds.has(id)) state.minimized.delete(id);
+  }
   renderSidebar();
+  renderMinimizedTray();
   if (!state.activeId && state.sessions.length > 0) {
     switchTo(orderedSessions()[0].id);
   }
@@ -1720,6 +1823,7 @@ EventsOn('session:event', (jsonStr) => {
   if (ev.kind === 'removed') {
     state.aliveById.delete(ev.session.id);
     state.dismissedDead.delete(ev.session.id);
+    state.minimized.delete(ev.session.id);
     let nextId = null;
     if (state.activeId === ev.session.id) {
       const ord = orderedSessions();
@@ -1770,6 +1874,7 @@ EventsOn('session:event', (jsonStr) => {
     if (state.activeId === ev.session.id) updateAppTitle();
   }
   renderSidebar();
+  if (ev.kind === 'removed' || ev.kind === 'updated') renderMinimizedTray();
 });
 
 EventsOn('pty:data', (id, b64) => {

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -46,14 +46,16 @@ html, body {
   grid-template-columns: var(--sidebar-width, 200px) 1fr;
   /* Row 1 is the daemon-mismatch banner, row 2 is the update-available
      banner — both collapse to 0 when hidden. Row 3 is the normal
-     sidebar + terms layout. */
-  grid-template-rows: auto auto 1fr;
+     sidebar + terms layout. Row 4 is the minimized-sessions tray;
+     collapses to 0 when empty (display: none). */
+  grid-template-rows: auto auto 1fr auto;
   height: 100vh;
   transition: grid-template-columns 120ms ease;
 }
-#sidebar { grid-row: 3; grid-column: 1; }
-#sidebar-resizer { grid-row: 3; grid-column: 1; }
+#sidebar { grid-row: 3 / span 2; grid-column: 1; }
+#sidebar-resizer { grid-row: 3 / span 2; grid-column: 1; }
 #terms { grid-row: 3; grid-column: 2; }
+#minimized-tray { grid-row: 4; grid-column: 2; }
 #update-banner { grid-row: 2; grid-column: 1 / -1; }
 
 body.resizing-sidebar { cursor: col-resize; user-select: none; }
@@ -614,6 +616,79 @@ body.resizing-sidebar #app { transition: none; }
 .term-host .tile-project {
   margin-left: auto;
   color: rgba(255, 255, 255, 0.6);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.term-host .tile-minimize {
+  flex-shrink: 0;
+  margin-left: 6px;
+  width: 18px;
+  height: 16px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.65);
+  font: 12px Menlo, monospace;
+  line-height: 1;
+  cursor: pointer;
+}
+.term-host .tile-minimize:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #fff;
+}
+
+#minimized-tray {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  background: #0a0a0a;
+  border-top: 1px solid #1a1a1a;
+  min-height: 28px;
+  scrollbar-width: thin;
+}
+#minimized-tray.hidden { display: none; }
+#minimized-tray .min-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid color-mix(in srgb, var(--session-color, #888) 30%, #1a1a1a);
+  border-radius: 3px;
+  padding: 2px 8px;
+  color: #ddd;
+  font: 11px Menlo, monospace;
+  cursor: pointer;
+  max-width: 240px;
+}
+#minimized-tray .min-chip:hover {
+  background: color-mix(in srgb, var(--session-color, #888) 15%, #0a0a0a);
+  border-color: color-mix(in srgb, var(--session-color, #888) 55%, #1a1a1a);
+  color: #fff;
+}
+#minimized-tray .min-chip .min-chip-color {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--session-color, #888);
+  flex-shrink: 0;
+}
+#minimized-tray .min-chip .min-chip-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+#minimized-tray .min-chip .min-chip-project {
+  color: rgba(255, 255, 255, 0.55);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.04em;

--- a/cmd/hivegui/frontend/test/e2e/minimize.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/minimize.spec.js
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+
+// E2E coverage for the session-minimize feature (#202).
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function bootWithSessions(page, count = 2) {
+  await page.goto('/');
+  await page.waitForFunction(() => document.querySelectorAll('#projects li').length > 0);
+  for (let i = 1; i < count; i++) {
+    await page.evaluate((n) => window.__hive.addSession(n), `s${i + 1}`);
+  }
+  await page.waitForFunction((n) => window.__hive.state.sessions.length >= n, count);
+}
+
+async function enterGridAll(page) {
+  await page.keyboard.press(`${MOD}+Shift+g`);
+  await expect(page.locator('#terms')).toHaveClass(/grid/);
+}
+
+test.describe('session minimize', () => {
+  test('tray hidden when no sessions minimized', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await expect(page.locator('#minimized-tray')).toHaveClass(/hidden/);
+  });
+
+  test('minimize hides tile from grid-all view and reveals tray chip', async ({ page }) => {
+    await bootWithSessions(page, 3);
+    await enterGridAll(page);
+
+    // Three tiles visible in grid.
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(3);
+
+    // Click the minimize button on the first tile.
+    const firstTile = page.locator('.term-host.in-grid').first();
+    const sid = await firstTile.evaluate((el) => el.dataset.sid);
+    await firstTile.locator('.tile-minimize').click();
+
+    // The tile is removed from the grid.
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(2);
+    // And appears in the tray.
+    const tray = page.locator('#minimized-tray');
+    await expect(tray).not.toHaveClass(/hidden/);
+    await expect(tray.locator('.min-chip')).toHaveCount(1);
+    await expect(tray.locator(`.min-chip[data-sid="${sid}"]`)).toBeVisible();
+  });
+
+  test('restore from tray returns session to grid', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await enterGridAll(page);
+
+    const firstTile = page.locator('.term-host.in-grid').first();
+    const sid = await firstTile.evaluate((el) => el.dataset.sid);
+    await firstTile.locator('.tile-minimize').click();
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(1);
+
+    await page.locator(`#minimized-tray .min-chip[data-sid="${sid}"]`).click();
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(2);
+    await expect(page.locator('#minimized-tray')).toHaveClass(/hidden/);
+  });
+
+  test('minimizing the active session moves focus to another visible tile', async ({ page }) => {
+    await bootWithSessions(page, 3);
+    await enterGridAll(page);
+    // Make the first tile active.
+    const tiles = page.locator('.term-host.in-grid');
+    const firstSid = await tiles.first().evaluate((el) => el.dataset.sid);
+    await tiles.first().click();
+    await page.waitForFunction((id) => window.__hive && document.querySelector(`.term-host.active[data-sid="${id}"]`),
+      firstSid);
+
+    // Minimize the active tile.
+    await tiles.first().locator('.tile-minimize').click();
+
+    // Active session should no longer be the minimized one.
+    const activeId = await page.evaluate(() => {
+      const a = document.querySelector('.term-host.active');
+      return a ? a.dataset.sid : null;
+    });
+    expect(activeId).not.toBe(firstSid);
+    expect(activeId).not.toBeNull();
+  });
+
+  test('removing a minimized session clears it from the tray', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await enterGridAll(page);
+    const firstTile = page.locator('.term-host.in-grid').first();
+    const sid = await firstTile.evaluate((el) => el.dataset.sid);
+    await firstTile.locator('.tile-minimize').click();
+    await expect(page.locator(`#minimized-tray .min-chip[data-sid="${sid}"]`)).toBeVisible();
+
+    await page.evaluate((id) => window.__hive.killSession(id), sid);
+    await expect(page.locator(`#minimized-tray .min-chip[data-sid="${sid}"]`)).toHaveCount(0);
+    await expect(page.locator('#minimized-tray')).toHaveClass(/hidden/);
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/minimized.test.js
+++ b/cmd/hivegui/frontend/test/unit/minimized.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { filterMinimized } from '../../src/lib/minimized.js';
+
+describe('filterMinimized', () => {
+  const sessions = [
+    { id: 'a', name: 'one' },
+    { id: 'b', name: 'two' },
+    { id: 'c', name: 'three' },
+  ];
+
+  it('returns input unchanged when set is empty', () => {
+    expect(filterMinimized(sessions, new Set())).toEqual(sessions);
+  });
+
+  it('removes sessions whose id is in the set', () => {
+    const out = filterMinimized(sessions, new Set(['b']));
+    expect(out.map((s) => s.id)).toEqual(['a', 'c']);
+  });
+
+  it('preserves order of surviving sessions', () => {
+    const out = filterMinimized(sessions, new Set(['a']));
+    expect(out.map((s) => s.id)).toEqual(['b', 'c']);
+  });
+
+  it('returns empty array when all sessions are minimized', () => {
+    const out = filterMinimized(sessions, new Set(['a', 'b', 'c']));
+    expect(out).toEqual([]);
+  });
+
+  it('tolerates null/undefined set by returning input unchanged', () => {
+    expect(filterMinimized(sessions, null)).toEqual(sessions);
+    expect(filterMinimized(sessions, undefined)).toEqual(sessions);
+  });
+});

--- a/docs/exec-plans/active/202-minimize-session-from-grid.md
+++ b/docs/exec-plans/active/202-minimize-session-from-grid.md
@@ -144,6 +144,12 @@ Per AGENTS.md: both unit and functional coverage.
 - **2026-05-15** — Plan approved. Stage: PLAN → IMPLEMENT.
 - **2026-05-15** — Implementation complete. New `lib/minimized.js` + 5 unit tests; tile minimize button; `#minimized-tray` chip row; `state.minimized` Set with cleanup on session removal and on `session:list` rebroadcast; CHANGELOG entry. All 71 Vitest tests + 12 Playwright tests pass.
 
+## PR convergence ledger
+
+<!-- Append-only. One line per /hs-review-loop iteration. -->
+
+- **2026-05-15 iter 1** — verdict: APPROVE; findings_hash: empty; threads_open: 0; action: stop; head_sha: e1d4a41.
+
 ## Open questions
 
 - Should the tray be horizontally scrollable when there are many minimized sessions, or wrap to a second row? Defer to PLAN.

--- a/docs/exec-plans/active/202-minimize-session-from-grid.md
+++ b/docs/exec-plans/active/202-minimize-session-from-grid.md
@@ -1,0 +1,149 @@
+# GUI: minimize sessions to remove from grid view; restore from a tray
+
+- **Spec:** [docs/product-specs/202-minimize-session-from-grid.md](../../product-specs/202-minimize-session-from-grid.md)
+- **Issue:** #202
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Add a frontend-only "minimize" state to sessions so users can hide a tile from the grid without killing the session. Minimized sessions still appear in the sidebar and are reachable in single-session mode. They surface in a small tray strip at the bottom of the terminals area, with click-to-restore. State is held in memory in the Wails renderer; cross-launch persistence is out of scope for v1.
+
+## Research
+
+### Frontend code surface (Wails renderer)
+
+All changes land in `cmd/hivegui/frontend/`. There is no backend / wire change — minimize is a renderer-local UI concept.
+
+- **Grid filter** — `cmd/hivegui/frontend/src/main.js:1600` `gridScopeSessions()` returns the list of sessions to tile. Two view modes:
+  - `grid-all` → `orderedSessions()` (every session, line 1601)
+  - `grid-project` → `state.sessions.filter(projectId === pid)` (lines 1602–1607)
+  - Adding a `!minimized` predicate to both branches removes minimized tiles from the grid.
+- **Grid render** — `renderGrid()` at `main.js:1325`. Iterates `gridScopeSessions()`, adds `.in-grid` class to in-scope hosts, removes it from everything else. Already handles "session present but not in grid" correctly (line 1346), so the filter change suffices for hiding.
+- **Tile DOM** — built once in `SessionTerm` constructor at `main.js:42–78`. Header (`.tile-header`) currently holds: color dot, name span, worktree glyph, term-title, project. Will add a minimize button at the right end of the header.
+- **Tile click → switch** — `main.js:277–293`. `mousedown` on a tile calls `setActive(id)` then re-renders. The minimize button needs `stopPropagation` so clicking it doesn't switch-then-minimize.
+- **Single-mode switching** — `main.js:1240` `switchTo(id)` works for any session id; it calls `ensureTerm()` which lazily creates terms. **Minimized sessions are still reachable** via the sidebar, the command palette (`main.js:2024` `switchTo`), and `⌘[/]` cycling (`main.js:1559–1567`) without any special-casing. No change needed there.
+- **View state** — `state.view` in `main.js:666` is `'single' | 'grid-project' | 'grid-all'`. We don't add a new view; minimize is orthogonal.
+- **Persistence** — `loadSavedView()` (`main.js:671`) shows the pattern for `localStorage`-backed state. v1 spec says minimize state does **not** persist across app launches, so we keep it in `state` only.
+
+### Where the tray goes
+
+- `index.html:64–65` —
+  ```
+  <main id="terms"></main>
+  <div id="status">connecting…</div>
+  ```
+- Add a `<div id="minimized-tray" class="hidden">` between `#terms` and `#status`. It only renders when `state.minimized.size > 0`.
+- Tray rows display: color dot, name, project label (mirrors tile header), restore button. Clicking a tray row restores AND switches to that session.
+
+### Session model
+
+- Frontend session shape (`main.js:654–669`): `state.sessions` is an array of `SessionInfo` wire objects (from `internal/wire/control.go:78`). We do **not** add a field to the wire struct. Instead, track minimized IDs in a renderer-local `Set`:
+  ```js
+  state.minimized = new Set();  // session IDs hidden from grid
+  ```
+- All hide/show logic reads `state.minimized.has(id)`. New session events default to "not minimized" (the Set never auto-populates). Session deletion (`session:remove` event) must `state.minimized.delete(id)` to avoid leaks.
+
+### Existing event hooks
+
+- `EventsOn('session:remove', ...)` and friends live around `main.js:1700–1770`. Look for the existing session-removed handler and add the `state.minimized.delete(id)` cleanup there.
+- `gridSpatialMove` (`main.js:2534–2538`) navigates the spatial grid; since it iterates `gridLayout.sessions` which comes from `gridScopeSessions()`, minimized tiles are naturally skipped.
+
+### Sidebar
+
+- The sidebar (`#sidebar`, drawn by code starting around `main.js:893`) lists every session. Spec says minimized sessions remain reachable, so the sidebar lists them unchanged. A small "minimized" indicator next to the name (e.g. dimmed style) is a nice-to-have but not required for v1.
+
+### Tests
+
+- `cmd/hivegui/frontend/test/` — Vitest unit tests + Playwright. `lib/grid.js` already has unit tests (`buildGridLayout`). The minimize filter on `gridScopeSessions` is pure → add a unit test there. A Playwright flow test covers click-to-minimize / click-to-restore golden path.
+
+### Constraints / Dependencies
+
+- No backend changes — no `internal/wire/`, `internal/worktree/`, or `cmd/hived/` work.
+- xterm terminals for minimized sessions stay attached in the DOM (`state.terms` keeps them) but are hidden because `.in-grid` is absent and `#terms` is in `grid` mode. Memory cost is identical to single-mode behaviour today.
+- ResizeObserver fires per-tile when grid layout changes (`main.js:107`). Minimizing a tile triggers a re-layout; remaining tiles' `fit.fit()` runs automatically — no extra refit needed.
+
+## Approach
+
+Renderer-local "minimize" — a per-session boolean held in `state.minimized: Set<string>`. The grid filter excludes minimized sessions, a small button on each tile header sets the flag, and a chip-row tray under the terminals lists minimized sessions with a click-to-restore action. No wire change, no `localStorage` persistence (v1).
+
+Chosen over the obvious alternative of adding a `minimized` field on `SessionInfo` (and a wire roundtrip): the spec explicitly scopes persistence as out-of-scope for v1, and minimize is a viewing concern not a session-lifecycle concern. Keeping it in the renderer means zero protocol churn and no migration cost if we later decide minimize should not persist at all.
+
+**Tray behaviour (resolving open questions):**
+- **Chip row** (horizontal), not a collapsible bar. Compact, one-row, matches the visual weight of the status bar above which it sits.
+- **Horizontal scroll** when overflow occurs (`overflow-x: auto`), no wrap. Wrapping would push the terminals area up unpredictably; scrolling keeps layout stable.
+- **`⌘[/]` cycles all sessions** (current behaviour), not just visible ones. Minimize is a "get this out of my grid for now" affordance; users still expect keyboard cycling to reach everything. This matches how single-mode already works.
+
+### Files to change
+
+1. `cmd/hivegui/frontend/src/main.js`
+   - **`state` init (~line 666)** — add `minimized: new Set()` field.
+   - **`SessionTerm` constructor (~line 42–78)** — append a `.tile-minimize` button to `.tile-header`. Click handler calls a new `minimizeSession(id)` and `stopPropagation()`s so the surrounding tile-mousedown handler at line 277 doesn't run.
+   - **`gridScopeSessions()` (line 1600)** — add `.filter((s) => !state.minimized.has(s.id))` to both `grid-all` and `grid-project` return paths.
+   - **New `minimizeSession(id)`** — `state.minimized.add(id)`; if `state.activeId === id`, pick the next visible session in `orderedSessions()` and `setActive()` it (so the focus indicator doesn't vanish); call `renderGrid()` and `renderMinimizedTray()`. If in single mode, do nothing visual — the tile isn't rendered as a grid tile anyway, but we still flip the flag so it disappears from the grid on next switch.
+   - **New `restoreSession(id)`** — `state.minimized.delete(id)`; `switchTo(id)` (works in both views); `renderMinimizedTray()`.
+   - **New `renderMinimizedTray()`** — toggle `.hidden` on `#minimized-tray`; rebuild its children as chip elements. Each chip = `<button class="min-chip">` with color dot, name, project label, dataset.sid. Single click = `restoreSession(sid)`.
+   - **Session removed handler (around `main.js:1700–1770`)** — `state.minimized.delete(ev.session.id)` and call `renderMinimizedTray()` on the session-removed event so leaks don't accumulate.
+   - **`setView()` (line 1611)** — call `renderMinimizedTray()` so the tray shows/hides correctly when toggling between grid and single. (Tray should still show in single mode — sessions are minimized from the grid, not from the app.)
+   - Initial call: `renderMinimizedTray()` after the first session list load (alongside the existing initial `renderGrid()` / `showSingle()`).
+
+2. `cmd/hivegui/frontend/index.html`
+   - Insert `<div id="minimized-tray" class="hidden" aria-label="Minimized sessions"></div>` between `<main id="terms">` (line 64) and `<div id="status">` (line 65).
+
+3. `cmd/hivegui/frontend/src/style.css`
+   - `.tile-minimize` — small icon button at right end of tile-header (visually like the existing dead-session close button — see `main.js:325` `.deadCloseBtn` for the pattern). Show a minus / em-dash glyph. Hover affordance only; no need for default visibility tweaks since `.tile-header` is already grid-mode-only.
+   - `#minimized-tray` — flex row, `overflow-x: auto`, fixed height (~28px), background matches `#status`, gap between chips. `.hidden { display: none; }` is presumably already defined globally.
+   - `.min-chip` — small pill button: color dot, name, project label, close-ish layout consistent with existing tile-header chrome.
+
+4. `CHANGELOG.md`
+   - Add to `## [Unreleased] / ### Added`: "Minimize sessions to hide them from the grid view; restore from a tray below the terminals." (Run `/hs-changelog-update` during IMPLEMENT.)
+
+5. `docs/features.md` (if minimize meets the "user-visible feature" bar per AGENTS.md doc maintenance — it does)
+   - Add a short paragraph describing the minimize/restore behaviour.
+
+### New files
+
+None. Tray DOM and styles fold into existing files. No new module in `lib/`.
+
+### Tests
+
+Per AGENTS.md: both unit and functional coverage.
+
+**Unit (Vitest, `cmd/hivegui/frontend/test/`)** — extract the filter as a tiny pure helper so it can be tested without the DOM:
+- New `cmd/hivegui/frontend/src/lib/minimized.js` exporting `filterMinimized(sessions, minimizedSet)`. (Tiny exception to "no new files" — pure logic belongs in `lib/` per the pattern of `lib/grid.js`.) `gridScopeSessions()` calls it.
+- New `cmd/hivegui/frontend/test/minimized.test.js`:
+  - `filterMinimized — returns input unchanged when set is empty`
+  - `filterMinimized — removes sessions whose id is in the set`
+  - `filterMinimized — empty set keeps order stable`
+  - `filterMinimized — minimizing all sessions returns empty array`
+
+**Functional (Playwright, `cmd/hivegui/frontend/test/`)** — extend the existing Playwright suite (look for a grid-view spec; if none, create `minimize.spec.js`):
+- `minimize hides tile from grid-all view`
+- `minimize hides tile from grid-project view`
+- `restore from tray returns session to grid and switches to it`
+- `minimized session is still focusable in single mode via sidebar`
+- `tray is empty / hidden when no sessions are minimized`
+- `removing a minimized session also clears it from the tray`
+
+### Risks / edge cases
+
+- **Active session being minimized.** If the active session gets minimized in grid mode, focus moves to the next visible session via `setActive()`. If every session is minimized, the grid renders empty — handled because `renderGrid()` already tolerates `n === 0`. Status bar should still update.
+- **`⌘[/]` cycling in grid mode.** Cycling lands on a minimized session → `setActive` highlights it but no tile shows. Mitigation: leave cycling all-inclusive (matches single mode), since cycling-to-minimized is no worse than cycling-to-different-project in `grid-project` mode today.
+- **Sidebar click on minimized session.** Already covered by `switchTo` — in grid mode, the session won't appear in the grid; in single mode it shows normally. No special-case needed but document in CHANGELOG so the behaviour isn't surprising.
+- **Session removal race.** If a session is removed while minimized, the `session:remove` cleanup must run before `renderMinimizedTray` reads stale entries — order matters in that handler.
+
+## Decision log
+
+- **2026-05-15** — Minimize is renderer-local (no wire change). Why: cross-launch persistence is out of scope for v1 per spec; backend doesn't need to know about UI visibility state.
+
+## Progress
+
+- **2026-05-15** — Spec, exec plan, and research drafted. Stage: RESEARCH.
+- **2026-05-15** — Plan approved. Stage: PLAN → IMPLEMENT.
+- **2026-05-15** — Implementation complete. New `lib/minimized.js` + 5 unit tests; tile minimize button; `#minimized-tray` chip row; `state.minimized` Set with cleanup on session removal and on `session:list` rebroadcast; CHANGELOG entry. All 71 Vitest tests + 12 Playwright tests pass.
+
+## Open questions
+
+- Should the tray be horizontally scrollable when there are many minimized sessions, or wrap to a second row? Defer to PLAN.
+- Visual treatment of the tray: chip row vs. a single collapsible bar? Lean toward chip row (compact, one row, scrolls). Defer to PLAN.
+- Should `⌘[/]` cycling include or skip minimized sessions in grid mode? Current `cycleSession` uses `orderedSessions()` (all sessions); in grid mode users may want it to follow the visible set. Defer to PLAN.

--- a/docs/exec-plans/active/202-minimize-session-from-grid.md
+++ b/docs/exec-plans/active/202-minimize-session-from-grid.md
@@ -2,7 +2,9 @@
 
 - **Spec:** [docs/product-specs/202-minimize-session-from-grid.md](../../product-specs/202-minimize-session-from-grid.md)
 - **Issue:** #202
-- **Stage:** IMPLEMENT
+- **PR:** #204
+- **Branch:** `feature/202-minimize-session`
+- **Stage:** REVIEW
 - **Status:** active
 
 ## Summary

--- a/docs/product-specs/202-minimize-session-from-grid.md
+++ b/docs/product-specs/202-minimize-session-from-grid.md
@@ -1,0 +1,32 @@
+# GUI: minimize sessions to remove from grid view; restore from a tray
+
+- **Issue:** #202
+- **Type:** enhancement
+- **Complexity:** M
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/202-minimize-session-from-grid.md](../exec-plans/active/202-minimize-session-from-grid.md)
+
+## Problem
+
+Users currently can't temporarily hide a session from the grid view without killing it. When many sessions are running, the grid (project view and all-sessions view) gets noisy and important sessions get crowded out.
+
+## Desired behavior
+
+Users can **minimize** a session: it stays alive (process keeps running, output keeps buffering) but is removed from the grid layout. Minimized sessions live in a lightweight UI affordance (tray / chip row) from which the user can **restore** them back to the grid. Switching to a minimized session in single-session mode still works — minimize is a grid-visibility concern only.
+
+## Success criteria
+
+- A per-tile control minimizes a session from both the project grid and the all-sessions grid.
+- A visible tray/affordance shows minimized sessions (name, project, status) and restores them on click.
+- Single-session mode can still focus a minimized session (via switcher or click-through).
+- Minimized state persists across grid ↔ single transitions within an app run.
+
+## Non-goals
+
+- Killing / archiving sessions.
+- Persisting minimized state across app restarts (decide during triage).
+- Keyboard shortcut for minimize (v1).
+
+## Notes
+
+GitHub issue: https://github.com/lucascaro/hive/issues/202

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -13,7 +13,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 | P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | REVIEW | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
 | P1 | #195 | GUI: shared TextDecoder across sessions produces garbled glyphs | IMPLEMENT | [195-shared-textdecoder-glyphs](195-shared-textdecoder-glyphs.md) |
-| P2 | #202 | GUI: minimize sessions to remove from grid view; restore from a tray | IMPLEMENT | [202-minimize-session-from-grid](202-minimize-session-from-grid.md) |
+| P2 | #202 | GUI: minimize sessions to remove from grid view; restore from a tray | REVIEW | [202-minimize-session-from-grid](202-minimize-session-from-grid.md) |
 
 ## Completed
 

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -13,6 +13,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | — | #142 | vt snapshot: CJK / wide-char column misalignment | TRIAGE | [142-vt-snapshot-cjk-wide-char-column-misalignment](142-vt-snapshot-cjk-wide-char-column-misalignment.md) |
 | P1 | #190 | GUI: session terminal text gets replaced by garbled glyphs over time; resize fixes it | REVIEW | [190-gui-text-replaced-with-garbled-glyphs](190-gui-text-replaced-with-garbled-glyphs.md) |
 | P1 | #195 | GUI: shared TextDecoder across sessions produces garbled glyphs | IMPLEMENT | [195-shared-textdecoder-glyphs](195-shared-textdecoder-glyphs.md) |
+| P2 | #202 | GUI: minimize sessions to remove from grid view; restore from a tray | IMPLEMENT | [202-minimize-session-from-grid](202-minimize-session-from-grid.md) |
 
 ## Completed
 


### PR DESCRIPTION
## Summary

Adds a per-tile **minimize** button that removes a session from grid views (both project-grid and all-sessions-grid) without killing it. Minimized sessions appear as chips in a new tray below the terminals; clicking a chip restores the session to the grid and switches to it.

### Design

- **Renderer-local state** — `state.minimized: Set<string>` in `cmd/hivegui/frontend/src/main.js`. No wire change. No `localStorage` persistence in v1 (per spec).
- **Minimize affordance** — `–` button at the right of each `.tile-header`, with `stopPropagation` so it doesn't trip the tile-mousedown handler.
- **Tray** — new `<div id="minimized-tray">` between `<main id="terms">` and `<div id="status">`, occupying a new row in the `#app` grid. Horizontal `overflow-x: auto` (chip row scrolls, doesn't wrap). Hidden when the set is empty.
- **Filter** — `gridScopeSessions()` runs the result through a new pure helper `filterMinimized()` (lives in `lib/minimized.js`, mirrors how `lib/grid.js` is structured for unit testing).
- **Active-session handoff** — if the active session is minimized while in grid mode, focus moves to the next visible session via `setActive()`.
- **Single-session mode unchanged** — `switchTo(id)` already works for any session id, so minimized sessions remain reachable from sidebar / command palette / `⌘[/]` cycling without special-casing.
- **Cleanup** — `state.minimized.delete(id)` on the `session:event` removed branch and on every `session:list` rebroadcast (drops ids whose sessions no longer exist).

### Open questions resolved

- Chip row vs collapsible bar → chip row (compact, single line).
- Overflow wrap vs scroll → scroll (keeps terminals area height stable).
- `⌘[/]` includes minimized vs only visible → includes all (matches single-mode behaviour; minimize is a viewing concern, not a "remove from app" concern).

## Test plan

- [x] Vitest unit: 5 new tests on `filterMinimized` (empty set, removal, order preserved, all-minimized, null tolerance)
- [x] Playwright e2e: 5 new tests — tray hidden when empty, minimize removes tile + reveals chip, restore returns to grid, active-tile handoff on minimize, removed session clears tray
- [x] All 71 Vitest + 12 Playwright tests pass
- [x] `go test ./internal/...` passes (backend untouched but verified)
- [ ] Manual: click minimize button on a tile in grid-all; verify chip appears; click chip; verify tile returns
- [ ] Manual: minimize the active tile in grid mode; verify focus jumps to next visible tile
- [ ] Manual: switch to a minimized session via sidebar in single mode; verify it shows normally

## Spec & plan

- Spec: `docs/product-specs/202-minimize-session-from-grid.md`
- Exec plan: `docs/exec-plans/active/202-minimize-session-from-grid.md`

Fixes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)