### PR TITLE
feat(agent): add Pi (pi.dev) as a launchable agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Agents: [Pi](https://pi.dev/) (`@earendil-works/pi-coding-agent`) is now
+  a launchable agent. Hive pins each session's id via `pi --session-id`, so
+  Restart resumes the exact conversation by id — unambiguous even when
+  sibling sessions share a worktree (same guarantee as Claude/Gemini).
 - GUI: keyboard-shortcuts help overlay on `⌘/`, listing every binding —
   including the ones no menu shows (terminal-level `Ctrl+Shift+C/V/A`
   copy/paste/select-all, `⇧↩` newline, launcher digit keys, sidebar

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hive
 
 A native desktop app for managing multiple AI coding agent sessions —
-Claude, Codex, Gemini, Copilot, Aider, plain shells — across projects.
+Claude, Codex, Gemini, Copilot, Aider, Pi, plain shells — across projects.
 
 > **`main` is now Hive v2 — the native daemon + GUI rewrite.** The legacy
 > tmux-backed TUI (Hive v1, `v0.14.x`) lives on the
@@ -20,7 +20,7 @@ What works:
 - Wails-based desktop GUI with xterm.js — full keyboard control,
   font scaling, dark theme
 - Projects (name, color, working dir) — sidebar tree
-- Agent launcher (Claude, Codex, Gemini, Copilot, Aider, shell)
+- Agent launcher (Claude, Codex, Gemini, Copilot, Aider, Pi, shell)
 - Grid view: per-project (⌘G) or all-sessions (⇧⌘G), spatial arrow nav
 - Multi-window (⇧⌘N) — independent windows share the same daemon
 - BEL → desktop notification + visual pulse on non-focused sessions

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,5 +1,5 @@
 // Package agent describes the AI-coding agents Hive can launch in a
-// session (Claude, Codex, Gemini, Copilot, Aider) plus a plain shell.
+// session (Claude, Codex, Gemini, Copilot, Aider, Pi) plus a plain shell.
 // The daemon spawns CreateSpec.Cmd directly; this package gives the
 // GUI and the daemon a shared catalog of "what does X require" so we
 // don't sprinkle agent names through the codebase.
@@ -24,6 +24,7 @@ const (
 	IDGemini  ID = "gemini"
 	IDCopilot ID = "copilot"
 	IDAider   ID = "aider"
+	IDPi      ID = "pi"
 )
 
 // Def describes one agent.
@@ -130,10 +131,32 @@ var (
 			Color:      "#ec4899",
 			InstallCmd: []string{"pip", "install", "aider-chat"},
 		},
+		IDPi: {
+			ID:        IDPi,
+			Name:      "Pi",
+			Cmd:       []string{"pi"},
+			ResumeCmd: []string{"pi", "-c"}, // fallback: continue most recent in cwd
+			Color:     "#06b6d4",
+			// Pi's own recommended install line keeps --ignore-scripts.
+			InstallCmd: []string{"npm", "install", "-g", "--ignore-scripts", "@earendil-works/pi-coding-agent"},
+			// `pi --session-id <id>` uses an exact, caller-chosen id,
+			// "creating it if missing" and reusing it (no fork) on later
+			// launches — verified against pi 0.79.3, which accepts our
+			// uuid4 ids. So, like Claude/Gemini, Hive pins its own entry
+			// id at first spawn and Restart resumes the same conversation
+			// by id; this is unambiguous even when sibling sessions share
+			// a cwd/worktree. The one flag both pins and resumes, so
+			// ResumeArgs reuses it (and ResumeCmd `pi -c` stays as the
+			// fallback for sessions launched with a user-supplied Cmd).
+			SessionIDFlag: "--session-id",
+			ResumeArgs: func(id, _ string) []string {
+				return []string{"pi", "--session-id", id}
+			},
+		},
 	}
 
 	// displayOrder is the order shown in the launcher.
-	displayOrder = []ID{IDShell, IDClaude, IDCodex, IDGemini, IDCopilot, IDAider}
+	displayOrder = []ID{IDShell, IDClaude, IDCodex, IDGemini, IDCopilot, IDAider, IDPi}
 )
 
 // Get returns the def for id, or zero Def + false if unknown.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -3,7 +3,7 @@ package agent
 import "testing"
 
 func TestBuiltinsPresent(t *testing.T) {
-	want := []ID{IDShell, IDClaude, IDCodex, IDGemini, IDCopilot, IDAider}
+	want := []ID{IDShell, IDClaude, IDCodex, IDGemini, IDCopilot, IDAider, IDPi}
 	for _, id := range want {
 		if _, ok := Get(id); !ok {
 			t.Errorf("missing built-in agent %s", id)
@@ -55,6 +55,44 @@ func TestClaudeDefSupportsSessionID(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("ResumeArgs[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestPiDefSupportsSessionID(t *testing.T) {
+	d, ok := Get(IDPi)
+	if !ok {
+		t.Fatalf("pi agent not registered")
+	}
+	if d.Name != "Pi" {
+		t.Errorf("pi Name = %q, want Pi", d.Name)
+	}
+	if len(d.Cmd) != 1 || d.Cmd[0] != "pi" {
+		t.Errorf("pi Cmd = %v, want [pi]", d.Cmd)
+	}
+	// `pi --session-id <id>` pins a caller-chosen id at first launch
+	// (verified against pi 0.79.3), so pi resumes unambiguously by id
+	// even when sibling sessions share a cwd.
+	if d.SessionIDFlag != "--session-id" {
+		t.Errorf("pi SessionIDFlag = %q, want --session-id", d.SessionIDFlag)
+	}
+	if d.ResumeArgs == nil {
+		t.Fatalf("pi ResumeArgs is nil; expected per-id resume support")
+	}
+	got := d.ResumeArgs("abc123", "/tmp/some/cwd")
+	want := []string{"pi", "--session-id", "abc123"}
+	if len(got) != len(want) {
+		t.Fatalf("ResumeArgs len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ResumeArgs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// Generic cwd-scoped continue stays as the fallback for sessions
+	// launched with a user-supplied Cmd (no SessionIDFlag injection).
+	wantResume := []string{"pi", "-c"}
+	if len(d.ResumeCmd) != len(wantResume) || d.ResumeCmd[0] != "pi" || d.ResumeCmd[1] != "-c" {
+		t.Errorf("pi ResumeCmd = %v, want %v", d.ResumeCmd, wantResume)
 	}
 }
 


### PR DESCRIPTION
## What

Adds [Pi](https://pi.dev/) (`@earendil-works/pi-coding-agent`) as a launchable agent in Hive, alongside Claude, Codex, Gemini, Copilot, and Aider.

The agent catalog lives in `internal/agent/agent.go`; the daemon spawns from it and the GUI launcher reads it dynamically via `ListAgents()`, so this is a Go-only change — no frontend edits.

## Resume by id

Pi exposes a flag the public docs omit:

```
--session-id <id>   Use exact project session ID, creating it if missing
```

Verified empirically against **pi 0.79.3** (in a throwaway `--session-dir`):

- First launch with a Hive-style v4 UUID → pi creates the session keyed by that exact id (filename **and** the first-line `session` record's `id`). pi accepts our UUID format.
- Re-launch with the same `--session-id` → pi **reuses** that one session, no fork.

So Pi maps onto Hive's existing Claude/Gemini path: `Create` pins the entry id at first spawn (`--session-id <entry-id>`) and `Restart`/`Revive` resume the exact conversation by id — unambiguous even when sibling sessions share a worktree. `pi -c` stays as the fallback `ResumeCmd` for sessions launched with a user-supplied `Cmd`.

This is more robust than the Codex/Copilot capture-from-disk path, so that follow-up is not needed for Pi.

## Changes

- `internal/agent/agent.go` — register `IDPi` (cmd `pi`, `--session-id` pinning + per-id `ResumeArgs`, color, install line with pi's recommended `--ignore-scripts`).
- `internal/agent/agent_test.go` — add `IDPi` to the built-ins list + `TestPiDefSupportsSessionID`.
- `README.md` / `CHANGELOG.md` — list Pi as a supported agent.

## Test

`go test ./internal/agent/ ./internal/registry/` passes; `go build ./cmd/hived` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)