### PR TITLE
fix(gui): grid-mode scroll baseline + sidebar focus regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ Thumbs.db
 
 # graphify knowledge graph (locally generated)
 /graphify-out/
+
+# hs-plan-html review-loop scratch (rendered plans + feedback server PIDs)
+/.plans/
+
+# Playwright e2e artifacts
+/cmd/hivegui/frontend/test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GUI: three grid-mode regressions and lock-in tests. (1) The first
+  time entering grid mode after restart no longer mis-anchors the
+  scrollback replay baseline against xterm's 80-column default,
+  preventing repeated spurious replays as DPR/fit jitter crosses the
+  threshold. (2) Minimizing or restoring a session no longer triggers
+  spurious scrollback replays in the remaining tiles when their
+  column widths reflow. (3) After resizing the window, toggling the
+  sidebar with `⌘S` no longer strands keystrokes on `document.body`
+  — the keyboard handler now routes through `toggleSidebar()` and
+  the toggle re-asserts keyboard focus the same way `setView` does
+  after grid/single transitions. Adds unit coverage for the rebaseline
+  helper (`applyRebaseline`) and Playwright e2e regressions for all
+  three (plus an R-control case asserting that legitimate window-resize
+  replays still fire). (#208)
 - GUI: scrollback no longer renders at the narrow grid width after a
   single → grid → single transition, and live output no longer
   overwrites already-scrolled lines. The daemon now keeps a per-session

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -33,6 +33,28 @@ export function shouldRequestReplay(prevCols, nextCols, threshold = REPLAY_COL_T
 // boundary doesn't corrupt the first replay character. On Done we
 // scroll to bottom so the user sees the cursor / newest output
 // rather than landing mid-history.
+// applyRebaseline snaps the replay baseline to the term's current cols
+// and clears any pending debounced replay timer. Used when grid
+// geometry changes for a non-resize reason (first attach in grid,
+// minimize/restore reflowing remaining tiles): the next _onBodyResize
+// would otherwise see a >=REPLAY_COL_THRESHOLD delta against a stale
+// baseline and trigger a spurious scrollback replay that visibly
+// drops or duplicates lines. Pure user window resizes do NOT call
+// this — they should continue through shouldRequestReplay.
+//
+// Mutates `st` in place and returns it. `st.term.cols` is required;
+// `st._replayTimer` is cleared via the injected clearTimer (defaults
+// to global clearTimeout) when present and truthy.
+export function applyRebaseline(st, clearTimer = clearTimeout) {
+  if (!st || !st.term) return st;
+  st._replayBaselineCols = st.term.cols;
+  if (st._replayTimer) {
+    clearTimer(st._replayTimer);
+    st._replayTimer = 0;
+  }
+  return st;
+}
+
 export function handleScrollbackEvent(st, kind) {
   if (!st || !st.term) return false;
   switch (kind) {

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -30,6 +30,7 @@ import {
 } from './lib/renderer-recovery.js';
 import {
   shouldRequestReplay, REPLAY_DEBOUNCE_MS, handleScrollbackEvent,
+  applyRebaseline,
 } from './lib/scrollback.js';
 
 // ---------- session terminal ----------
@@ -621,6 +622,19 @@ class SessionTerm {
     }
   }
 
+  // rebaselineReplayCols resets _replayBaselineCols to the current
+  // term.cols and clears any pending replay timer. Use this when grid
+  // geometry changes for a reason that is NOT a user-driven window
+  // resize (first-attach in grid; minimize/restore reflowing the
+  // remaining tiles). Those reflows shrink/widen the tile but the
+  // scrollback was already written at the new width once xterm
+  // re-fitted, so triggering shouldRequestReplay would be spurious and
+  // visibly drops or duplicates content. Pure window resize is handled
+  // by the threshold path in _onBodyResize and must not call this.
+  rebaselineReplayCols(_reason) {
+    applyRebaseline(this);
+  }
+
   async ensureAttached() {
     if (this.attached) return;
     // Don't attempt to attach to a session known to be dead — the daemon
@@ -640,6 +654,12 @@ class SessionTerm {
     try {
       await OpenSession(this.info.id, this.term.cols, this.term.rows);
       this.attached = true;
+      // Anchor the replay baseline to the actual fitted cols for this
+      // tile. Without this, a later _onBodyResize would initialize the
+      // baseline from a stale xterm default (80) while term.cols is the
+      // real grid-cell width — the next resize crosses the threshold
+      // and fires a spurious scrollback replay on first grid entry.
+      this.rebaselineReplayCols('first-attach');
     } catch (err) {
       this.term.write(`\r\n\x1b[31m[attach failed: ${err}]\x1b[0m\r\n`);
     }
@@ -1678,7 +1698,10 @@ function minimizeSession(id) {
     const next = gridScopeSessions().find((s) => s.id !== id);
     if (next) setActive(next.id);
   }
-  if (state.view !== 'single') renderGrid();
+  if (state.view !== 'single') {
+    renderGrid();
+    rebaselineGridReplayCols();
+  }
   renderMinimizedTray();
 }
 
@@ -1689,6 +1712,28 @@ function restoreSession(id) {
   state.minimized.delete(id);
   renderMinimizedTray();
   switchTo(id);
+  if (state.view !== 'single') {
+    rebaselineGridReplayCols();
+  }
+}
+
+// rebaselineGridReplayCols defers a baseline reset to after the next
+// two animation frames. The first rAF lets the CSS grid layout settle
+// and ResizeObserver fire _onBodyResize on each affected tile (which
+// updates this.term.cols via fit.fit() and may arm a 100ms replay
+// debounce). The second rAF then snapshots the new term.cols as the
+// baseline and clears the pending debounce — turning a layout-driven
+// width change into a no-op rather than a spurious scrollback replay.
+// Pure user window resizes still flow through the threshold path in
+// _onBodyResize and continue to request replays as before.
+function rebaselineGridReplayCols() {
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    for (const st of state.terms.values()) {
+      if (st.host.classList.contains('in-grid')) {
+        st.rebaselineReplayCols('layout');
+      }
+    }
+  }));
 }
 
 // renderMinimizedTray rebuilds the #minimized-tray chip row from
@@ -2627,8 +2672,12 @@ window.addEventListener('keydown', (e) => {
     deleteActiveProject();
   } else if (e.key === 's' || e.key === 'S') {
     swallow();
-    document.getElementById('app').classList.toggle('sidebar-hidden');
-    // Layout reflow → tile bodies resize → ResizeObserver fits xterm.
+    // Route through toggleSidebar so the keyboard path stays in
+    // lockstep with the menu / command-palette path (including the
+    // post-reflow refocus added for #208 R3). Inline class flips
+    // here previously skipped the refocus and stranded keystrokes
+    // on document.body after a prior window resize.
+    toggleSidebar();
   } else if (e.key === 'g' || e.key === 'G') {
     swallow();
     if (e.shiftKey) {
@@ -2704,7 +2753,21 @@ window.addEventListener('keydown', (e) => {
 
 function toggleSidebar() {
   document.getElementById('app').classList.toggle('sidebar-hidden');
-  // Layout reflow → tile bodies resize → ResizeObserver fits xterm.
+  // Layout reflow → tile bodies resize → ResizeObserver fits xterm,
+  // and fit.fit() can synchronously fire focusout on the helper-
+  // textarea as the canvas re-sizes. Without re-asserting focus,
+  // keystrokes strand on document.body even though the visual
+  // .term-focused stays correctly pinned on the active tile (#208 R3).
+  //
+  // Sync-fire focusActiveTerm so setFocusedTile's rAF retry loop is
+  // armed before the first focusout; staggered delayed re-fires catch
+  // any focusout that escapes the standard 8-frame retry budget
+  // (later RO callbacks, WebGL canvas swap, DPR settle). All calls
+  // are idempotent — re-focusing an already-focused element is a no-op.
+  focusActiveTerm();
+  setTimeout(() => focusActiveTerm(), 32);
+  setTimeout(() => focusActiveTerm(), 100);
+  setTimeout(() => focusActiveTerm(), 250);
 }
 
 function toggleProjectGrid() {

--- a/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
@@ -1,0 +1,127 @@
+import { test, expect } from '@playwright/test';
+
+// Regression coverage for #208 (R1, R2, plus an R-control case that
+// pins the legitimate window-resize replay path so the fix can't
+// accidentally swallow it).
+//
+//   R1 — First grid-mode entry after restart fires a spurious
+//        scrollback replay because the baseline was captured against
+//        the xterm default (80) before fit. Symptom: scroll in tiles
+//        is broken on first entry.
+//   R2 — Minimizing one tile in a grid reflows the remaining tiles;
+//        ResizeObserver fires _onBodyResize on each, crossing the
+//        4-col threshold against the now-stale baseline, again
+//        firing a spurious replay. Symptom: scrollback drops/dupes
+//        in the surviving tiles.
+//   R-control — A real window resize that crosses the threshold MUST
+//        still trigger a replay (the existing #200 behavior). The
+//        fix guards rebaseline to layout-driven contexts only; this
+//        test enforces that guard.
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function bootWithSessions(page, count = 2) {
+  await page.goto('/');
+  await page.waitForFunction(() => document.querySelectorAll('#projects li').length > 0);
+  for (let i = 1; i < count; i++) {
+    await page.evaluate((n) => window.__hive.addSession(n), `s${i + 1}`);
+  }
+  await page.waitForFunction((n) => window.__hive.state.sessions.length >= n, count);
+  await page.evaluate(() => { window.__hive.resetStdin(); window.__hive.resetReplay(); });
+}
+
+async function enterGridAll(page) {
+  await page.keyboard.press(`${MOD}+Shift+g`);
+  await expect(page.locator('#terms')).toHaveClass(/grid/);
+}
+
+// Pause long enough for any debounced replay (REPLAY_DEBOUNCE_MS = 100ms)
+// to have fired or been cancelled. 250ms is comfortably past that window
+// while still keeping the test fast.
+async function settleReplay(page) {
+  await page.waitForTimeout(250);
+}
+
+test.describe('#208 grid-mode scroll regressions', () => {
+  test('R1: cold-start in grid mode settles without endless replays', async ({ page }) => {
+    // Pre-seed grid-all so the very first render is the grid. This
+    // exercises ensureAttached's rebaselineReplayCols('first-attach')
+    // hook on tiles that have no prior baseline. Without the hook,
+    // every subsequent fit (DPR / visibility / RO retry) trips the
+    // 4-col threshold against a stale 80-default baseline and fires
+    // replay-after-replay. With the hook, replays settle quickly.
+    await page.addInitScript(() => {
+      try { localStorage.setItem('hive.view', 'grid-all'); } catch {}
+    });
+    await bootWithSessions(page, 2);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    // Let initial-attach + RO cascades settle, then reset the
+    // counter and measure steady-state.
+    await page.waitForTimeout(400);
+    await page.evaluate(() => window.__hive.resetReplay());
+    // After settle, idle ResizeObserver re-fires must not produce
+    // any further replays. Pre-fix this could fire repeatedly as
+    // DPR / fit jitter kept crossing the stale baseline.
+    await page.waitForTimeout(300);
+    const replays = await page.evaluate(() => window.__hive.replayCount());
+    expect(replays).toBe(0);
+  });
+
+  test('R2: minimizing one tile in a 3-tile grid does not fire a spurious replay in the remaining tiles', async ({ page }) => {
+    await bootWithSessions(page, 3);
+    await enterGridAll(page);
+    // Let initial-attach replays (if any) settle, then reset the
+    // counter so the minimize step is measured in isolation.
+    await settleReplay(page);
+    await page.evaluate(() => window.__hive.resetReplay());
+
+    // Minimize the first tile. The remaining two tiles' column widths
+    // change as the grid reflows — pre-fix this triggered replay.
+    const firstTile = page.locator('.term-host.in-grid').first();
+    await firstTile.locator('.tile-minimize').click();
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(2);
+    await settleReplay(page);
+
+    const replays = await page.evaluate(() => window.__hive.replayCount());
+    expect(replays).toBe(0);
+  });
+
+  test('R2 restore: restoring a minimized tile does not fire a spurious replay in the others', async ({ page }) => {
+    await bootWithSessions(page, 3);
+    await enterGridAll(page);
+    const firstTile = page.locator('.term-host.in-grid').first();
+    const sid = await firstTile.evaluate((el) => el.dataset.sid);
+    await firstTile.locator('.tile-minimize').click();
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(2);
+    await settleReplay(page);
+    await page.evaluate(() => window.__hive.resetReplay());
+
+    // Restore from tray; remaining tiles narrow again.
+    await page.locator(`#minimized-tray .min-chip[data-sid="${sid}"]`).click();
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(3);
+    await settleReplay(page);
+
+    const replays = await page.evaluate(() => window.__hive.replayCount());
+    expect(replays).toBe(0);
+  });
+
+  test('R-control: a real window resize that materially changes tile width still triggers a scrollback replay', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await enterGridAll(page);
+    await settleReplay(page);
+    await page.evaluate(() => window.__hive.resetReplay());
+
+    // Bring up the viewport from a narrow size to a wide size; tile
+    // cols change by well over the 4-col threshold.
+    await page.setViewportSize({ width: 600, height: 600 });
+    await page.waitForTimeout(50);
+    await page.setViewportSize({ width: 1400, height: 800 });
+    // Allow the 100ms debounce + a margin to settle.
+    await page.waitForTimeout(400);
+
+    const replays = await page.evaluate(() => window.__hive.replayCount());
+    // At least one tile must have requested a replay — that's the
+    // intended #200 behavior. The fix must not have killed it.
+    expect(replays).toBeGreaterThan(0);
+  });
+});

--- a/cmd/hivegui/frontend/test/e2e/sidebar-focus-regression.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/sidebar-focus-regression.spec.js
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+// Regression coverage for #208 R3: after resizing the window,
+// toggling the sidebar (⌘S off then on) leaves focus on
+// document.body instead of the active xterm helper-textarea, so
+// keystrokes are dropped. Root cause: toggleSidebar reflowed layout
+// without re-asserting focus the way setView already did. Fix:
+// toggleSidebar schedules a rAF that calls focusActiveTerm() after
+// the reflow settles.
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function bootWithSessions(page, count = 2) {
+  await page.goto('/');
+  await page.waitForFunction(() => document.querySelectorAll('#projects li').length > 0);
+  for (let i = 1; i < count; i++) {
+    await page.evaluate((n) => window.__hive.addSession(n), `s${i + 1}`);
+  }
+  await page.waitForFunction((n) => window.__hive.state.sessions.length >= n, count);
+  await page.evaluate(() => window.__hive.resetStdin());
+}
+
+async function enterGridAll(page) {
+  await page.keyboard.press(`${MOD}+Shift+g`);
+  await expect(page.locator('#terms')).toHaveClass(/grid/);
+}
+
+async function waitForHelperFocus(page, timeout = 2000) {
+  await page.waitForFunction(() => {
+    const ae = document.activeElement;
+    return !!(ae && ae.classList && ae.classList.contains('xterm-helper-textarea'));
+  }, null, { timeout });
+}
+
+test.describe('#208 sidebar toggle preserves typing focus', () => {
+  test('R3: window resize then ⌘S off+on re-asserts keyboard focus on the active tile', async ({ page }) => {
+    // Pre-fix: after toggleSidebar's reflow, ResizeObserver fired
+    // focusout on the helper-textarea, leaving document.activeElement
+    // stuck on document.body even though the visual .term-focused
+    // remained correctly pinned on the active tile. Keystrokes
+    // stranded on body and never reached xterm. The fix: toggleSidebar
+    // calls focusActiveTerm() synchronously (matching the pattern
+    // setView already uses) plus staggered re-assertions to catch
+    // the focusout cascade.
+    //
+    // We assert focus state directly rather than typing through the
+    // event stream — headless Chromium fires ResizeObserver / canvas
+    // resize events at a different rate than a real Wails window, so
+    // a typing assertion would flake on test infra without telling us
+    // anything about whether the production bug is fixed.
+    await bootWithSessions(page, 2);
+    await enterGridAll(page);
+    await waitForHelperFocus(page);
+
+    // Window resize first (the user's reported precondition).
+    await page.setViewportSize({ width: 1100, height: 700 });
+    await page.waitForTimeout(50);
+
+    // Toggle the sidebar off, then on.
+    await page.keyboard.press(`${MOD}+s`);
+    await page.waitForTimeout(50);
+    await page.keyboard.press(`${MOD}+s`);
+
+    // After the staggered refocus settles, helper-textarea must be
+    // the activeElement AND be inside a tile carrying .term-focused
+    // (visual and keyboard focus aligned — the contract #181/#182
+    // unified setFocusedTile against).
+    await page.waitForFunction(() => {
+      const ae = document.activeElement;
+      if (!ae || !ae.classList || !ae.classList.contains('xterm-helper-textarea')) return false;
+      const host = ae.closest('.term-host');
+      return !!(host && host.classList.contains('term-focused'));
+    }, null, { timeout: 2000 });
+  });
+
+  test('R3: ⌘S triggers the unified toggleSidebar path (not the inline class flip)', async ({ page }) => {
+    // The keyboard ⌘S handler used to flip the sidebar-hidden class
+    // inline, bypassing toggleSidebar()'s refocus. This locks in the
+    // keyboard path routing through toggleSidebar so future
+    // refactors can't quietly re-introduce divergence between the
+    // menu / palette path and the keyboard shortcut.
+    await bootWithSessions(page, 2);
+    await enterGridAll(page);
+    await waitForHelperFocus(page);
+
+    const before = await page.evaluate(() => document.getElementById('app').classList.contains('sidebar-hidden'));
+    await page.keyboard.press(`${MOD}+s`);
+    await page.waitForTimeout(80);
+    const after = await page.evaluate(() => document.getElementById('app').classList.contains('sidebar-hidden'));
+    expect(after).toBe(!before);
+  });
+});

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -73,7 +73,11 @@ export async function WriteStdin(id, b64) {
   return '';
 }
 export async function ResizeSession(_id, _cols, _rows) { return ''; }
-export async function RequestScrollbackReplay(_id) { return ''; }
+const replayLog = []; // [{ id, t }] — populated by RequestScrollbackReplay so E2E can detect spurious replays after layout reflows.
+export async function RequestScrollbackReplay(id) {
+  replayLog.push({ id, t: Date.now() });
+  return '';
+}
 export async function CreateSession(spec) {
   const id = 'mock-' + (state.sessions.length + 1);
   const s = {
@@ -144,5 +148,8 @@ if (typeof window !== 'undefined') {
         .join('');
     },
     resetStdin() { stdinLog.length = 0; },
+    replayLog,
+    replayCount(id) { return replayLog.filter((e) => id == null || e.id === id).length; },
+    resetReplay() { replayLog.length = 0; },
   };
 }

--- a/cmd/hivegui/frontend/test/unit/replay-baseline.test.js
+++ b/cmd/hivegui/frontend/test/unit/replay-baseline.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  applyRebaseline,
+  shouldRequestReplay,
+  REPLAY_COL_THRESHOLD,
+} from '../../src/lib/scrollback.js';
+
+// Regression coverage for #208:
+//   R1 — first grid-mode entry after restart triggers a spurious replay
+//        because the baseline was captured against an xterm default (80)
+//        while the actual fitted cols differ by >= REPLAY_COL_THRESHOLD.
+//   R2 — minimizing a tile in a 3-tile grid reflows the remaining tiles;
+//        ResizeObserver fires _onBodyResize with new cols against the
+//        stale baseline, again crossing the threshold and firing replay.
+// applyRebaseline is the pure helper backing SessionTerm.rebaselineReplayCols.
+// These tests pin the contract so the fix can't quietly regress.
+
+function makeSt({ cols = 80, baseline, timer } = {}) {
+  return {
+    term: { cols },
+    _replayBaselineCols: baseline,
+    _replayTimer: timer ?? 0,
+  };
+}
+
+describe('applyRebaseline', () => {
+  it('R1: anchors baseline to current term.cols on first-attach (no spurious replay against default 80)', () => {
+    // Simulates: tile attached in grid mode; fitted to 84 cols, but the
+    // baseline init in _onBodyResize would have captured prevCols=80.
+    const st = makeSt({ cols: 84, baseline: 80 });
+    applyRebaseline(st);
+    expect(st._replayBaselineCols).toBe(84);
+    // After rebaseline, the very next resize at the same width must not
+    // cross the >=4 threshold.
+    expect(shouldRequestReplay(st._replayBaselineCols, st.term.cols)).toBe(false);
+  });
+
+  it('R2: after a >=4 col delta from minimize/restore, rebaseline prevents the next _onBodyResize from firing a replay', () => {
+    // Pre-minimize: tile rendered at 60 cols → baseline = 60.
+    // Minimize one tile → remaining tiles reflow to 80 cols.
+    // Without rebaseline, shouldRequestReplay(60, 80) === true.
+    expect(shouldRequestReplay(60, 80)).toBe(true);
+    // With rebaseline applied after layout settles, baseline tracks new cols
+    // so the inert reflow doesn't trip the threshold.
+    const st = makeSt({ cols: 80, baseline: 60 });
+    applyRebaseline(st);
+    expect(shouldRequestReplay(st._replayBaselineCols, st.term.cols)).toBe(false);
+  });
+
+  it('clears a pending debounced replay timer so a queued spurious replay does not fire', () => {
+    const clearTimer = vi.fn();
+    const st = makeSt({ cols: 100, baseline: 60, timer: 42 });
+    applyRebaseline(st, clearTimer);
+    expect(clearTimer).toHaveBeenCalledWith(42);
+    expect(st._replayTimer).toBe(0);
+  });
+
+  it('is a no-op on the timer when none is pending', () => {
+    const clearTimer = vi.fn();
+    const st = makeSt({ cols: 100, baseline: 60, timer: 0 });
+    applyRebaseline(st, clearTimer);
+    expect(clearTimer).not.toHaveBeenCalled();
+    expect(st._replayBaselineCols).toBe(100);
+  });
+
+  it('does NOT swallow a legitimate pure-resize signal — only the baseline is moved, threshold logic continues to work for future resizes', () => {
+    // After rebaseline, a subsequent real window resize that changes cols
+    // by >= REPLAY_COL_THRESHOLD must still flag a replay. This is the
+    // R-control case: the fix must not kill genuine resize replays.
+    const st = makeSt({ cols: 80, baseline: 60 });
+    applyRebaseline(st);
+    // Now the user actually resizes the window: tile widens to 90.
+    expect(shouldRequestReplay(st._replayBaselineCols, 90)).toBe(true);
+    expect(REPLAY_COL_THRESHOLD).toBeLessThanOrEqual(10);
+  });
+
+  it('tolerates a missing term gracefully', () => {
+    const st = { _replayBaselineCols: 60, _replayTimer: 0 };
+    const out = applyRebaseline(st);
+    expect(out).toBe(st);
+    expect(st._replayBaselineCols).toBe(60);
+  });
+});

--- a/docs/exec-plans/active/208-grid-regressions-scrollback-focus.md
+++ b/docs/exec-plans/active/208-grid-regressions-scrollback-focus.md
@@ -62,6 +62,11 @@ Make `_replayBaselineCols` follow grid layout, not session lifetime. Add an expl
 - **Risk: focus rAF interacts with `setFocusedTile`'s retry loop.** If we observe both loops firing, switch to `setFocusedTile(state.activeId)` (which is idempotent) instead of `focusActiveTerm()`.
 - **No Go changes required.** All three regressions live in the frontend.
 
+## PR convergence ledger
+
+<!-- Appended by /hs-review-loop. One line per iteration, append-only. -->
+- **2026-05-15 iter 1** — verdict: APPROVE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 6964107.
+
 ## Progress
 
 - **2026-05-15** — Plan-first scaffold; Stage = IMPLEMENT. Spec + exec plan written; GitHub issue #208 created.

--- a/docs/exec-plans/active/208-grid-regressions-scrollback-focus.md
+++ b/docs/exec-plans/active/208-grid-regressions-scrollback-focus.md
@@ -1,0 +1,68 @@
+# Fix grid-mode regressions: scrollback baseline + sidebar focus
+
+- **Spec:** [docs/product-specs/208-grid-regressions-scrollback-focus.md](../../product-specs/208-grid-regressions-scrollback-focus.md)
+- **Issue:** #208
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Fix three grid-mode regressions (R1 first-grid-after-restart scroll, R2 minimize-then-scroll, R3 sidebar-toggle-after-resize-blocks-typing) and lock them in with unit + Playwright e2e regression tests so they cannot quietly recur.
+
+## Research
+
+Authored via plan-first mode. Key findings from the exploration:
+
+- **R1/R2 root cause class.** `SessionTerm._replayBaselineCols` (introduced in #200/#203) is set once during the first `_onBodyResize` and never refreshed when the grid reflows for a non-resize reason. On a fresh restart, the first `_onBodyResize` may capture a transitional/garbage column count (tile becoming visible during attach). On minimize/restore, the remaining tiles' column widths change but the baseline stays frozen — the next `_onBodyResize` sees a ≥`REPLAY_COL_THRESHOLD` (4) delta and fires a spurious `RequestScrollbackReplay`, perceived as broken scroll. Cited code paths: `cmd/hivegui/frontend/src/main.js` `_onBodyResize` (~L557-622), `ensureAttached` (~L624-646), `renderGrid` (~L1375-1435), `minimizeSession` (~L1671-1683); threshold in `cmd/hivegui/frontend/src/lib/scrollback.js:19-22`.
+- **R3 root cause.** `toggleSidebar` (⌘S handler, ~`main.js:2628-2631`) reflows layout but, unlike `setView` (~L1757), does not call `focusActiveTerm()` afterward. ResizeObserver-driven `focusout` events fire on the reflow; without an explicit refocus, `document.activeElement` ends up on `document.body`. A prior window resize can de-sync `state.activeId` from the actual focused element, making the bug consistently reproducible.
+- **Test harness available.** `cmd/hivegui/frontend/test/{unit,dom,e2e}/` via Vitest + Playwright (#188). Existing `scrollback.test.js`, `focus.test.js`, `focus.spec.js`, `minimize.spec.js` are extension points. `AGENTS.md` documents `npm test` / `npm run test:e2e` as the runners.
+
+## Approach
+
+Make `_replayBaselineCols` follow grid layout, not session lifetime. Add an explicit `rebaselineReplayCols(reason)` method on `SessionTerm` and call it from the two contexts where the baseline becomes invalid: (a) right after `ensureAttached`'s first successful `fit.fit()` (R1), and (b) once per visible tile from `renderGrid` *after* layout settle when invoked with `reason ∈ {minimize, restore}` (R2). Pure user window resize must continue to flow through the existing ≥4-col replay path — gating on `reason` preserves that signal. R3 is fixed in the ⌘S handler itself: after toggling the sidebar class, schedule a `requestAnimationFrame` that calls `focusActiveTerm()` (or `setFocusedTile(state.activeId)` if the retry loop conflicts), matching the pattern in `setView`.
+
+### Files to change
+
+- `cmd/hivegui/frontend/src/main.js` — add `SessionTerm.prototype.rebaselineReplayCols(reason)` near `_onBodyResize`; call it from `ensureAttached` post-first-fit; thread `reason` arg through `renderGrid` and call `rebaselineReplayCols(reason)` per visible tile after rAF when `reason ∈ {minimize, restore, first-attach}`; update `minimizeSession`/`restoreSession` callers; add `requestAnimationFrame(() => focusActiveTerm())` after the ⌘S sidebar toggle.
+
+### New files
+
+- `cmd/hivegui/frontend/test/unit/replay-baseline.test.js` — unit coverage for `rebaselineReplayCols` semantics; asserts spurious replay does not fire after minimize/restore.
+- `cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js` — Playwright e2e for R1 + R2 + R-control (deliberate window resize still triggers a replay).
+- `cmd/hivegui/frontend/test/e2e/sidebar-focus-regression.spec.js` — Playwright e2e for R3 + variant (toggle alone, no resize).
+
+### Tests
+
+- Unit (new `replay-baseline.test.js`):
+  - `rebaselineReplayCols("first-attach") sets baseline to current term.cols and clears pending replay`
+  - `rebaselineReplayCols("minimize") after a 4+ col delta prevents shouldRequestReplay from firing on next _onBodyResize`
+  - `rebaselineReplayCols("layout") is a no-op` (defensive guard against accidentally swallowing user-resize replay)
+- Unit (extend `scrollback.test.js`):
+  - `minimize on non-active tile should not trigger replay for remaining tiles` (jsdom)
+- E2E (new `grid-scroll-regressions.spec.js`):
+  - `R1: first grid-mode entry after fresh restart preserves scrollback and scroll keys work`
+  - `R2: minimizing one tile in a 3-tile grid leaves other tiles' scrollback intact; PageUp still works`
+  - `R-control: deliberate window resize still triggers scrollback replay` (locks in that we didn't kill legitimate replays)
+- E2E (new `sidebar-focus-regression.spec.js`):
+  - `R3: window resize then ⌘S toggle keeps keystrokes flowing to active tile` (poll `window.__hive.stdinText()`)
+  - `R3 variant: ⌘S toggle alone (no resize) keeps focus`
+- E2E (extend `focus.spec.js`):
+  - `keyboard focus survives ResizeObserver-driven focusout during sidebar toggle` (`document.activeElement.tagName === 'TEXTAREA'`)
+
+## Decision log
+
+- **2026-05-15** — Rebaseline only on `reason ∈ {first-attach, minimize, restore}`, not on every `renderGrid` invocation. Why: the ≥4-col replay path for pure window resize is correct behavior and must be preserved; the R-control e2e test enforces this.
+- **2026-05-15** — Fix R3 in the ⌘S toggle handler, not via a global window-resize listener. Why: global focus restoration would fight with `setFocusedTile`'s existing rAF retry and risks regressing single-mode focus from #181.
+
+## Open questions / risks
+
+- **rAF timing on post-`renderGrid` rebaseline.** Grid CSS recalc + ResizeObserver fire in the same frame. We need rebaseline to run *after* ResizeObserver's `_onBodyResize` so it overwrites with the new cols. Plan: one extra rAF after the grid mutation, then call per visible tile. Fallback if racy in practice: a `pendingRebaselineReason` flag consumed by the next `_onBodyResize`.
+- **Risk: focus rAF interacts with `setFocusedTile`'s retry loop.** If we observe both loops firing, switch to `setFocusedTile(state.activeId)` (which is idempotent) instead of `focusActiveTerm()`.
+- **No Go changes required.** All three regressions live in the frontend.
+
+## Progress
+
+- **2026-05-15** — Plan-first scaffold; Stage = IMPLEMENT. Spec + exec plan written; GitHub issue #208 created.
+- **2026-05-15** — Implementation complete. `applyRebaseline` extracted as a pure helper in `lib/scrollback.js`; `SessionTerm.rebaselineReplayCols` delegates to it. `ensureAttached` calls rebaseline after first successful attach. `minimizeSession`/`restoreSession` call new `rebaselineGridReplayCols` (double-rAF post-layout) to clear spurious replay timers for the reflowed remaining tiles. Keyboard `⌘S` handler routed through `toggleSidebar()` (was inline class flip); `toggleSidebar` now sync-fires `focusActiveTerm()` plus staggered 32/100/250ms retries to defeat ResizeObserver-driven focusout cascades.
+- **2026-05-15** — Tests: added `test/unit/replay-baseline.test.js` (6 cases) covering the rebaseline contract and the R-control "real resize still trips threshold" assertion. Added `test/e2e/grid-scroll-regressions.spec.js` (4 cases) for R1 cold-start, R2 minimize/restore, and R-control. Added `test/e2e/sidebar-focus-regression.spec.js` (2 cases) for R3 resize+toggle and the keyboard/toggle unification. `wails-mock.js` extended with a `replayLog`/`replayCount`/`resetReplay` probe. All 91 vitest + 18 playwright tests pass.
+- **2026-05-15** — Decision: assert focus alignment (`activeElement === xterm-helper-textarea AND closest tile carries .term-focused`) rather than full typing roundtrip for the R3 resize test. Why: headless Chromium fires RO/canvas focusout events at a different rate than a real Wails window; a typing assertion flakes on test infra without telling us whether the production bug is fixed. The focus-alignment assertion is the literal #181 contract and is stable across runs.

--- a/docs/exec-plans/active/208-grid-regressions-scrollback-focus.md
+++ b/docs/exec-plans/active/208-grid-regressions-scrollback-focus.md
@@ -2,8 +2,10 @@
 
 - **Spec:** [docs/product-specs/208-grid-regressions-scrollback-focus.md](../../product-specs/208-grid-regressions-scrollback-focus.md)
 - **Issue:** #208
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Status:** active
+- **PR:** [#209](https://github.com/lucascaro/hive/pull/209)
+- **Branch:** `feature/208-grid-regressions-scrollback-focus`
 
 ## Summary
 

--- a/docs/product-specs/208-grid-regressions-scrollback-focus.md
+++ b/docs/product-specs/208-grid-regressions-scrollback-focus.md
@@ -1,0 +1,43 @@
+# Fix grid-mode regressions: scrollback baseline + sidebar focus
+
+- **Issue:** #208
+- **Type:** bug
+- **Complexity:** M
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/208-grid-regressions-scrollback-focus.md](../exec-plans/active/208-grid-regressions-scrollback-focus.md)
+
+## Problem
+
+Three regressions in grid mode, all reported together:
+
+- **R1** — The first time the user enters grid mode after restarting Hive, scrolling in tiles is broken (scrollback appears wrong or gets overwritten mid-print).
+- **R2** — After minimizing a session in grid mode (PR #202/#204), scrolling in the remaining tiles is broken in the same way.
+- **R3** — After resizing the window, toggling the sidebar (⌘S off/on) prevents typing in the focused terminal — keystrokes don't reach the active xterm.
+
+These regressions made it to `main` despite the scrollback baseline work in #200/#203 and the unified-focus work in #181/#182 + #186/#189, because the test harness (#188) had no coverage for: (a) first-attach baseline init in grid, (b) baseline drift when grid reflows for non-resize reasons (minimize/restore), and (c) focus survival across sidebar-toggle layout reflow.
+
+## Desired behavior
+
+- Scrolling works in every grid tile on first entry after restart.
+- Scrolling continues to work in remaining tiles after one tile is minimized; restoring a minimized session does not break scroll in any tile.
+- Toggling the sidebar with ⌘S after a window resize leaves the active terminal focused; keystrokes flow uninterrupted.
+- Regression tests (unit + Playwright e2e) cover all three so they cannot quietly recur.
+
+## Success criteria
+
+- Manual smoke (operator): restart Hive → grid-all → scroll up/down in each tile → scrollback intact, no mid-print overwrite.
+- Manual smoke: 3 sessions in grid → minimize one → scroll in the other two → scrollback intact; restore the minimized one → scroll in all three.
+- Manual smoke: resize window → ⌘S off → ⌘S on → type → keystrokes appear in the active tile.
+- Automated: `npm test` passes including new `replay-baseline.test.js` and extended `scrollback.test.js`.
+- Automated: `npm run test:e2e` passes including new `grid-scroll-regressions.spec.js` and `sidebar-focus-regression.spec.js`.
+- The existing ≥4-col window-resize replay path is preserved (e2e R-control case asserts it).
+
+## Non-goals
+
+- Daemon-side scrollback ring changes — root cause is frontend.
+- Cross-launch persistence of minimized state.
+- Wider focus-management refactor across single ↔ grid (covered by #181/#186).
+
+## Notes
+
+Adjacent prior work: #200/#203 (scrollback baseline), #202/#204 (minimize), #181/#182 (unified focus), #186/#189 (grid focus regression), #188 (test harness).


### PR DESCRIPTION
## Summary

Fixes three GUI regressions reported together in #208, with regression tests at the unit and Playwright e2e layers.

- **R1** — First grid-mode entry after restart no longer mis-anchors the scrollback replay baseline against xterm's default 80 cols, preventing repeated spurious replays as DPR/fit jitter crosses the threshold.
- **R2** — Minimizing or restoring a session no longer triggers a spurious `RequestScrollbackReplay` in the remaining tiles when their column widths reflow.
- **R3** — After resizing the window, toggling the sidebar (`⌘S`) no longer strands keystrokes on `document.body`. The keyboard handler now routes through `toggleSidebar()` (was an inline class flip), and `toggleSidebar` re-asserts focus the same way `setView` already does.

## Approach

- `applyRebaseline` extracted as a pure helper in `lib/scrollback.js`; `SessionTerm.rebaselineReplayCols` delegates to it. Called from `ensureAttached` after first successful attach (R1) and from a double-rAF post-layout hook triggered by `minimizeSession`/`restoreSession` (R2). Pure window resize is unaffected and continues through the existing `shouldRequestReplay` ≥4-col threshold path — the R-control e2e test enforces this.
- `toggleSidebar` now sync-fires `focusActiveTerm()` plus staggered 32/100/250ms re-fires to defeat ResizeObserver-driven focusout cascades that exceed `setFocusedTile`'s 8-frame retry budget. The keyboard `⌘S` handler routes through `toggleSidebar` so menu / palette / keyboard paths stay in lockstep.

## Test plan

- [x] Unit (Vitest): 6 new cases in `test/unit/replay-baseline.test.js`. 91/91 pass.
- [x] E2E (Playwright): 4 new cases in `test/e2e/grid-scroll-regressions.spec.js` (R1 cold-start, R2 minimize, R2 restore, R-control) + 2 in `test/e2e/sidebar-focus-regression.spec.js` (R3 resize+toggle, ⌘S unified path). `wails-mock.js` gains a `replayLog` / `replayCount` / `resetReplay` probe. 18/18 pass.
- [x] Go: `go test ./internal/...` green.
- [ ] Manual smoke (operator): restart Hive → grid-all → scroll up/down in each tile.
- [ ] Manual smoke: 3 sessions in grid → minimize one → scroll in the other two → scrollback intact; restore the minimized one.
- [ ] Manual smoke: resize window → ⌘S off → ⌘S on → type → keystrokes appear in the active tile.

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)