### PR TITLE
debug(gui): instrument grid-mode freeze (heartbeat + grid/focus/keydown probes)

### DIFF
--- a/cmd/hivegui/frontend/src/app/focus.js
+++ b/cmd/hivegui/frontend/src/app/focus.js
@@ -8,6 +8,7 @@ import {
   decideFocusAction, ACTION_CLEAR, ACTION_PRESERVE, ACTION_FOCUS,
 } from '../lib/focus.js';
 import { anyModalOpen } from './modals/registry.js';
+import { scrollTrace } from './trace.js';
 
 let deps = {
   ensureTerm: () => {},
@@ -123,6 +124,20 @@ export function setFocusedTile(id) {
 function applyFocus(id, attempt) {
   const st = state.terms.get(id);
   if (!st) { sweepFocusBorder(); return; }
+  // Freeze probe: count + record every focus-drive attempt. Several
+  // setFocusedTile() calls fire during a grid switch and each arms an
+  // 8-frame rAF retry chain; in grid mode with many tiles those chains
+  // overlap and can hammer focus() every frame. A focusApply count that
+  // dwarfs the renderGrid count — or focus-apply events that never stop
+  // — would mark the focus reconciliation loop as the storm source.
+  if (scrollTrace.rec.enabled) {
+    scrollTrace.count('focusApply');
+    const ae = document.activeElement;
+    scrollTrace.rec('focus-apply', {
+      id, attempt, view: state.view,
+      ae: ae ? `${ae.tagName}.${ae.className || ''}`.trim() : 'none',
+    });
+  }
   const action = decideFocusAction(focusSnapshot(id));
   if (action.kind === ACTION_CLEAR || action.kind === ACTION_PRESERVE) {
     sweepFocusBorder();

--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -312,9 +312,9 @@ function copyScrollTrace() {
   SetClipboardText(JSON.stringify(dump)).catch(reportFailure('copy scroll trace'));
   const n = dump.ring?.length ?? 0;
   const body = dump.enabled
-    ? `Copied ${n} scroll event${n === 1 ? '' : 's'} to the clipboard.`
-    : 'Scroll debug is OFF — run "Toggle Scroll Debug" first, reload, reproduce, then copy.';
-  Notify('Hive', 'Scroll trace', body, 'scroll-trace').catch(() => {});
+    ? `Copied ${n} trace event${n === 1 ? '' : 's'} to the clipboard.`
+    : 'Debug Trace is OFF — run "Toggle Debug Trace" first, reload, reproduce, then copy.';
+  Notify('Hive', 'Debug Trace', body, 'scroll-trace').catch(() => {});
 }
 
 const menuActions = {

--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -24,6 +24,7 @@ import {
   switchTo, setView, gridSpatialMove, shiftActiveProject,
 } from './view.js';
 import { manualUpdateCheck } from './banners.js';
+import { scrollTrace } from './trace.js';
 
 let deps = {
   bumpFontSize: () => {},
@@ -37,6 +38,24 @@ export function initKeyboard(injected) {
 
 
 window.addEventListener('keydown', (e) => {
+  // Freeze probe: record every keydown that reaches the renderer, with
+  // the view and focus target at arrival. This is the discriminator for
+  // the "keys do nothing in grid mode" report:
+  //   • keydown events keep arriving but `ae` is BODY (not a terminal
+  //     textarea) → keyboard focus was lost; the thread is fine.
+  //   • NO keydown events recorded during the freeze window → the event
+  //     never reached the renderer (thread blocked, or the OS/menu layer
+  //     swallowed it). Cross-check against heartbeat-stall gaps.
+  if (scrollTrace.rec.enabled) {
+    scrollTrace.count('keydown');
+    const ae = document.activeElement;
+    scrollTrace.rec('keydown', {
+      key: e.key,
+      mods: `${e.metaKey ? 'M' : ''}${e.ctrlKey ? 'C' : ''}${e.altKey ? 'A' : ''}${e.shiftKey ? 'S' : ''}`,
+      view: state.view,
+      ae: ae ? `${ae.tagName}.${ae.className || ''}`.trim() : 'none',
+    });
+  }
   if (!launcherEl.classList.contains('hidden')) {
     const handle = (fn) => { e.preventDefault(); e.stopPropagation(); fn(); };
     if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey)) return handle(() => moveLauncherSelection(+1));

--- a/cmd/hivegui/frontend/src/app/trace.js
+++ b/cmd/hivegui/frontend/src/app/trace.js
@@ -53,10 +53,19 @@ const STALL_FACTOR = 2; // only record gaps > 2x the nominal interval as stalls
 let _maxStallMs = 0;
 if (scrollTrace.rec.enabled && typeof window !== 'undefined') {
   let lastBeat = performance.now();
+  // A hidden window throttles (or, on system sleep, pauses) background
+  // timers, so the gap across a hide/sleep is NOT a main-thread stall —
+  // recording it would inflate maxStallMs and corrupt the evidence this
+  // dump exists to provide. Skip ticks while hidden, and re-baseline on
+  // the hidden -> visible transition so the wake gap isn't logged.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') lastBeat = performance.now();
+  });
   setInterval(() => {
     const t = performance.now();
     const gap = t - lastBeat;
     lastBeat = t;
+    if (document.visibilityState !== 'visible') return; // throttled, not blocked
     if (gap > HEARTBEAT_MS * STALL_FACTOR) {
       if (gap > _maxStallMs) _maxStallMs = gap;
       scrollTrace.count('heartbeatStalls');

--- a/cmd/hivegui/frontend/src/app/trace.js
+++ b/cmd/hivegui/frontend/src/app/trace.js
@@ -33,15 +33,62 @@ export function snapshotScrollJump() {
   } catch { /* storage unavailable — the live ring is still dumpable */ }
 }
 
+// ---------- main-thread heartbeat watchdog ----------
+//
+// A freeze has two very different shapes, and the fix differs completely:
+//   1. The main thread is BLOCKED (a busy rAF/ResizeObserver storm, or a
+//      synchronous loop) — keystrokes, paints and timers all stall.
+//   2. The thread is HEALTHY but keyboard focus was lost — the app paints
+//      and the menu works, yet typed keys land on <body> and vanish.
+// Both look identical to a user ("frozen, but the menu still works"),
+// because the native menu runs in the main process either way.
+//
+// A setInterval callback can only run when the main thread yields, so the
+// gap between consecutive ticks measures how long the thread was blocked.
+// Under shape (1) the gap balloons far past the interval; under shape (2)
+// the heartbeat stays smooth. That split is the first question any dump of
+// this trace should answer — so it's recorded before anything else.
+const HEARTBEAT_MS = 250;
+const STALL_FACTOR = 2; // only record gaps > 2x the nominal interval as stalls
+let _maxStallMs = 0;
+if (scrollTrace.rec.enabled && typeof window !== 'undefined') {
+  let lastBeat = performance.now();
+  setInterval(() => {
+    const t = performance.now();
+    const gap = t - lastBeat;
+    lastBeat = t;
+    if (gap > HEARTBEAT_MS * STALL_FACTOR) {
+      if (gap > _maxStallMs) _maxStallMs = gap;
+      scrollTrace.count('heartbeatStalls');
+      const ae = document.activeElement;
+      scrollTrace.rec('heartbeat-stall', {
+        // How long the main thread was unresponsive, in ms.
+        gap: Math.round(gap),
+        // The view + focus target AT the stall: was it grid mode, and was
+        // keyboard focus on a terminal textarea or stranded on <body>?
+        grid: !!document.getElementById('terms')?.classList.contains('grid'),
+        ae: ae ? `${ae.tagName}.${ae.className || ''}`.trim() : 'none',
+      });
+    }
+  }, HEARTBEAT_MS);
+}
+
 if (typeof window !== 'undefined') {
   window.__hive_scrolltrace = scrollTrace.ring;
   // Operator-facing dump handle: returns the full live ring plus the
-  // frozen last-jump window, and best-effort copies the JSON to the
+  // frozen last-jump window, the rotation-proof counters, and the worst
+  // observed main-thread stall. Best-effort copies the JSON to the
   // clipboard so a user hitting the bug can paste it straight back.
   window.__hive_dumpscroll = () => {
     let lastJump = null;
     try { lastJump = JSON.parse(localStorage.getItem(LASTJUMP_KEY) || 'null'); } catch { /* ignore */ }
-    const dump = { enabled: scrollTrace.rec.enabled, ring: scrollTrace.ring.slice(), lastJump };
+    const dump = {
+      enabled: scrollTrace.rec.enabled,
+      ring: scrollTrace.ring.slice(),
+      lastJump,
+      counters: { ...scrollTrace.counters },
+      maxStallMs: Math.round(_maxStallMs),
+    };
     try { navigator.clipboard?.writeText(JSON.stringify(dump)); } catch { /* clipboard may be denied */ }
     return dump;
   };

--- a/cmd/hivegui/frontend/src/app/view.js
+++ b/cmd/hivegui/frontend/src/app/view.js
@@ -129,6 +129,7 @@ let gridLayout = { rows: 1, cols: 1, sessions: [], assignments: [], cellMap: [] 
 // current grid scope. Tiles for other sessions are hidden but kept
 // alive (so their xterm scrollback persists across mode switches).
 export function renderGrid() {
+  const _t0 = deps.scrollTrace.rec.enabled ? performance.now() : 0;
   termsHost.classList.remove('single');
   termsHost.classList.add('grid');
   const gridSessions = gridScopeSessions();
@@ -181,6 +182,18 @@ export function renderGrid() {
   }
 
   gridLayout = { rows, cols, sessions: gridSessions, assignments, cellMap };
+
+  // Freeze probe: count + time each layout pass. A runaway count (the
+  // container ResizeObserver → renderGrid → tile fit → container resize
+  // feedback loop) or a single multi-hundred-ms pass points straight at
+  // the grid relayout as the stall source. dur is the synchronous cost
+  // of this pass; ms is wall-clock so a storm shows as tight spacing.
+  if (deps.scrollTrace.rec.enabled) {
+    deps.scrollTrace.count('renderGrid');
+    deps.scrollTrace.rec('render-grid', {
+      n, rows, cols, dur: Math.round(performance.now() - _t0),
+    });
+  }
 
   // No explicit refit pass: each tile's ResizeObserver fires when its
   // body box changes (CSS grid cell resized, in-grid class toggled,
@@ -471,6 +484,11 @@ export function setView(view) {
 // warning that fires when a callback synchronously mutates layout.
 let _gridReflowQueued = false;
 new ResizeObserver(() => {
+  // Freeze probe: count every container RO firing (including the ones
+  // coalesced away by the queued guard). If this races far ahead of the
+  // render-grid count, the container is being resized in a tight loop —
+  // the classic ResizeObserver feedback storm.
+  if (deps.scrollTrace.rec.enabled) deps.scrollTrace.count('gridContainerResize');
   if (state.view === 'single' || _gridReflowQueued) return;
   _gridReflowQueued = true;
   requestAnimationFrame(() => {

--- a/cmd/hivegui/frontend/src/lib/scroll-debug.js
+++ b/cmd/hivegui/frontend/src/lib/scroll-debug.js
@@ -19,7 +19,16 @@ export function createScrollTrace({ enabled, now, cap = SCROLL_TRACE_CAP }) {
     if (ring.length > cap) ring.splice(0, ring.length - cap);
   }
   rec.enabled = enabled;
-  return { rec, ring };
+  // Monotonic counters that survive ring rotation. Under a render/focus
+  // storm the 2000-entry ring fills in ~1s and the early evidence scrolls
+  // away; the counters keep the totals (how many renderGrid calls, focus
+  // re-applies, heartbeat stalls, …) legible in any later dump.
+  const counters = Object.create(null);
+  function count(name, by = 1) {
+    if (!enabled) return;
+    counters[name] = (counters[name] || 0) + by;
+  }
+  return { rec, ring, count, counters };
 }
 
 // Classify a single viewport move for the scroll-jump auto-detector.

--- a/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
+++ b/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
@@ -33,6 +33,30 @@ describe('createScrollTrace', () => {
   it('default cap is SCROLL_TRACE_CAP', () => {
     expect(SCROLL_TRACE_CAP).toBe(2000);
   });
+
+  it('count() is a no-op when disabled', () => {
+    const { count, counters } = createScrollTrace({ enabled: false });
+    count('renderGrid');
+    count('renderGrid');
+    expect({ ...counters }).toEqual({});
+  });
+
+  it('count() accumulates per-name totals when enabled', () => {
+    const { count, counters } = createScrollTrace({ enabled: true, now: () => 0 });
+    count('renderGrid');
+    count('renderGrid');
+    count('focusApply', 3);
+    expect(counters.renderGrid).toBe(2);
+    expect(counters.focusApply).toBe(3);
+  });
+
+  it('counters survive ring rotation (totals outlive the capped ring)', () => {
+    const { rec, count, ring, counters } = createScrollTrace({ enabled: true, now: () => 0, cap: 3 });
+    for (let i = 0; i < 10; i++) { rec('render-grid', { i }); count('renderGrid'); }
+    // Ring dropped the oldest, but the counter kept every increment.
+    expect(ring.length).toBe(3);
+    expect(counters.renderGrid).toBe(10);
+  });
 });
 
 describe('classifyViewportMove', () => {

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -109,15 +109,17 @@ func buildAppMenu(a *App) *menu.Menu {
 
 	m.Append(menu.WindowMenu()) // Minimize / Zoom / Front
 
-	// Debug submenu — surfaces the hive.debug scroll tracer without
-	// requiring devtools (production WKWebView builds ship with the web
-	// inspector disabled). "Toggle Scroll Debug" arms the tracer and
-	// reloads (the tracer latches its on/off at page load); "Copy Scroll
-	// Trace" puts the captured event ring on the clipboard so it can be
-	// pasted straight into a bug report — no console needed.
+	// Debug submenu — surfaces the hive.debug tracer (scroll/replay,
+	// grid relayout, focus reconciliation, keydown routing, and a
+	// main-thread heartbeat) without requiring devtools (production
+	// WKWebView builds ship with the web inspector disabled). "Toggle
+	// Debug Trace" arms the tracer and reloads (the tracer latches its
+	// on/off at page load); "Copy Debug Trace" puts the captured event
+	// ring + counters on the clipboard so it can be pasted straight into
+	// a bug report — no console needed.
 	debug := m.AddSubmenu("Debug")
-	debug.AddText("Toggle Scroll Debug (Reloads)", nil, emit("menu:toggle-scroll-debug"))
-	debug.AddText("Copy Scroll Trace", nil, emit("menu:copy-scroll-trace"))
+	debug.AddText("Toggle Debug Trace (Reloads)", nil, emit("menu:toggle-scroll-debug"))
+	debug.AddText("Copy Debug Trace", nil, emit("menu:copy-scroll-trace"))
 
 	// Help submenu — macOS auto-injects a Search field that
 	// fuzzy-matches every item in every other menu, so the user can


### PR DESCRIPTION
## Why

Grid mode can **freeze** — keyboard shortcuts go dead while the native menu still works, and switching to focus (single-session) mode via the menu restores responsiveness. The freeze is deterministic (survives a restart) and specific to rendering multiple sessions at once.

The hard part: that symptom has **two completely different root causes** that look identical to the user, because the native menu runs in the main process either way:
1. **Main thread BLOCKED** — a busy `requestAnimationFrame` / `ResizeObserver` storm or a sync loop. Keystrokes, paints, and timers all stall.
2. **Thread HEALTHY but keyboard focus LOST** — the app paints fine, but typed keys land on `<body>` and vanish.

This PR adds instrumentation to tell them apart **before** attempting any fix, reusing the existing `hive.debug` trace ring and Debug-menu clipboard dump (works without devtools — production WKWebView ships with the inspector disabled).

## What

All probes gated on `hive.debug=1` (zero cost for normal users):

| Probe | File | Answers |
|---|---|---|
| Main-thread heartbeat watchdog | `trace.js` | How long the thread was blocked (`heartbeat-stall`, `maxStallMs`). Smooth under a freeze ⇒ focus bug, not a busy loop. **The discriminator.** |
| Rotation-proof counters | `lib/scroll-debug.js` | Totals survive the 2000-entry ring rotating (fills in ~1s under a storm). |
| `renderGrid` count + timing, container RO count | `view.js` | A RO → renderGrid → fit → resize feedback storm. |
| `applyFocus` count + record | `focus.js` | Overlapping 8-frame focus-retry chains hammering `focus()` across N tiles. |
| keydown probe (key + view + activeElement) | `keyboard.js` | Whether keys reach the renderer and where focus sits when they do. |
| Menu relabel "Scroll Debug/Trace" → "Debug Trace" | `menu_darwin.go` | Tracer is no longer scroll-specific (event names unchanged). |

## How to capture (on the affected machine)

1. **Debug → Toggle Debug Trace (Reloads)** (arms the tracer; must precede repro since the heartbeat latches at load).
2. Enter grid mode, reproduce the freeze.
3. Use the menu to switch to focus mode (responsive again).
4. **Debug → Copy Debug Trace** → paste the JSON into the issue.

## Testing

- 178 frontend unit tests pass (`npm test`).
- `gofmt` clean.
- Note: `npm run build` / `go build` require the Wails-generated bindings + `frontend/dist` (full `wails build`); standalone they fail identically on `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)