### PR TITLE
fix(daemon): surface swallowed failures across registry, worktree, bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Daemon diagnosability hardening: failures that were previously
+  swallowed are now logged. Registry metadata-persist failures (12
+  sites — session/project entries and order indexes) warn with the
+  operation that lost the write; dropping a slow session/project event
+  listener warns instead of silently desyncing the GUI (and the event
+  buffers grew 16→64 so a many-session reorder can't overflow a
+  healthy listener); pidfile cleanup failures are logged at shutdown.
+  Worktree creation failures now report every attempted strategy
+  (joined errors instead of last-attempt-only), and existing-branch
+  detection uses `git rev-parse` exit codes instead of matching git's
+  locale-dependent error text. The `hived-ws-bridge` test shim rejects
+  malformed JSON-RPC params instead of running handlers on zeroed
+  structs, and serializes concurrent frame writes per daemon
+  connection so racing writers can't corrupt the wire stream.
 - GUI: scrolling discipline on mode switch and resize. Switching
   display modes (focused / grid / grid-project) now always snaps
   every visible tile to the bottom — mode toggles are deliberate

--- a/cmd/hived-ws-bridge/main.go
+++ b/cmd/hived-ws-bridge/main.go
@@ -184,12 +184,13 @@ func (s *session) emit(name string, args ...any) {
 	_ = s.ws.WriteJSON(rpcResp{Event: name, Args: args})
 }
 
