### PR TITLE
fix(gui): keep a follower pinned to the bottom across the replay restream

### DIFF
--- a/cmd/hivegui/frontend/src/app/events.js
+++ b/cmd/hivegui/frontend/src/app/events.js
@@ -10,7 +10,7 @@ import { setStatus, flashStatus, reportFailure } from './dom.js';
 import { orderedSessions } from './selectors.js';
 import { renderSidebar, updateSidebarSelection } from './sidebar.js';
 import { pruneCollapsed } from '../lib/collapsed.js';
-import { handleScrollbackEvent } from '../lib/scrollback.js';
+import { handleScrollbackEvent, abandonReplays } from '../lib/scrollback.js';
 
 let deps = {
   switchTo: () => {},
@@ -169,6 +169,7 @@ export function wireDaemonEvents(injected) {
         // session's prompt lands on a clean screen instead of stacking on
         // the old cursor position.
         try { t.term.reset(); } catch {}
+        abandonReplays(t); // the wipe abandons any in-flight restream
         t.attached = false;
         t.setDead(false);
       }
@@ -246,6 +247,7 @@ export function wireDaemonEvents(injected) {
         if (st.needsReattach && ev.session.alive) {
           st.needsReattach = false;
           try { st.term.reset(); } catch {}
+          abandonReplays(st); // the wipe abandons any in-flight restream
           const visible =
             (state.view === 'single' && state.activeId === ev.session.id) ||
             (state.view !== 'single' && st.host.classList.contains('in-grid'));
@@ -295,6 +297,10 @@ export function wireDaemonEvents(injected) {
     const st = state.terms.get(id);
     if (st) {
       st.attached = false;
+      // The connection dropped: any in-flight replay's done will never
+      // arrive, so clear the in-flight count (else it pins the viewport
+      // to the bottom forever after reattach).
+      abandonReplays(st);
       // Mark the term as needing reattach. Restart Session closes the
       // daemon-side PTY (which lands here) and respawns; the subsequent
       // session:event(updated, alive=true) is where we re-OpenSession.

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -484,6 +484,10 @@ export class SessionTerm {
     this._lastUserScrollTs = -Infinity;
     this._lastReplayTs = -Infinity;
     this._lastViewportY = this.term.buffer.active?.viewportY ?? 0;
+    // Set by handleScrollbackEvent while a replay restream is in flight, and
+    // a reentrancy guard for the bottom re-pin below.
+    this._replaysInFlight = 0;
+    this._repinning = false;
 
     // Keyboard scrollback (Shift+PageUp/Down, Shift+Home/End) is user
     // intent too. xterm handles these internally; we only timestamp them
@@ -508,6 +512,22 @@ export class SessionTerm {
       const userDriven = (now - this._lastUserScrollTs) <= USER_SCROLL_GRACE_MS;
       if (userDriven) {
         this._followBottom = (buf.baseY - to) <= STICKY_BOTTOM_LINES;
+      }
+
+      // Keep a FOLLOWING viewport glued to the bottom for the WHOLE replay
+      // restream, not just at replay-done. A full-buffer restream spans many
+      // frames; the begin handler's term.reset() wipes the viewport to the
+      // top and cap-trim then strands it in history, so without this the
+      // viewport drifts up mid-restream and only re-snaps at done — a visible
+      // scroll-jump (the user-reported signature: following:true, tiny
+      // sinceReplayMs). Re-pin only a genuine follower (never a reader
+      // scrolled up: _followBottom is false for them, and a user gesture this
+      // tick set it above). Reentrancy-guarded — scrollToBottom re-enters
+      // onScroll, which then sees us at the bottom and stops.
+      if (this._replaysInFlight > 0 && this._followBottom && !this._repinning
+        && (buf.baseY - to) > STICKY_BOTTOM_LINES && !userDriven) {
+        this._repinning = true;
+        try { this.term.scrollToBottom(); } finally { this._repinning = false; }
       }
 
       // Scroll-jump auto-detector (gated on hive.debug=1): record any

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -69,6 +69,18 @@ export function applyRebaseline(st, clearTimer = clearTimeout) {
   return st;
 }
 
+// Abandon any in-flight scrollback replays for this term. The in-flight
+// counter keeps a FOLLOWING viewport pinned to the bottom during a restream
+// (see SessionTerm.onScroll); it is incremented on replay-begin and only
+// decremented on the matching replay-done. A dropped connection or a buffer
+// wipe for a non-replay reason (disconnect, reattach, revival) means those
+// done events will never arrive — so the count must be cleared here, or it
+// leaks >0 and pins the viewport to the bottom forever, re-correcting the
+// parse-driven cap-trim drift that #228 deliberately leaves alone.
+export function abandonReplays(st) {
+  if (st) st._replaysInFlight = 0;
+}
+
 // `trace` (optional) is scrollTrace.rec — when supplied, the replay
 // restore decision is recorded at parse time (wantsBottom, the captured
 // fromBottom distance, the computed scrollToLine target, and the

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -120,12 +120,21 @@ export function handleScrollbackEvent(st, kind, trace) {
       // order and the fresh decoder must be in place for the first
       // replay chunk, not parse time.
       if (st.decoder) st.decoder = new TextDecoder('utf-8');
+      // Mark a replay as in flight so the term's onScroll can keep a
+      // FOLLOWING viewport pinned to the bottom for the whole restream
+      // (a full-buffer replay spans many frames; the reset above wipes the
+      // viewport to the top and cap-trim then strands it in history). A
+      // counter, not a flag: resizes can overlap, so several replays are
+      // in flight at once and the last done must not clear an earlier
+      // replay's pin. Decremented in the done handler's parse-ordered finish.
+      st._replaysInFlight = (st._replaysInFlight || 0) + 1;
       return true;
     }
     case 'scrollback_replay_done': {
       const wantsBottom = st._replayWantsBottom !== false;
       delete st._replayWantsBottom;
       const finish = () => {
+        st._replaysInFlight = Math.max(0, (st._replaysInFlight || 0) - 1);
         // Consume the captured distance here, at parse time — the
         // begin handler sets it from its own parse-ordered callback,
         // which at done-EVENT time has usually not flushed yet (the

--- a/cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.js
+++ b/cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.js
@@ -94,21 +94,19 @@ test('single full-buffer session: no transient viewport-jump on threshold-crossi
       }
     }
   }
-  await page.waitForTimeout(1500);
-
-  const finalGap = await page.evaluate(() => {
-    const st = [...(window.__hive_state?.terms?.values() || [])][0];
-    const buf = st?.term?.buffer?.active;
-    return buf ? buf.baseY - buf.viewportY : null;
-  });
   const replays = await traceTags(page, 'replay-request');
-  // eslint-disable-next-line no-console
-  console.log(`STRAND_STATS maxGap=${maxGapWhileFollowing} strandedSamples=${strandedSamples} finalGap=${finalGap}`);
-
   expect(replays, 'no replays fired — test is vacuous').toBeGreaterThan(0);
   // The invariant: a follower is never left stranded up in history while a
   // resize replay restreams. A brief one-frame reset blip is tolerable; a
   // sustained strand (multiple samples off-bottom) is the bug.
   expect(strandedSamples, `follower stranded mid-history for ${strandedSamples} samples (maxGap=${maxGapWhileFollowing})`).toBeLessThanOrEqual(1);
-  expect(finalGap, 'follower did not end at the bottom').toBe(0);
+
+  // And it must settle AT the bottom. Poll (not a fixed wait): a 60k-line
+  // replay re-parse can outlast any fixed sleep on a slow runner — matching
+  // the convergence pattern the sibling scroll-codex specs use.
+  await expect.poll(async () => page.evaluate(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const buf = st?.term?.buffer?.active;
+    return buf ? buf.baseY - buf.viewportY : null;
+  }), { timeout: 12000, intervals: [250, 500] }).toBe(0);
 });

--- a/cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.js
+++ b/cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.js
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+
+// Regression guard for the restream strand: a FOLLOWING viewport must stay
+// pinned to the bottom for the WHOLE resize-replay restream, not just end
+// there. The begin handler's term.reset() wipes the viewport to the top and
+// cap-trim then strands it in history; on the buggy build the viewport sits
+// mid-history for ~1s (until replay-done re-snaps it) — the user-reported
+// "scrolling jumps" (trace signature: following:true, tiny sinceReplayMs).
+// The existing scroll-codex specs assert only the FINAL position / the replay
+// DECISION (wants=false), so they miss this transient. Here we sample the
+// gap (baseY - viewportY) across the restream and assert the follower is
+// never left stranded. Deterministic: the strand window is ~1s wide, far
+// larger than the sampling interval.
+
+const WS_URL = process.env.WS_BRIDGE_URL;
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((url) => {
+    window.__WS_BRIDGE_URL = url;
+    try { localStorage.setItem('hive.debug', '1'); } catch {}
+  }, WS_URL);
+});
+
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    try {
+      const trace = await page.evaluate(() => window.__hive_scrolltrace);
+      await testInfo.attach('scrolltrace', { body: JSON.stringify(trace ?? null), contentType: 'application/json' });
+    } catch { /* ignore */ }
+  }
+});
+
+async function bootWithTerm(page) {
+  test.skip(!WS_URL, 'WS_BRIDGE_URL not set');
+  await page.goto('/');
+  await page.waitForFunction(() => document.querySelectorAll('#projects li.session-item').length >= 1, null, { timeout: 10000 });
+  await page.waitForFunction(() => !!document.querySelector('.term-host .xterm-helper-textarea'), null, { timeout: 10000 });
+  await page.evaluate(() => {
+    const h = document.querySelector('.term-host.active .xterm-helper-textarea') || document.querySelector('.term-host .xterm-helper-textarea');
+    h.focus();
+  });
+  await page.keyboard.type('stty -echo\n');
+  await page.waitForTimeout(200);
+}
+
+function scrollState(page) {
+  return page.evaluate(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const buf = st?.term?.buffer?.active;
+    if (!buf) return null;
+    return { viewportY: buf.viewportY, baseY: buf.baseY, type: buf.type };
+  });
+}
+
+function traceTags(page, tag) {
+  return page.evaluate((t) => (window.__hive_scrolltrace || []).filter((e) => e.tag === t).length, tag);
+}
+
+test('single full-buffer session: no transient viewport-jump on threshold-crossing resizes', async ({ page }) => {
+  await bootWithTerm(page);
+  // Flood well past the 5000-line cap so cap-trim + bottom-follow loss is armed.
+  await page.keyboard.type(
+    `awk 'BEGIN{for(j=0;j<60000;j++) printf "HIVE_SCROLL_%06d ................................................\\n", j}'; echo HIVE_PUMP_DONE\n`,
+  );
+  await expect.poll(async () => (await scrollState(page))?.baseY ?? 0,
+    { timeout: 30000, intervals: [200, 400] }).toBeGreaterThan(4500);
+
+  // The user has NOT scrolled — they are following the bottom. Fire spaced
+  // threshold-crossing resizes while the flood is still parsing, and sample
+  // the viewport gap throughout: a follower must stay pinned to the bottom
+  // across the WHOLE restream, not just end there. The gap (baseY-viewportY)
+  // strands wide-open on the buggy build (the viewport sits mid-history for
+  // ~1s until replay-done re-snaps it) and stays ~0 once the restream re-pin
+  // holds it down.
+  const widths = [780, 1240, 820, 1200, 900, 1100];
+  let maxGapWhileFollowing = 0;
+  let strandedSamples = 0;
+  for (const w of widths) {
+    await page.setViewportSize({ width: w, height: 640 });
+    // Sample a few times across each resize's replay window.
+    for (let i = 0; i < 4; i++) {
+      await page.waitForTimeout(90);
+      const s = await page.evaluate(() => {
+        const st = [...(window.__hive_state?.terms?.values() || [])][0];
+        const buf = st?.term?.buffer?.active;
+        if (!buf) return null;
+        return { gap: buf.baseY - buf.viewportY, baseY: buf.baseY, following: st._followBottom };
+      });
+      // Only meaningful once the buffer has real scrollback and the user is
+      // still a follower (never scrolled).
+      if (s && s.following && s.baseY > 1000) {
+        maxGapWhileFollowing = Math.max(maxGapWhileFollowing, s.gap);
+        if (s.gap > 100) strandedSamples++;
+      }
+    }
+  }
+  await page.waitForTimeout(1500);
+
+  const finalGap = await page.evaluate(() => {
+    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const buf = st?.term?.buffer?.active;
+    return buf ? buf.baseY - buf.viewportY : null;
+  });
+  const replays = await traceTags(page, 'replay-request');
+  // eslint-disable-next-line no-console
+  console.log(`STRAND_STATS maxGap=${maxGapWhileFollowing} strandedSamples=${strandedSamples} finalGap=${finalGap}`);
+
+  expect(replays, 'no replays fired — test is vacuous').toBeGreaterThan(0);
+  // The invariant: a follower is never left stranded up in history while a
+  // resize replay restreams. A brief one-frame reset blip is tolerable; a
+  // sustained strand (multiple samples off-bottom) is the bug.
+  expect(strandedSamples, `follower stranded mid-history for ${strandedSamples} samples (maxGap=${maxGapWhileFollowing})`).toBeLessThanOrEqual(1);
+  expect(finalGap, 'follower did not end at the bottom').toBe(0);
+});

