### PR TITLE
fix(gui): scroll wheel in Claude / alt-buffer sessions + Debug trace menu

### DIFF
--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -6,7 +6,7 @@
 
 import {
   EventsOn, KillSession, KillProject, Confirm, UpdateSession,
-  OpenNewWindow, CloseWindow, OpenTerminalAt,
+  OpenNewWindow, CloseWindow, OpenTerminalAt, SetClipboardText, Notify,
 } from '../bridge.js';
 import { state } from './state.js';
 import { reportFailure } from './dom.js';
@@ -269,6 +269,32 @@ export function switchToNthSession(n) {
   if (n - 1 < ord.length) switchTo(ord[n - 1].id);
 }
 
+// Debug: arm/disarm the scroll tracer. trace.js latches hive.debug at
+// module load, so the new state only takes effect after a reload — do it
+// here so the user never needs the devtools console to flip the gate.
+function toggleScrollDebug() {
+  let on = false;
+  try { on = localStorage.getItem('hive.debug') === '1'; } catch { /* storage off */ }
+  try { localStorage.setItem('hive.debug', on ? '0' : '1'); } catch { /* storage off */ }
+  location.reload();
+}
+
+// Debug: copy the captured scroll trace to the clipboard via the Go side
+// (works without devtools and without a clipboard user-gesture). Reuses
+// window.__hive_dumpscroll (trace.js) so the dump shape matches what the
+// e2e harness and bug reports expect.
+function copyScrollTrace() {
+  const dump = typeof window.__hive_dumpscroll === 'function'
+    ? window.__hive_dumpscroll()
+    : { enabled: false, ring: window.__hive_scrolltrace || [], lastJump: null };
+  SetClipboardText(JSON.stringify(dump)).catch(reportFailure('copy scroll trace'));
+  const n = dump.ring?.length ?? 0;
+  const body = dump.enabled
+    ? `Copied ${n} scroll event${n === 1 ? '' : 's'} to the clipboard.`
+    : 'Scroll debug is OFF — run "Toggle Scroll Debug" first, reload, reproduce, then copy.';
+  Notify('Hive', 'Scroll trace', body, 'scroll-trace').catch(() => {});
+}
+
 const menuActions = {
   'menu:new-session': () => openLauncher(),
   'menu:new-session-worktree': () => openLauncher(undefined, { forceWorktree: true }),
@@ -297,6 +323,8 @@ const menuActions = {
   // (Escape/⌘/ in the window listener) never sees ⌘/ while the menu
   // owns it.
   'menu:keyboard-shortcuts': () => toggleHelpOverlay(),
+  'menu:toggle-scroll-debug': () => toggleScrollDebug(),
+  'menu:copy-scroll-trace': () => copyScrollTrace(),
 };
 for (const [name, fn] of Object.entries(menuActions)) {
   EventsOn(name, fn);

--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -276,6 +276,9 @@ function toggleScrollDebug() {
   let on = false;
   try { on = localStorage.getItem('hive.debug') === '1'; } catch { /* storage off */ }
   try { localStorage.setItem('hive.debug', on ? '0' : '1'); } catch { /* storage off */ }
+  // The reload is intentional and unavoidable: trace.js reads hive.debug
+  // once at module load, so the new state only takes effect on a fresh load.
+  // The menu label says "(Reloads)" so this isn't a surprise.
   location.reload();
 }
 

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -220,8 +220,12 @@ export class SessionTerm {
         const dy = e.clientY - this._pendingClickY;
         if (dx * dx + dy * dy >= 25) return; // dragged → selection, leave it
         const buf = this.term.buffer.active;
-        if (buf.type !== 'normal') return;
-        if (this.term.modes && this.term.modes.mouseTrackingMode && this.term.modes.mouseTrackingMode !== 'none') return;
+        // Same "is this gesture ours to interpret?" test as the wheel
+        // handler — only in the normal buffer with mouse reporting off.
+        if (!shouldScrollViewport({
+          bufferType: buf?.type,
+          mouseTrackingMode: this.term.modes?.mouseTrackingMode,
+        })) return;
         const rect = screen.getBoundingClientRect();
         const cellW = rect.width / this.term.cols;
         const cellH = rect.height / this.term.rows;

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -26,7 +26,7 @@ import {
 } from '../lib/scrollback.js';
 import { scrollTrace, snapshotScrollJump } from './trace.js';
 import { classifyViewportMove } from '../lib/scroll-debug.js';
-import { wheelToScrollLines } from '../lib/wheel-scroll.js';
+import { wheelToScrollLines, shouldScrollViewport } from '../lib/wheel-scroll.js';
 import { onSessionBell, clearAttention } from './events.js';
 import { minimizeSession, updateAppTitle, showSingle, renderGrid } from './view.js';
 import { updateSidebarSelection } from './sidebar.js';
@@ -436,6 +436,16 @@ export class SessionTerm {
     const linesPerPixel = 1 / 14; // ~one line per ~14 px of delta
     const maxLinesPerEvent = 8;   // about half a screen on a small tile
     this.host.addEventListener('wheel', (e) => {
+      // Only take over the wheel in the normal buffer with mouse reporting
+      // off. In the alternate buffer (Claude, vim, htop) scrollLines is a
+      // no-op, and with mouse tracking on the app expects the wheel as mouse
+      // events — swallowing it here is why Claude wouldn't scroll while pi
+      // (a plain line buffer) did. Let xterm handle those natively.
+      const buf = this.term.buffer.active;
+      if (!shouldScrollViewport({
+        bufferType: buf?.type,
+        mouseTrackingMode: this.term.modes?.mouseTrackingMode,
+      })) return;
       e.preventDefault();
       e.stopPropagation();
       // Stamp user-scroll intent so the jump detector attributes the

--- a/cmd/hivegui/frontend/src/lib/wheel-scroll.js
+++ b/cmd/hivegui/frontend/src/lib/wheel-scroll.js
@@ -21,6 +21,25 @@
 const DOM_DELTA_LINE = 1;
 const DOM_DELTA_PAGE = 2;
 
+// Whether the GUI should take over the wheel and turn it into local
+// scrollback (preventDefault + term.scrollLines). ONLY in the normal buffer
+// with mouse reporting OFF:
+//   - In the alternate buffer (full-screen TUIs — Claude, vim, htop) there is
+//     no scrollback, so term.scrollLines is a no-op.
+//   - When the running program has enabled mouse tracking it expects the
+//     wheel forwarded to it as mouse events so it can scroll its OWN content.
+// Taking over in either case swallows the gesture (capture-phase
+// preventDefault + stopPropagation) and the app can never scroll — which is
+// exactly why the terminal scrolled in a plain shell / pi but not in Claude.
+// When this returns false we let the event fall through to xterm's native
+// handling (forward-to-app, or Shift+wheel local scroll). Pure so the
+// buffer/mode matrix is unit-testable without xterm.
+export function shouldScrollViewport({ bufferType, mouseTrackingMode }) {
+  if (bufferType !== 'normal') return false;
+  if (mouseTrackingMode && mouseTrackingMode !== 'none') return false;
+  return true;
+}
+
 export function wheelToScrollLines(e, { linesPerPixel, maxLinesPerEvent }) {
   let deltaY = e.deltaY;
   let deltaMode = e.deltaMode;

--- a/cmd/hivegui/frontend/src/lib/wheel-scroll.js
+++ b/cmd/hivegui/frontend/src/lib/wheel-scroll.js
@@ -1,9 +1,12 @@
 // Wheel → terminal-line conversion, normalized across platforms.
 //
 // The GUI takes over wheel handling (capture phase + preventDefault) so
-// xterm's own wheel→lines math never runs — see SessionTerm. That means
-// EVERY wheel scroll flows through this one function; if it returns 0,
-// the terminal cannot scroll at all.
+// xterm's own wheel→lines math never runs — see SessionTerm. This function
+// runs only when shouldScrollViewport (below) says the gesture is ours to
+// interpret: the normal buffer with mouse reporting off. In that case every
+// wheel scroll flows through it, and if it returns 0 the terminal cannot
+// scroll at all. (Alt-buffer / mouse-tracking events bail before reaching
+// here and fall through to xterm.)
 //
 // The original math assumed pixel deltas (deltaMode 0) and a populated
 // standard `deltaY`, which holds on Chromium and on recent macOS. But

--- a/cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.js
+++ b/cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.js
@@ -1,0 +1,233 @@
+import { test, expect } from '@playwright/test';
+
+// Repro for "the terminal won't scroll by mouse wheel or trackpad on one of my
+// Macs" (selection-drag still scrolls). PR #229 theorized a WKWebView quirk
+// (deltaMode LINE/PAGE or deltaY=0 with the value only in legacy wheelDeltaY)
+// and normalized the math in lib/wheel-scroll.js — yet the Mac still doesn't
+// scroll, which means the root cause is OUTSIDE that pure function.
+//
+// The existing scroll-codex.spec drives scrolling via page.mouse.wheel, which
+// in Chromium ONLY emits pixel-mode (deltaMode 0) events. So it can never
+// exercise the line-mode handler path or catch a term.scrollLines() no-op —
+// which is exactly why CI stays green while the Mac fails.
+//
+// These tests dispatch SYNTHETIC wheel events of each suspect shape directly at
+// .term-host (where SessionTerm's capture-phase listener lives) and assert the
+// terminal viewport ACTUALLY moves — exercising handler → wheelToScrollLines →
+// term.scrollLines → viewport end-to-end, not the math in isolation. This is an
+// integration layer CI currently lacks; it will lock in whichever fix we land.
+//
+// NOTE: this harness runs Chromium, not WKWebView, so it reproduces branches
+// B (lines still 0) / C (scrollLines no-op) / D (re-pin) deterministically. For
+// branch A (no JS wheel event at all) the affected-Mac scroll trace is the
+// authority — Chromium always delivers the synthetic event we dispatch.
+
+const WS_URL = process.env.WS_BRIDGE_URL;
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((url) => {
+    window.__WS_BRIDGE_URL = url;
+    // Arm the scroll tracer (window.__hive_scrolltrace) before main.js loads,
+    // so a failure attaches the derived `lines` per wheel event below.
+    try { localStorage.setItem('hive.debug', '1'); } catch {}
+  }, WS_URL);
+});
+
+// On failure, attach the armed scroll trace so the artifact shows the raw
+// delta we dispatched vs. the line count the handler derived (lines===0 ⇒ math
+// gap; lines!==0 with no viewport move ⇒ scrollLines no-op). Best-effort.
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    try {
+      const trace = await page.evaluate(() => window.__hive_scrolltrace);
+      await testInfo.attach('scrolltrace', {
+        body: JSON.stringify(trace ?? null),
+        contentType: 'application/json',
+      });
+    } catch { /* page closed / nav race — keep the real failure */ }
+  }
+});
+
+async function bootWithTerm(page) {
+  test.skip(!WS_URL, 'WS_BRIDGE_URL not set — globalSetup did not run');
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li.session-item').length >= 1,
+    null, { timeout: 10000 },
+  );
+  await page.waitForFunction(
+    () => !!document.querySelector('.term-host .xterm-helper-textarea'),
+    null, { timeout: 10000 },
+  );
+  await page.evaluate(() => {
+    const helper = document.querySelector('.term-host.active .xterm-helper-textarea')
+      || document.querySelector('.term-host .xterm-helper-textarea');
+    helper.focus();
+  });
+  await page.keyboard.type('stty -echo\n');
+  await page.waitForTimeout(200);
+}
+
+// Bounded high-rate marker pump (bursty: flood, sleep) — fills scrollback so
+// there is history above the viewport to scroll INTO, then stops so the read
+// position is stable.
+async function startMarkerPump(page, count, burst = 40) {
+  await page.keyboard.type(
+    `i=0; while [ $i -lt ${count} ]; do awk -v s=$i -v n=${burst} 'BEGIN{for(j=s;j<s+n;j++) printf "HIVE_SCROLL_%06d ................................................\\n", j}'; i=$((i+${burst})); sleep 0.05; done; echo HIVE_PUMP_DONE\n`,
+  );
+}
+
+function bufferLines(page) {
+  return page.evaluate(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const buf = st?.term?.buffer?.active;
+    if (!buf) return [];
+    const out = [];
+    for (let i = 0; i < buf.length; i++) {
+      out.push(buf.getLine(i)?.translateToString(true) || '');
+    }
+    return out;
+  });
+}
+
+function scrollState(page) {
+  return page.evaluate(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const buf = st?.term?.buffer?.active;
+    if (!buf) return null;
+    return { viewportY: buf.viewportY, baseY: buf.baseY, type: buf.type };
+  });
+}
+
+// Dispatch a real WheelEvent at the element actually under the terminal's
+// center (via elementFromPoint — the same hit-test the browser does), so the
+// event must propagate up through the capture phase to SessionTerm's listener
+// on .term-host. This is faithful to a webview-delivered gesture: it exercises
+// not just the handler math but that the event PATH reaches the handler at all.
+async function dispatchWheel(page, init, times = 6) {
+  await page.evaluate(({ init, times }) => {
+    const host = document.querySelector('.term-host.active')
+      || document.querySelector('.term-host');
+    const r = host.getBoundingClientRect();
+    const target = document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2)
+      || host;
+    // `wheelDeltaY` is a legacy read-only getter, not a WheelEvent constructor
+    // member — it can't be passed via the init dict, so override it on the
+    // instance to simulate a webview that only populates the deprecated field.
+    const { wheelDeltaY, ...ctor } = init;
+    for (let i = 0; i < times; i++) {
+      const ev = new WheelEvent('wheel', { bubbles: true, cancelable: true, ...ctor });
+      if (wheelDeltaY !== undefined) {
+        Object.defineProperty(ev, 'wheelDeltaY', { value: wheelDeltaY, configurable: true });
+      }
+      target.dispatchEvent(ev);
+    }
+  }, { init, times });
+  await page.waitForTimeout(100);
+}
+
+// Count whether the GUI's wheel takeover (term.scrollLines) actually ran for a
+// dispatched gesture. Distinguishes "handler bailed, event went to the app"
+// (count 0 — correct under mouse tracking / alt buffer) from "handler ran"
+// (count > 0). Wraps scrollLines once per session and resets the counter per call.
+async function countTakeover(page, init) {
+  await page.evaluate(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    window.__takeoverCalls = 0;
+    if (st && !st.__wheelWrapped) {
+      const orig = st.term.scrollLines.bind(st.term);
+      st.term.scrollLines = (n) => { window.__takeoverCalls++; return orig(n); };
+      st.__wheelWrapped = true;
+    }
+  });
+  await dispatchWheel(page, init);
+  return page.evaluate(() => window.__takeoverCalls);
+}
+
+// Make the running program enable mouse tracking (DECSET 1000), as Claude/vim
+// do. The bytes flow shell → pty → xterm, which sets term.modes.mouseTrackingMode.
+async function enableMouseTracking(page) {
+  await page.keyboard.type("printf '\\033[?1000h'\n");
+  await page.waitForFunction(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    return st?.term?.modes?.mouseTrackingMode && st.term.modes.mouseTrackingMode !== 'none';
+  }, null, { timeout: 5000 });
+}
+
+// Switch the session into the alternate screen buffer (DECSET 1049), as a
+// full-screen TUI does — there is no scrollback there, so scrollLines is a no-op.
+async function enterAltBuffer(page) {
+  await page.keyboard.type("printf '\\033[?1049h'\n");
+  await page.waitForFunction(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    return st?.term?.buffer?.active?.type === 'alternate';
+  }, null, { timeout: 5000 });
+}
+
+// Fill scrollback and confirm the viewport is following the bottom, so any
+// subsequent upward move is unambiguously the wheel gesture's doing.
+async function primeScrollback(page) {
+  await bootWithTerm(page);
+  await startMarkerPump(page, 200);
+  await expect.poll(
+    async () => (await bufferLines(page)).join('\n'),
+    { timeout: 15000, intervals: [250, 500] },
+  ).toContain('HIVE_PUMP_DONE');
+  const at = await scrollState(page);
+  expect(at.baseY, 'scrollback should be populated').toBeGreaterThan(0);
+  expect(at.viewportY, 'viewport should start at the bottom').toBe(at.baseY);
+}
+
+// The control: pixel-mode deltaY is the normal macOS-trackpad / Chromium path
+// and the shape that works on the user's other Macs. If this ever fails the
+// takeover itself is broken; it also guards against a fix regressing the
+// working path.
+test('pixel-mode wheel scrolls into history (control — the working path)', async ({ page }) => {
+  await primeScrollback(page);
+  await dispatchWheel(page, { deltaMode: 0, deltaY: -300 });
+  const after = await scrollState(page);
+  expect(after.viewportY, 'pixel wheel did not scroll up').toBeLessThan(after.baseY);
+});
+
+// The suspected unscrollable-Mac shape: a wheel notch reported as a line count
+// (deltaMode 1) rather than pixels.
+test('line-mode wheel scrolls into history (deltaMode 1)', async ({ page }) => {
+  await primeScrollback(page);
+  await dispatchWheel(page, { deltaMode: 1, deltaY: -3 });
+  const after = await scrollState(page);
+  expect(after.viewportY, 'line-mode wheel did not scroll up').toBeLessThan(after.baseY);
+});
+
+// The other suspected shape: standard deltaY is 0 and only the deprecated
+// wheelDeltaY (opposite sign, pixel-scale) carries the gesture.
+test('legacy wheelDeltaY-only wheel scrolls into history (deltaY 0)', async ({ page }) => {
+  await primeScrollback(page);
+  await dispatchWheel(page, { deltaMode: 0, deltaY: 0, wheelDeltaY: 120 });
+  const after = await scrollState(page);
+  expect(after.viewportY, 'wheelDeltaY-only wheel did not scroll up').toBeLessThan(after.baseY);
+});
+
+// THE ACTUAL REGRESSION ("scrolls in pi, not in Claude" on the same machine).
+// When the running program enables mouse tracking it expects the wheel as
+// mouse events; the GUI's capture-phase preventDefault + scrollLines takeover
+// swallowed the gesture, so the app could never scroll. The takeover must bail
+// and let xterm forward the wheel to the app.
+test('mouse-tracking session forwards the wheel to the app, not the scrollback takeover', async ({ page }) => {
+  await primeScrollback(page);
+  // Sanity: in the plain normal buffer (pi) the takeover runs.
+  expect(await countTakeover(page, { deltaMode: 1, deltaY: -3 }),
+    'takeover should run in a plain normal buffer').toBeGreaterThan(0);
+  // Claude enables mouse tracking → the takeover must NOT swallow the wheel.
+  await enableMouseTracking(page);
+  expect(await countTakeover(page, { deltaMode: 1, deltaY: -3 }),
+    'takeover swallowed the wheel under mouse tracking (Claude could not scroll)').toBe(0);
+});
+
+// Full-screen TUIs run in the alternate buffer where scrollLines is a no-op;
+// the takeover must bail there too so the app receives the wheel.
+test('alternate-buffer session does not swallow the wheel', async ({ page }) => {
+  await bootWithTerm(page);
+  await enterAltBuffer(page);
+  expect(await countTakeover(page, { deltaMode: 1, deltaY: -3 }),
+    'takeover ran in the alternate buffer').toBe(0);
+});

