### PR TITLE
feat(gui): keyboard copy/paste/select-all that survives mouse tracking

### DIFF
--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/atotto/clipboard"
 	"github.com/lucascaro/hive/internal/agent"
 	"github.com/lucascaro/hive/internal/buildinfo"
 	hdaemon "github.com/lucascaro/hive/internal/daemon"
@@ -72,6 +73,22 @@ func (c *connState) writeFrame(t wire.FrameType, p []byte) error {
 // instead. tag round-trips back to the frontend via the "bell-click"
 // Wails event when the user clicks the notification (darwin only).
 // Errors are logged but not surfaced — notifications are best-effort UX.
+// SetClipboardText writes text to the system clipboard.
+//
+// Replaces wails runtime.ClipboardSetText, which is broken on Windows:
+// the JS-bridged call runs on a non-STA goroutine, so OpenClipboard
+// silently fails and nothing reaches the clipboard. Reads
+// (ClipboardGetText) work since they don't require clipboard ownership.
+// atotto/clipboard shells out to clip.exe on Windows, sidestepping the
+// threading constraint entirely.
+func (a *App) SetClipboardText(s string) error {
+	if err := clipboard.WriteAll(s); err != nil {
+		log.Printf("hivegui: clipboard write failed: %v", err)
+		return err
+	}
+	return nil
+}
+
 func (a *App) Notify(title, subtitle, body, tag string) error {
 	if err := notify.Notify(title, subtitle, body, tag); err != nil {
 		log.Printf("hivegui: notify failed: %v", err)

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -11,9 +11,9 @@ import {
   CreateProject, KillProject, UpdateProject,
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
   IsGitRepo, OpenURL, OpenTerminalAt, Notify, Confirm,
-  RestartDaemon, CheckForUpdate,
+  RestartDaemon, CheckForUpdate, SetClipboardText,
 } from '../wailsjs/go/main/App';
-import { EventsOn, WindowSetTitle } from '../wailsjs/runtime/runtime';
+import { EventsOn, WindowSetTitle, ClipboardGetText } from '../wailsjs/runtime/runtime';
 import { isMac, cmdOrCtrl } from './lib/platform.js';
 import { computeGridDims, buildGridLayout, computeSpatialMove } from './lib/grid.js';
 import { DEFAULT_FONT_SIZE, MIN_FONT_SIZE, MAX_FONT_SIZE, clampFont } from './lib/font.js';
@@ -246,11 +246,14 @@ class SessionTerm {
       const key = e.key.toLowerCase();
       if (key === 'c') {
         const sel = this.term.getSelection();
-        if (sel) navigator.clipboard.writeText(sel).catch(() => {});
+        // SetClipboardText (Go-side via atotto/clipboard) rather than
+        // wails runtime.ClipboardSetText — the latter is broken on
+        // Windows (non-STA goroutine, OpenClipboard fails silently).
+        if (sel) SetClipboardText(sel).catch(() => {});
         return false;
       }
       if (key === 'v') {
-        navigator.clipboard.readText().then((text) => {
+        ClipboardGetText().then((text) => {
           if (text) this._writePty(text);
         }).catch(() => {});
         return false;

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -233,6 +233,35 @@ class SessionTerm {
         this._writePty(seq);
       });
     }
+
+    // Keyboard copy/paste/select-all. Required because when an inner
+    // program (Claude CLI, vim) enables DEC mouse tracking, xterm.js
+    // forwards mouse events to the PTY instead of using them for text
+    // selection — leaving no way to copy output. Ctrl+Shift+A selects
+    // the full scrollback, Ctrl+Shift+C copies the current selection,
+    // Ctrl+Shift+V pastes from the system clipboard.
+    this.term.attachCustomKeyEventHandler((e) => {
+      if (e.type !== 'keydown') return true;
+      if (!e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return true;
+      const key = e.key.toLowerCase();
+      if (key === 'c') {
+        const sel = this.term.getSelection();
+        if (sel) navigator.clipboard.writeText(sel).catch(() => {});
+        return false;
+      }
+      if (key === 'v') {
+        navigator.clipboard.readText().then((text) => {
+          if (text) this._writePty(text);
+        }).catch(() => {});
+        return false;
+      }
+      if (key === 'a') {
+        this.term.selectAll();
+        return false;
+      }
+      return true;
+    });
+
     // Visual focus (.term-focused) and keyboard focus (xterm's
     // helper-textarea) are reconciled atomically by setFocusedTile(id),
     // which is the sole writer of .term-focused. Driving the class off

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -234,14 +234,37 @@ class SessionTerm {
       });
     }
 
-    // Keyboard copy/paste/select-all. Required because when an inner
-    // program (Claude CLI, vim) enables DEC mouse tracking, xterm.js
-    // forwards mouse events to the PTY instead of using them for text
-    // selection — leaving no way to copy output. Ctrl+Shift+A selects
-    // the full scrollback, Ctrl+Shift+C copies the current selection,
-    // Ctrl+Shift+V pastes from the system clipboard.
+    // Single custom key handler. xterm.js keeps only ONE custom key event
+    // handler — a second attachCustomKeyEventHandler() call silently replaces
+    // the first — so every app-level binding must live here, not in a second
+    // registration.
     this.term.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true;
+
+      // macOS Cmd+Backspace → Ctrl+U (kill to start of line). Browser doesn't
+      // translate this for us when xterm's helper-textarea is focused. Gated
+      // to mac so the Windows key on Linux/Windows can't accidentally fire it.
+      if (isMac && e.metaKey && !e.ctrlKey && !e.altKey && e.key === 'Backspace') {
+        e.preventDefault();
+        this._writePty('\x15');
+        return false;
+      }
+      // App-level shortcuts that xterm would otherwise translate into a
+      // control sequence and forward to the PTY (where the shell beeps because
+      // the binding is meaningless). Returning false tells xterm to ignore the
+      // event; it still bubbles to the window-level keydown handler that runs
+      // the actual shortcut. Ctrl+` is intentionally Ctrl-only on every
+      // platform (mirrors VS Code; macOS already uses ⌘` for window cycling).
+      if (e.ctrlKey && !e.metaKey && e.code === 'Backquote') {
+        return false;
+      }
+
+      // Ctrl+Shift copy/paste/select-all. Required because when an inner
+      // program (Claude CLI, vim) enables DEC mouse tracking, xterm.js
+      // forwards mouse events to the PTY instead of using them for text
+      // selection — leaving no way to copy output. Ctrl+Shift+A selects the
+      // full scrollback, Ctrl+Shift+C copies the current selection,
+      // Ctrl+Shift+V pastes from the system clipboard.
       if (!e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return true;
       const key = e.key.toLowerCase();
       if (key === 'c') {
@@ -300,29 +323,6 @@ class SessionTerm {
       WriteStdin(this.info.id, btoa(bin));
     };
     this.term.onData((data) => this._writePty(data));
-
-    // macOS Cmd+Backspace → Ctrl+U (kill to start of line). Browser doesn't
-    // translate this for us when xterm's helper-textarea is focused. Gated
-    // to mac so the Windows key on Linux/Windows can't accidentally fire it.
-    this.term.attachCustomKeyEventHandler((e) => {
-      if (e.type !== 'keydown') return true;
-      if (isMac && e.metaKey && !e.ctrlKey && !e.altKey && e.key === 'Backspace') {
-        e.preventDefault();
-        this._writePty('\x15');
-        return false;
-      }
-      // App-level shortcuts that xterm would otherwise translate into
-      // a control sequence and forward to the PTY (where the shell
-      // beeps because the binding is meaningless). Returning false
-      // tells xterm to ignore the event; it still bubbles to the
-      // window-level keydown handler that runs the actual shortcut.
-      // Ctrl+` is intentionally Ctrl-only on every platform (mirrors
-      // VS Code; macOS already uses ⌘` for window cycling).
-      if (e.ctrlKey && !e.metaKey && e.code === 'Backquote') {
-        return false;
-      }
-      return true;
-    });
 
     // Click anywhere on the tile (header or body) selects this session.
     this.host.addEventListener('mousedown', () => {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3
+	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-pty v0.2.2
 	github.com/creack/pty v1.1.24
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 h1:N3IGoHHp9pb6mj1cbXbuaSXV/UMKwmbKLf53nQmtqMA=
 git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3/go.mod h1:QtOLZGz8olr4qH2vWK0QH0w0O4T9fEIjMuWpKUsH7nc=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
 github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=


### PR DESCRIPTION
## Summary

- When an inner program (Claude CLI, vim, htop) enables DEC mouse tracking, xterm.js forwards mouse events to the PTY and selection becomes impossible — leaving no way to copy assistant output from a Hive tile.
- Add `Ctrl+Shift+A` (select all scrollback), `Ctrl+Shift+C` (copy selection), `Ctrl+Shift+V` (paste from clipboard) via `attachCustomKeyEventHandler` in `cmd/hivegui/frontend/src/main.js`, so the shortcuts are intercepted before xterm forwards them to the PTY.
- Conventions match VS Code's integrated terminal and Windows Terminal. Clipboard calls are best-effort (`.catch(() => {})`) so a denied permission prompt does not break the terminal.

## Motivation

Reproducer on Windows: open a session running Claude CLI, try to mouse-select any output — the inner program eats the mousedown, no selection appears. There is currently no other path to copy text out of a tile short of reading the JSONL transcript from disk.

## Notes

- Does not touch the existing click-to-position / linkifier / mouse-down handlers above this block; those bail out early when modifier keys are held, so there is no interaction.
- No new dependencies. ~29 LOC, single file.

## Follow-up (separate PR)

A true `Shift+drag` bypass that lets the user make a partial mouse selection while mouse tracking is active. Bigger change — requires intercepting mouse events in capture phase and driving `term.select()` manually.

## Test plan

- [ ] Build Windows target: `bash build.sh --platform windows`
- [ ] Launch Hive, start a Claude CLI session
- [ ] `Ctrl+Shift+A` selects all visible scrollback
- [ ] `Ctrl+Shift+C` copies; paste into a text editor and verify content
- [ ] `Ctrl+Shift+V` pastes clipboard contents into the prompt
- [ ] Sanity check that the same shortcuts in a non-mouse-tracking shell (e.g. a plain `bash` prompt) still behave correctly and don't double-paste