### PR TITLE
fix(gui): surface silent action failures; Enter/Escape work in renames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GUI: action failures are no longer silent. Copying/pasting inside a
+  terminal, creating/duplicating/restarting/closing a session, renaming
+  or recoloring or reordering sessions and projects, saving a project,
+  and opening the agent launcher now show an error in the status bar
+  when the underlying daemon call fails (e.g. connection lost) —
+  previously the click just did nothing, with no trace. Status-bar
+  errors are guaranteed a minimum visibility window (1.5s), pulse red,
+  auto-hide (errors 6s, info 2.5s), revert to the persistent status
+  ("connected" / session name) instead of going blank, and are
+  announced to screen readers (`role="status"`, `aria-live="polite"`).
+  Also fixed: opening the launcher when its sidebar anchor row isn't in
+  the DOM could throw and leave the launcher unopened with no feedback.
+- GUI: Enter now commits and Escape now cancels inline renames (session
+  rows, project rows, and tile headers). A capture-phase
+  `stopPropagation()` listener on the rename input was cancelling the
+  same input's bubble-phase Enter/Escape handler (DOM dispatch skips
+  the bubble invocation once the stop-propagation flag is set), so
+  Enter did nothing and Escape couldn't cancel — the rename only ever
+  committed when the input lost focus, including after an attempted
+  Escape. The handlers now live in the single capture-phase listener.
 - GUI: keystrokes typed immediately after switching to a grid view are no
   longer dropped. Switching to grid reparents the active tile and triggers
   async resize/fit on neighbour tiles, both of which momentarily blurred the

--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -63,7 +63,7 @@
   </div>
   <main id="terms"></main>
   <div id="minimized-tray" class="hidden" role="toolbar" aria-label="Minimized sessions"></div>
-  <div id="status">connecting…</div>
+  <div id="status" role="status" aria-live="polite">connecting…</div>
 </div>
 <script src="./src/main.js" type="module"></script>
 </body>

--- a/cmd/hivegui/frontend/src/lib/status.js
+++ b/cmd/hivegui/frontend/src/lib/status.js
@@ -1,0 +1,58 @@
+// Status-bar controller with a persistent slot and a transient flash
+// layer. Pure (all effects injected) so the semantics are unit-testable
+// without a DOM.
+//
+// The status bar serves two kinds of messages that used to clobber each
+// other through a bare textContent write:
+//   - persistent state ("connected", "control disconnected", the name
+//     of the session you just switched to) — owned by set();
+//   - per-action feedback ("copy failed: …", "creating session…") —
+//     owned by flash(), which auto-reverts to the persistent slot.
+//
+// Guarantees:
+//   - a flash is visible for at least FLASH_MIN_MS before a set() may
+//     replace it (so an error isn't wiped by nav feedback a frame later);
+//   - a flash auto-expires (errors linger longer than info);
+//   - set() during an active flash is never lost — it lands in the
+//     persistent slot and renders when the flash ends.
+
+export const FLASH_ERROR_MS = 6000;
+export const FLASH_INFO_MS = 2500;
+export const FLASH_MIN_MS = 1500;
+
+export function createStatus({ render, setTimer, clearTimer, now }) {
+  let persistent = { text: '', isError: false };
+  let flashActive = false;
+  let flashTimer = 0;
+  let flashStarted = 0;
+
+  function endFlash() {
+    flashActive = false;
+    flashTimer = 0;
+    render(persistent.text, persistent.isError);
+  }
+
+  function set(text, isError = false) {
+    persistent = { text, isError };
+    if (!flashActive) {
+      render(text, isError);
+      return;
+    }
+    if (now() - flashStarted >= FLASH_MIN_MS) {
+      clearTimer(flashTimer);
+      endFlash();
+    }
+    // Else: the flash keeps the screen; the stored persistent text
+    // renders when it expires.
+  }
+
+  function flash(text, isError = false) {
+    if (flashTimer) clearTimer(flashTimer);
+    flashActive = true;
+    flashStarted = now();
+    render(text, isError);
+    flashTimer = setTimer(endFlash, isError ? FLASH_ERROR_MS : FLASH_INFO_MS);
+  }
+
+  return { set, flash };
+}

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -34,6 +34,7 @@ import {
   shouldRequestReplay, REPLAY_DEBOUNCE_MS, handleScrollbackEvent,
   applyRebaseline,
 } from './lib/scrollback.js';
+import { createStatus } from './lib/status.js';
 
 // ---------- session terminal ----------
 
@@ -286,13 +287,13 @@ class SessionTerm {
         // SetClipboardText (Go-side via atotto/clipboard) rather than
         // wails runtime.ClipboardSetText — the latter is broken on
         // Windows (non-STA goroutine, OpenClipboard fails silently).
-        if (sel) SetClipboardText(sel).catch(() => {});
+        if (sel) SetClipboardText(sel).catch(reportFailure('copy'));
         return false;
       }
       if (key === 'v') {
         ClipboardGetText().then((text) => {
           if (text) this._writePty(text);
-        }).catch(() => {});
+        }).catch(reportFailure('paste'));
         return false;
       }
       if (key === 'a') {
@@ -548,17 +549,23 @@ class SessionTerm {
       this._renameInput = null;
       this.tileName.style.display = '';
       if (commit && next && next !== this.info.name) {
-        UpdateSession(this.info.id, next, '', -1);
+        UpdateSession(this.info.id, next, '', -1).catch(reportFailure('rename'));
       }
       refocusActiveTerm();
     };
+    // ONE capture-phase listener handles Enter/Escape AND shields the
+    // input from xterm / global hotkey handlers. It must be a single
+    // listener: stopPropagation() from a capture listener at the target
+    // also cancels the target's own bubble-phase listeners (DOM dispatch
+    // skips the bubble invocation once the flag is set), so a separate
+    // bubble-phase Enter handler would never run — Enter/Escape were
+    // dead and renames only ever committed via blur.
     input.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter') { e.stopPropagation(); finish(true); }
-      else if (e.key === 'Escape') { e.stopPropagation(); finish(false); }
-    });
+      e.stopPropagation();
+      if (e.key === 'Enter') finish(true);
+      else if (e.key === 'Escape') finish(false);
+    }, { capture: true });
     input.addEventListener('blur', () => finish(true));