--- a/cmd/hivegui/frontend/test/unit/wheel-scroll.test.js
+++ b/cmd/hivegui/frontend/test/unit/wheel-scroll.test.js
@@ -93,4 +93,12 @@ describe('shouldScrollViewport', () => {
     expect(shouldScrollViewport({ bufferType: 'normal', mouseTrackingMode: 'any' })).toBe(false);
     expect(shouldScrollViewport({ bufferType: 'alternate', mouseTrackingMode: 'any' })).toBe(false);
   });
+
+  // The live handler passes buf?.type, which can be undefined before the
+  // buffer is ready — anything that isn't exactly 'normal' must bail.
+  it('does NOT take over for a missing/empty buffer type', () => {
+    expect(shouldScrollViewport({ bufferType: undefined, mouseTrackingMode: 'none' })).toBe(false);
+    expect(shouldScrollViewport({ bufferType: null, mouseTrackingMode: 'none' })).toBe(false);
+    expect(shouldScrollViewport({ bufferType: '', mouseTrackingMode: 'none' })).toBe(false);
+  });
 });

--- a/cmd/hivegui/frontend/test/unit/wheel-scroll.test.js
+++ b/cmd/hivegui/frontend/test/unit/wheel-scroll.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { wheelToScrollLines } from '../../src/lib/wheel-scroll.js';
+import { wheelToScrollLines, shouldScrollViewport } from '../../src/lib/wheel-scroll.js';
 
 // The GUI takes over wheel handling (capture phase + preventDefault) so
 // EVERY wheel scroll flows through this math — if it returns 0, the
