### PR TITLE
style(daemon): gofmt internal/daemon/daemon.go (#206)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -525,4 +525,3 @@ func (f *frameSink) Close() error { return f.conn.Close() }
 func bootstrapWanted(opts session.Options) bool {
 	return opts.Shell != "" || opts.Cols != 0 || opts.Rows != 0 || len(opts.Env) > 0
 }
-


### PR DESCRIPTION
Closes #206. Single trailing newline removed by `gofmt -w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)