### PR TITLE
fix(agent): fail loudly for unknown agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Agents: creating a session for an agent unsupported by the running daemon now fails loudly instead of silently opening a generic shell, avoiding confusing GUI/daemon version-skew behavior for newly added agents like Pi.
 - GUI: scrollback replays no longer destroy the reading position
   ("scrolling jumps around with codex"). When a window resize, sidebar
   drag, or grid reflow triggered a scrollback replay while the user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Agents: creating a session for an agent unsupported by the running daemon now fails loudly instead of silently opening a generic shell, avoiding confusing GUI/daemon version-skew behavior for newly added agents like Pi.
+- Agents: creating a session for an agent unsupported by the running daemon
+  now fails loudly instead of silently opening a generic shell, avoiding
+  confusing GUI/daemon version-skew behavior for newly added agents like Pi.
 - GUI: scrollback replays no longer destroy the reading position
   ("scrolling jumps around with codex"). When a window resize, sidebar
   drag, or grid reflow triggered a scrollback replay while the user

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -342,7 +342,7 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 
 	if spec.Agent != "" {
 		if _, ok := agent.Get(agent.ID(spec.Agent)); !ok {
-			return nil, fmt.Errorf("%w: %s", ErrUnknownAgent, spec.Agent)
+			return nil, fmt.Errorf("%w: %q", ErrUnknownAgent, spec.Agent)
 		}
 	}
 
@@ -599,7 +599,7 @@ func (r *Registry) Revive(id string, opts session.Options) error {
 
 	if agentID != "" {
 		if _, ok := agent.Get(agent.ID(agentID)); !ok {
-			err := fmt.Errorf("%w: %s", ErrUnknownAgent, agentID)
+			err := fmt.Errorf("%w: %q", ErrUnknownAgent, agentID)
 			r.mu.Lock()
 			if e, ok := r.entries[id]; ok {
 				e.LastError = err.Error()

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -28,6 +28,13 @@ import (
 // ErrNotFound is returned when a session ID isn't known.
 var ErrNotFound = errors.New("registry: session not found")
 
+// ErrUnknownAgent is returned when a client asks to create/revive an
+// agent session whose ID is not in this build's agent catalog. Failing
+// loudly is preferable to silently opening a generic shell, which can
+// happen during GUI/daemon version skew (for example, a newer GUI
+// listing an agent that an older hived does not know yet).
+var ErrUnknownAgent = errors.New("registry: unknown agent")
+
 // startSession is the package-level seam used to spawn the underlying
 // PTY. Tests swap this to capture the resolved session.Options
 // without forking real agent binaries (e.g. to inspect agent argv);
@@ -333,6 +340,12 @@ func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
 	}
 	r.mu.Unlock()
 
+	if spec.Agent != "" {
+		if _, ok := agent.Get(agent.ID(spec.Agent)); !ok {
+			return nil, fmt.Errorf("%w: %s", ErrUnknownAgent, spec.Agent)
+		}
+	}
+
 	// Pre-resolve the worktree branch+path so the session name can
 	// match the worktree directory. ResolveBranchAndPath only picks a
 	// free name; the actual `git worktree add` happens further down.
@@ -583,6 +596,22 @@ func (r *Registry) Revive(id string, opts session.Options) error {
 		projectCwd = p.Cwd
 	}
 	r.mu.Unlock()
+
+	if agentID != "" {
+		if _, ok := agent.Get(agent.ID(agentID)); !ok {
+			err := fmt.Errorf("%w: %s", ErrUnknownAgent, agentID)
+			r.mu.Lock()
+			if e, ok := r.entries[id]; ok {
+				e.LastError = err.Error()
+				info := e.Info()
+				r.mu.Unlock()
+				r.broadcast(wire.SessionEventUpdated, info)
+			} else {
+				r.mu.Unlock()
+			}
+			return err
+		}
+	}
 
 	if projectCwd != "" {
 		opts.Cwd = projectCwd

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"errors"
 	"runtime"
 	"slices"
 	"sync"
@@ -53,6 +54,71 @@ func freshRegistry(t *testing.T) *Registry {
 	}
 	t.Cleanup(func() { _ = r.Close() })
 	return r
+}
+
+func TestCreateUnknownAgentFailsWithoutStartingShell(t *testing.T) {
+	r := freshRegistry(t)
+	rec := captureStartSession(t)
+
+	_, err := r.Create(wire.CreateSpec{Agent: "future-agent", Name: "future"})
+	if !errors.Is(err, ErrUnknownAgent) {
+		t.Fatalf("Create unknown agent error = %v, want ErrUnknownAgent", err)
+	}
+	if got := len(r.List()); got != 0 {
+		t.Fatalf("registry entries after failed Create = %d, want 0", got)
+	}
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if got := len(rec.opts); got != 0 {
+		t.Fatalf("startSession calls = %d, want 0 (must not silently start a shell)", got)
+	}
+}
+
+func TestReviveUnknownAgentFailsWithoutStartingShell(t *testing.T) {
+	r := freshRegistry(t)
+	rec := captureStartSession(t)
+
+	r.mu.Lock()
+	e := &Entry{ID: "unknown-1", Name: "future", Agent: "future-agent", Created: time.Now().UTC()}
+	r.entries[e.ID] = e
+	r.order = append(r.order, e.ID)
+	r.mu.Unlock()
+
+	err := r.Revive(e.ID, session.Options{})
+	if !errors.Is(err, ErrUnknownAgent) {
+		t.Fatalf("Revive unknown agent error = %v, want ErrUnknownAgent", err)
+	}
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if got := len(rec.opts); got != 0 {
+		t.Fatalf("startSession calls = %d, want 0 (must not silently revive a shell)", got)
+	}
+	if got := r.Get(e.ID).LastError; got == "" {
+		t.Fatalf("LastError is empty, want unknown-agent error surfaced on entry")
+	}
+}
+
+func TestCreateAppendsSessionIDForPi(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+	rec := captureStartSession(t)
+
+	a, err := r.Create(wire.CreateSpec{Agent: string(agent.IDPi), Name: "pi"})
+	if err != nil {
+		t.Fatalf("Create pi: %v", err)
+	}
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.opts) != 1 {
+		t.Fatalf("startSession calls = %d, want 1", len(rec.opts))
+	}
+	want := []string{"pi", "--session-id", a.ID}
+	if !slices.Equal(rec.opts[0].Cmd, want) {
+		t.Fatalf("pi Create cmd = %v, want %v", rec.opts[0].Cmd, want)
+	}
+	if got := r.Get(a.ID).AgentSessionID; got != a.ID {
+		t.Fatalf("pi AgentSessionID = %q, want entry id %q", got, a.ID)
+	}
 }
 
 func TestCreateListKill(t *testing.T) {
@@ -687,4 +753,3 @@ func TestCreateWithExplicitCmdSkipsAgentSessionIDPin(t *testing.T) {
 		t.Errorf("AgentSessionID = %q, want empty (caller-supplied Cmd was not pinned)", got)
 	}
 }
-


### PR DESCRIPTION
## Summary
- return an explicit unknown-agent error instead of silently opening a shell when the daemon does not recognize an agent ID
- add regression coverage for unknown-agent creation and Pi's session-id launch argv
- update the changelog

## Tests
- go test ./internal/registry ./internal/agent
- go test ./cmd/hived ./cmd/hived-ws-bridge ./internal/...

Note: `go test ./...` still fails in this checkout because `cmd/hivegui` expects generated `frontend/dist` embed files.