-    // Stop xterm / global hotkey handlers from grabbing keystrokes.
-    input.addEventListener('keydown', (e) => e.stopPropagation(), { capture: true });
   }
 
   setProject(name, color) {
@@ -730,6 +737,8 @@ class SessionTerm {
   }
 
   destroy() {
+    // Intentionally silent: destroy() tears down a session that's already
+    // gone; a failed CloseAttach has nothing for the user to act on.
     CloseAttach(this.info.id).catch(() => {});
     if (this._revealRaf) cancelAnimationFrame(this._revealRaf);
     this.ro.disconnect();
@@ -766,9 +775,7 @@ class SessionTerm {
   }
 
   _closeDead() {
-    KillSession(this.info.id, true).catch((err) => {
-      setStatus(`close failed: ${err}`, true);
-    });
+    KillSession(this.info.id, true).catch(reportFailure('close'));
   }
 
   _dismissDead() {
@@ -891,6 +898,8 @@ function onSessionDeath(info) {
   state.terms.get(info.id)?.host.classList.add('attention');
   updateSidebarSelection();
   const proj = state.projects.find((p) => p.id === (info.projectId ?? info.project_id));
+  // Best-effort like fireBellNotification: the overlay + sidebar pulse
+  // already cover the user if the OS notification fails.
   Notify(info.name || 'Session', proj?.name ?? '', 'Session ended.', info.id).catch(() => {});
 }
 
@@ -925,10 +934,32 @@ termsHost.classList.add('single');
 const projectsUL = document.getElementById('projects');
 const status = document.getElementById('status');
 
+const statusCtl = createStatus({
+  render: (text, isError) => {
+    status.textContent = text;
+    status.classList.toggle('error', isError);
+  },
+  setTimer: (fn, ms) => window.setTimeout(fn, ms),
+  clearTimer: (id) => window.clearTimeout(id),
+  now: () => Date.now(),
+});
+
+// setStatus owns the persistent slot: connection state, nav feedback.
 function setStatus(text, isError = false) {
-  status.textContent = text;
-  status.classList.toggle('error', isError);
+  statusCtl.set(text, isError);
 }
+
+// flashStatus owns transient per-action feedback; it auto-reverts to
+// the persistent slot (errors linger 6s, info 2.5s — see lib/status.js).
+function flashStatus(text, isError = false) {
+  statusCtl.flash(text, isError);
+}
+
+// reportFailure builds a .catch handler that surfaces a failed user
+// action in the status bar. Wails mutation promises reject when the
+// daemon connection is down (or the call throws Go-side), which used
+// to be swallowed — the button click just silently did nothing.
+const reportFailure = (what) => (err) => flashStatus(`${what} failed: ${err}`, true);
 
 // orderedSessions returns sessions sorted by (project order, session order)
 // so navigation always matches what the user sees.
@@ -1156,7 +1187,7 @@ function reorderDroppedProject(draggedID, targetID, above) {
   let newOrder = above ? targetIdx : targetIdx + 1;
   if (draggedIdx < newOrder) newOrder -= 1;
   if (newOrder === draggedIdx) return;
-  UpdateProject(draggedID, '', '', '', newOrder);
+  UpdateProject(draggedID, '', '', '', newOrder).catch(reportFailure('reorder project'));
 }
 
 function renderSession(s, projectColor) {
@@ -1195,7 +1226,7 @@ function renderSession(s, projectColor) {
   colorInput.type = 'color';
   colorInput.value = s.color || '#888888';
   colorInput.addEventListener('input', (e) => {
-    UpdateSession(s.id, '', e.target.value, -1);
+    UpdateSession(s.id, '', e.target.value, -1).catch(reportFailure('color change'));
   });
   swatch.appendChild(colorInput);
 
@@ -1295,7 +1326,7 @@ function reorderDroppedSession(draggedID, targetID, above) {
   if (draggedGlobalIdx >= 0 && draggedGlobalIdx < globalTargetIdx) {
     globalTargetIdx -= 1;
   }
-  UpdateSession(draggedID, '', '', globalTargetIdx);
+  UpdateSession(draggedID, '', '', globalTargetIdx).catch(reportFailure('reorder'));
 }
 
 function beginRenameSession(sess, li, nameEl) {
@@ -1313,16 +1344,19 @@ function beginRenameSession(sess, li, nameEl) {
     const next = input.value.trim();
     input.replaceWith(nameEl);
     if (commit && next && next !== sess.name) {
-      UpdateSession(sess.id, next, '', -1);
+      UpdateSession(sess.id, next, '', -1).catch(reportFailure('rename'));
     }
     refocusActiveTerm();
   };
+  // Single capture-phase listener — see the tile-rename comment in
+  // SessionTerm for why Enter/Escape must live in the same listener
+  // that calls stopPropagation().
   input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') { e.stopPropagation(); finish(true); }
-    else if (e.key === 'Escape') { e.stopPropagation(); finish(false); }
-  });
+    e.stopPropagation();
+    if (e.key === 'Enter') finish(true);
+    else if (e.key === 'Escape') finish(false);
+  }, { capture: true });
   input.addEventListener('blur', () => finish(true));
-  input.addEventListener('keydown', (e) => e.stopPropagation(), { capture: true });
 }
 
 function beginRenameProject(proj, nameEl) {
@@ -1340,16 +1374,19 @@ function beginRenameProject(proj, nameEl) {
     const next = input.value.trim();
     input.replaceWith(nameEl);
     if (commit && next && next !== proj.name) {
-      UpdateProject(proj.id, next, '', '', -1);
+      UpdateProject(proj.id, next, '', '', -1).catch(reportFailure('rename project'));
     }
     refocusActiveTerm();
   };
+  // Single capture-phase listener — see the tile-rename comment in
+  // SessionTerm for why Enter/Escape must live in the same listener
+  // that calls stopPropagation().
   input.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') { e.stopPropagation(); finish(true); }
-    else if (e.key === 'Escape') { e.stopPropagation(); finish(false); }
-  });
+    e.stopPropagation();
+    if (e.key === 'Enter') finish(true);
+    else if (e.key === 'Escape') finish(false);
+  }, { capture: true });
   input.addEventListener('blur', () => finish(true));