--- a/cmd/hivegui/frontend/test/unit/scrollback.test.js
+++ b/cmd/hivegui/frontend/test/unit/scrollback.test.js
@@ -111,6 +111,30 @@ describe('handleScrollbackEvent', () => {
     expect(st._replayPrevFromBottom).toBe(40);
   });
 
+  it('tracks in-flight replays: begin increments at event time, done decrements at parse time', () => {
+    // Drives the SessionTerm onScroll re-pin that keeps a follower glued to
+    // the bottom for the whole restream. The decrement must be parse-ordered
+    // (in finish), so the pin holds until the restream is fully parsed.
+    const { st, flush } = makeSt({ baseY: 50, viewportY: 50 });
+    handleScrollbackEvent(st, 'scrollback_replay_begin');
+    expect(st._replaysInFlight).toBe(1);
+    handleScrollbackEvent(st, 'scrollback_replay_done');
+    expect(st._replaysInFlight, 'still in flight until the restream parses').toBe(1);
+    flush();
+    expect(st._replaysInFlight).toBe(0);
+  });
+
+  it('overlapping replays: counter holds >0 until the LAST done parses, never negative', () => {
+    const { st, flush } = makeSt({ baseY: 50, viewportY: 50 });
+    handleScrollbackEvent(st, 'scrollback_replay_begin');
+    handleScrollbackEvent(st, 'scrollback_replay_begin');
+    expect(st._replaysInFlight).toBe(2);
+    handleScrollbackEvent(st, 'scrollback_replay_done');
+    handleScrollbackEvent(st, 'scrollback_replay_done');
+    flush();
+    expect(st._replaysInFlight).toBe(0);
+  });
+
   it('capture is parse-ordered: backlog parsed before the wipe counts toward the distance', () => {
     const { st, flush } = makeSt({ baseY: 100, viewportY: 60 });
     // Codex-rate backlog already queued at begin time; parsing it adds

--- a/cmd/hivegui/frontend/test/unit/scrollback.test.js
+++ b/cmd/hivegui/frontend/test/unit/scrollback.test.js
@@ -5,6 +5,7 @@ import {
   REPLAY_DEBOUNCE_MS,
   handleScrollbackEvent,
   applyRebaseline,
+  abandonReplays,
 } from '../../src/lib/scrollback.js';
 
 describe('shouldRequestReplay', () => {
@@ -133,6 +134,17 @@ describe('handleScrollbackEvent', () => {
     handleScrollbackEvent(st, 'scrollback_replay_done');
     flush();
     expect(st._replaysInFlight).toBe(0);
+  });
+
+  it('abandonReplays clears the in-flight count when a begin never gets its done', () => {
+    // Disconnect / reattach / revival wipe the buffer without a replay-done;
+    // without this the counter leaks >0 and pins the viewport forever.
+    const { st } = makeSt({ baseY: 50, viewportY: 50 });
+    handleScrollbackEvent(st, 'scrollback_replay_begin');
+    expect(st._replaysInFlight).toBe(1);
+    abandonReplays(st);
+    expect(st._replaysInFlight).toBe(0);
+    expect(() => abandonReplays(null)).not.toThrow();
   });
 
   it('capture is parse-ordered: backlog parsed before the wipe counts toward the distance', () => {


### PR DESCRIPTION
## Problem

"Scrolling jumps" while following live output: on a resize / grid↔single reflow the terminal viewport briefly jumped to the **top** or **stranded mid-history** before snapping back. The affected Mac's scroll trace pinned the signature:

```
viewport-jump  following:true  sinceReplayMs:42  from:633 to:0
```

`following:true` + tiny `sinceReplayMs` ⇒ the move happened **during a scrollback replay**, not from a user gesture.

## Root cause

A resize arms a debounced replay (~130 ms later) that `term.reset()`s xterm and re-streams the raw byte ring. A **full-buffer** restream spans many frames; the reset wipes the viewport to the top, and cap-trim then strands it in history. Nothing re-pins a **following** viewport until `replay-done`, so for the whole restream the follower sits up in history.

`#228` fixed the *wrong-decision* case (a `wants=false` restore for an unscrolled user). This is the residual transient on the **correct** `wants=true` path — the decision is right, but the viewport isn't held at the bottom while the restream runs.

## Reproduction (new test, verified to fail pre-fix)

`test/e2e-real/scroll-restream-strand.spec.js` floods past the 5000-line cap, fires threshold-crossing resizes, and **samples the viewport gap across each restream**:

| build | result |
|---|---|
| pre-fix | `maxGap=5000`, **12 stranded samples** — follower sat mid-history the whole restream |
| fixed | `maxGap=0`, **0 stranded**, ends at bottom |

The existing scroll-codex specs assert only the *final* position or the replay *decision*, so they never caught this transient.

## Fix

- Track in-flight replays with a **counter** in `scrollback.js` (begin ++ / done --). A counter, not a flag, because resizes overlap and several replays run at once — the last `done` must not clear an earlier replay's pin. Decrement is parse-ordered (in `finish`), so the pin holds until the restream is fully parsed.
- In `SessionTerm.onScroll`, re-pin to the bottom while a replay is in flight **and** the session is a genuine follower (`_followBottom` true, no user gesture this tick). Reentrancy-guarded.
- A **reader scrolled up** has `_followBottom === false` and is never touched — the "not yanked to bottom" guarantee from #228 is unchanged (its e2e guard stays green).

## Tests

- **e2e-real**: the strand reproduction above.
- **unit**: in-flight counter increments at begin (event time), decrements at done (parse time), and holds `>0` across overlapping replays / never goes negative.
- Full suite green: **177 unit + 12 e2e-real** (incl. all 4 scroll-codex guards).

## Scope

GUI-only (`cmd/hivegui/`); builds on #231 (now merged). Rebuild + relaunch the GUI; `hived` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)