### PR TITLE
fix(gui): stop terminal scroll-jump on resize with a full scrollback

### DIFF
--- a/cmd/hivegui/frontend/src/app/events.js
+++ b/cmd/hivegui/frontend/src/app/events.js
@@ -282,8 +282,12 @@ export function wireDaemonEvents(injected) {
           id, viewportY: buf?.viewportY, baseY: buf?.baseY,
           wants: st._replayWantsBottom,
         });
+        // Mark replay activity so the scroll-jump detector can label a
+        // following up-move as replay-driven (tiny sinceReplayMs) vs an
+        // unrelated renderer/resize jump.
+        try { st._lastReplayTs = performance.now(); } catch { /* no perf clock */ }
       }
-      handleScrollbackEvent(st, ev.kind);
+      handleScrollbackEvent(st, ev.kind, deps.scrollTrace.rec.enabled ? deps.scrollTrace.rec : undefined);
     } catch { /* ignore */ }
   });
 

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -24,12 +24,27 @@ import {
 import {
   shouldRequestReplay, REPLAY_DEBOUNCE_MS, applyRebaseline,
 } from '../lib/scrollback.js';
-import { scrollTrace } from './trace.js';
+import { scrollTrace, snapshotScrollJump } from './trace.js';
+import { classifyViewportMove } from '../lib/scroll-debug.js';
 import { onSessionBell, clearAttention } from './events.js';
 import { minimizeSession, updateAppTitle, showSingle, renderGrid } from './view.js';
 import { updateSidebarSelection } from './sidebar.js';
 import { setActive, setFocusedTile, refocusActiveTerm } from './focus.js';
 
+
+// Monotonic millisecond clock for the scroll-jump detector. Falls back
+// to 0 where performance isn't available (never in a real renderer).
+function nowMs() {
+  try { return performance.now(); } catch { return 0; }
+}
+
+// A viewport within this many lines of the bottom counts as "at the
+// bottom". Tolerates TUIs (codex etc.) that park a line or two short.
+const STICKY_BOTTOM_LINES = 2;
+
+// How recently a user scroll gesture must have fired for an onScroll to
+// count as user-driven (vs parse-driven cap-trim drift).
+const USER_SCROLL_GRACE_MS = 250;
 
 export class SessionTerm {
   constructor(info) {
@@ -419,6 +434,9 @@ export class SessionTerm {
     this.host.addEventListener('wheel', (e) => {
       e.preventDefault();
       e.stopPropagation();
+      // Stamp user-scroll intent so the jump detector attributes the
+      // resulting onScroll to the user, not to a renderer/replay event.
+      this._lastUserScrollTs = nowMs();
       let lines = Math.round(e.deltaY * linesPerPixel);
       if (lines === 0) {
         // Sub-pixel events — preserve direction so a slow scroll
@@ -429,6 +447,63 @@ export class SessionTerm {
       if (lines < -maxLinesPerEvent) lines = -maxLinesPerEvent;
       if (lines !== 0) this.term.scrollLines(lines);
     }, { capture: true, passive: false });
+
+    // Follow-intent tracking (ALWAYS ON — this is the fix for the
+    // scroll-jump bug). "Is the user at the bottom?" must be derived from
+    // the user's own scroll gestures, never from buffer geometry: during
+    // heavy output at the scrollback cap, xterm transiently drops the
+    // viewport off the bottom (cap-trim pins baseY at the cap while
+    // viewportY drifts) even though the user never scrolled. Inferring
+    // wasAtBottom from `baseY - viewportY` in _onBodyResize then mis-read
+    // "not at bottom" and armed a restore-into-history replay. We instead
+    // latch _followBottom from real scroll gestures and ignore parse-
+    // driven drift.
+    this._followBottom = true;
+    this._lastUserScrollTs = -Infinity;
+    this._lastReplayTs = -Infinity;
+    this._lastViewportY = this.term.buffer.active?.viewportY ?? 0;
+
+    // Keyboard scrollback (Shift+PageUp/Down, Shift+Home/End) is user
+    // intent too. xterm handles these internally; we only timestamp them
+    // so the onScroll below attributes the resulting move to the user.
+    this.body.addEventListener('keydown', (e) => {
+      if (e.shiftKey && (e.key === 'PageUp' || e.key === 'PageDown'
+        || e.key === 'Home' || e.key === 'End')) {
+        this._lastUserScrollTs = nowMs();
+      }
+    }, { capture: true });
+
+    this.term.onScroll(() => {
+      const buf = this.term.buffer.active;
+      if (!buf) return;
+      const from = this._lastViewportY;
+      const to = buf.viewportY;
+      this._lastViewportY = to;
+      const now = nowMs();
+      // Only a recent user gesture may change follow-intent. A move with
+      // no gesture behind it is parse-driven cap-trim drift — ignore it,
+      // so a wobbling viewport never clears "follow the bottom".
+      const userDriven = (now - this._lastUserScrollTs) <= USER_SCROLL_GRACE_MS;
+      if (userDriven) {
+        this._followBottom = (buf.baseY - to) <= STICKY_BOTTOM_LINES;
+      }
+
+      // Scroll-jump auto-detector (gated on hive.debug=1): record any
+      // UPWARD move no user gesture explains, and freeze the trace so
+      // heavy output can't rotate the evidence away before it's dumped.
+      if (scrollTrace.rec.enabled
+        && classifyViewportMove({ from, to, lastUserScrollTs: this._lastUserScrollTs, now }) === 'auto-up') {
+        scrollTrace.rec('viewport-jump', {
+          id: this.info.id,
+          from, to, baseY: buf.baseY, bufType: buf.type,
+          cols: this.term.cols, rows: this.term.rows, view: state.view,
+          attached: this.attached, following: this._followBottom,
+          sinceReplayMs: this._lastReplayTs > -Infinity ? Math.round(now - this._lastReplayTs) : null,
+          sinceUserScrollMs: this._lastUserScrollTs > -Infinity ? Math.round(now - this._lastUserScrollTs) : null,
+        });
+        snapshotScrollJump();
+      }
+    });
   }
 
   _attachWebgl() {
@@ -456,11 +531,17 @@ export class SessionTerm {
     // unit-tested without xterm or a real WebGL context.
     const dead = this.webgl;
     this.webgl = null;
-    recoverFromContextLoss({
+    if (scrollTrace.rec.enabled) scrollTrace.rec('webgl-context-loss', { id: this.info.id });
+    const { reattached } = recoverFromContextLoss({
       dispose: () => dead?.dispose(),
       reattach: () => this._attachWebgl(),
       refresh: () => this.term.refresh(0, this.term.rows - 1),
     });
+    // reattached=false means we just fell back to the DOM renderer — its
+    // char metrics differ from WebGL's, so the next fit can shift cols
+    // and fire a replay no user action explains. Logging it lets the
+    // trace tie a "spontaneous" jump back to a renderer fallback.
+    if (scrollTrace.rec.enabled) scrollTrace.rec('webgl-recover', { id: this.info.id, reattached });
   }
 
   _installRendererRecoveryListeners() {
@@ -468,6 +549,7 @@ export class SessionTerm {
     // call when no WebGL addon is loaded (DOM renderer ignores the
     // atlas hint and still benefits from the refresh).
     this._refreshRenderer = () => {
+      if (scrollTrace.rec.enabled) scrollTrace.rec('renderer-refresh', { id: this.info.id });
       try { this.webgl?.clearTextureAtlas(); } catch {}
       try { this.term.refresh(0, this.term.rows - 1); } catch {}
     };
@@ -625,13 +707,16 @@ export class SessionTerm {
     // Preserve "viewport pinned to bottom" across the resize. xterm's
     // own resize doesn't auto-snap to bottom after reflow; without this,
     // a user scrolled to the latest line would land mid-history.
-    // Tolerance: codex (and similar TUIs) sometimes leave the viewport
-    // a line or two short of the bottom; treat that as "at bottom" so
-    // resize doesn't strand the user mid-history. Anything further up
-    // is deliberate scrollback — leave it alone.
-    const STICKY_BOTTOM_LINES = 2;
+    //
+    // wasAtBottom comes from _followBottom — the user's own scroll
+    // intent — NOT from `baseY - viewportY`. Under heavy output at the
+    // scrollback cap, xterm transiently drops the viewport off the bottom
+    // (cap-trim) for a user who never scrolled; the old geometry check
+    // mis-read that as "scrolled up" and armed a restore-into-history
+    // replay (the scroll-jump bug). _followBottom is latched only by real
+    // gestures, so cap-trim drift can't flip it.
     const buf = this.term.buffer.active;
-    const wasAtBottom = buf ? (buf.baseY - buf.viewportY) <= STICKY_BOTTOM_LINES : true;
+    const wasAtBottom = this._followBottom;
     // Swallow throw and continue: a transient FitAddon error (e.g. a
     // race against teardown) shouldn't drop the daemon-side resize.
     const prevCols = this.term.cols;
@@ -679,6 +764,11 @@ export class SessionTerm {
       scrollTrace.rec('resize', {
         id: this.info.id, prevCols, cols: this.term.cols,
         baseline: this._replayBaselineCols, wasAtBottom,
+        // Raw geometry behind wasAtBottom: during heavy output xterm can
+        // lose bottom-follow (baseY pinned at the scrollback cap while
+        // viewportY drifts), so wasAtBottom reads false even though the
+        // user never scrolled — the suspected arm of a spurious up-jump.
+        baseY: buf?.baseY, viewportY: buf?.viewportY, bufType: buf?.type,
       });
     }
     if (this.attached && shouldRequestReplay(this._replayBaselineCols, this.term.cols)) {

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -496,7 +496,10 @@ export class SessionTerm {
       // viewportY would read as a huge spurious jump and pollute the trace.
       if (scrollTrace.rec.enabled
         && from <= buf.baseY
-        && classifyViewportMove({ from, to, lastUserScrollTs: this._lastUserScrollTs, now }) === 'auto-up') {
+        && classifyViewportMove({
+          from, to, lastUserScrollTs: this._lastUserScrollTs, now,
+          userGraceMs: USER_SCROLL_GRACE_MS,
+        }) === 'auto-up') {
         scrollTrace.rec('viewport-jump', {
           id: this.info.id,
           from, to, baseY: buf.baseY, bufType: buf.type,

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -491,7 +491,11 @@ export class SessionTerm {
       // Scroll-jump auto-detector (gated on hive.debug=1): record any
       // UPWARD move no user gesture explains, and freeze the trace so
       // heavy output can't rotate the evidence away before it's dumped.
+      // Skip when `from` exceeds the current baseY: the buffer just shrank
+      // (term.reset() on replay-begin / reattach), so the stale pre-reset
+      // viewportY would read as a huge spurious jump and pollute the trace.
       if (scrollTrace.rec.enabled
+        && from <= buf.baseY
         && classifyViewportMove({ from, to, lastUserScrollTs: this._lastUserScrollTs, now }) === 'auto-up') {
         scrollTrace.rec('viewport-jump', {
           id: this.info.id,

--- a/cmd/hivegui/frontend/src/app/trace.js
+++ b/cmd/hivegui/frontend/src/app/trace.js
@@ -11,6 +11,38 @@ export const scrollTrace = createScrollTrace({
     try { return localStorage.getItem('hive.debug') === '1'; } catch { return false; }
   })(),
 });
+// localStorage key holding the trace window snapshotted at the moment a
+// suspicious auto-up scroll was detected. The live ring is capped at
+// 2000 entries and heavy agent output rotates it fast — by the time a
+// user notices the jump and runs the dump, the evidence may already be
+// gone. snapshotScrollJump() freezes the tail the instant the detector
+// fires, and it survives a reload (so a user can capture, reload, and
+// still hand over the record).
+const LASTJUMP_KEY = 'hive.scrolltrace.lastjump';
+
+// Freeze the current trace tail to localStorage. Called by the
+// scroll-jump detector (SessionTerm.onScroll) when it records an
+// unexplained upward viewport move. Best-effort: storage may be full or
+// disabled — never throw into the scroll path.
+export function snapshotScrollJump() {
+  try {
+    localStorage.setItem(LASTJUMP_KEY, JSON.stringify({
+      at: Date.now(),
+      ring: scrollTrace.ring.slice(-400),
+    }));
+  } catch { /* storage unavailable — the live ring is still dumpable */ }
+}
+
 if (typeof window !== 'undefined') {
   window.__hive_scrolltrace = scrollTrace.ring;
+  // Operator-facing dump handle: returns the full live ring plus the
+  // frozen last-jump window, and best-effort copies the JSON to the
+  // clipboard so a user hitting the bug can paste it straight back.
+  window.__hive_dumpscroll = () => {
+    let lastJump = null;
+    try { lastJump = JSON.parse(localStorage.getItem(LASTJUMP_KEY) || 'null'); } catch { /* ignore */ }
+    const dump = { enabled: scrollTrace.rec.enabled, ring: scrollTrace.ring.slice(), lastJump };
+    try { navigator.clipboard?.writeText(JSON.stringify(dump)); } catch { /* clipboard may be denied */ }
+    return dump;
+  };
 }

--- a/cmd/hivegui/frontend/src/lib/scroll-debug.js
+++ b/cmd/hivegui/frontend/src/lib/scroll-debug.js
@@ -21,3 +21,23 @@ export function createScrollTrace({ enabled, now, cap = SCROLL_TRACE_CAP }) {
   rec.enabled = enabled;
   return { rec, ring };
 }
+
+// Classify a single viewport move for the scroll-jump auto-detector.
+// The reported bug moves the viewport UP into history (xterm's ydisp
+// decreases) with no user gesture behind it. `from`/`to` are the
+// previous and new viewportY; `lastUserScrollTs` is when the user last
+// drove a scroll (wheel / scroll key), `now` the move's timestamp, both
+// on the same monotonic clock. Returns:
+//   - null       the move wasn't upward (down-scroll or no-op) — never the bug
+//   - 'user-up'  upward, but a user gesture fired within `userGraceMs` — expected
+//   - 'auto-up'  upward with NO recent user gesture — the suspicious case the
+//                detector records (a resize/replay/renderer event moved it)
+// Pure so the detector's decision can be unit-tested without xterm.
+export function classifyViewportMove({ from, to, lastUserScrollTs, now, userGraceMs = 250 }) {
+  if (!(to < from)) return null;
+  const userDriven =
+    typeof lastUserScrollTs === 'number' &&
+    typeof now === 'number' &&
+    (now - lastUserScrollTs) <= userGraceMs;
+  return userDriven ? 'user-up' : 'auto-up';
+}

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -69,7 +69,13 @@ export function applyRebaseline(st, clearTimer = clearTimeout) {
   return st;
 }
 
-export function handleScrollbackEvent(st, kind) {
+// `trace` (optional) is scrollTrace.rec — when supplied, the replay
+// restore decision is recorded at parse time (wantsBottom, the captured
+// fromBottom distance, the computed scrollToLine target, and the
+// resulting viewport). This is the smoking gun for the jump-up bug: a
+// `wantsBottom:false` restore to a target far above baseY while the user
+// was actually at the bottom shows the heuristic misfired.
+export function handleScrollbackEvent(st, kind, trace) {
   if (!st || !st.term) return false;
   switch (kind) {
     case 'scrollback_replay_begin': {
@@ -131,6 +137,16 @@ export function handleScrollbackEvent(st, kind) {
         delete st._replayPrevFromBottom;
         if (wantsBottom) {
           if (typeof st.term.scrollToBottom === 'function') st.term.scrollToBottom();
+          // Replay landed at the bottom — keep following. (Without this,
+          // a stale _followBottom=false could survive a snap-to-bottom.)
+          st._followBottom = true;
+          if (trace) {
+            const b = st.term.buffer?.active;
+            trace('replay-restore', {
+              id: st.info?.id, wants: true, fromBottom,
+              baseY: b?.baseY, viewportY: b?.viewportY,
+            });
+          }
           return;
         }
         // Restore the reader's distance from the bottom. Soft-wrapped
@@ -138,8 +154,19 @@ export function handleScrollbackEvent(st, kind) {
         // this is an approximation — but it keeps the reader in
         // history near where they were instead of at the bottom.
         const buf = st.term.buffer?.active;
+        let target;
         if (typeof fromBottom === 'number' && buf && typeof st.term.scrollToLine === 'function') {
-          st.term.scrollToLine(Math.max(0, buf.baseY - fromBottom));
+          target = Math.max(0, buf.baseY - fromBottom);
+          st.term.scrollToLine(target);
+        }
+        // Replay restored a scrolled-up reading position — stay un-
+        // followed so the next resize preserves it too.
+        st._followBottom = false;
+        if (trace) {
+          trace('replay-restore', {
+            id: st.info?.id, wants: false, fromBottom, target,
+            baseY: buf?.baseY, viewportY: st.term.buffer?.active?.viewportY,
+          });
         }
       };
       // Parse-ordered: at done-event time the replay bytes may still

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -158,10 +158,12 @@ export function handleScrollbackEvent(st, kind, trace) {
         if (typeof fromBottom === 'number' && buf && typeof st.term.scrollToLine === 'function') {
           target = Math.max(0, buf.baseY - fromBottom);
           st.term.scrollToLine(target);
+          // Only un-follow when a restore ACTUALLY moved the viewport into
+          // history. Latching false unconditionally here would strand a
+          // user who has since scrolled back to the bottom while a stale
+          // wants=false replay was still in flight (no scrollToLine ran).
+          st._followBottom = false;
         }
-        // Replay restored a scrolled-up reading position — stay un-
-        // followed so the next resize preserves it too.
-        st._followBottom = false;
         if (trace) {
           trace('replay-restore', {
             id: st.info?.id, wants: false, fromBottom, target,

--- a/cmd/hivegui/frontend/src/lib/view-scroll.js
+++ b/cmd/hivegui/frontend/src/lib/view-scroll.js
@@ -55,6 +55,9 @@ export function snapVisibleTermsToBottom(terms) {
         st.term.write('', () => st.term.scrollToBottom());
       }
       st._replayWantsBottom = true;
+      // A mode switch is a deliberate "land at the bottom" — resume
+      // following so the next resize keeps the user pinned there.
+      st._followBottom = true;
       delete st._replayPrevFromBottom;
     }
   }

--- a/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.js
+++ b/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.js
@@ -241,6 +241,62 @@ test('viewport converges to the bottom after a mode switch under continuous outp
   expect(await traceTags(page, 'replay-request')).toBeGreaterThan(0);
 });
 
+test('full scrollback: an unscrolled user is not stranded in history by a resize under load', async ({ page }) => {
+  // Regression guard for the cap-trim jump-up. The bug only arms once
+  // xterm's 5000-line scrollback is FULL: cap-trim then pins baseY at the
+  // cap while the viewport drifts off-bottom during heavy parse, so
+  // _onBodyResize's geometry check `(baseY - viewportY) <= 2` mis-reads
+  // "not at bottom" for a user who never scrolled — arming a
+  // wants=false replay that strands the viewport up in history. The other
+  // scroll specs pump <1500 lines (below the cap) and never hit this.
+  await bootWithTerm(page);
+
+  // Flat-out flood well past the cap so it keeps parsing through the
+  // resizes below (bottom-follow stays lost the whole time).
+  await page.keyboard.type(
+    `awk 'BEGIN{for(j=0;j<60000;j++) printf "HIVE_SCROLL_%06d ................................................\\n", j}'; echo HIVE_PUMP_DONE\n`,
+  );
+
+  // Wait until the buffer is genuinely at the cap.
+  await expect.poll(
+    async () => (await scrollState(page))?.baseY ?? 0,
+    { timeout: 30000, intervals: [200, 400] },
+  ).toBeGreaterThan(4500);
+
+  // The user has NOT scrolled. Fire spaced threshold-crossing resizes
+  // while the flood is still parsing — each lands inside the cap-trim
+  // bottom-follow-loss window. A correct client keeps the user pinned to
+  // the bottom; the buggy one strands them up in history.
+  for (const w of [780, 1240, 820, 1200]) {
+    await page.setViewportSize({ width: w, height: 640 });
+    await page.waitForTimeout(350);
+  }
+
+  await page.waitForTimeout(1500); // let the last replay land
+
+  const s = await scrollState(page);
+  const restores = await page.evaluate(
+    () => (window.__hive_scrolltrace || []).filter((e) => e.tag === 'replay-restore'),
+  );
+  const wantsFalse = restores.filter((r) => r.wants === false);
+
+  // Sanity / non-vacuity: the buffer hit the cap and resizes actually
+  // fired replays (an invariant that holds over zero replays proves
+  // nothing).
+  expect(s.baseY, 'buffer never reached the scrollback cap').toBeGreaterThan(4500);
+  expect(restores.length, 'no resize replay fired — scenario is vacuous').toBeGreaterThan(0);
+
+  // The invariant: a user who NEVER scrolled must never be handed a
+  // restore-into-history (wants=false) replay. On the buggy code the
+  // cap-trim mis-read of wasAtBottom produces these; the follow-intent
+  // fix eliminates them. Deterministic regardless of whether a later
+  // event happens to re-snap the viewport to the bottom.
+  expect(
+    wantsFalse.length,
+    `unscrolled user got ${wantsFalse.length} restore-into-history replay(s): ${JSON.stringify(wantsFalse.slice(0, 4))}`,
+  ).toBe(0);
+});
+
 test('a reader scrolled into history is not yanked to the bottom by a resize replay', async ({ page }) => {
   await bootWithTerm(page);
   // Fill scrollback, then stop output so the read position is stable.

--- a/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
+++ b/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { createScrollTrace, SCROLL_TRACE_CAP } from '../../src/lib/scroll-debug.js';
+import {
+  createScrollTrace, SCROLL_TRACE_CAP, classifyViewportMove,
+} from '../../src/lib/scroll-debug.js';
 
 describe('createScrollTrace', () => {
   it('records nothing when disabled', () => {
@@ -30,5 +32,38 @@ describe('createScrollTrace', () => {
 
   it('default cap is SCROLL_TRACE_CAP', () => {
     expect(SCROLL_TRACE_CAP).toBe(2000);
+  });
+});
+
+describe('classifyViewportMove', () => {
+  // The jump-up bug moves the viewport UP (ydisp decreases) with no
+  // user gesture behind it. Downward / no-op moves are never the bug.
+  it('returns null when the viewport did not move up', () => {
+    expect(classifyViewportMove({ from: 10, to: 10, lastUserScrollTs: 0, now: 0 })).toBe(null);
+    expect(classifyViewportMove({ from: 10, to: 20, lastUserScrollTs: 0, now: 0 })).toBe(null);
+  });
+
+  it('labels an up-move within the user grace window as user-up', () => {
+    // User wheeled 100ms ago, then the viewport moved up → that's them.
+    expect(classifyViewportMove({
+      from: 100, to: 40, lastUserScrollTs: 900, now: 1000, userGraceMs: 250,
+    })).toBe('user-up');
+  });
+
+  it('treats the grace boundary as inclusive (still user-up)', () => {
+    expect(classifyViewportMove({
+      from: 100, to: 40, lastUserScrollTs: 750, now: 1000, userGraceMs: 250,
+    })).toBe('user-up');
+  });
+
+  it('labels an up-move with no recent user gesture as auto-up (the suspicious case)', () => {
+    expect(classifyViewportMove({
+      from: 100, to: 40, lastUserScrollTs: 100, now: 1000, userGraceMs: 250,
+    })).toBe('auto-up');
+  });
+
+  it('labels an up-move as auto-up when no user gesture was ever recorded', () => {
+    expect(classifyViewportMove({ from: 100, to: 40, lastUserScrollTs: null, now: 1000 })).toBe('auto-up');
+    expect(classifyViewportMove({ from: 100, to: 40, now: 1000 })).toBe('auto-up');
   });
 });

--- a/cmd/hivegui/frontend/test/unit/scrollback.test.js
+++ b/cmd/hivegui/frontend/test/unit/scrollback.test.js
@@ -196,6 +196,44 @@ describe('handleScrollbackEvent', () => {
     expect(handleScrollbackEvent(undefined, 'scrollback_replay_begin')).toBe(false);
     expect(handleScrollbackEvent({}, 'scrollback_replay_begin')).toBe(false);
   });
+
+  // _followBottom is the cap-trim fix's source of truth for "is the user
+  // at the bottom?" in _onBodyResize. A replay-done must keep it honest.
+  it('done with wants=true re-latches _followBottom = true (snap resumes following)', () => {
+    const { st, flush } = makeSt();
+    st._followBottom = false; // user had been scrolled up
+    st._replayWantsBottom = true; // but this replay snaps to bottom
+    handleScrollbackEvent(st, 'scrollback_replay_done');
+    flush();
+    expect(st.term.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(st._followBottom).toBe(true);
+  });
+
+  it('done with wants=false un-follows ONLY when a restore actually ran', () => {
+    const { st, flush } = makeSt({ baseY: 100, viewportY: 60 });
+    handleScrollbackEvent(st, 'scrollback_replay_begin'); // captures fromBottom
+    st._followBottom = true;
+    st._replayWantsBottom = false;
+    st.term.write('replay-bytes', () => { st.term.buffer.active.baseY = 120; });
+    handleScrollbackEvent(st, 'scrollback_replay_done');
+    flush();
+    expect(st.term.scrollToLine).toHaveBeenCalledWith(80); // restore ran
+    expect(st._followBottom).toBe(false);
+  });
+
+  it('done with wants=false does NOT un-follow when no restore ran (guards stranding)', () => {
+    // wants=false but no begin/capture → _replayPrevFromBottom undefined →
+    // scrollToLine is skipped. _followBottom must be left untouched: a user
+    // who scrolled back to the bottom while a stale replay was in flight
+    // must not be armed for a phantom restore-into-history on the next resize.
+    const { st, flush } = makeSt({ baseY: 100, viewportY: 100 });
+    st._followBottom = true;
+    st._replayWantsBottom = false;
+    handleScrollbackEvent(st, 'scrollback_replay_done');
+    flush();
+    expect(st.term.scrollToLine).not.toHaveBeenCalled();
+    expect(st._followBottom).toBe(true);
+  });
 });
 
 describe('applyRebaseline clears stale restore intent (the pair)', () => {

--- a/cmd/hivegui/frontend/test/unit/view-scroll.test.js
+++ b/cmd/hivegui/frontend/test/unit/view-scroll.test.js
@@ -65,6 +65,23 @@ describe('snapVisibleTermsToBottom', () => {
     expect(t._replayWantsBottom).toBe(true);
   });
 
+  it('resumes follow-intent on snapped terms (_followBottom = true)', () => {
+    // A mode switch is a deliberate "land at bottom", so the next resize
+    // must keep the user pinned there — even if they had scrolled up
+    // before (which had set _followBottom = false).
+    const t = makeTerm();
+    t._followBottom = false;
+    snapVisibleTermsToBottom([t]);
+    expect(t._followBottom).toBe(true);
+  });
+
+  it('does not resume follow-intent on skipped terms', () => {
+    const detached = makeTerm({ attached: false });
+    detached._followBottom = false;
+    snapVisibleTermsToBottom([detached]);
+    expect(detached._followBottom).toBe(false);
+  });
+
   it('does not set _replayWantsBottom on skipped terms', () => {
     const detached = makeTerm({ attached: false });
     const hidden = makeTerm({ h: 0 });


### PR DESCRIPTION
## Problem

Terminals scrolled up into history on their own during heavy agent output — intermittent and cross-machine. Reported as "agent sessions scroll up to show earlier parts of the conversation, very annoying."

## Root cause — a cap-trim bug

It only arms once xterm's 5000-line scrollback is **full**. Under heavy output, xterm trims from the top and transiently loses bottom-follow (`baseY` pinned at the cap while `viewportY` drifts) for a user who never scrolled. `_onBodyResize` inferred "at bottom?" from `baseY - viewportY <= 2`, mis-read that as "scrolled up", and armed a `wantsBottom=false` replay that restored the viewport up into history.

This is why it was "exposure-time" dependent (time to fill the buffer) and why it evaded ~15 prior scroll fixes (#141…#222) and a dedicated e2e suite: **the existing scroll specs pump <1500 lines — below the 5000 cap — so the buffer never fills and cap-trim never triggers.**

## Fix

Derive "is the user at the bottom?" from an explicit `_followBottom` flag, latched **only by real user scroll gestures** (wheel + Shift+Page/Home/End via `term.onScroll`) and immune to parse-driven drift. Set true at deliberate snap points (mode-switch snap, replay-done `wants=true`), false on a genuine scrolled-up restore.

## Also included

Passive scroll-jump **instrumentation**, gated entirely on `localStorage.hive.debug=1` (zero overhead otherwise), used to diagnose this: an `onScroll` auto-detector, `replay-restore` logging, and `window.__hive_dumpscroll()` with a localStorage snapshot so evidence survives heavy output / reload.

## Validation

- **Deterministic repro** against a real isolated `hived`: flood >5000 lines, resize under load → unscrolled user got a `wants=false` restore (stranded up to 5000 lines into history). Reliably red before the fix, green after.
- Unit: 156/156
- e2e-real scroll-codex: 4/4 — new repro passes, and the opposite-direction guards still hold (converges-to-bottom on mode switch; a scrolled-up reader is *not* yanked down)
- mock e2e scroll/grid/focus regressions: 13/13
- Confirmed gone in the real app by the reporter.

Note: the new e2e repro flakes only under `--repeat-each` (repeats share one daemon → non-vacuity guard); rock-solid on single runs, which is how CI executes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)