-  input.addEventListener('keydown', (e) => e.stopPropagation(), { capture: true });
 }
 
 function ensureTerm(info) {
@@ -2193,7 +2230,7 @@ daemonBannerRestart.addEventListener('click', async () => {
     // RestartDaemon quits this process on success; control returns
     // here only on failure paths.
   } catch (err) {
-    setStatus(`restart failed: ${err}`, true);
+    flashStatus(`restart failed: ${err}`, true);
     showDaemonBanner(`Restart failed: ${err}`);
   } finally {
     daemonBannerRestart.disabled = false;
@@ -2317,6 +2354,8 @@ EventsOn('update:available', (info) => applyUpdateInfo(info));
 // Pull once on load. The Go side's periodic loop only fires every
 // 6h, so without this the user wouldn't see an "available" banner
 // until 6h after launch.
+// Intentionally silent: background boot poll. The manual menu path
+// below surfaces every outcome, including failures.
 CheckForUpdate().then((info) => applyUpdateInfo(info)).catch(() => {});
 
 // Guard against double-firing CheckForUpdate from the menu — clicking
@@ -2352,7 +2391,7 @@ EventsOn('bell-click', (sessionId) => {
 
 EventsOn('control:error', async (jsonStr) => {
   let e;
-  try { e = JSON.parse(jsonStr); } catch { setStatus('hived error', true); return; }
+  try { e = JSON.parse(jsonStr); } catch { flashStatus('hived error', true); return; }
   // Worktree-dirty kill: confirm with the user. The daemon already
   // refused to kill, so we can safely retry with force=true if the
   // user accepts.
@@ -2370,12 +2409,10 @@ EventsOn('control:error', async (jsonStr) => {
     // before issuing a second kill that would just produce a confusing
     // "no_such_session" control error.
     if (!state.sessions.find((s) => s.id === e.session_id)) return;
-    KillSession(e.session_id, true).catch((err) => {
-      setStatus(`force kill failed: ${err}`, true);
-    });
+    KillSession(e.session_id, true).catch(reportFailure('force kill'));
     return;
   }
-  setStatus(`${e.code}: ${e.message}`, true);
+  flashStatus(`${e.code}: ${e.message}`, true);
   console.warn('hived control error:', e);
 });
 
@@ -2432,7 +2469,7 @@ function activateLauncherSelection() {
       it.agent.id,
       launcherState.projectId || '',
       launcherState.duplicateCwd,
-    );
+    ).catch(reportFailure('duplicate session'));
   } else {
     CreateSession(
       it.agent.id,
@@ -2440,7 +2477,7 @@ function activateLauncherSelection() {
       '', '',
       0, 0,
       !!launcherState.useWorktree,
-    );
+    ).catch(reportFailure('new session'));
   }
   closeLauncher();
 }
@@ -2468,13 +2505,21 @@ function openLauncher(projectId, opts) {
       // Anchor next to the resolved project's + button so the user
       // can see which project the new session lands in. Falls back
       // to the global new-project button if the project's row isn't
-      // currently in the DOM (e.g. its header is offscreen).
+      // currently in the DOM (e.g. its header is offscreen), and to a
+      // fixed spot over the sidebar if neither anchor exists — a
+      // missing anchor must not throw and leave the launcher unopened
+      // (the throw used to vanish into this chain's empty catch).
       const anchorEl =
         document.querySelector(`.project[data-pid="${launcherState.projectId}"] .project-actions button`) ??
         document.getElementById('new-project-btn');
-      const r = anchorEl.getBoundingClientRect();
-      launcherEl.style.left = `${r.left}px`;
-      launcherEl.style.top = `${r.bottom + 4}px`;
+      if (anchorEl) {
+        const r = anchorEl.getBoundingClientRect();
+        launcherEl.style.left = `${r.left}px`;
+        launcherEl.style.top = `${r.bottom + 4}px`;
+      } else {
+        launcherEl.style.left = '16px';
+        launcherEl.style.top = '64px';
+      }
 
       // Worktree toggle row at the top of the menu. Disabled (and
       // visually muted) when the active project's cwd isn't a git
@@ -2509,7 +2554,12 @@ function openLauncher(projectId, opts) {
               launcherState.useWorktree = false;
               wtLabel.textContent = 'Worktree (project is not a git repo)';
             }
-          }).catch(() => {});
+          }).catch(() => {
+            // Intentionally silent: the probe rejects only when the
+            // bridge itself is down. Worst case the daemon later
+            // refuses worktree creation via control:error, which IS
+            // surfaced.
+          });
         }
       }
       // Detection (exec.LookPath on the daemon side) is best-effort:
@@ -2561,7 +2611,7 @@ function openLauncher(projectId, opts) {
               a.id,
               launcherState.projectId || '',
               launcherState.duplicateCwd,
-            );
+            ).catch(reportFailure('duplicate session'));
           } else {
             CreateSession(
               a.id,
@@ -2569,7 +2619,7 @@ function openLauncher(projectId, opts) {
               '', '',
               0, 0,
               !!launcherState.useWorktree,
-            );
+            ).catch(reportFailure('new session'));
           }
           closeLauncher();
         });
@@ -2586,7 +2636,10 @@ function openLauncher(projectId, opts) {
       // Drop the active tile's visual focus — modal owns the keyboard.
       setFocusedTile(null);
     })
