### PR TITLE
test(gui): restore directory→environment routing under vitest 4

### DIFF
--- a/cmd/hivegui/frontend/test/dom/environment.test.js
+++ b/cmd/hivegui/frontend/test/dom/environment.test.js
@@ -1,0 +1,16 @@
+// Guardrail: the vitest config's `dom` project must provide a jsdom
+// environment to every test/dom/ file BY DIRECTORY — without a
+// per-file `// @vitest-environment jsdom` magic comment.
+//
+// This file deliberately omits that comment. If a future vitest
+// upgrade or config edit breaks the directory→environment routing
+// (as vitest 4 silently did when it removed `environmentMatchGlobs`),
+// `document` will be undefined here and this test fails — catching the
+// regression instead of letting other dom tests pass for the wrong
+// reason or silently degrade to the node environment.
+import { test, expect } from 'vitest';
+
+test('test/dom/ files run under jsdom by directory routing, no magic comment required', () => {
+  expect(typeof document, 'document should exist (jsdom env)').toBe('object');
+  expect(typeof window, 'window should exist (jsdom env)').toBe('object');
+});

--- a/cmd/hivegui/frontend/vitest.config.js
+++ b/cmd/hivegui/frontend/vitest.config.js
@@ -4,15 +4,35 @@ import { defineConfig } from 'vitest/config';
 //   test/unit/   → pure modules, node env, fast
 //   test/dom/    → jsdom + xterm/wails mocks
 //
-// The default `npm test` runs both; tweak with --dir.
+// vitest 4 removed `environmentMatchGlobs`, so the directory→env
+// routing is expressed as two projects instead. This keeps the
+// guardrail automatic: a new test/dom/ file gets jsdom even if its
+// author forgets the `// @vitest-environment jsdom` magic comment
+// (the comment still works and overrides, but is no longer required).
+// `npm test` (`vitest run`) runs both projects and reports a combined
+// total. Playwright specs (test/e2e*, *.spec.js) are excluded by the
+// `*.test.js` include and run via their own runner.
 export default defineConfig({
   test: {
-    environmentMatchGlobs: [
-      ['test/dom/**', 'jsdom'],
-      ['test/unit/**', 'node'],
-    ],
-    include: ['test/**/*.test.js'],
     globals: false,
     reporters: 'default',
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          include: ['test/unit/**/*.test.js'],
+          environment: 'node',
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'dom',
+          include: ['test/dom/**/*.test.js'],
+          environment: 'jsdom',
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to #216 (vitest 2→4). That bump silently broke the test config: vitest 4 **removed** `environmentMatchGlobs`, so `vitest.config.js`'s `test/dom → jsdom` / `test/unit → node` routing became a no-op. The suite kept passing only because every current `test/dom/` file happens to carry a `// @vitest-environment jsdom` magic comment — but the automatic guardrail was gone, so a future dom test added without that comment would have silently run in the **node** environment (no `document`), passing for the wrong reason or failing confusingly.

## Change

- Express the directory→environment routing as vitest 4 **`projects`** (the supported replacement). The magic comment still works and overrides per-file, but is no longer required.
- Add `test/dom/environment.test.js` — deliberately **comment-less** — asserting `document`/`window` exist. It locks the guardrail: if a future vitest upgrade or config edit breaks by-directory routing again, this test fails loudly instead of the regression going silent.

## Verification

- Probe files with **no** magic comment route correctly: `test/dom/*` → jsdom (`document` is object), `test/unit/*` → node (`document` undefined).
- Full vitest suite: **151 passing** (23 files), clean `|dom|`/`|unit|` project labels.
- Mock e2e: **52 passing** — Playwright's `*.spec.js` runner is unaffected (the `*.test.js` include still excludes it).

No production-code changes; test harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)