@@ -72,5 +72,25 @@ describe('wheelToScrollLines', () => {
       expect(wheelToScrollLines({ deltaY: undefined, deltaMode: 0 }, OPTS)).toBe(0);
       expect(wheelToScrollLines({ deltaY: NaN, deltaMode: 0 }, OPTS)).toBe(0);
     });
+  });
+});
+
+describe('shouldScrollViewport', () => {
+  // The takeover is correct ONLY in the normal buffer with mouse reporting
+  // off. Everywhere else the wheel must reach xterm/the app — this is the
+  // "scrolls in pi, not in Claude" regression.
+  it('takes over in the normal buffer with mouse reporting off (pi / plain shell)', () => {
+    expect(shouldScrollViewport({ bufferType: 'normal', mouseTrackingMode: 'none' })).toBe(true);
+    expect(shouldScrollViewport({ bufferType: 'normal', mouseTrackingMode: undefined })).toBe(true);
+  });
+
+  it('does NOT take over in the alternate buffer (full-screen TUIs)', () => {
+    expect(shouldScrollViewport({ bufferType: 'alternate', mouseTrackingMode: 'none' })).toBe(false);
+  });
+
+  it('does NOT take over when mouse tracking is active (Claude, vim)', () => {
+    expect(shouldScrollViewport({ bufferType: 'normal', mouseTrackingMode: 'vt200' })).toBe(false);
+    expect(shouldScrollViewport({ bufferType: 'normal', mouseTrackingMode: 'any' })).toBe(false);
+    expect(shouldScrollViewport({ bufferType: 'alternate', mouseTrackingMode: 'any' })).toBe(false);
   });
 });

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -109,6 +109,16 @@ func buildAppMenu(a *App) *menu.Menu {
 
 	m.Append(menu.WindowMenu()) // Minimize / Zoom / Front
 
+	// Debug submenu — surfaces the hive.debug scroll tracer without
+	// requiring devtools (production WKWebView builds ship with the web
+	// inspector disabled). "Toggle Scroll Debug" arms the tracer and
+	// reloads (the tracer latches its on/off at page load); "Copy Scroll
+	// Trace" puts the captured event ring on the clipboard so it can be
+	// pasted straight into a bug report — no console needed.
+	debug := m.AddSubmenu("Debug")
+	debug.AddText("Toggle Scroll Debug (Reloads)", nil, emit("menu:toggle-scroll-debug"))
+	debug.AddText("Copy Scroll Trace", nil, emit("menu:copy-scroll-trace"))
+
 	// Help submenu — macOS auto-injects a Search field that
 	// fuzzy-matches every item in every other menu, so the user can
 	// search all actions from the menu bar without opening the palette.


### PR DESCRIPTION
## Problem

The terminal wouldn't scroll by mouse wheel or trackpad in a **Claude** session, while **pi** and plain shells scrolled fine — same machine, same WKWebView. Selection-drag still scrolled (xterm drives that internally).

## Root cause

The wheel takeover unconditionally `preventDefault` + `stopPropagation` + `term.scrollLines()`. In the **alternate buffer** (full-screen TUIs — Claude, vim, htop) `scrollLines` is a no-op, and when the app has enabled **mouse tracking** it expects the wheel forwarded as mouse events. Either way the gesture was swallowed and the app could never scroll. The click handlers already guard on `buf.type === 'normal' && mouseTrackingMode === 'none'` (`session-term.js:222`) — the **wheel handler was missing the same guard**.

`#229` mis-diagnosed this as a WKWebView `deltaMode`/`wheelDeltaY` quirk and normalized the math. The affected Mac's own scroll trace disproves that: every wheel event is plain pixel-mode (`deltaMode:0`) with a correct non-zero line count, and the unscrollable session is in `bufType:"alternate"` — the cause is the buffer/mode, not the delta shape.

## Fix

- Extract a pure, unit-tested `shouldScrollViewport({ bufferType, mouseTrackingMode })` predicate (co-located with `wheelToScrollLines`). The handler bails via it and lets xterm forward the wheel natively otherwise.
- Normal-buffer scrollback (pi) and the momentum-fling cap are unchanged.

## Tests

- 3 unit cases for the predicate.
- 2 `e2e-real` regression tests: enable mouse tracking / enter the alternate buffer and assert the wheel is no longer swallowed — **verified to fail on the pre-fix handler**.
- Full suite green: 174 unit + 11 e2e-real. Existing scroll-codex tests unaffected.
- Confirmed live on the affected Mac: Claude now scrolls; pi/shell scrollback unchanged.

## Also included

A **Debug** menu (macOS): "Toggle Scroll Debug (Reloads)" + "Copy Scroll Trace" — surfaces the `hive.debug` tracer without devtools (production WKWebView has the inspector disabled). This is what captured the ground-truth trace that pinned the bug.

## Scope / follow-up

GUI-only (`cmd/hivegui/`); `hived` untouched — rebuild + relaunch the GUI, sessions reattach. A separate resize/replay `viewport-jump` (top-snap under grid-all + large column change) showed up in the same trace and is **left as a follow-up**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)