-    .catch(() => {});
+    // Anything thrown in the chain above (not just a ListAgents
+    // rejection) used to land here silently — the user pressed ⌘T and
+    // nothing happened, with no trace.
+    .catch(reportFailure('launcher'));
 }
 
 function closeLauncher() {
@@ -2619,21 +2672,21 @@ function duplicateActiveSession() {
   if (!s) return;
   const cwd = resolveSessionCwd(s);
   if (!cwd) {
-    setStatus('cannot duplicate: source session has no cwd', true);
+    flashStatus('cannot duplicate: source session has no cwd', true);
     return;
   }
   const pid = s.projectId ?? s.project_id ?? '';
   if (s.agent) bumpAgentUsage(s.agent);
-  DuplicateSession(s.agent || '', pid, cwd);
+  DuplicateSession(s.agent || '', pid, cwd).catch(reportFailure('duplicate session'));
 }
 
 function restartActiveSession() {
   const s = state.sessions.find((x) => x.id === state.activeId);
   if (!s) {
-    setStatus('no active session to restart', true);
+    flashStatus('no active session to restart', true);
     return;
   }
-  RestartSession(s.id);
+  RestartSession(s.id).catch(reportFailure('restart'));
 }
 
 function duplicateActiveSessionChooseTool() {
@@ -2641,7 +2694,7 @@ function duplicateActiveSessionChooseTool() {
   if (!s) return;
   const cwd = resolveSessionCwd(s);
   if (!cwd) {
-    setStatus('cannot duplicate: source session has no cwd', true);
+    flashStatus('cannot duplicate: source session has no cwd', true);
     return;
   }
   const pid = s.projectId ?? s.project_id ?? '';
@@ -2670,6 +2723,8 @@ function openProjectEditor(project) {
   if (project) {
     editorCwd.value = project.cwd ?? '';
   } else {
+    // Intentionally silent: cosmetic default for an empty field;
+    // Browse… still works if this fails.
     LaunchDir().then((d) => { editorCwd.value = d || ''; }).catch(() => {});
     editorCwd.value = '';
   }
@@ -2691,9 +2746,9 @@ function saveProjectEditor() {
   const color = editorColor.value;
   if (!name) return;
   if (editorState.editing) {
-    UpdateProject(editorState.editing.id, name, color, cwd, -1);
+    UpdateProject(editorState.editing.id, name, color, cwd, -1).catch(reportFailure('save project'));
   } else {
-    CreateProject(name, color, cwd);
+    CreateProject(name, color, cwd).catch(reportFailure('create project'));
   }
   closeProjectEditor();
 }
@@ -2768,9 +2823,7 @@ window.addEventListener('keydown', (e) => {
   // Handled before the ⌘/Ctrl gate below so it fires on mac too.
   if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.code === 'Backquote') {
     swallow();
-    OpenTerminalAt(activeCwd()).catch((err) => {
-      setStatus(`open terminal: ${err}`, true);
-    });
+    OpenTerminalAt(activeCwd()).catch(reportFailure('open terminal'));
     return;
   }
 
@@ -2834,9 +2887,7 @@ window.addEventListener('keydown', (e) => {
   } else if (e.key === 'n' || e.key === 'N') {
     swallow();
     if (e.shiftKey) {
-      OpenNewWindow().catch((err) => {
-        setStatus(`window failed: ${err}`, true);
-      });
+      OpenNewWindow().catch(reportFailure('window'));
     } else {
       // ⌘N — new project. (⌥⌘N is reserved by macOS Spotlight.)
       openProjectEditor(null);
@@ -2849,7 +2900,7 @@ window.addEventListener('keydown', (e) => {
       // force=false: lets the daemon refuse with worktree_dirty if
       // the worktree has uncommitted changes; the control:error
       // handler then shows a confirm dialog and retries with force.
-      KillSession(state.activeId, false);
+      KillSession(state.activeId, false).catch(reportFailure('close'));
     }
   } else if (/^[1-9]$/.test(e.key)) {
     const idx = parseInt(e.key, 10) - 1;
@@ -2944,7 +2995,7 @@ const menuActions = {
   'menu:new-project': () => openProjectEditor(null),
   'menu:delete-project': () => deleteActiveProject(),
   'menu:command-palette': () => openCommandPalette(),
-  'menu:close-session': () => { if (state.activeId) KillSession(state.activeId, false); },
+  'menu:close-session': () => { if (state.activeId) KillSession(state.activeId, false).catch(reportFailure('close')); },
   'menu:zoom-in': () => bumpFontSize(+1),
   'menu:zoom-out': () => bumpFontSize(-1),
   'menu:zoom-reset': () => resetFontSize(),
@@ -2981,9 +3032,7 @@ async function confirmAndDeleteProject(proj) {
     : `Delete project "${proj.name}"?`;
   const ok = await Confirm('Delete project', msg);
   if (!ok) return;
-  KillProject(proj.id, sessions.length > 0).catch((err) => {
-    setStatus(`delete failed: ${err}`, true);
-  });
+  KillProject(proj.id, sessions.length > 0).catch(reportFailure('delete project'));
 }
 
 function deleteActiveProject() {
@@ -3001,9 +3050,9 @@ const paletteCommands = [
   { id: 'duplicate-session-choose-tool', name: 'Duplicate Session (choose tool)…', shortcut: '⇧⌘P', run: duplicateActiveSessionChooseTool },
   { id: 'restart-session',      name: 'Restart Session',             shortcut: '',       run: restartActiveSession },
   { id: 'delete-project',       name: 'Delete Active Project…',      shortcut: '⇧⌘⌫',    run: () => deleteActiveProject() },
-  { id: 'close-session',        name: 'Close Session',               shortcut: '⌘W',     run: () => { if (state.activeId) KillSession(state.activeId, false); } },
-  { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch((err) => setStatus(`window failed: ${err}`, true)) },
-  { id: 'open-os-terminal',     name: 'Open OS Terminal Here',       shortcut: '⌃`',     run: () => OpenTerminalAt(activeCwd()).catch((err) => setStatus(`open terminal: ${err}`, true)) },
+  { id: 'close-session',        name: 'Close Session',               shortcut: '⌘W',     run: () => { if (state.activeId) KillSession(state.activeId, false).catch(reportFailure('close')); } },
+  { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch(reportFailure('window')) },
+  { id: 'open-os-terminal',     name: 'Open OS Terminal Here',       shortcut: '⌃`',     run: () => OpenTerminalAt(activeCwd()).catch(reportFailure('open terminal')) },
   { id: 'close-window',         name: 'Close Window',                shortcut: '⇧⌘W',    run: () => CloseWindow() },
   { id: 'toggle-sidebar',       name: 'Toggle Sidebar',              shortcut: '⌘S',     run: toggleSidebar },
   { id: 'toggle-project-grid',  name: 'Toggle Project Grid',         shortcut: '⌘G',     run: toggleProjectGrid },

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -113,7 +113,7 @@ class SessionTerm {
       // Route OSC 8 hyperlinks (used by Claude CLI and others) through
       // the OS default browser via the Wails backend.
       linkHandler: {
-        activate: (_e, uri) => { if (uri) OpenURL(uri); },
+        activate: (_e, uri) => { if (uri) OpenURL(uri).catch(reportFailure('open link')); },
       },
     });
     this.fit = new FitAddon();
@@ -153,7 +153,7 @@ class SessionTerm {
     // ⌘-click when mouse reporting is active) follows it.
     try {
       this.term.loadAddon(new WebLinksAddon((event, uri) => {
-        if (uri) OpenURL(uri);
+        if (uri) OpenURL(uri).catch(reportFailure('open link'));
       }));
     } catch (err) {
       // Non-fatal; sessions still work without clickable links.
@@ -335,6 +335,9 @@ class SessionTerm {
       const bytes = new TextEncoder().encode(data);
       let bin = '';
       for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+      // Intentionally no reportFailure: this fires per keystroke, so a
+      // dead daemon would flood the status bar with one error per key.
+      // The disconnect itself is surfaced once ("control disconnected").
       WriteStdin(this.info.id, btoa(bin));
     };
     this.term.onData((data) => this._writePty(data));
@@ -637,6 +640,9 @@ class SessionTerm {
     const prevCols = this.term.cols;
     try { this.fit.fit(); } catch { /* keep going with last-known dims */ }
     if (this.attached) {
+      // Intentionally no reportFailure: resize fires continuously during
+      // window/sidebar drags, so a dead daemon would flood the status
+      // bar. The disconnect is surfaced once ("control disconnected").
       ResizeSession(this.info.id, this.term.cols, this.term.rows);
     }
     if (wasAtBottom) this.term.scrollToBottom();
@@ -919,13 +925,16 @@ function bumpFontSize(delta) {
   if (next === state.fontSize) return;
   state.fontSize = next;
   applyFontSize();
-  setStatus(`font ${state.fontSize}px`);
+  // flashStatus (not setStatus): per-action feedback must auto-revert,
+  // not overwrite the persistent slot ("control disconnected", session
+  // name) until the next nav event.
+  flashStatus(`font ${state.fontSize}px`);
 }
 
 function resetFontSize() {
   state.fontSize = DEFAULT_FONT_SIZE;
   applyFontSize();
-  setStatus(`font ${state.fontSize}px`);
+  flashStatus(`font ${state.fontSize}px`);
 }
 
 const termsHost = document.getElementById('terms');
@@ -2302,7 +2311,7 @@ function hideUpdateBanner() { updateBannerEl.classList.add('hidden'); }
 
 updateBannerDownload.addEventListener('click', () => {
   const url = updateBannerEl.dataset.url;
-  if (url) OpenURL(url);
+  if (url) OpenURL(url).catch(reportFailure('open link'));
 });
 updateBannerDismiss.addEventListener('click', () => {
   const v = updateBannerEl.dataset.version || '';
@@ -2895,7 +2904,7 @@ window.addEventListener('keydown', (e) => {
   } else if (e.key === 'w' || e.key === 'W') {
     swallow();
     if (e.shiftKey) {
-      CloseWindow();
+      CloseWindow().catch(reportFailure('close window'));
     } else if (state.activeId) {
       // force=false: lets the daemon refuse with worktree_dirty if
       // the worktree has uncommitted changes; the control:error
@@ -3053,7 +3062,7 @@ const paletteCommands = [
   { id: 'close-session',        name: 'Close Session',               shortcut: '⌘W',     run: () => { if (state.activeId) KillSession(state.activeId, false).catch(reportFailure('close')); } },
   { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch(reportFailure('window')) },
   { id: 'open-os-terminal',     name: 'Open OS Terminal Here',       shortcut: '⌃`',     run: () => OpenTerminalAt(activeCwd()).catch(reportFailure('open terminal')) },
-  { id: 'close-window',         name: 'Close Window',                shortcut: '⇧⌘W',    run: () => CloseWindow() },
+  { id: 'close-window',         name: 'Close Window',                shortcut: '⇧⌘W',    run: () => CloseWindow().catch(reportFailure('close window')) },
   { id: 'toggle-sidebar',       name: 'Toggle Sidebar',              shortcut: '⌘S',     run: toggleSidebar },
   { id: 'toggle-project-grid',  name: 'Toggle Project Grid',         shortcut: '⌘G',     run: toggleProjectGrid },
   { id: 'toggle-all-grid',      name: 'Toggle All Sessions Grid',    shortcut: '⇧⌘G',    run: toggleAllGrid },

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -2896,7 +2896,7 @@ window.addEventListener('keydown', (e) => {
   } else if (e.key === 'n' || e.key === 'N') {
     swallow();
     if (e.shiftKey) {
-      OpenNewWindow().catch(reportFailure('window'));
+      OpenNewWindow().catch(reportFailure('new window'));
     } else {
       // ⌘N — new project. (⌥⌘N is reserved by macOS Spotlight.)
       openProjectEditor(null);
@@ -3060,7 +3060,7 @@ const paletteCommands = [
   { id: 'restart-session',      name: 'Restart Session',             shortcut: '',       run: restartActiveSession },
   { id: 'delete-project',       name: 'Delete Active Project…',      shortcut: '⇧⌘⌫',    run: () => deleteActiveProject() },
   { id: 'close-session',        name: 'Close Session',               shortcut: '⌘W',     run: () => { if (state.activeId) KillSession(state.activeId, false).catch(reportFailure('close')); } },
-  { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch(reportFailure('window')) },
+  { id: 'new-window',           name: 'New Window',                  shortcut: '⇧⌘N',    run: () => OpenNewWindow().catch(reportFailure('new window')) },
   { id: 'open-os-terminal',     name: 'Open OS Terminal Here',       shortcut: '⌃`',     run: () => OpenTerminalAt(activeCwd()).catch(reportFailure('open terminal')) },
   { id: 'close-window',         name: 'Close Window',                shortcut: '⇧⌘W',    run: () => CloseWindow().catch(reportFailure('close window')) },
   { id: 'toggle-sidebar',       name: 'Toggle Sidebar',              shortcut: '⌘S',     run: toggleSidebar },
@@ -3186,7 +3186,7 @@ function moveActiveSession(delta, reorder) {
       .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
     const sIdx = sib.findIndex((s) => s.id === state.activeId);
     const next = (sIdx + delta + sib.length) % sib.length;
-    UpdateSession(state.activeId, '', '', next);
+    UpdateSession(state.activeId, '', '', next).catch(reportFailure('reorder'));
     return;
   }
   const next = (idx + delta + n) % n;

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -908,6 +908,9 @@ body.resizing-sidebar #app { transition: none; }
   0%   { background: rgba(220, 50, 50, 0.9); }
   100% { background: rgba(120, 20, 20, 0.65); }
 }
+@media (prefers-reduced-motion: reduce) {
+  #status.error { animation: none; }
+}
 
 /* Stale-daemon banner: row 1 of the #app grid, spanning sidebar +
    terms columns. Pushes the rest of the UI down rather than overlaying

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -899,7 +899,15 @@ body.resizing-sidebar #app { transition: none; }
   padding: 2px 6px;
   border-radius: 3px;
 }
-#status.error { color: #ff7a7a; }
+#status.error {
+  color: #ff9a9a;
+  background: rgba(120, 20, 20, 0.65);
+  animation: status-error-pulse 0.5s ease-out 1;
+}
+@keyframes status-error-pulse {
+  0%   { background: rgba(220, 50, 50, 0.9); }
+  100% { background: rgba(120, 20, 20, 0.65); }
+}
 
 /* Stale-daemon banner: row 1 of the #app grid, spanning sidebar +
    terms columns. Pushes the rest of the UI down rather than overlaying

--- a/cmd/hivegui/frontend/test/e2e/silent-failures.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/silent-failures.spec.js
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test';
+
+// E2E for the silent-failure surfacing pass: when a daemon call fails,
+// the status bar must show a user-visible error instead of the action
+// silently doing nothing. Failures are injected one-shot via the
+// Wails-mock's window.__hive.failNext(method, message).
+
+const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function boot(page) {
+  await page.goto('/');
+  await page.waitForFunction(() => document.querySelectorAll('#projects li').length > 0);
+}
+
+test('boot lands a persistent non-error status', async ({ page }) => {
+  await boot(page);
+  // After connect, setActive overwrites "connected" with the active
+  // session's name — the persistent slot ends at "main".
+  await expect(page.locator('#status')).toHaveText('main');
+  await expect(page.locator('#status')).not.toHaveClass(/error/);
+});
+
+test('failed CreateSession via launcher shows an error and adds no session', async ({ page }) => {
+  await boot(page);
+  const before = await page.evaluate(() => window.__hive.state.sessions.length);
+  await page.evaluate(() => window.__hive.failNext('CreateSession', 'daemon went away'));
+
+  // ⌘T opens the launcher; Enter activates the selected agent row.
+  await page.keyboard.press(`${mod}+t`);
+  await expect(page.locator('#launcher')).toBeVisible();
+  await expect(page.locator('#launcher .launcher-item').first()).toBeVisible();
+  await page.keyboard.press('Enter');
+
+  const status = page.locator('#status');
+  await expect(status).toHaveClass(/error/);
+  await expect(status).toHaveText(/new session failed:.*daemon went away/);
+  expect(await page.evaluate(() => window.__hive.state.sessions.length)).toBe(before);
+});
+
+test('failed KillSession shows an error and the session survives', async ({ page }) => {
+  await boot(page);
+  await page.evaluate(() => window.__hive.failNext('KillSession', 'boom'));
+
+  await page.keyboard.press(`${mod}+w`);
+
+  const status = page.locator('#status');
+  await expect(status).toHaveClass(/error/);
+  await expect(status).toHaveText(/close failed:.*boom/);
+  // The bootstrap session is still listed.
+  await expect(page.locator('#projects li[data-sid="s1"]')).toBeVisible();
+});
+
+test('failed rename shows an error', async ({ page }) => {
+  await boot(page);
+  await page.evaluate(() => window.__hive.failNext('UpdateSession', 'no daemon'));
+
+  const row = page.locator('#projects li[data-sid="s1"] .name');
+  await row.dblclick();
+  const input = page.locator('#projects li[data-sid="s1"] input.name-input');
+  await input.fill('renamed');
+  await input.press('Enter');
+
+  const status = page.locator('#status');
+  await expect(status).toHaveClass(/error/);
+  await expect(status).toHaveText(/rename failed:.*no daemon/);
+});
+
+test('error flash auto-reverts to the persistent status', async ({ page }) => {
+  await boot(page);
+  await page.evaluate(() => window.__hive.failNext('KillSession', 'transient'));
+  await page.keyboard.press(`${mod}+w`);
+  await expect(page.locator('#status')).toHaveText(/close failed/);
+  // FLASH_ERROR_MS is 6s — after expiry the persistent slot (the
+  // active session's name) returns.
+  await expect(page.locator('#status')).toHaveText('main', { timeout: 8000 });
+  await expect(page.locator('#status')).not.toHaveClass(/error/);
+});
+
+test('Enter commits a rename, Escape cancels it', async ({ page }) => {
+  // Locks the fix for the dead bubble-phase rename listener: a capture
+  // listener's stopPropagation() used to cancel the same input's
+  // bubble-phase Enter/Escape handler, so Enter did nothing and Escape
+  // could not cancel (the later blur committed anyway).
+  await boot(page);
+  const row = page.locator('#projects li[data-sid="s1"] .name');
+  await row.dblclick();
+  let input = page.locator('#projects li[data-sid="s1"] input.name-input');
+  await input.fill('kept');
+  await input.press('Enter');
+  await expect(page.locator('#projects li[data-sid="s1"] .name')).toHaveText('kept');
+
+  await page.locator('#projects li[data-sid="s1"] .name').dblclick();
+  input = page.locator('#projects li[data-sid="s1"] input.name-input');
+  await input.fill('discarded');
+  await input.press('Escape');
+  await expect(page.locator('#projects li[data-sid="s1"] .name')).toHaveText('kept');
+});
+
+test('launcher selects an agent and creates a session on the happy path', async ({ page }) => {
+  await boot(page);
+  const before = await page.evaluate(() => window.__hive.state.sessions.length);
+  await page.keyboard.press(`${mod}+t`);
+  await expect(page.locator('#launcher .launcher-item').first()).toContainText('Shell');
+  await page.keyboard.press('Enter');
+  await page.waitForFunction(
+    (n) => window.__hive.state.sessions.length === n + 1,
+    before,
+  );
+  await expect(page.locator('#launcher')).toBeHidden();
+});

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -194,11 +194,11 @@ export async function UpdateProject(id, name, color, cwd, _order) {
 }
 export async function LaunchDir() { return ''; }
 export async function PickDirectory() { return ''; }
-export async function OpenNewWindow() { return ''; }
-export async function CloseWindow() { return ''; }
+export async function OpenNewWindow() { maybeFail('OpenNewWindow'); return ''; }
+export async function CloseWindow() { maybeFail('CloseWindow'); return ''; }
 export async function IsGitRepo(_dir) { return false; }
-export async function OpenURL(_url) { return ''; }
-export async function OpenTerminalAt(_dir) { return ''; }
+export async function OpenURL(_url) { maybeFail('OpenURL'); return ''; }
+export async function OpenTerminalAt(_dir) { maybeFail('OpenTerminalAt'); return ''; }
 export async function Notify(_title, _body) { return ''; }
 export async function Confirm(_title, _body) { return true; }
 export async function RestartDaemon() { return ''; }

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -32,8 +32,22 @@ export function WindowSetTitle(t) { document.title = t; }
 // SetClipboardText (App), both aliased here. The mock keeps an in-memory
 // clipboard so copy/paste paths don't throw at module load.
 let clipboard = '';
-export async function ClipboardGetText() { return clipboard; }
-export async function SetClipboardText(text) { clipboard = String(text ?? ''); }
+export async function ClipboardGetText() { maybeFail('ClipboardGetText'); return clipboard; }
+export async function SetClipboardText(text) { maybeFail('SetClipboardText'); clipboard = String(text ?? ''); }
+
+// --- failure injection ---
+//
+// window.__hive.failNext(method, message) arms a one-shot rejection for
+// the named binding, so E2E can assert that a failed daemon call
+// surfaces user-visible feedback instead of being silently swallowed.
+const failures = new Map(); // method name -> error message
+function maybeFail(method) {
+  if (failures.has(method)) {
+    const msg = failures.get(method);
+    failures.delete(method);
+    throw new Error(msg);
+  }
+}
 
 // --- App bindings ---
 
@@ -86,6 +100,7 @@ export async function RequestScrollbackReplay(id) {
   return '';
 }
 export async function CreateSession(spec) {
+  maybeFail('CreateSession');
   const id = 'mock-' + (state.sessions.length + 1);
   const s = {
     id, name: spec.name || `s${state.sessions.length + 1}`,
@@ -98,25 +113,37 @@ export async function CreateSession(spec) {
   emit('session:event', JSON.stringify({ kind: 'added', session: s }));
   return id;
 }
-export async function DuplicateSession(id) { return CreateSession({ name: 'dup' }); }
+export async function DuplicateSession(id) { maybeFail('DuplicateSession'); return CreateSession({ name: 'dup' }); }
 export async function KillSession(id) {
+  maybeFail('KillSession');
   const i = state.sessions.findIndex((s) => s.id === id);
   if (i < 0) return '';
   const [removed] = state.sessions.splice(i, 1);
   emit('session:event', JSON.stringify({ kind: 'removed', session: removed }));
   return '';
 }
-export async function RestartSession(_id) { return ''; }
-export async function UpdateSession(req) {
-  const s = state.sessions.find((x) => x.id === req.session_id);
+export async function RestartSession(_id) { maybeFail('RestartSession'); return ''; }
+// Positional args matching the real Wails binding (and the e2e-real
+// bridge): UpdateSession(id, name, color, order). Empty string / -1
+// mean "no change". The old object-shaped signature silently no-op'd
+// every rename driven through the UI.
+export async function UpdateSession(id, name, color, _order) {
+  maybeFail('UpdateSession');
+  const s = state.sessions.find((x) => x.id === id);
   if (!s) return '';
-  if (req.name != null) s.name = req.name;
-  if (req.color != null) s.color = req.color;
+  if (name) s.name = name;
+  if (color) s.color = color;
   emit('session:event', JSON.stringify({ kind: 'updated', session: s }));
   return '';
 }
-export async function ListAgents() { return []; }
+// One real-shaped agent so launcher E2E can exercise the full
+// open → select → create flow (matches internal/agent's wire shape).
+export async function ListAgents() {
+  maybeFail('ListAgents');
+  return [{ id: 'shell', name: 'Shell', color: '#888', available: true, installCmd: [] }];
+}
 export async function CreateProject(req) {
+  maybeFail('CreateProject');
   const id = 'p-' + (state.projects.length + 1);
   const p = { id, name: req.name || 'new', color: req.color || '#0af',
     cwd: req.cwd || '', order: state.projects.length,
@@ -125,8 +152,8 @@ export async function CreateProject(req) {
   emit('project:event', JSON.stringify({ kind: 'added', project: p }));
   return id;
 }
-export async function KillProject(_id) { return ''; }
-export async function UpdateProject(_req) { return ''; }
+export async function KillProject(_id) { maybeFail('KillProject'); return ''; }
+export async function UpdateProject(_req) { maybeFail('UpdateProject'); return ''; }
 export async function LaunchDir() { return ''; }
 export async function PickDirectory() { return ''; }
 export async function OpenNewWindow() { return ''; }
@@ -158,5 +185,6 @@ if (typeof window !== 'undefined') {
     replayLog,
     replayCount(id) { return replayLog.filter((e) => id == null || e.id === id).length; },
     resetReplay() { replayLog.length = 0; },
+    failNext(method, message = 'injected failure') { failures.set(method, message); },
   };
 }

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -99,21 +99,27 @@ export async function RequestScrollbackReplay(id) {
   replayLog.push({ id, t: Date.now() });
   return '';
 }
-export async function CreateSession(spec) {
+// Positional args matching the real Wails binding:
+// CreateSession(agentID, projectID, name, color, cols, rows, useWorktree).
+export async function CreateSession(agentID, projectID, name, color, _cols, _rows, _useWorktree) {
   maybeFail('CreateSession');
   const id = 'mock-' + (state.sessions.length + 1);
   const s = {
-    id, name: spec.name || `s${state.sessions.length + 1}`,
-    color: spec.color || '#0af', order: state.sessions.length,
-    created: new Date().toISOString(), alive: true, agent: spec.agent || '',
-    project_id: spec.project_id || 'p1',
+    id, name: name || `s${state.sessions.length + 1}`,
+    color: color || '#0af', order: state.sessions.length,
+    created: new Date().toISOString(), alive: true, agent: agentID || '',
+    project_id: projectID || 'p1',
     worktree_path: '', worktree_branch: '', last_error: '',
   };
   state.sessions.push(s);
   emit('session:event', JSON.stringify({ kind: 'added', session: s }));
   return id;
 }
-export async function DuplicateSession(id) { maybeFail('DuplicateSession'); return CreateSession({ name: 'dup' }); }
+// Positional: DuplicateSession(agentID, projectID, cwd).
+export async function DuplicateSession(agentID, projectID, _cwd) {
+  maybeFail('DuplicateSession');
+  return CreateSession(agentID, projectID, 'dup', '', 0, 0, false);
+}
 export async function KillSession(id) {
   maybeFail('KillSession');
   const i = state.sessions.findIndex((s) => s.id === id);
@@ -142,18 +148,50 @@ export async function ListAgents() {
   maybeFail('ListAgents');
   return [{ id: 'shell', name: 'Shell', color: '#888', available: true, installCmd: [] }];
 }
-export async function CreateProject(req) {
+// Project mutations are positional too, matching the real bindings
+// (cmd/hivegui/app.go): CreateProject(name, color, cwd),
+// KillProject(id, killSessions), UpdateProject(id, name, color, cwd,
+// order). The old object-shaped/no-op forms silently no-op'd every
+// project create/save/delete driven through the UI — the same defect
+// UpdateSession had.
+export async function CreateProject(name, color, cwd) {
   maybeFail('CreateProject');
   const id = 'p-' + (state.projects.length + 1);
-  const p = { id, name: req.name || 'new', color: req.color || '#0af',
-    cwd: req.cwd || '', order: state.projects.length,
+  const p = { id, name: name || 'new', color: color || '#0af',
+    cwd: cwd || '', order: state.projects.length,
     created: new Date().toISOString() };
   state.projects.push(p);
   emit('project:event', JSON.stringify({ kind: 'added', project: p }));
   return id;
 }
-export async function KillProject(_id) { maybeFail('KillProject'); return ''; }
-export async function UpdateProject(_req) { maybeFail('UpdateProject'); return ''; }
+export async function KillProject(id, killSessions) {
+  maybeFail('KillProject');
+  const i = state.projects.findIndex((p) => p.id === id);
+  if (i < 0) return '';
+  if (killSessions) {
+    for (let j = state.sessions.length - 1; j >= 0; j--) {
+      if (state.sessions[j].project_id === id) {
+        const [rs] = state.sessions.splice(j, 1);
+        emit('session:event', JSON.stringify({ kind: 'removed', session: rs }));
+      }
+    }
+  }
+  const [removed] = state.projects.splice(i, 1);
+  emit('project:event', JSON.stringify({ kind: 'removed', project: removed }));
+  return '';
+}
+// Empty string / -1 mean "no change", mirroring UpdateSession (order is
+// accepted but not modelled, same as UpdateSession's _order).
+export async function UpdateProject(id, name, color, cwd, _order) {
+  maybeFail('UpdateProject');
+  const p = state.projects.find((x) => x.id === id);
+  if (!p) return '';
+  if (name) p.name = name;
+  if (color) p.color = color;
+  if (cwd) p.cwd = cwd;
+  emit('project:event', JSON.stringify({ kind: 'updated', project: p }));
+  return '';
+}
 export async function LaunchDir() { return ''; }
 export async function PickDirectory() { return ''; }
 export async function OpenNewWindow() { return ''; }
@@ -171,7 +209,7 @@ if (typeof window !== 'undefined') {
   window.__hive = {
     state,
     emit,
-    addSession(name) { return CreateSession({ name }); },
+    addSession(name) { return CreateSession('', 'p1', name, '', 0, 0, false); },
     killSession(id) { return KillSession(id); },
     listeners,
     stdinLog,

--- a/cmd/hivegui/frontend/test/unit/status.test.js
+++ b/cmd/hivegui/frontend/test/unit/status.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createStatus, FLASH_ERROR_MS, FLASH_INFO_MS, FLASH_MIN_MS,
+} from '../../src/lib/status.js';
+
+// Manual timer/clock harness — createStatus takes injected timers, so
+// no vi.useFakeTimers needed and the semantics are explicit.
+function harness() {
+  const rendered = []; // [{ text, isError }]
+  let clock = 0;
+  let nextId = 1;
+  const timers = new Map(); // id -> { at, fn }
+  const ctl = createStatus({
+    render: (text, isError) => rendered.push({ text, isError }),
+    setTimer: (fn, ms) => {
+      const id = nextId++;
+      timers.set(id, { at: clock + ms, fn });
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    now: () => clock,
+  });
+  const advance = (ms) => {
+    clock += ms;
+    for (const [id, t] of [...timers]) {
+      if (t.at <= clock) {
+        timers.delete(id);
+        t.fn();
+      }
+    }
+  };
+  const last = () => rendered[rendered.length - 1];
+  return { ctl, advance, last, rendered };
+}
+
+describe('createStatus', () => {
+  let h;
+  beforeEach(() => { h = harness(); });
+
+  it('set renders immediately when no flash is active', () => {
+    h.ctl.set('connected');
+    expect(h.last()).toEqual({ text: 'connected', isError: false });
+  });
+
+  it('error flash renders, then reverts to the persistent slot after FLASH_ERROR_MS', () => {
+    h.ctl.set('connected');
+    h.ctl.flash('copy failed: boom', true);
+    expect(h.last()).toEqual({ text: 'copy failed: boom', isError: true });
+    h.advance(FLASH_ERROR_MS - 1);
+    expect(h.last()).toEqual({ text: 'copy failed: boom', isError: true });
+    h.advance(1);
+    expect(h.last()).toEqual({ text: 'connected', isError: false });
+  });
+
+  it('info flash reverts after the shorter FLASH_INFO_MS', () => {
+    h.ctl.set('connected');
+    h.ctl.flash('creating session…');
+    h.advance(FLASH_INFO_MS);
+    expect(h.last()).toEqual({ text: 'connected', isError: false });
+  });
+
+  it('set during a young flash is deferred, then rendered at flash expiry', () => {
+    h.ctl.flash('close failed: boom', true);
+    h.advance(FLASH_MIN_MS - 1);
+    h.ctl.set('session two'); // nav feedback must not wipe a fresh error
+    expect(h.last()).toEqual({ text: 'close failed: boom', isError: true });
+    h.advance(FLASH_ERROR_MS - (FLASH_MIN_MS - 1));
+    expect(h.last()).toEqual({ text: 'session two', isError: false });
+  });
+
+  it('set after FLASH_MIN_MS replaces the flash immediately', () => {
+    h.ctl.flash('close failed: boom', true);
+    h.advance(FLASH_MIN_MS);
+    h.ctl.set('session two');
+    expect(h.last()).toEqual({ text: 'session two', isError: false });
+    // The flash timer was cancelled — nothing re-renders later.
+    const renders = h.rendered.length;
+    h.advance(FLASH_ERROR_MS * 2);
+    expect(h.rendered.length).toBe(renders);
+  });
+
+  it('a newer flash replaces an active one and resets the revert timer', () => {
+    h.ctl.set('connected');
+    h.ctl.flash('first failed', true);
+    h.advance(FLASH_ERROR_MS - 100);
+    h.ctl.flash('second failed', true);
+    expect(h.last()).toEqual({ text: 'second failed', isError: true });
+    h.advance(200); // first flash's deadline passes — must not revert yet
+    expect(h.last()).toEqual({ text: 'second failed', isError: true });
+    h.advance(FLASH_ERROR_MS);
+    expect(h.last()).toEqual({ text: 'connected', isError: false });
+  });
+
+  it('persistent error state survives an info flash', () => {
+    h.ctl.set('control disconnected', true);
+    h.ctl.flash('font 14px');
+    h.advance(FLASH_INFO_MS);
+    expect(h.last()).toEqual({ text: 'control disconnected', isError: true });
+  });
+});


### PR DESCRIPTION
## Summary

Frontend silent-failure pass — when a user action's daemon call fails, the status bar now says so instead of the click silently doing nothing. Found and fixed a real dormant bug along the way: **Enter/Escape in inline renames have been dead** (details below).

### Status controller (`src/lib/status.js`)
`setStatus` keeps its signature but is now backed by a pure controller with a **persistent slot** (connection state, nav feedback) and a **transient flash layer** (`flashStatus`): errors get ≥1.5s guaranteed visibility, auto-hide after 6s (info 2.5s), and revert to the persistent status instead of leaving the bar blank or being clobbered by nav feedback a frame later. `#status` is now a polite `aria-live` region with an error pulse.

### Failure feedback wired at every user-initiated call
Clipboard copy/paste (Ctrl+Shift+C/V), create/duplicate/restart/close session, create/save/delete project, rename/recolor/reorder sessions+projects, launcher open, OS terminal, new window. Intentionally-silent sites (teardown `CloseAttach`, `Notify` fallbacks, background update poll, `IsGitRepo` probe, `LaunchDir` default) now carry justification comments. Launcher null-anchor throw → fixed with a position fallback.

### Real bug: rename Enter/Escape were dead code
All three rename flows registered Enter/Escape on the **bubble phase** plus a separate **capture-phase `stopPropagation()`** listener on the same input. Per DOM dispatch, stop-propagation set during the target's capture invocation skips the target's bubble invocation entirely — so Enter never committed, and Escape couldn't cancel (the eventual blur committed anyway, **even after the user pressed Escape**). The handlers now live in the single capture-phase listener. Locked by a dedicated e2e test.

### Test-harness fix
The wails-mock's `UpdateSession(req)` took an object while the real binding (and e2e-real bridge) is positional — UI-driven renames silently no-op'd in e2e. Now positional. Mock also gains `window.__hive.failNext(method, msg)` one-shot failure injection and a real-shaped `ListAgents` response.

## Tests

- `test/unit/status.test.js` — 7 cases over flash/set semantics with injected timers
- `test/e2e/silent-failures.spec.js` — failed CreateSession/KillSession/rename surface status errors and mutate nothing; flash auto-revert; **Enter commits / Escape cancels rename**; launcher happy path
- Full matrix: vitest 117/117, mock e2e 41 passed / 1 skipped, e2e-real 2/2 (temp-dir isolated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)