-// parseParams decodes a request's params into v. Absent params are
-// allowed and leave v at its zero value (the JS bridge always sends at
-// least {}); malformed params are an error so a handler never runs on
-// a silently zeroed struct.
+// parseParams decodes a request's params into v. Absent params — and
+// literal null, JSON-RPC's spelling of absent — are allowed and leave
+// v at its zero value (the JS bridge always sends at least {});
+// malformed params are an error so a handler never runs on a silently
+// zeroed struct.
 func parseParams(raw json.RawMessage, v any) error {
-	if len(raw) == 0 {
+	if len(raw) == 0 || string(raw) == "null" {
 		return nil
 	}
 	if err := json.Unmarshal(raw, v); err != nil {

--- a/cmd/hived-ws-bridge/main.go
+++ b/cmd/hived-ws-bridge/main.go
@@ -96,9 +96,35 @@ type session struct {
 	sockPath string
 
 	mu       sync.Mutex
-	control  net.Conn
-	attaches map[string]net.Conn // session id → attach conn
+	control  *lockedConn
+	attaches map[string]*lockedConn // session id → attach conn
 }
+
+// lockedConn serializes frame writes to one daemon connection.
+// wire.WriteFrame issues two Writes (header, then payload), so two
+// goroutines writing the same conn unserialized interleave mid-frame
+// and corrupt the stream. Reads stay lock-free: each conn has exactly
+// one reader goroutine, and socket reads never contend with writes.
+type lockedConn struct {
+	mu sync.Mutex
+	c  net.Conn
+}
+
+func (lc *lockedConn) writeFrame(t wire.FrameType, p []byte) error {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	return wire.WriteFrame(lc.c, t, p)
+}
+
+func (lc *lockedConn) writeJSON(t wire.FrameType, v any) error {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	return wire.WriteJSON(lc.c, t, v)
+}
+
+// Close is intentionally not guarded by lc.mu: net.Conn.Close is safe
+// concurrently with a blocked Write and must be able to unblock one.
+func (lc *lockedConn) Close() error { return lc.c.Close() }
 
 func serveWS(w http.ResponseWriter, r *http.Request, sockPath string) {
 	c, err := upgrader.Upgrade(w, r, nil)
@@ -107,7 +133,7 @@ func serveWS(w http.ResponseWriter, r *http.Request, sockPath string) {
 		return
 	}
 	defer c.Close()
-	s := &session{ws: c, sockPath: sockPath, attaches: make(map[string]net.Conn)}
+	s := &session{ws: c, sockPath: sockPath, attaches: make(map[string]*lockedConn)}
 	defer s.closeAll()
 	for {
 		_, raw, err := c.ReadMessage()
@@ -119,6 +145,11 @@ func serveWS(w http.ResponseWriter, r *http.Request, sockPath string) {
 			s.respond(0, nil, fmt.Errorf("parse: %w", err))
 			continue
 		}
+		// Goroutine-per-request, unbounded by design: the only client is
+		// the localhost Playwright runner, whose request rate is bounded
+		// by the test code itself. A semaphore here could deadlock the
+		// harness (a blocked ConnectControl holding a slot while the
+		// test pumps WriteStdin). dispatch recovers panics.
 		go s.dispatch(req)
 	}
 }
@@ -153,6 +184,20 @@ func (s *session) emit(name string, args ...any) {
 	_ = s.ws.WriteJSON(rpcResp{Event: name, Args: args})
 }
 
+// parseParams decodes a request's params into v. Absent params are
+// allowed and leave v at its zero value (the JS bridge always sends at
+// least {}); malformed params are an error so a handler never runs on
+// a silently zeroed struct.
+func parseParams(raw json.RawMessage, v any) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(raw, v); err != nil {
+		return fmt.Errorf("invalid params: %w", err)
+	}
+	return nil
+}
+
 func (s *session) dispatch(req rpcReq) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -164,11 +209,17 @@ func (s *session) dispatch(req rpcReq) {
 		s.respond(req.ID, "", s.connectControl())
 	case "CreateSession":
 		var p wire.CreateSpec
-		_ = json.Unmarshal(req.Params, &p)
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
 		s.respond(req.ID, "", s.controlWriteJSON(wire.FrameCreateSession, p))
 	case "KillSession":
 		var p wire.KillSessionReq
-		_ = json.Unmarshal(req.Params, &p)
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
 		s.respond(req.ID, "", s.controlWriteJSON(wire.FrameKillSession, p))
 	case "OpenSession":
 		var p struct {
@@ -176,7 +227,10 @@ func (s *session) dispatch(req rpcReq) {
 			Cols int    `json:"cols"`
 			Rows int    `json:"rows"`
 		}
-		_ = json.Unmarshal(req.Params, &p)
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
 		info, err := s.openSession(p.ID, p.Cols, p.Rows)
 		s.respond(req.ID, info, err)
 	case "WriteStdin":
@@ -184,7 +238,10 @@ func (s *session) dispatch(req rpcReq) {
 			ID  string `json:"id"`
 			B64 string `json:"b64"`
 		}
-		_ = json.Unmarshal(req.Params, &p)
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
 		s.respond(req.ID, "", s.writeStdin(p.ID, p.B64))
 	case "ResizeSession":
 		var p struct {
@@ -192,19 +249,28 @@ func (s *session) dispatch(req rpcReq) {
 			Cols int    `json:"cols"`
 			Rows int    `json:"rows"`
 		}
-		_ = json.Unmarshal(req.Params, &p)
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
 		s.respond(req.ID, "", s.attachWriteJSON(p.ID, wire.FrameResize, wire.Resize{Cols: p.Cols, Rows: p.Rows}))
 	case "RequestScrollbackReplay":
 		var p struct {
 			ID string `json:"id"`
 		}
-		_ = json.Unmarshal(req.Params, &p)
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
 		s.respond(req.ID, "", s.attachWriteFrame(p.ID, wire.FrameRequestReplay, nil))
 	case "CloseAttach":
 		var p struct {
 			ID string `json:"id"`
 		}
-		_ = json.Unmarshal(req.Params, &p)
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
 		s.respond(req.ID, "", s.closeAttach(p.ID))
 	default:
 		// Frontend imports a lot of methods we don't implement (Notify,
@@ -228,14 +294,15 @@ func (s *session) connectControl() error {
 		return err
 	}
 	_ = welcome // build-id is irrelevant for tests
+	lc := &lockedConn{c: conn}
 	s.mu.Lock()
-	s.control = conn
+	s.control = lc
 	s.mu.Unlock()
-	go s.controlReadLoop(conn)
+	go s.controlReadLoop(lc)
 	return nil
 }
 
-func (s *session) controlReadLoop(conn net.Conn) {
+func (s *session) controlReadLoop(conn *lockedConn) {
 	defer func() {
 		s.mu.Lock()
 		if s.control == conn {
@@ -246,7 +313,7 @@ func (s *session) controlReadLoop(conn net.Conn) {
 		s.emit("control:disconnect", "")
 	}()
 	for {
-		ft, payload, err := wire.ReadFrame(conn)
+		ft, payload, err := wire.ReadFrame(conn.c)
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				log.Printf("ws-bridge: control read: %v", err)
@@ -288,18 +355,20 @@ func (s *session) openSession(id string, cols, rows int) (*attachInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	lc := &lockedConn{c: conn}
 	s.mu.Lock()
-	s.attaches[id] = conn
+	s.attaches[id] = lc
 	s.mu.Unlock()
-	go s.attachReadLoop(id, conn)
-	// Issue preferred size if non-zero and differs from welcome.
+	go s.attachReadLoop(id, lc)
+	// Issue preferred size if non-zero and differs from welcome. Routed
+	// through the locked writer — it races with WriteStdin dispatches.
 	if cols > 0 && rows > 0 && (cols != welcome.Cols || rows != welcome.Rows) {
-		_ = wire.WriteJSON(conn, wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
+		_ = lc.writeJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
 	}
 	return &attachInfo{SessionID: id, Cols: welcome.Cols, Rows: welcome.Rows}, nil
 }
 
-func (s *session) attachReadLoop(id string, conn net.Conn) {
+func (s *session) attachReadLoop(id string, conn *lockedConn) {
 	defer func() {
 		s.mu.Lock()
 		if s.attaches[id] == conn {
@@ -310,7 +379,7 @@ func (s *session) attachReadLoop(id string, conn net.Conn) {
 		s.emit("pty:disconnect", id)
 	}()
 	for {
-		ft, payload, err := wire.ReadFrame(conn)
+		ft, payload, err := wire.ReadFrame(conn.c)
 		if err != nil {
 			return
 		}
@@ -366,7 +435,7 @@ func (s *session) controlWriteJSON(t wire.FrameType, v any) error {
 	if c == nil {
 		return errors.New("no control connection")
 	}
-	return wire.WriteJSON(c, t, v)
+	return c.writeJSON(t, v)
 }
 
 func (s *session) attachWriteFrame(id string, t wire.FrameType, p []byte) error {
@@ -376,7 +445,7 @@ func (s *session) attachWriteFrame(id string, t wire.FrameType, p []byte) error 
 	if c == nil {
 		return fmt.Errorf("no attach for %s", id)
 	}
-	return wire.WriteFrame(c, t, p)
+	return c.writeFrame(t, p)
 }
 
 func (s *session) attachWriteJSON(id string, t wire.FrameType, v any) error {
@@ -386,7 +455,7 @@ func (s *session) attachWriteJSON(id string, t wire.FrameType, v any) error {
 	if c == nil {
 		return fmt.Errorf("no attach for %s", id)
 	}
-	return wire.WriteJSON(c, t, v)
+	return c.writeJSON(t, v)
 }
 
 // --- helpers ---

--- a/cmd/hived-ws-bridge/main_test.go
+++ b/cmd/hived-ws-bridge/main_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/lucascaro/hive/internal/wire"
+)
+
+// dialTestBridge spins up serveWS against a daemon socket that does not
+// exist (dispatch-level behavior needs no live daemon) and returns a
+// connected WS client. All paths live under t.TempDir(): the isolation
+// guard runs only in main(), and nothing here can touch real state.
+func dialTestBridge(t *testing.T) *websocket.Conn {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "nonexistent.sock")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveWS(w, r, sockPath)
+	}))
+	t.Cleanup(srv.Close)
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", url, err)
+	}
+	t.Cleanup(func() { _ = ws.Close() })
+	return ws
+}
+
+// roundTrip sends one JSON-RPC request and reads frames until the
+// response with the matching id arrives (skipping event notifications).
+func roundTrip(t *testing.T, ws *websocket.Conn, id int, method, rawParams string) rpcResp {
+	t.Helper()
+	req := fmt.Sprintf(`{"id":%d,"method":%q,"params":%s}`, id, method, rawParams)
+	if err := ws.WriteMessage(websocket.TextMessage, []byte(req)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_ = ws.SetReadDeadline(deadline)
+		_, raw, err := ws.ReadMessage()
+		if err != nil {
+			t.Fatalf("read response for %s: %v", method, err)
+		}
+		var resp rpcResp
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			t.Fatalf("unmarshal response: %v (%s)", err, raw)
+		}
+		if resp.ID == id {
+			return resp
+		}
+	}
+}
+
+func TestDispatchRejectsMalformedParams(t *testing.T) {
+	ws := dialTestBridge(t)
+
+	methods := []string{
+		"CreateSession", "KillSession", "OpenSession", "WriteStdin",
+		"ResizeSession", "RequestScrollbackReplay", "CloseAttach",
+	}
+	for i, m := range methods {
+		t.Run(m+"/number", func(t *testing.T) {
+			resp := roundTrip(t, ws, 100+i, m, `42`)
+			if !strings.Contains(resp.Error, "invalid params") {
+				t.Errorf("%s with numeric params: error = %q, want invalid params", m, resp.Error)
+			}
+		})
+		t.Run(m+"/array", func(t *testing.T) {
+			resp := roundTrip(t, ws, 200+i, m, `["x"]`)
+			if !strings.Contains(resp.Error, "invalid params") {
+				t.Errorf("%s with array params: error = %q, want invalid params", m, resp.Error)
+			}
+		})
+	}
+}
+
+// TestDispatchEmptyParamsStillPermissive pins the happy-path contract:
+// {} params must reach the handler, whose failure (no daemon behind
+// the socket) is an execution error, not a parse error.
+func TestDispatchEmptyParamsStillPermissive(t *testing.T) {
+	ws := dialTestBridge(t)
+	resp := roundTrip(t, ws, 1, "CreateSession", `{}`)
+	if !strings.Contains(resp.Error, "no control connection") {
+		t.Errorf("CreateSession with {}: error = %q, want execution error %q", resp.Error, "no control connection")
+	}
+	// Unknown methods keep returning empty success.
+	resp = roundTrip(t, ws, 2, "Notify", `{}`)
+	if resp.Error != "" {
+		t.Errorf("unknown method: error = %q, want success", resp.Error)
+	}
+}
+
+// TestConcurrentAttachWritesAreSerialized proves frame writes from
+// concurrent goroutines cannot interleave mid-frame. Before lockedConn,
+// wire.WriteFrame's two Writes (header, payload) from racing goroutines
+// corrupted the stream; this test fails on that code.
+func TestConcurrentAttachWritesAreSerialized(t *testing.T) {
+	client, server := net.Pipe()
+	defer server.Close()
+	s := &session{attaches: map[string]*lockedConn{"sid": {c: client}}}
+
+	const goroutines, frames = 10, 50
+	got := make(map[string]int)
+	done := make(chan error, 1)
+	go func() {
+		for range goroutines * frames {
+			ft, payload, err := wire.ReadFrame(server)
+			if err != nil {
+				done <- fmt.Errorf("read frame after %d ok frames: %w", len(got), err)
+				return
+			}
+			if ft != wire.FrameData {
+				done <- fmt.Errorf("frame type %v, want FrameData", ft)
+				return
+			}
+			got[string(payload)]++
+		}
+		done <- nil
+	}()
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Go(func() {
+			for i := range frames {
+				payload := fmt.Sprintf("g%02d-i%02d", g, i)
+				if err := s.attachWriteFrame("sid", wire.FrameData, []byte(payload)); err != nil {
+					t.Errorf("attachWriteFrame %s: %v", payload, err)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reader did not finish; stream likely corrupted")
+	}
+
+	if len(got) != goroutines*frames {
+		t.Fatalf("distinct payloads = %d, want %d", len(got), goroutines*frames)
+	}
+	for p, n := range got {
+		if n != 1 {
+			t.Errorf("payload %q seen %d times, want 1", p, n)
+		}
+	}
+}

--- a/cmd/hived-ws-bridge/main_test.go
+++ b/cmd/hived-ws-bridge/main_test.go
@@ -93,8 +93,14 @@ func TestDispatchEmptyParamsStillPermissive(t *testing.T) {
 	if !strings.Contains(resp.Error, "no control connection") {
 		t.Errorf("CreateSession with {}: error = %q, want execution error %q", resp.Error, "no control connection")
 	}
+	// Literal null is JSON-RPC's spelling of absent params — it must
+	// reach the handler like {}, not be rejected as malformed.
+	resp = roundTrip(t, ws, 2, "CreateSession", `null`)
+	if !strings.Contains(resp.Error, "no control connection") {
+		t.Errorf("CreateSession with null: error = %q, want execution error %q", resp.Error, "no control connection")
+	}
 	// Unknown methods keep returning empty success.
-	resp = roundTrip(t, ws, 2, "Notify", `{}`)
+	resp = roundTrip(t, ws, 3, "Notify", `{}`)
 	if resp.Error != "" {
 		t.Errorf("unknown method: error = %q, want success", resp.Error)
 	}

--- a/cmd/hived/main.go
+++ b/cmd/hived/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -76,7 +77,7 @@ func main() {
 	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600); err != nil {
 		log.Printf("hived: write pidfile: %v", err)
 	}
-	defer os.Remove(pidPath)
+	defer removePidfile(pidPath)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	sigCh := make(chan os.Signal, 1)
@@ -89,5 +90,15 @@ func main() {
 
 	if err := d.Run(ctx); err != nil {
 		log.Fatalf("hived: run: %v", err)
+	}
+}
+
+// removePidfile deletes the pidfile, logging any failure other than
+// "already gone" — a stale pidfile makes the GUI's Restart action
+// signal the wrong process, so a failed cleanup must be diagnosable
+// from hived.log.
+func removePidfile(path string) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Printf("hived: remove pidfile %s: %v", path, err)
 	}
 }

--- a/cmd/hived/main_test.go
+++ b/cmd/hived/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRemovePidfile(t *testing.T) {
+	capture := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		var buf bytes.Buffer
+		orig := log.Writer()
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(orig) })
+		return &buf
+	}
+
+	t.Run("removes existing file silently", func(t *testing.T) {
+		buf := capture(t)
+		path := filepath.Join(t.TempDir(), "hived.sock.pid")
+		if err := os.WriteFile(path, []byte("123"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		removePidfile(path)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("pidfile still exists after removePidfile")
+		}
+		if got := buf.String(); got != "" {
+			t.Errorf("expected no log output; got %q", got)
+		}
+	})
+
+	t.Run("missing file is silent", func(t *testing.T) {
+		buf := capture(t)
+		removePidfile(filepath.Join(t.TempDir(), "never-existed.pid"))
+		if got := buf.String(); got != "" {
+			t.Errorf("ErrNotExist should be suppressed (double shutdown is normal); got %q", got)
+		}
+	})
+
+	t.Run("undeletable file logs a warning", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("chmod-based failure injection requires POSIX permissions")
+		}
+		if os.Getuid() == 0 {
+			t.Skip("root bypasses permission bits")
+		}
+		buf := capture(t)
+		dir := filepath.Join(t.TempDir(), "locked")
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatalf("Mkdir: %v", err)
+		}
+		path := filepath.Join(dir, "hived.sock.pid")
+		if err := os.WriteFile(path, []byte("123"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Chmod(dir, 0o500); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+		removePidfile(path)
+		if !strings.Contains(buf.String(), "remove pidfile") {
+			t.Errorf("expected 'remove pidfile' warning; got %q", buf.String())
+		}
+	})
+}

--- a/internal/registry/persist_logging_test.go
+++ b/internal/registry/persist_logging_test.go
@@ -1,0 +1,189 @@
+package registry
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lucascaro/hive/internal/wire"
+)
+
+// captureLog redirects the stdlib logger into a buffer for the duration
+// of the test. The registry logs diagnosability warnings through it.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(orig) })
+	return &buf
+}
+
+// skipIfChmodIneffective skips tests that inject persist failures by
+// revoking directory write permission — meaningless on Windows and as
+// root, where permission bits don't deny access.
+func skipIfChmodIneffective(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based failure injection requires POSIX permissions")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission bits")
+	}
+}
+
+func TestPersistLoggedHelpersWarnOnFailure(t *testing.T) {
+	skipIfChmodIneffective(t)
+	stateDir := t.TempDir()
+	r, err := Open(stateDir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	sessDir := SessionsDir(stateDir)
+	projDir := ProjectsDir(stateDir)
+	for _, d := range []string{sessDir, projDir} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatalf("MkdirAll %s: %v", d, err)
+		}
+		if err := os.Chmod(d, 0o500); err != nil {
+			t.Fatalf("Chmod %s: %v", d, err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(d, 0o700) })
+	}
+
+	cases := []struct {
+		name string
+		call func()
+		want string
+	}{
+		{
+			name: "entry",
+			call: func() { r.persistEntryLoggedLocked(&Entry{ID: "test-entry"}, "test-op") },
+			want: "test-op: persist session test-entry failed",
+		},
+		{
+			name: "session index",
+			call: func() { r.persistIndexLoggedLocked("test-op") },
+			want: "test-op: persist session index failed",
+		},
+		{
+			name: "project",
+			call: func() { r.persistProjectLoggedLocked(&Project{ID: "test-proj"}, "test-op") },
+			want: "test-op: persist project test-proj failed",
+		},
+		{
+			name: "project index",
+			call: func() { r.persistProjectIndexLoggedLocked("test-op") },
+			want: "test-op: persist project index failed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := captureLog(t)
+			tc.call()
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("expected log containing %q; got: %q", tc.want, buf.String())
+			}
+		})
+	}
+}
+
+func TestPersistLoggedHelpersSilentOnSuccess(t *testing.T) {
+	stateDir := t.TempDir()
+	r, err := Open(stateDir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	buf := captureLog(t)
+	r.persistEntryLoggedLocked(&Entry{ID: "ok-entry"}, "test-op")
+	r.persistIndexLoggedLocked("test-op")
+	r.persistProjectLoggedLocked(&Project{ID: "ok-proj"}, "test-op")
+	r.persistProjectIndexLoggedLocked("test-op")
+	if got := buf.String(); strings.Contains(got, "persist") {
+		t.Errorf("happy path should log nothing; got: %q", got)
+	}
+}
+
+func TestBroadcastDropsAndWarnsOnSlowListener(t *testing.T) {
+	r := freshRegistry(t)
+	buf := captureLog(t)
+
+	slow, unsubSlow := r.Subscribe()
+	storm := cap(slow) + 1
+	for range storm {
+		r.broadcast(wire.SessionEventUpdated, wire.SessionInfo{ID: "storm"})
+	}
+
+	if !strings.Contains(buf.String(), "dropping slow session-event listener") {
+		t.Errorf("expected slow-listener warning; got: %q", buf.String())
+	}
+
+	// The dropped channel holds cap(slow) buffered events and must then
+	// be closed — that is the signal a client uses to resubscribe.
+	closed := false
+	deadline := time.After(2 * time.Second)
+	for !closed {
+		select {
+		case _, ok := <-slow:
+			if !ok {
+				closed = true
+			}
+		case <-deadline:
+			t.Fatal("dropped listener channel was never closed")
+		}
+	}
+
+	// Unsubscribing after the drop must be a harmless no-op (no double
+	// close panic).
+	unsubSlow()
+
+	// The registry must keep serving listeners subscribed after a drop.
+	fresh, unsubFresh := r.Subscribe()
+	defer unsubFresh()
+	r.broadcast(wire.SessionEventUpdated, wire.SessionInfo{ID: "after-drop"})
+	select {
+	case ev := <-fresh:
+		if ev.Session.ID != "after-drop" {
+			t.Errorf("fresh listener got %q, want %q", ev.Session.ID, "after-drop")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("fresh listener received nothing after slow-listener drop")
+	}
+}
+
+func TestBroadcastProjectDropsAndWarns(t *testing.T) {
+	r := freshRegistry(t)
+	buf := captureLog(t)
+
+	slow, unsubSlow := r.SubscribeProjects()
+	storm := cap(slow) + 1
+	for range storm {
+		r.broadcastProject(wire.ProjectEventUpdated, wire.ProjectInfo{ID: "storm"})
+	}
+
+	if !strings.Contains(buf.String(), "dropping slow project-event listener") {
+		t.Errorf("expected slow-listener warning; got: %q", buf.String())
+	}
+
+	closed := false
+	deadline := time.After(2 * time.Second)
+	for !closed {
+		select {
+		case _, ok := <-slow:
+			if !ok {
+				closed = true
+			}
+		case <-deadline:
+			t.Fatal("dropped project listener channel was never closed")
+		}
+	}
+	unsubSlow()
+}

--- a/internal/registry/persist_logging_test.go
+++ b/internal/registry/persist_logging_test.go
@@ -86,7 +86,11 @@ func TestPersistLoggedHelpersWarnOnFailure(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			buf := captureLog(t)
+			// The *Locked helpers are called under r.mu everywhere in
+			// production — honor the same contract here.
+			r.mu.Lock()
 			tc.call()
+			r.mu.Unlock()
 			if !strings.Contains(buf.String(), tc.want) {
 				t.Errorf("expected log containing %q; got: %q", tc.want, buf.String())
 			}
@@ -103,10 +107,14 @@ func TestPersistLoggedHelpersSilentOnSuccess(t *testing.T) {
 	t.Cleanup(func() { _ = r.Close() })
 
 	buf := captureLog(t)
+	// The *Locked helpers are called under r.mu everywhere in
+	// production — honor the same contract here.
+	r.mu.Lock()
 	r.persistEntryLoggedLocked(&Entry{ID: "ok-entry"}, "test-op")
 	r.persistIndexLoggedLocked("test-op")
 	r.persistProjectLoggedLocked(&Project{ID: "ok-proj"}, "test-op")
 	r.persistProjectIndexLoggedLocked("test-op")
+	r.mu.Unlock()
 	if got := buf.String(); strings.Contains(got, "persist") {
 		t.Errorf("happy path should log nothing; got: %q", got)
 	}

--- a/internal/registry/projects.go
+++ b/internal/registry/projects.go
@@ -121,7 +121,7 @@ func (r *Registry) MigrateOrphanSessions() {
 	for _, e := range r.entries {
 		if e.ProjectID == "" {
 			e.ProjectID = defID
-			_ = r.persistEntryLocked(e)
+			r.persistEntryLoggedLocked(e, "migrate orphan sessions")
 			dirty = true
 		}
 	}
@@ -213,7 +213,7 @@ func (r *Registry) KillProject(id string, killSessions bool) error {
 	if !killSessions {
 		for _, e := range affected {
 			e.ProjectID = targetID
-			_ = r.persistEntryLocked(e)
+			r.persistEntryLoggedLocked(e, "delete project (reassign)")
 		}
 	}
 
@@ -226,7 +226,7 @@ func (r *Registry) KillProject(id string, killSessions bool) error {
 	}
 	// Intentionally NOT renumbering — same rationale as Kill().
 	// See registry.go for the full comment.
-	_ = r.persistProjectIndexLocked()
+	r.persistProjectIndexLoggedLocked("delete project")
 
 	dir := filepath.Join(ProjectsDir(r.stateDir), id)
 	info := p.Info()
@@ -322,7 +322,7 @@ func (r *Registry) renumberProjectsLocked() {
 	for i, id := range r.projectOrder {
 		if p := r.projects[id]; p != nil {
 			p.Order = i
-			_ = r.persistProjectLocked(p)
+			r.persistProjectLoggedLocked(p, "renumber projects")
 		}
 	}
 }
@@ -330,7 +330,9 @@ func (r *Registry) renumberProjectsLocked() {
 // SubscribeProjects returns a channel that receives ProjectEvent.
 // Slow consumers are dropped — listeners must drain promptly.
 func (r *Registry) SubscribeProjects() (ProjectListener, func()) {
-	ch := make(ProjectListener, 16)
+	// 64 for the same reason as Subscribe: order changes broadcast one
+	// event per project under lock.
+	ch := make(ProjectListener, 64)
 	r.mu.Lock()
 	r.projectListeners[ch] = struct{}{}
 	r.mu.Unlock()
@@ -352,6 +354,9 @@ func (r *Registry) broadcastProject(kind string, info wire.ProjectInfo) {
 		select {
 		case ch <- ev:
 		default:
+			// Same contract as broadcastLocked: drops must be loud.
+			log.Printf("registry: dropping slow project-event listener (buffer %d full, %d listeners); client is desynced until it resubscribes",
+				cap(ch), len(r.projectListeners))
 			delete(r.projectListeners, ch)
 			close(ch)
 		}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -447,7 +447,7 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	if nameFromBranch && wtBranch == "" {
 		r.mu.Lock()
 		e.Name = agent.RandomName(agent.ID(spec.Agent))
-		_ = r.persistEntryLocked(e)
+		r.persistEntryLoggedLocked(e, "create (rename fallback)")
 		r.mu.Unlock()
 	}
 
@@ -492,7 +492,7 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 		}
 	}
 	if wtPath != "" || e.AgentSessionID != "" {
-		_ = r.persistEntryLocked(e)
+		r.persistEntryLoggedLocked(e, "create")
 	}
 	// Kick off the post-spawn capture for agents that don't support
 	// caller-chosen ids (Codex). The cancel func is stored so
@@ -538,7 +538,7 @@ func (r *Registry) startAgentSessionIDCaptureLocked(e *Entry, cwd string) {
 			return
 		}
 		e2.AgentSessionID = captured
-		_ = r.persistEntryLocked(e2)
+		r.persistEntryLoggedLocked(e2, "agent-session-id capture")
 		info := e2.Info()
 		r.mu.Unlock()
 		r.broadcast(wire.SessionEventUpdated, info)
@@ -601,7 +601,7 @@ func (r *Registry) Revive(id string, opts session.Options) error {
 			r.mu.Lock()
 			e.WorktreePath = ""
 			e.WorktreeBranch = ""
-			_ = r.persistEntryLocked(e)
+			r.persistEntryLoggedLocked(e, "revive (worktree missing)")
 			info := e.Info()
 			r.mu.Unlock()
 			r.broadcast(wire.SessionEventUpdated, info)
@@ -758,8 +758,8 @@ func (r *Registry) Adopt(s *session.Session, name, color string) (*Entry, error)
 	}
 	r.entries[id] = e
 	r.order = append(r.order, id)
-	_ = r.persistEntryLocked(e)
-	_ = r.persistIndexLocked()
+	r.persistEntryLoggedLocked(e, "adopt")
+	r.persistIndexLoggedLocked("adopt")
 	r.mu.Unlock()
 	r.broadcast(wire.SessionEventAdded, e.Info())
 	go r.watchSessionExit(id, s)
@@ -876,7 +876,7 @@ func (r *Registry) Kill(id string, force bool) error {
 	// — the sort-by-Order render handles holes fine, and not
 	// touching the field means we never have to broadcast spurious
 	// SessionEventUpdated for sessions the user didn't touch.
-	_ = r.persistIndexLocked()
+	r.persistIndexLoggedLocked("kill")
 	dir := filepath.Join(SessionsDir(r.stateDir), id)
 	r.mu.Unlock()
 
@@ -956,7 +956,11 @@ func (r *Registry) Update(req wire.UpdateSessionReq) (*Entry, error) {
 // returned cleanup function unsubscribes and closes the channel.
 // Slow consumers are dropped — listeners must drain promptly.
 func (r *Registry) Subscribe() (Listener, func()) {
-	ch := make(Listener, 16)
+	// 64, not 16: Update with an order change broadcasts one event per
+	// session while holding r.mu (see renumberLocked), so a listener
+	// that's merely a beat behind on a many-session registry could
+	// overflow a small buffer and get dropped.
+	ch := make(Listener, 64)
 	r.mu.Lock()
 	r.listeners[ch] = struct{}{}
 	r.mu.Unlock()
@@ -1030,7 +1034,7 @@ func (r *Registry) renumberLocked() {
 	// them rather than diff: the volume is small.
 	for _, id := range r.order {
 		if e := r.entries[id]; e != nil {
-			_ = r.persistEntryLocked(e)
+			r.persistEntryLoggedLocked(e, "renumber")
 		}
 	}
 }
@@ -1066,6 +1070,35 @@ func (r *Registry) persistIndexLocked() error {
 	return writeJSON(filepath.Join(SessionsDir(r.stateDir), "index.json"), idx)
 }
 
+// persistEntryLoggedLocked persists e, logging (rather than returning)
+// any failure. For mutation paths that must proceed regardless: the
+// in-memory registry stays authoritative, but a failed write means the
+// on-disk copy is stale until the next successful persist, so the
+// failure must at least leave a trace in the log.
+func (r *Registry) persistEntryLoggedLocked(e *Entry, op string) {
+	if err := r.persistEntryLocked(e); err != nil {
+		log.Printf("registry: %s: persist session %s failed (on-disk metadata now stale): %v", op, e.ID, err)
+	}
+}
+
+func (r *Registry) persistIndexLoggedLocked(op string) {
+	if err := r.persistIndexLocked(); err != nil {
+		log.Printf("registry: %s: persist session index failed (on-disk order now stale): %v", op, err)
+	}
+}
+
+func (r *Registry) persistProjectLoggedLocked(p *Project, op string) {
+	if err := r.persistProjectLocked(p); err != nil {
+		log.Printf("registry: %s: persist project %s failed (on-disk metadata now stale): %v", op, p.ID, err)
+	}
+}
+
+func (r *Registry) persistProjectIndexLoggedLocked(op string) {
+	if err := r.persistProjectIndexLocked(); err != nil {
+		log.Printf("registry: %s: persist project index failed (on-disk order now stale): %v", op, err)
+	}
+}
+
 func (r *Registry) broadcast(kind string, info wire.SessionInfo) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1078,7 +1111,11 @@ func (r *Registry) broadcastLocked(kind string, info wire.SessionInfo) {
 		select {
 		case ch <- ev:
 		default:
-			// drop slow listener
+			// Listener can't keep up. Dropping it silently would leave
+			// the client permanently desynced with no trace — warn so
+			// "the GUI went stale" can be correlated with this moment.
+			log.Printf("registry: dropping slow session-event listener (buffer %d full, %d listeners); client is desynced until it resubscribes",
+				cap(ch), len(r.listeners))
 			delete(r.listeners, ch)
 			close(ch)
 		}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -63,15 +63,12 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 		return fmt.Errorf("create worktree parent dir: %w", err)
 	}
 
-	// Best-effort: refresh `origin` so the upstream tip we branch from
-	// reflects the latest remote state. Failures are logged via the
-	// returned base ref staying empty (callers fall back to HEAD).
-	upstream := upstreamBaseRef(repoDir)
-
 	// Existing branch? Probe the ref directly — exit-code based, so it
 	// works regardless of git's message locale. (The substring check
 	// below stays only as a TOCTOU safety net for a branch created
-	// between this probe and the add.)
+	// between this probe and the add.) Probed before upstreamBaseRef:
+	// checking out an existing branch never branches from upstream, so
+	// it must not pay the fetch's network latency.
 	if branchExists(repoDir, branch) {
 		out, err := gitWorktreeAdd(repoDir, worktreePath, branch)
 		if err != nil {
@@ -80,6 +77,11 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 		}
 		return nil
 	}
+
+	// Best-effort: refresh `origin` so the upstream tip we branch from
+	// reflects the latest remote state. Failures are logged via the
+	// returned base ref staying empty (callers fall back to HEAD).
+	upstream := upstreamBaseRef(repoDir)
 
 	var attempts []error
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -68,46 +68,84 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 	// returned base ref staying empty (callers fall back to HEAD).
 	upstream := upstreamBaseRef(repoDir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	args := []string{"-C", repoDir, "worktree", "add", "-b", branch, worktreePath}
-	if upstream != "" {
-		args = append(args, upstream)
-	}
-	cmd := exec.CommandContext(ctx, "git", args...)
-	out, err := cmd.CombinedOutput()
-	if err == nil {
-		return nil
-	}
-	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("git worktree add timed out after 30s")
-	}
-	// Fall back to checking out an existing branch.
-	if strings.Contains(string(out), "already exists") || strings.Contains(string(out), "fatal: A branch named") {
-		ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel2()
-		cmd2 := exec.CommandContext(ctx2, "git", "-C", repoDir, "worktree", "add", worktreePath, branch)
-		if out2, err2 := cmd2.CombinedOutput(); err2 != nil {
-			return fmt.Errorf("git worktree add: %s", strings.TrimSpace(string(out2)))
+	// Existing branch? Probe the ref directly — exit-code based, so it
+	// works regardless of git's message locale. (The substring check
+	// below stays only as a TOCTOU safety net for a branch created
+	// between this probe and the add.)
+	if branchExists(repoDir, branch) {
+		out, err := gitWorktreeAdd(repoDir, worktreePath, branch)
+		if err != nil {
+			return fmt.Errorf("git worktree add (existing branch %s): %s: %w",
+				branch, strings.TrimSpace(string(out)), err)
 		}
 		return nil
 	}
+
+	var attempts []error
+
+	// Attempt 1: new branch from the upstream tip (or HEAD when no
+	// upstream resolved).
+	args := []string{"-b", branch, worktreePath}
+	if upstream != "" {
+		args = append(args, upstream)
+	}
+	out, err := gitWorktreeAdd(repoDir, args...)
+	if err == nil {
+		return nil
+	}
+	attempts = append(attempts, fmt.Errorf("new branch %s (base %q): %s: %w",
+		branch, upstream, strings.TrimSpace(string(out)), err))
+
+	// The branch appeared between the probe above and the add (TOCTOU):
+	// fall back to checking it out. gitWorktreeAdd pins LC_ALL=C, so
+	// these substrings are stable across user locales.
+	if strings.Contains(string(out), "already exists") || strings.Contains(string(out), "fatal: A branch named") {
+		out2, err2 := gitWorktreeAdd(repoDir, worktreePath, branch)
+		if err2 == nil {
+			return nil
+		}
+		attempts = append(attempts, fmt.Errorf("existing branch %s: %s: %w",
+			branch, strings.TrimSpace(string(out2)), err2))
+		return fmt.Errorf("git worktree add: %w", errors.Join(attempts...))
+	}
+
 	// If we asked for an upstream base ref and it failed for some other
 	// reason (e.g. ref disappeared between fetch and add), retry without
 	// the explicit base ref so HEAD is used. This keeps creation robust
 	// in offline / shallow / sandboxed environments.
 	if upstream != "" {
-		ctx3, cancel3 := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel3()
-		cmd3 := exec.CommandContext(ctx3, "git", "-C", repoDir, "worktree", "add", "-b", branch, worktreePath)
-		if out3, err3 := cmd3.CombinedOutput(); err3 == nil {
+		out3, err3 := gitWorktreeAdd(repoDir, "-b", branch, worktreePath)
+		if err3 == nil {
 			return nil
-		} else {
-			out, err = out3, err3
 		}
+		attempts = append(attempts, fmt.Errorf("new branch %s (no base): %s: %w",
+			branch, strings.TrimSpace(string(out3)), err3))
 	}
-	return fmt.Errorf("git worktree add: %s", strings.TrimSpace(string(out)))
+	return fmt.Errorf("git worktree add: %w", errors.Join(attempts...))
+}
+
+// gitWorktreeAdd runs `git -C repoDir worktree add <args…>` with a 30s
+// timeout and a C locale. The locale pin keeps CreateWorktree's
+// error-text fallback meaningful on non-English systems.
+func gitWorktreeAdd(repoDir string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	full := append([]string{"-C", repoDir, "worktree", "add"}, args...)
+	cmd := exec.CommandContext(ctx, "git", full...)
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	out, err := cmd.CombinedOutput()
+	if err != nil && ctx.Err() == context.DeadlineExceeded {
+		return out, fmt.Errorf("timed out after 30s")
+	}
+	return out, err
+}
+
+// branchExists reports whether refs/heads/<branch> exists in repoDir.
+func branchExists(repoDir, branch string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "git", "-C", repoDir,
+		"rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil
 }
 
 // upstreamBaseRef returns the short name of the upstream default ref

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -246,11 +246,57 @@ func TestCreateWorktree_BranchAlreadyExists(t *testing.T) {
 	if out, err := exec.Command("git", "-C", repo, "branch", "topic").CombinedOutput(); err != nil {
 		t.Fatalf("git branch: %v\n%s", err, out)
 	}
+	topicSHA := revParse(t, repo, "topic")
 	wt := WorktreePath(repo, "topic")
 	if err := CreateWorktree(repo, "topic", wt); err != nil {
-		t.Fatalf("CreateWorktree should fall back when branch exists: %v", err)
+		t.Fatalf("CreateWorktree should check out an existing branch: %v", err)
 	}
 	defer Cleanup(repo, wt)
+	// The worktree must actually be on the existing branch's tip — the
+	// rev-parse probe (not git's localized error text) routes us here.
+	if got := revParse(t, wt, "HEAD"); got != topicSHA {
+		t.Errorf("worktree HEAD = %s, want topic tip %s", got, topicSHA)
+	}
+}
+
+func TestCreateWorktree_ExistingBranchCheckedOutElsewhereReportsContext(t *testing.T) {
+	skipNoGit(t)
+	repo := initRepo(t)
+	mustGit(t, repo, "branch", "topic")
+	wtA := WorktreePath(repo, "topic")
+	if err := CreateWorktree(repo, "topic", wtA); err != nil {
+		t.Fatalf("first CreateWorktree: %v", err)
+	}
+	defer Cleanup(repo, wtA)
+
+	// A second worktree for the same branch must fail (git refuses), and
+	// the error must say which strategy failed instead of a bare git dump.
+	wtB := filepath.Join(repo, ".worktrees", "topic-second")
+	err := CreateWorktree(repo, "topic", wtB)
+	if err == nil {
+		t.Fatal("second CreateWorktree for same branch should fail")
+	}
+	if !strings.Contains(err.Error(), "existing branch topic") {
+		t.Errorf("error should name the existing-branch strategy; got: %v", err)
+	}
+}
+
+func TestCreateWorktree_AllAttemptsFailJoinsErrors(t *testing.T) {
+	repo, _, _ := initRepoWithUpstream(t)
+	// ".." is invalid in ref names, so both the with-base and no-base
+	// attempts fail. The joined error must carry context from each.
+	bad := "bad..name"
+	err := CreateWorktree(repo, bad, filepath.Join(repo, ".worktrees", "bad-name"))
+	if err == nil {
+		t.Fatal("CreateWorktree with invalid branch name should fail")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `(base "origin/main")`) {
+		t.Errorf("error should report the upstream-base attempt; got: %v", err)
+	}
+	if !strings.Contains(msg, "(no base)") {
+		t.Errorf("error should report the no-base retry attempt; got: %v", err)
+	}
 }
 
 func TestCleanup_MissingDir(t *testing.T) {


### PR DESCRIPTION
## Summary

Backend robustness & diagnosability cluster — failures that were previously swallowed now leave a trace, and two real correctness bugs in the ws-bridge are fixed. No behavior redesign.

- **registry**: all 12 fire-and-forget `_ = r.persist…` sites now log failures (`persist*LoggedLocked` helpers) — a failed write left on-disk metadata silently stale. Slow session/project event listeners are dropped **with a warning** instead of silently desyncing the GUI; subscribe buffers grow 16→64 since an order-change broadcast emits one event per session under lock.
- **worktree**: `CreateWorktree` joins every attempt's error (`errors.Join`) instead of losing attempts 1–2; existing-branch detection now uses `git rev-parse --verify` exit codes instead of locale-dependent error-text matching (fallback substring check pinned to `LC_ALL=C`).
- **hived-ws-bridge**: (1) malformed JSON-RPC params return an `invalid params` error instead of running handlers on zeroed structs; (2) frame writes to a daemon conn are serialized per-conn — `wire.WriteFrame` issues two `Write`s, so concurrent writers interleaved mid-frame and corrupted the wire stream. Goroutine-per-request dispatch assessed and kept (comment documents why).
- **hived**: pidfile removal failures (other than `ErrNotExist`) are logged at shutdown.

## Tests

- `TestPersistLoggedHelpersWarnOnFailure` / `SilentOnSuccess` — chmod-based failure injection (skips on Windows/root)
- `TestBroadcastDropsAndWarnsOnSlowListener` (+ project variant) — drop is per-listener, channel closes, registry keeps serving, double-unsub safe
- `TestCreateWorktree_AllAttemptsFailJoinsErrors`, `_ExistingBranchCheckedOutElsewhereReportsContext`, strengthened `_BranchAlreadyExists` (asserts worktree HEAD == branch tip)
- `TestDispatchRejectsMalformedParams` (all 7 methods × number/array params) + `TestDispatchEmptyParamsStillPermissive` (negative control: `{}` still reaches handlers)
- `TestConcurrentAttachWritesAreSerialized` — 10 goroutines × 50 frames over net.Pipe, all 500 decode cleanly; fails on the pre-fix code
- `TestRemovePidfile` — removed/missing/undeletable cases

`go build ./... && go vet ./...` clean; all touched packages pass (`worktree`, `registry`, `wire`, `testclient`, `session`, `daemon`, `cmd/hived`, `cmd/hived-ws-bridge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)