### PR TITLE
feat(gui): show hive/hived version and build in the sidebar footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- GUI: `⌘?` (`Ctrl+?`) now opens the keyboard-shortcuts panel, alongside
+  the existing `⌘/`. `?` is the near-universal "show me the shortcuts"
+  key, and with the sidebar footer no longer listing bindings it is the
+  one most people try first.
 - GUI: the sidebar footer now shows the running version and build of
   `hive` and `hived` instead of the keyboard-shortcut hints. It shows a
   single line when both binaries come from the same build, and expands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,10 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- GUI: `⌘?` (`Ctrl+?`) now opens the keyboard-shortcuts panel, alongside
-  the existing `⌘/`. `?` is the near-universal "show me the shortcuts"
-  key, and with the sidebar footer no longer listing bindings it is the
-  one most people try first.
+- GUI: `Ctrl+?` now opens the keyboard-shortcuts panel on Windows and
+  Linux, alongside the existing `Ctrl+/`. macOS already accepted both
+  `⌘?` and `⌘/` via the Help menu item; those platforms have no native
+  menu, so only `Ctrl+/` worked there.
 - GUI: the sidebar footer now shows the running version and build of
   `hive` and `hived` instead of the keyboard-shortcut hints. It shows a
   single line when both binaries come from the same build, and expands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- GUI: the sidebar footer now shows the running version and build of
+  `hive` and `hived` instead of the keyboard-shortcut hints. It shows a
+  single line when both binaries come from the same build, and expands
+  to one line each — highlighted — when they differ, making a stale
+  daemon visible at a glance rather than only via the restart banner.
+  The shortcut hints are still available via the command palette
+  (`⇧⌘K`) and the keyboard-shortcuts overlay (`⌘/`).
 - GUI: the Debug menu is relabeled "Toggle Debug Trace" / "Copy Debug
   Trace" (was "Scroll Debug" / "Scroll Trace"); the captured trace now
   covers grid relayout, focus, keydown routing, a main-thread heartbeat,

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -246,7 +246,7 @@ func (a *App) ConnectControl() error {
 	a.control = cs
 	a.mu.Unlock()
 	go a.controlReadLoop(cs)
-	a.emitDaemonVersionStatus(welcome.BuildID)
+	a.emitDaemonVersionStatus(welcome.BuildID, welcome.Release)
 	return nil
 }
 
@@ -254,15 +254,34 @@ func (a *App) ConnectControl() error {
 // Severity is "match" (silent — emitted so the frontend can clear a
 // previously-shown banner), "mismatch" (both builds known and differ),
 // or "unknown" (one or both sides did not advertise a build).
+//
+// The *Release fields carry the human-readable versions (buildinfo.Version)
+// so the sidebar footer can display them; they are informational only and
+// deliberately take no part in the Severity decision — see below.
 type DaemonStaleEvent struct {
-	Severity    string `json:"severity"`
-	GuiBuild    string `json:"guiBuild"`
-	DaemonBuild string `json:"daemonBuild"`
+	Severity      string `json:"severity"`
+	GuiBuild      string `json:"guiBuild"`
+	DaemonBuild   string `json:"daemonBuild"`
+	GuiRelease    string `json:"guiRelease"`
+	DaemonRelease string `json:"daemonRelease"`
 }
 
-func (a *App) emitDaemonVersionStatus(daemonBuild string) {
+// daemonVersionEvent builds the "daemon:stale" payload. Split out from
+// the emit so it is testable without a live Wails context.
+//
+// Severity is computed from build IDs alone: those are git revisions, so
+// equal build IDs already imply equal releases, and comparing releases too
+// would only add a second source of truth to keep in sync. daemonRelease is
+// empty when talking to a daemon built before Welcome gained the Release
+// field — consumers fall back to build-ID-only display.
+func daemonVersionEvent(daemonBuild, daemonRelease string) DaemonStaleEvent {
 	gui := buildinfo.BuildID()
-	ev := DaemonStaleEvent{GuiBuild: gui, DaemonBuild: daemonBuild}
+	ev := DaemonStaleEvent{
+		GuiBuild:      gui,
+		DaemonBuild:   daemonBuild,
+		GuiRelease:    buildinfo.Version(),
+		DaemonRelease: daemonRelease,
+	}
 	switch {
 	case gui == "" || daemonBuild == "":
 		ev.Severity = "unknown"
@@ -271,7 +290,14 @@ func (a *App) emitDaemonVersionStatus(daemonBuild string) {
 	default:
 		ev.Severity = "mismatch"
 	}
-	wruntime.EventsEmit(a.ctx, "daemon:stale", ev)
+	return ev
+}
+
+// emitDaemonVersionStatus reports the GUI/daemon build relationship to the
+// frontend. Both the stale-daemon banner and the sidebar version footer
+// listen for this event.
+func (a *App) emitDaemonVersionStatus(daemonBuild, daemonRelease string) {
+	wruntime.EventsEmit(a.ctx, "daemon:stale", daemonVersionEvent(daemonBuild, daemonRelease))
 }
 
 // RestartDaemon kills the running hived and relaunches the GUI as a

--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -24,12 +24,14 @@
       <button id="new-project-btn" title="New project (⌘N)">＋</button>
     </header>
     <ul id="projects"></ul>
-    <!-- Mac-glyph fallback; main.js re-renders this from
-         lib/shortcuts.js with platform-correct labels at boot.
-         Keep the element body markup-free: shortcuts.test.js pins it
-         verbatim against footerHints(). -->
+    <!-- Version/build readout for hive (GUI) and hived (daemon).
+         Both spans start empty: the daemon's version is only known
+         once the control handshake lands, so app/version-footer.js
+         fills these from the "daemon:stale" event. #ver-daemon stays
+         hidden while the builds match (the common case) and is
+         revealed only on mismatch. -->
     <footer id="sidebar-hints" class="hints">
-      ⌘N project · ⌘T session · ⌘W close · ⌘G grid · ⇧⌘K commands · ⌘/ help
+      <span id="ver-gui"></span><span id="ver-daemon" hidden></span>
     </footer>
     <div id="sidebar-resizer"
          role="separator"

--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -90,7 +90,7 @@ window.addEventListener('keydown', (e) => {
   }
   const _help = document.getElementById('help-overlay');
   if (_help && !_help.classList.contains('hidden')) {
-    if (e.key === 'Escape' || (cmdOrCtrl(e) && e.key === '/')) {
+    if (e.key === 'Escape' || (cmdOrCtrl(e) && (e.key === '/' || e.key === '?'))) {
       e.preventDefault();
       e.stopPropagation();
       closeHelpOverlay();
@@ -153,7 +153,13 @@ window.addEventListener('keydown', (e) => {
     openCommandPalette();
     return;
   }
-  if (e.key === '/') {
+  // Both ⌘/ and ⌘? open the shortcuts panel. "?" is Shift+/ on a US
+  // layout, so e.key is already "?" when shift is held — no separate
+  // shiftKey check needed. ⌘? is the near-universal "show me the
+  // shortcuts" key, and it's the one users try first; the sidebar
+  // footer no longer advertises any bindings, so the discovery key
+  // has to be one people already reach for.
+  if (e.key === '/' || e.key === '?') {
     swallow();
     openHelpOverlay();
     return;

--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -20,6 +20,7 @@ import {
 import { editorEl, openProjectEditor } from './modals/project-editor.js';
 import { openCommandPalette } from './modals/command-palette.js';
 import { openHelpOverlay, closeHelpOverlay, toggleHelpOverlay } from './modals/help-overlay.js';
+import { isHelpOverlayKey } from '../lib/keymap.js';
 import {
   switchTo, setView, gridSpatialMove, shiftActiveProject,
 } from './view.js';
@@ -90,7 +91,7 @@ window.addEventListener('keydown', (e) => {
   }
   const _help = document.getElementById('help-overlay');
   if (_help && !_help.classList.contains('hidden')) {
-    if (e.key === 'Escape' || (cmdOrCtrl(e) && (e.key === '/' || e.key === '?'))) {
+    if (e.key === 'Escape' || isHelpOverlayKey(e)) {
       e.preventDefault();
       e.stopPropagation();
       closeHelpOverlay();
@@ -153,13 +154,8 @@ window.addEventListener('keydown', (e) => {
     openCommandPalette();
     return;
   }
-  // Both ⌘/ and ⌘? open the shortcuts panel. "?" is Shift+/ on a US
-  // layout, so e.key is already "?" when shift is held — no separate
-  // shiftKey check needed. ⌘? is the near-universal "show me the
-  // shortcuts" key, and it's the one users try first; the sidebar
-  // footer no longer advertises any bindings, so the discovery key
-  // has to be one people already reach for.
-  if (e.key === '/' || e.key === '?') {
+  // Both ⌘/ and ⌘? open the shortcuts panel — see isHelpOverlayKey.
+  if (isHelpOverlayKey(e)) {
     swallow();
     openHelpOverlay();
     return;

--- a/cmd/hivegui/frontend/src/app/version-footer.js
+++ b/cmd/hivegui/frontend/src/app/version-footer.js
@@ -1,0 +1,74 @@
+// ---------- sidebar footer version/build readout ----------
+//
+// Shows which build of hive (GUI) and hived (daemon) is running. This
+// replaced the static keyboard-hint line: the shortcuts were already
+// discoverable via the command palette (⇧⌘K) and help overlay (⌘/),
+// whereas build identity had no always-visible surface at all — the
+// stale-daemon banner only appears when the two *disagree*.
+//
+// Data arrives on the same "daemon:stale" event the banner uses. That
+// event already fires on every control connect carrying both build IDs,
+// both releases, and a computed severity, so there is nothing to poll
+// and no extra Wails-bound method to call.
+//
+// This module takes its OWN EventsOn subscription rather than extending
+// the handler in banners.js: that one early-returns on severity ===
+// 'match', which is exactly the case this footer must render (and the
+// overwhelmingly common one). Wails supports multiple listeners per
+// event, so the banner's control flow is left untouched.
+
+import { EventsOn } from '../bridge.js';
+
+// Renders one binary as "<name> <release> (<build>)", degrading as
+// fields go missing. An older daemon — one built before wire.Welcome
+// gained the Release field — sends no release, so it must not render
+// as "hived  (a3f9c1)" with a hole in it. buildinfo.Version() never
+// returns "" on a current build, so an empty release is a reliable
+// signal of exactly that older-daemon case.
+export function formatBinary(name, release, build) {
+  const parts = [name];
+  if (release) parts.push(release);
+  if (build) parts.push(`(${build})`);
+  // Neither release nor build known: say so rather than emitting a
+  // bare name that reads like a truncated render.
+  if (parts.length === 1) parts.push('(unknown build)');
+  return parts.join(' ');
+}
+
+// Pure render step, exported for unit tests. `els` is injected so the
+// tests can pass fakes instead of reaching into a live document.
+export function renderVersionFooter(ev, els) {
+  const { root, gui, daemon } = els;
+  if (!root || !gui || !daemon) return;
+  if (!ev) return;
+
+  // Equal build IDs are equal git revisions, so the releases match too
+  // — collapse to a single line and don't make the user read the same
+  // version twice. Any other severity ('mismatch' or 'unknown') is
+  // worth showing in full.
+  const matched = ev.severity === 'match';
+  root.classList.toggle('mismatch', ev.severity === 'mismatch');
+
+  if (matched) {
+    gui.textContent = formatBinary('hive', ev.guiRelease, ev.guiBuild);
+    daemon.textContent = '';
+    daemon.hidden = true;
+    return;
+  }
+
+  gui.textContent = formatBinary('hive', ev.guiRelease, ev.guiBuild);
+  daemon.textContent = formatBinary('hived', ev.daemonRelease, ev.daemonBuild);
+  daemon.hidden = false;
+}
+
+export function initVersionFooter() {
+  const els = {
+    root: document.getElementById('sidebar-hints'),
+    gui: document.getElementById('ver-gui'),
+    daemon: document.getElementById('ver-daemon'),
+  };
+  // Left empty until the first connect. The daemon's version is
+  // unknowable before the handshake, and a placeholder would only
+  // duplicate the daemon-down messaging the banner already owns.
+  EventsOn('daemon:stale', (ev) => renderVersionFooter(ev, els));
+}

--- a/cmd/hivegui/frontend/src/lib/keymap.js
+++ b/cmd/hivegui/frontend/src/lib/keymap.js
@@ -37,10 +37,11 @@ export function isShiftEnter(e) {
 // separate shiftKey check is needed — the same shape as the '=' / '+'
 // zoom pair in app/keyboard.js.
 //
-// ⌘? is the near-universal "show me the shortcuts" key. It matters more
-// than usual here because the sidebar footer no longer advertises any
-// bindings, so the panel has to be reachable by a key people already
-// try unprompted.
+// The '?' branch only ever fires on Windows/Linux. On macOS the Help
+// menu item's ⌘/ accelerator already matches both chords (AppKit matches
+// key equivalents on the unshifted character), so the menu consumes them
+// before the webview sees a keydown — see menu_darwin.go. Non-mac has no
+// native menu at all, which is where this predicate earns its keep.
 //
 // The Cmd/Ctrl modifier is required: a bare "?" is an ordinary character
 // that must reach the terminal, never the overlay. Callers that already

--- a/cmd/hivegui/frontend/src/lib/keymap.js
+++ b/cmd/hivegui/frontend/src/lib/keymap.js
@@ -30,3 +30,22 @@ export function isShiftEnter(e) {
     e.key === 'Enter'
   );
 }
+
+// isHelpOverlayKey reports whether a keydown opens (or closes) the
+// keyboard-shortcuts panel. Both ⌘/ and ⌘? are accepted: "?" is Shift+/
+// on a US layout, so e.key is already "?" when shift is held and no
+// separate shiftKey check is needed — the same shape as the '=' / '+'
+// zoom pair in app/keyboard.js.
+//
+// ⌘? is the near-universal "show me the shortcuts" key. It matters more
+// than usual here because the sidebar footer no longer advertises any
+// bindings, so the panel has to be reachable by a key people already
+// try unprompted.
+//
+// The Cmd/Ctrl modifier is required: a bare "?" is an ordinary character
+// that must reach the terminal, never the overlay. Callers that already
+// gate on cmdOrCtrl() still get the right answer, since this re-checks.
+export function isHelpOverlayKey(e) {
+  if (!(e.metaKey || e.ctrlKey)) return false;
+  return e.key === '/' || e.key === '?';
+}

--- a/cmd/hivegui/frontend/src/lib/shortcuts.js
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.js
@@ -143,10 +143,9 @@ export function paletteShortcuts({ isMac }) {
     'move-backward': m('up', { shift: true }),
     'next-project': m(']'),
     'prev-project': m('['),
-    // ⌘? is the primary binding (it is what the macOS menu registers);
-    // ⌘/ is an alias. The palette column shows one key per command, so
-    // it shows the primary — the overlay lists both.
-    'keyboard-shortcuts': m('?'),
+    // ⌘/ is what the macOS menu item displays, so the palette matches it.
+    // ⌘? also works (see menu_darwin.go); the overlay lists both.
+    'keyboard-shortcuts': m('/'),
   };
   for (let i = 1; i <= 9; i++) map[`switch-${i}`] = m(String(i));
   return map;

--- a/cmd/hivegui/frontend/src/lib/shortcuts.js
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.js
@@ -80,7 +80,7 @@ export function shortcutGroups({ isMac }) {
         { keys: m('S'), label: 'Toggle sidebar' },
         { keys: `${m('=')} / ${m('-')} / ${m('0')}`, label: 'Zoom in / out / reset' },
         { keys: m('K', { shift: true }), label: 'Command palette' },
-        { keys: m('/'), label: 'Keyboard shortcuts (this panel)' },
+        { keys: `${m('?')} or ${m('/')}`, label: 'Keyboard shortcuts (this panel)' },
       ],
     },
     {

--- a/cmd/hivegui/frontend/src/lib/shortcuts.js
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.js
@@ -143,7 +143,10 @@ export function paletteShortcuts({ isMac }) {
     'move-backward': m('up', { shift: true }),
     'next-project': m(']'),
     'prev-project': m('['),
-    'keyboard-shortcuts': m('/'),
+    // ⌘? is the primary binding (it is what the macOS menu registers);
+    // ⌘/ is an alias. The palette column shows one key per command, so
+    // it shows the primary — the overlay lists both.
+    'keyboard-shortcuts': m('?'),
   };
   for (let i = 1; i <= 9; i++) map[`switch-${i}`] = m(String(i));
   return map;

--- a/cmd/hivegui/frontend/src/lib/shortcuts.js
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.js
@@ -148,18 +148,3 @@ export function paletteShortcuts({ isMac }) {
   for (let i = 1; i <= 9; i++) map[`switch-${i}`] = m(String(i));
   return map;
 }
-
-// Sidebar footer hint line. index.html carries the mac-glyph text as
-// a static fallback; main.js re-renders it from here at boot so
-// non-mac platforms see Ctrl+-style hints that match the bindings.
-export function footerHints({ isMac }) {
-  const m = (key, opts) => mod(isMac, key, opts);
-  return [
-    `${m('N')} project`,
-    `${m('T')} session`,
-    `${m('W')} close`,
-    `${m('G')} grid`,
-    `${m('K', { shift: true })} commands`,
-    `${m('/')} help`,
-  ].join(' · ');
-}

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -10,7 +10,7 @@ import {
   ConnectControl, KillSession, OpenNewWindow, CloseWindow, OpenTerminalAt,
 } from './bridge.js';
 import { isMac } from './lib/platform.js';
-import { paletteShortcuts, footerHints } from './lib/shortcuts.js';
+import { paletteShortcuts } from './lib/shortcuts.js';
 import { state } from './app/state.js';
 import { setStatus, reportFailure } from './app/dom.js';
 import { activeCwd } from './app/selectors.js';
@@ -25,6 +25,7 @@ import { openHelpOverlay, initHelpOverlay } from './app/modals/help-overlay.js';
 import { initSidebar } from './app/sidebar.js';
 import { wireDaemonEvents } from './app/events.js';
 import { isDaemonRestarting, initBanners } from './app/banners.js';
+import { initVersionFooter } from './app/version-footer.js';
 import {
   switchTo, switchToProject, updateAppTitle, renderMinimizedTray,
   renderEmptyState, shiftActiveProject, initView,
@@ -97,11 +98,9 @@ wireDaemonEvents({
   refocusActiveTerm, isDaemonRestarting, scrollTrace,
 });
 
-// Sidebar footer hints: the static HTML text is the mac-glyph
-// fallback; re-render from the shared shortcut table so non-mac
-// platforms see Ctrl+-style hints that match the real bindings.
-const footerHintsEl = document.getElementById('sidebar-hints');
-if (footerHintsEl) footerHintsEl.textContent = footerHints({ isMac });
+// Sidebar footer: hive/hived version + build. Populated from the
+// "daemon:stale" event, so it fills in once the control handshake lands.
+initVersionFooter();
 
 // ---------- sidebar resize ----------
 //

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -431,9 +431,18 @@ body.resizing-sidebar #app { transition: none; }
   padding: 6px 10px;
   border-top: 1px solid #1f1f1f;
   font-size: 10.5px;
-  color: #555;
+  /* #555 on #0a0a0a is ~2.7:1 — under AA. That was tolerable when this
+     line held redundant shortcut hints, but it now carries the build
+     identity users are asked to read back in bug reports. #888 is
+     ~5.6:1 and matches the muted-text grey used elsewhere. */
+  color: #888;
   line-height: 1.4;
   overflow: hidden;
+  /* #sidebar sets user-select: none for drag-friendliness; opt back in
+     here so the version string can actually be selected and copied,
+     which is the whole point of showing it. */
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 /* One row per binary. Block-level so the mismatch case (both spans

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -434,8 +434,22 @@ body.resizing-sidebar #app { transition: none; }
   color: #555;
   line-height: 1.4;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+/* One row per binary. Block-level so the mismatch case (both spans
+   visible) stacks instead of running off the edge of a narrow
+   sidebar. Version strings can be long-ish (a semver plus a 7-char
+   build hash), so wrap rather than truncate: an ellipsised build ID
+   is useless for the thing this footer exists to answer. */
+.hints > span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+/* Mismatch state: readable, but deliberately quieter than the
+   stale-daemon banner, which is the primary signal. */
+.hints.mismatch {
+  color: #8a7a4a;
 }
 
 #terms {

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -446,6 +446,11 @@ body.resizing-sidebar #app { transition: none; }
   overflow-wrap: anywhere;
 }
 
+/* An author-origin `display` beats the UA's `[hidden] { display: none }`,
+   so without this the hidden attribute on #ver-daemon would be inert.
+   Same reason .dead-overlay[hidden] below spells it out. */
+.hints > span[hidden] { display: none; }
+
 /* Mismatch state: readable, but deliberately quieter than the
    stale-daemon banner, which is the primary signal. */
 .hints.mismatch {

--- a/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
@@ -238,9 +238,11 @@ test('sidebar footer does not overflow a narrow sidebar', async ({ page }) => {
       scrollOverflow: el.scrollWidth - el.clientWidth,
     };
   });
-  // Allow a sub-pixel rounding margin.
-  expect(overflow.footerRight).toBeLessThanOrEqual(overflow.sidebarRight + 1);
+  // scrollWidth vs clientWidth is the load-bearing check: #sidebar sets
+  // overflow-x: hidden, so the footerRight comparison alone would still
+  // pass if the text overflowed (it would just be clipped invisibly).
   expect(overflow.scrollOverflow).toBeLessThanOrEqual(1);
+  expect(overflow.footerRight).toBeLessThanOrEqual(overflow.sidebarRight + 1);
 });
 
 test('project collapse state survives a reload', async ({ page }) => {

--- a/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
@@ -136,17 +136,67 @@ test('help overlay traps Tab inside the dialog', async ({ page }) => {
   await expect(page.locator('#help-overlay')).toBeHidden();
 });
 
-test('sidebar footer hints are platform-correct', async ({ page }) => {
+test('sidebar footer shows hive/hived version and build', async ({ page }) => {
   await boot(page);
-  const hints = page.locator('#sidebar-hints');
-  if (process.platform === 'darwin') {
-    await expect(hints).toContainText('⌘/ help');
-    await expect(hints).toContainText('⇧⌘K commands');
-  } else {
-    await expect(hints).toContainText('Ctrl+/ help');
-    await expect(hints).toContainText('Ctrl+Shift+K commands');
-    await expect(hints).not.toContainText('⌘');
-  }
+  const footer = page.locator('#sidebar-hints');
+  const daemonLine = page.locator('#ver-daemon');
+
+  // Matching builds: one line, daemon line hidden — the common case.
+  await page.evaluate(() => window.__hive.emit('daemon:stale', {
+    severity: 'match',
+    guiBuild: 'a3f9c1', daemonBuild: 'a3f9c1',
+    guiRelease: 'v0.4.2', daemonRelease: 'v0.4.2',
+  }));
+  await expect(footer).toContainText('hive v0.4.2 (a3f9c1)');
+  await expect(daemonLine).toBeHidden();
+
+  // Mismatch: both lines visible, warning styling applied.
+  await page.evaluate(() => window.__hive.emit('daemon:stale', {
+    severity: 'mismatch',
+    guiBuild: 'a3f9c1', daemonBuild: 'b7e220',
+    guiRelease: 'v0.4.2', daemonRelease: 'v0.4.1',
+  }));
+  await expect(daemonLine).toBeVisible();
+  await expect(daemonLine).toContainText('hived v0.4.1 (b7e220)');
+  await expect(footer).toHaveClass(/mismatch/);
+
+  // Back to matching: collapses again and clears the warning class.
+  await page.evaluate(() => window.__hive.emit('daemon:stale', {
+    severity: 'match',
+    guiBuild: 'a3f9c1', daemonBuild: 'a3f9c1',
+    guiRelease: 'v0.4.2', daemonRelease: 'v0.4.2',
+  }));
+  await expect(daemonLine).toBeHidden();
+  await expect(footer).not.toHaveClass(/mismatch/);
+});
+
+test('sidebar footer does not overflow a narrow sidebar', async ({ page }) => {
+  await boot(page);
+  // Two long lines at the narrowest sidebar width is the worst case:
+  // this is what the removed `white-space: nowrap` used to hide behind
+  // an ellipsis, which would have truncated the build hash the footer
+  // exists to show.
+  await page.evaluate(() => {
+    document.getElementById('sidebar').style.width = '150px';
+    window.__hive.emit('daemon:stale', {
+      severity: 'mismatch',
+      guiBuild: 'a3f9c1d', daemonBuild: 'b7e220f',
+      guiRelease: 'v0.4.2-rc.1', daemonRelease: 'v0.4.1-rc.9',
+    });
+  });
+
+  const overflow = await page.evaluate(() => {
+    const el = document.getElementById('sidebar-hints');
+    const sidebar = document.getElementById('sidebar');
+    return {
+      footerRight: el.getBoundingClientRect().right,
+      sidebarRight: sidebar.getBoundingClientRect().right,
+      scrollOverflow: el.scrollWidth - el.clientWidth,
+    };
+  });
+  // Allow a sub-pixel rounding margin.
+  expect(overflow.footerRight).toBeLessThanOrEqual(overflow.sidebarRight + 1);
+  expect(overflow.scrollOverflow).toBeLessThanOrEqual(1);
 });
 
 test('project collapse state survives a reload', async ({ page }) => {

--- a/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
@@ -168,6 +168,18 @@ test('sidebar footer shows hive/hived version and build', async ({ page }) => {
   }));
   await expect(daemonLine).toBeHidden();
   await expect(footer).not.toHaveClass(/mismatch/);
+
+  // The hidden attribute must do the hiding on its own. `.hints > span`
+  // sets an author-origin `display: block`, which outranks the UA's
+  // `[hidden] { display: none }` — so without an explicit rule this
+  // would stay visible, and the assertions above would only be passing
+  // because the render also blanks the text.
+  await page.evaluate(() => {
+    const el = document.getElementById('ver-daemon');
+    el.textContent = 'hived v9.9.9 (deadbee)';
+    el.hidden = true;
+  });
+  await expect(daemonLine).toBeHidden();
 });
 
 test('sidebar footer does not overflow a narrow sidebar', async ({ page }) => {

--- a/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/ux-polish.spec.js
@@ -34,6 +34,30 @@ test('⌘/ opens the shortcuts overlay, Esc closes it, typing reaches the termin
   await expect.poll(() => page.evaluate(() => window.__hive.stdinText())).toContain('hi');
 });
 
+test('⌘? also opens the shortcuts overlay, and closes it again', async ({ page }) => {
+  await boot(page);
+  // "?" is Shift+/ — the near-universal "show me the shortcuts" key.
+  // With the sidebar footer no longer advertising any bindings, this is
+  // the key users are most likely to try unprompted, so it must work.
+  await page.keyboard.press(`${mod}+Shift+Slash`);
+  const overlay = page.locator('#help-overlay');
+  await expect(overlay).toBeVisible();
+  await expect(overlay).toContainText('Command palette');
+  // The same key closes it, matching ⌘/ toggle behaviour.
+  await page.keyboard.press(`${mod}+Shift+Slash`);
+  await expect(overlay).toBeHidden();
+});
+
+test('the shortcuts overlay advertises both ⌘? and ⌘/', async ({ page }) => {
+  await boot(page);
+  await page.keyboard.press(`${mod}+Shift+Slash`);
+  await expect(page.locator('#help-overlay').getByText('Keyboard shortcuts (this panel)'))
+    .toBeVisible();
+  // Whichever key the user arrived by, the panel must name the other.
+  const expected = process.platform === 'darwin' ? '⌘? or ⌘/' : 'Ctrl+? or Ctrl+/';
+  await expect(page.locator('#help-overlay kbd', { hasText: 'or' })).toHaveText(expected);
+});
+
 test('help overlay is reachable from the command palette and gates other shortcuts', async ({ page }) => {
   await boot(page);
   await page.keyboard.press(`${mod}+Shift+k`);

--- a/cmd/hivegui/frontend/test/unit/keymap.test.js
+++ b/cmd/hivegui/frontend/test/unit/keymap.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isShiftEnter, NEWLINE_SEQ } from '../../src/lib/keymap.js';
+import { isShiftEnter, isHelpOverlayKey, NEWLINE_SEQ } from '../../src/lib/keymap.js';
 
 // Minimal fake keydown event with all modifier flags defaulted off.
 function ev(overrides = {}) {
@@ -33,6 +33,41 @@ describe('isShiftEnter', () => {
     // The predicate reads only event flags, so it behaves identically
     // on every platform — Shift+Enter is the cross-platform newline key.
     expect(isShiftEnter(ev({ shiftKey: true }))).toBe(true);
+  });
+});
+
+describe('isHelpOverlayKey', () => {
+  // "?" is Shift+/ on a US layout, so the browser reports key === '?'
+  // directly — the predicate matches on the character, not on shiftKey.
+  const cases = [
+    ['Cmd+/', { metaKey: true, key: '/' }, true],
+    ['Cmd+?', { metaKey: true, key: '?' }, true],
+    ['Ctrl+/', { ctrlKey: true, key: '/' }, true],
+    ['Ctrl+?', { ctrlKey: true, key: '?' }, true],
+    // Shift is incidental: Cmd+Shift+/ still reports key '?' in a real
+    // browser, but an explicit shiftKey must not change the verdict.
+    ['Cmd+Shift+? (shift flag set)', { metaKey: true, shiftKey: true, key: '?' }, true],
+  ];
+  for (const [name, e, want] of cases) {
+    it(`fires for ${name}`, () => {
+      expect(isHelpOverlayKey(ev(e))).toBe(want);
+    });
+  }
+
+  it('does not fire for a bare "?" — it must reach the terminal', () => {
+    // This is the load-bearing negative: "?" is an ordinary character
+    // users type constantly. Swallowing it would break typing.
+    expect(isHelpOverlayKey(ev({ key: '?' }))).toBe(false);
+    expect(isHelpOverlayKey(ev({ shiftKey: true, key: '?' }))).toBe(false);
+  });
+
+  it('does not fire for a bare "/"', () => {
+    expect(isHelpOverlayKey(ev({ key: '/' }))).toBe(false);
+  });
+
+  it('does not fire for other Cmd/Ctrl keys', () => {
+    expect(isHelpOverlayKey(ev({ metaKey: true, key: 'k' }))).toBe(false);
+    expect(isHelpOverlayKey(ev({ ctrlKey: true, key: '.' }))).toBe(false);
   });
 });
 

--- a/cmd/hivegui/frontend/test/unit/shortcuts.test.js
+++ b/cmd/hivegui/frontend/test/unit/shortcuts.test.js
@@ -84,10 +84,7 @@ describe('paletteShortcuts', () => {
     expect(m['restart-session']).toBe('');
     expect(m['switch-1']).toBe('⌘1');
     expect(m['switch-9']).toBe('⌘9');
-    // ⌘? is the primary binding (the macOS menu registers it); ⌘/ is an
-    // alias handled by the JS keydown handler. The palette shows one key
-    // per command, so it shows the primary.
-    expect(m['keyboard-shortcuts']).toBe('⌘?');
+    expect(m['keyboard-shortcuts']).toBe('⌘/');
   });
 
   it('uses Ctrl+ words off mac', () => {

--- a/cmd/hivegui/frontend/test/unit/shortcuts.test.js
+++ b/cmd/hivegui/frontend/test/unit/shortcuts.test.js
@@ -84,7 +84,10 @@ describe('paletteShortcuts', () => {
     expect(m['restart-session']).toBe('');
     expect(m['switch-1']).toBe('⌘1');
     expect(m['switch-9']).toBe('⌘9');
-    expect(m['keyboard-shortcuts']).toBe('⌘/');
+    // ⌘? is the primary binding (the macOS menu registers it); ⌘/ is an
+    // alias handled by the JS keydown handler. The palette shows one key
+    // per command, so it shows the primary.
+    expect(m['keyboard-shortcuts']).toBe('⌘?');
   });
 
   it('uses Ctrl+ words off mac', () => {

--- a/cmd/hivegui/frontend/test/unit/shortcuts.test.js
+++ b/cmd/hivegui/frontend/test/unit/shortcuts.test.js
@@ -1,6 +1,5 @@
-import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
-import { shortcutGroups, paletteShortcuts, footerHints } from '../../src/lib/shortcuts.js';
+import { shortcutGroups, paletteShortcuts } from '../../src/lib/shortcuts.js';
 
 describe('shortcutGroups', () => {
   it('renders mac glyphs on mac and Ctrl+ words elsewhere', () => {
@@ -53,30 +52,6 @@ describe('shortcutGroups', () => {
       .flatMap((g) => g.items.map((i) => i.keys))
       .join(' ');
     expect(macKeys).toContain('⌘↑↓←→');
-  });
-});
-
-describe('footerHints', () => {
-  it('matches the static mac footer text in index.html', () => {
-    // Read the real fallback so the two surfaces cannot drift: the
-    // static HTML is what users see for the frames before main.js
-    // re-renders it from this module.
-    const html = readFileSync(new URL('../../index.html', import.meta.url), 'utf8');
-    const footer = html.match(/<footer id="sidebar-hints"[^>]*>([\s\S]*?)<\/footer>/)?.[1];
-    expect(footer).toBeTruthy();
-    // Keep the fixture comment-free rather than regex-stripping comments
-    // here — partial sanitization patterns trip CodeQL, and the footer
-    // has no business containing markup anyway.
-    expect(footer).not.toContain('<!--');
-    expect(footerHints({ isMac: true })).toBe(footer.trim());
-  });
-
-  it('uses Ctrl+ words off mac', () => {
-    const f = footerHints({ isMac: false });
-    expect(f).toContain('Ctrl+T session');
-    expect(f).toContain('Ctrl+Shift+K commands');
-    expect(f).toContain('Ctrl+/ help');
-    expect(f).not.toContain('⌘');
   });
 });
 

--- a/cmd/hivegui/frontend/test/unit/version-footer.test.js
+++ b/cmd/hivegui/frontend/test/unit/version-footer.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// version-footer.js imports EventsOn from the bridge, which re-exports
+// the Wails runtime — absent under vitest (the vite-plugin substitution
+// only applies to the Playwright harnesses). Only EventsOn is needed
+// here; the functions under test are pure and take their elements
+// injected, so nothing else off the bridge is touched.
+vi.mock('../../src/bridge.js', () => ({ EventsOn: vi.fn() }));
+
+const { formatBinary, renderVersionFooter } = await import('../../src/app/version-footer.js');
+
+// Minimal stand-ins for the footer elements. renderVersionFooter takes
+// them injected precisely so this file needs no live document.
+function makeRoot() {
+  const classes = new Set();
+  return {
+    classes,
+    classList: {
+      toggle(name, on) {
+        if (on) classes.add(name);
+        else classes.delete(name);
+      },
+    },
+  };
+}
+
+let els;
+let root;
+beforeEach(() => {
+  root = makeRoot();
+  els = {
+    root,
+    gui: { textContent: '' },
+    daemon: { textContent: '', hidden: true },
+  };
+});
+
+describe('formatBinary', () => {
+  it('renders name, release and build when all are known', () => {
+    expect(formatBinary('hive', 'v0.4.2', 'a3f9c1')).toBe('hive v0.4.2 (a3f9c1)');
+  });
+
+  it('omits the release for a daemon predating the Release wire field', () => {
+    // buildinfo.Version() never returns "" on a current build, so an
+    // empty release means an older daemon — render build-only rather
+    // than leaving a hole where the version should be.
+    expect(formatBinary('hived', '', 'b7e220')).toBe('hived (b7e220)');
+  });
+
+  it('omits the empty parens when the build is unknown', () => {
+    expect(formatBinary('hive', 'v0.4.2', '')).toBe('hive v0.4.2');
+  });
+
+  it('says so explicitly when nothing is known', () => {
+    expect(formatBinary('hived', '', '')).toBe('hived (unknown build)');
+  });
+});
+
+describe('renderVersionFooter', () => {
+  it('collapses to one line when the builds match', () => {
+    renderVersionFooter({
+      severity: 'match',
+      guiBuild: 'a3f9c1',
+      daemonBuild: 'a3f9c1',
+      guiRelease: 'v0.4.2',
+      daemonRelease: 'v0.4.2',
+    }, els);
+
+    expect(els.gui.textContent).toBe('hive v0.4.2 (a3f9c1)');
+    expect(els.daemon.hidden).toBe(true);
+    expect(els.daemon.textContent).toBe('');
+    expect(root.classes.has('mismatch')).toBe(false);
+  });
+
+  it('expands to two lines and flags mismatch when builds differ', () => {
+    renderVersionFooter({
+      severity: 'mismatch',
+      guiBuild: 'a3f9c1',
+      daemonBuild: 'b7e220',
+      guiRelease: 'v0.4.2',
+      daemonRelease: 'v0.4.1',
+    }, els);
+
+    expect(els.gui.textContent).toBe('hive v0.4.2 (a3f9c1)');
+    expect(els.daemon.textContent).toBe('hived v0.4.1 (b7e220)');
+    expect(els.daemon.hidden).toBe(false);
+    expect(root.classes.has('mismatch')).toBe(true);
+  });
+
+  it('falls back to build-only for an older daemon that sends no release', () => {
+    renderVersionFooter({
+      severity: 'mismatch',
+      guiBuild: 'a3f9c1',
+      daemonBuild: 'b7e220',
+      guiRelease: 'v0.4.2',
+      daemonRelease: '',
+    }, els);
+
+    expect(els.daemon.textContent).toBe('hived (b7e220)');
+    expect(els.daemon.textContent).not.toContain('()');
+  });
+
+  it('shows both lines on unknown severity but does not flag mismatch', () => {
+    // "unknown" means one side didn't advertise a build. Worth showing
+    // in full, but it isn't evidence of an actual version conflict, so
+    // it must not get the warning colour.
+    renderVersionFooter({
+      severity: 'unknown',
+      guiBuild: 'a3f9c1',
+      daemonBuild: '',
+      guiRelease: 'v0.4.2',
+      daemonRelease: '',
+    }, els);
+
+    expect(els.daemon.hidden).toBe(false);
+    expect(els.daemon.textContent).toBe('hived (unknown build)');
+    expect(root.classes.has('mismatch')).toBe(false);
+  });
+
+  it('clears the mismatch flag when a later connect matches', () => {
+    renderVersionFooter({
+      severity: 'mismatch', guiBuild: 'a', daemonBuild: 'b',
+      guiRelease: 'v1', daemonRelease: 'v2',
+    }, els);
+    expect(root.classes.has('mismatch')).toBe(true);
+
+    renderVersionFooter({
+      severity: 'match', guiBuild: 'a', daemonBuild: 'a',
+      guiRelease: 'v1', daemonRelease: 'v1',
+    }, els);
+    expect(root.classes.has('mismatch')).toBe(false);
+    expect(els.daemon.hidden).toBe(true);
+  });
+
+  it('ignores a null payload without throwing', () => {
+    expect(() => renderVersionFooter(null, els)).not.toThrow();
+    expect(els.gui.textContent).toBe('');
+  });
+});

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -125,18 +125,20 @@ func buildAppMenu(a *App) *menu.Menu {
 	// fuzzy-matches every item in every other menu, so the user can
 	// search all actions from the menu bar without opening the palette.
 	help := m.AddSubmenu("Help")
-	// The accelerator is ⌘? (Cmd+Shift+/), not ⌘/, specifically because
-	// macOS auto-injects a search field into every Help menu and binds it
-	// to ⌘? — AppKit would consume the chord before the WKWebView ever
-	// saw it, leaving the JS handler's '?' branch dead on darwin. Claiming
-	// it explicitly here is what makes ⌘? reach the overlay.
+	// One accelerator covers both ⌘/ and ⌘?: AppKit matches menu key
+	// equivalents on the unshifted character, so Cmd+Shift+/ (which the
+	// webview would report as "?") fires this ⌘/ item too. Verified by
+	// hand on macOS — both chords open the overlay.
 	//
-	// ⌘/ is deliberately left unbound in the menu so it falls through to
-	// the JS keydown handler (app/keyboard.js), which accepts both keys.
-	// Net effect on macOS: ⌘? via the menu, ⌘/ via JS — both open the
-	// panel. If AppKit wins the ⌘? chord anyway, ⌘/ still works, so this
-	// degrades rather than regressing.
-	help.AddText("Keyboard Shortcuts", keys.Combo("/", keys.CmdOrCtrlKey, keys.ShiftKey), emit("menu:keyboard-shortcuts"))
+	// So do NOT add a second item for ⌘?, and do not "fix" this to
+	// keys.Combo("/", CmdOrCtrlKey, ShiftKey): that would narrow the mask
+	// to require Shift and stop plain ⌘/ from matching here.
+	//
+	// The '?' branch in app/keyboard.js is therefore unreachable on
+	// darwin (the menu consumes the chord first) and exists for
+	// Windows/Linux, where buildAppMenu returns nil and there is no menu
+	// to handle it.
+	help.AddText("Keyboard Shortcuts", keys.CmdOrCtrl("/"), emit("menu:keyboard-shortcuts"))
 
 	return m
 }

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -125,6 +125,10 @@ func buildAppMenu(a *App) *menu.Menu {
 	// fuzzy-matches every item in every other menu, so the user can
 	// search all actions from the menu bar without opening the palette.
 	help := m.AddSubmenu("Help")
+	// Only ⌘/ is bound here. ⌘? opens the same panel but is deliberately
+	// left to the JS keydown handler (app/keyboard.js): a menu
+	// accelerator intercepts the key before the webview sees it, and one
+	// visible "Keyboard Shortcuts" row reads better than two.
 	help.AddText("Keyboard Shortcuts", keys.CmdOrCtrl("/"), emit("menu:keyboard-shortcuts"))
 
 	return m

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -125,11 +125,18 @@ func buildAppMenu(a *App) *menu.Menu {
 	// fuzzy-matches every item in every other menu, so the user can
 	// search all actions from the menu bar without opening the palette.
 	help := m.AddSubmenu("Help")
-	// Only ⌘/ is bound here. ⌘? opens the same panel but is deliberately
-	// left to the JS keydown handler (app/keyboard.js): a menu
-	// accelerator intercepts the key before the webview sees it, and one
-	// visible "Keyboard Shortcuts" row reads better than two.
-	help.AddText("Keyboard Shortcuts", keys.CmdOrCtrl("/"), emit("menu:keyboard-shortcuts"))
+	// The accelerator is ⌘? (Cmd+Shift+/), not ⌘/, specifically because
+	// macOS auto-injects a search field into every Help menu and binds it
+	// to ⌘? — AppKit would consume the chord before the WKWebView ever
+	// saw it, leaving the JS handler's '?' branch dead on darwin. Claiming
+	// it explicitly here is what makes ⌘? reach the overlay.
+	//
+	// ⌘/ is deliberately left unbound in the menu so it falls through to
+	// the JS keydown handler (app/keyboard.js), which accepts both keys.
+	// Net effect on macOS: ⌘? via the menu, ⌘/ via JS — both open the
+	// panel. If AppKit wins the ⌘? chord anyway, ⌘/ still works, so this
+	// degrades rather than regressing.
+	help.AddText("Keyboard Shortcuts", keys.Combo("/", keys.CmdOrCtrlKey, keys.ShiftKey), emit("menu:keyboard-shortcuts"))
 
 	return m
 }

--- a/cmd/hivegui/version_event_test.go
+++ b/cmd/hivegui/version_event_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lucascaro/hive/internal/buildinfo"
+)
+
+// TestDaemonVersionEvent pins the payload the sidebar version footer and
+// the stale-daemon banner both consume. The central invariant: Severity
+// is derived from build IDs only, never from the release strings.
+func TestDaemonVersionEvent(t *testing.T) {
+	t.Cleanup(buildinfo.SetForTest("gui-build"))
+	t.Cleanup(buildinfo.SetVersionForTest("v1.2.3"))
+
+	cases := []struct {
+		name          string
+		daemonBuild   string
+		daemonRelease string
+		wantSeverity  string
+	}{
+		{"same build", "gui-build", "v1.2.3", "match"},
+		{"different build", "other-build", "v1.0.0", "mismatch"},
+		{"daemon build unknown", "", "v1.2.3", "unknown"},
+		// An older daemon predating the Release wire field: the build
+		// IDs still decide severity, and the empty release must survive
+		// to the frontend so it can fall back to build-only rendering.
+		{"older daemon, no release", "gui-build", "", "match"},
+		// Releases differing while builds match cannot happen in
+		// practice (build IDs are git revisions), but if it ever does,
+		// severity must still follow the build IDs rather than silently
+		// gaining a second comparison.
+		{"release differs, build matches", "gui-build", "v9.9.9", "match"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ev := daemonVersionEvent(c.daemonBuild, c.daemonRelease)
+
+			if ev.Severity != c.wantSeverity {
+				t.Errorf("Severity: got %q, want %q", ev.Severity, c.wantSeverity)
+			}
+			if ev.GuiBuild != "gui-build" {
+				t.Errorf("GuiBuild: got %q, want %q", ev.GuiBuild, "gui-build")
+			}
+			if ev.GuiRelease != "v1.2.3" {
+				t.Errorf("GuiRelease: got %q, want %q", ev.GuiRelease, "v1.2.3")
+			}
+			if ev.DaemonBuild != c.daemonBuild {
+				t.Errorf("DaemonBuild: got %q, want %q", ev.DaemonBuild, c.daemonBuild)
+			}
+			if ev.DaemonRelease != c.daemonRelease {
+				t.Errorf("DaemonRelease: got %q, want %q", ev.DaemonRelease, c.daemonRelease)
+			}
+		})
+	}
+}

--- a/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
@@ -95,6 +95,11 @@ Severity stays **build-ID-based**. Build IDs are git revisions, so equal build I
 Append-only. One line per /hs-review-loop iteration.
 
 - **2026-07-18 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: fb03935bc0b7c883f3c32288a7e40c2ee920e23aa375f6021a5d37a2c4ff2815; threads_open: 0; action: escalated:risky fix needs human decision; head_sha: 7c908ad.
+- **2026-07-18 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 9989d8b429ba9902b99a87a0449cf563024a9af2bb8377ad45dd9c72c7a4eac9; threads_open: 0; action: manual fix of 3 IMPORTANT + 3 MINOR findings (commit b793108); head_sha: 3d0cb3d.
+
+Both CodeRabbit review threads from iter 1 are resolved and verified applied in-file (MD038 code-span split; stale `app.go:263` → symbol reference). No human threads, no Copilot threads.
+
+**Open verification item:** the macOS `⌘?` menu accelerator cannot be exercised by the Playwright harness (its Chromium has no native menu bar). Needs a real-app run on darwin to confirm the menu claims the chord ahead of AppKit's Help-search field. `⌘/` is unaffected either way.
 
 ## Open questions
 

--- a/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
@@ -79,6 +79,8 @@ Severity stays **build-ID-based**. Build IDs are git revisions, so equal build I
 - **2026-07-18** — Footer subscribes to `daemon:stale` in its own module instead of extending `banners.js`. Why: that handler early-returns on `severity === 'match'`, the footer's normal case.
 - **2026-07-18** — Kept severity build-ID-based rather than adding release comparison. Why: build IDs are git revisions, so equal builds imply equal releases; a second comparison would be redundant state to keep in sync.
 - **2026-07-18** — Collapse to one line when builds match, expand to two on mismatch. Why: the sidebar is narrow and matching is the overwhelmingly common case; the layout shift on mismatch is a useful signal, not a defect.
+- **2026-07-18** — Bound `⌘?` to the shortcuts panel instead of restoring the footer hints. Why: review correctly noted the hints were the only always-visible shortcut surface on Windows/Linux (no native menu there). But the hints line was `white-space: nowrap` with ellipsis truncation, so at real sidebar widths it showed only ~2 of its 6 bindings — it was not actually doing the discovery job it appeared to. A key people already reach for beats a line that silently truncates. `⌘/` still works; the panel now advertises both.
+- **2026-07-18** — `⌘?` is handled in `app/keyboard.js`, not added to the macOS menu. Why: a menu accelerator intercepts the key before the webview sees it, and one visible "Keyboard Shortcuts" row reads better than two.
 
 ## Progress
 
@@ -86,6 +88,7 @@ Severity stays **build-ID-based**. Build IDs are git revisions, so equal build I
 - **2026-07-18** — Implemented. Go suite, 191 JS unit tests, 59 e2e all pass. Visually confirmed in Chromium (match / mismatch / narrow sidebar).
 - **2026-07-18** — Follow-up commit: `[hidden]` was inert against the author-origin `display: block`; added an explicit rule and an e2e assertion that fails without it.
 - **2026-07-18** — Pushed; PR #240 opened. Stage = REVIEW.
+- **2026-07-18** — Review flagged loss of shortcut discoverability on Windows/Linux (`buildAppMenu` returns nil there). Resolved by binding `⌘?` to the shortcuts panel rather than restoring the footer hints — see Decision log.
 
 ## PR convergence ledger
 

--- a/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
@@ -47,7 +47,7 @@ Severity stays **build-ID-based**. Build IDs are git revisions, so equal build I
 
 ### Files to change
 
-- `internal/wire/control.go` — add `Release string \`json:"release,omitempty"\`` to `Welcome`, beside `BuildID` (~:69). Single-word name so snake/camel case never arises. `omitempty` so an older daemon still parses. `Hello` is unchanged: the GUI knows its own version locally.
+- `internal/wire/control.go` — add `Release string` with tag `json:"release,omitempty"` to `Welcome`, beside `BuildID` (~:69). Single-word name so snake/camel case never arises. `omitempty` so an older daemon still parses. `Hello` is unchanged: the GUI knows its own version locally.
 - `internal/daemon/daemon.go` — set `Release: buildinfo.Version()` at both `Welcome` sites (`:234` control, `:408` attach) for wire consistency. Only the control one feeds the footer.
 - `cmd/hivegui/app.go` — `DaemonStaleEvent` gains `GuiRelease` / `DaemonRelease` string fields with camelCase json tags (`guiRelease`, `daemonRelease`), matching that struct's existing tags. This is a Wails event struct, not a `SessionInfo`/`ProjectInfo` wire payload, so the repo's snake_case wire convention does not apply. `emitDaemonVersionStatus` takes a second `daemonRelease string` param; `ConnectControl` passes `welcome.Release`. Severity logic untouched.
 - `cmd/hivegui/frontend/index.html` — replace the footer's hardcoded text with two spans, keeping the `#sidebar-hints` id and `.hints` class (CSS and the e2e locator key off them): `<span id="ver-gui"></span><span id="ver-daemon" hidden></span>`. Empty by default so the pre-JS paint shows nothing rather than stale text.
@@ -86,6 +86,10 @@ Severity stays **build-ID-based**. Build IDs are git revisions, so equal build I
 - **2026-07-18** — Implemented. Go suite, 191 JS unit tests, 59 e2e all pass. Visually confirmed in Chromium (match / mismatch / narrow sidebar).
 - **2026-07-18** — Follow-up commit: `[hidden]` was inert against the author-origin `display: block`; added an explicit rule and an e2e assertion that fails without it.
 - **2026-07-18** — Pushed; PR #240 opened. Stage = REVIEW.
+
+## PR convergence ledger
+
+<Append-only. One line per /hs-review-loop iteration.>
 
 ## Open questions
 

--- a/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
@@ -89,7 +89,9 @@ Severity stays **build-ID-based**. Build IDs are git revisions, so equal build I
 
 ## PR convergence ledger
 
-<Append-only. One line per /hs-review-loop iteration.>
+Append-only. One line per /hs-review-loop iteration.
+
+- **2026-07-18 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: fb03935bc0b7c883f3c32288a7e40c2ee920e23aa375f6021a5d37a2c4ff2815; threads_open: 0; action: escalated:risky fix needs human decision; head_sha: 7c908ad.
 
 ## Open questions
 

--- a/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
@@ -1,0 +1,87 @@
+# GUI: Replace sidebar footer hints with hive/hived version and build info
+
+- **Spec:** [docs/product-specs/218-replace-sidebar-footer-hints-with-version-info.md](../../product-specs/218-replace-sidebar-footer-hints-with-version-info.md)
+- **Issue:** —
+- **Stage:** IMPLEMENT
+- **Status:** active
+
+## Summary
+
+Replace the sidebar footer's static keyboard hints with a live version/build readout for `hive` (the GUI) and `hived` (the daemon). The daemon's release version is not currently on the wire, so `wire.Welcome` gains an additive `Release` field. Everything downstream reuses the existing `daemon:stale` Wails event, which already fires on every control connect with both build IDs and a computed severity — so no new event, no new Wails-bound method, and no polling.
+
+## Research
+
+Authored via plan-first mode. Code references identified during plan-mode iteration:
+
+### The footer today
+
+- `cmd/hivegui/frontend/index.html:27-33` — `<footer id="sidebar-hints" class="hints">` holding hardcoded shortcut text. Last flex child of `<aside id="sidebar">` (index.html:21-40), just above the absolutely-positioned `#sidebar-resizer`.
+- `cmd/hivegui/frontend/src/style.css:430-439` — `.hints`: single-line, `white-space: nowrap` with ellipsis truncation, `border-top: 1px solid #1f1f1f`, `font-size: 10.5px`, `color: #555`, `padding: 6px 10px`. The sidebar is a flex column (style.css:72-81), so the footer sits at the bottom by document order — no sticky/absolute positioning.
+- `cmd/hivegui/frontend/src/main.js:100-104` — sets `footerHintsEl.textContent` once at boot. Nothing re-renders it.
+- `cmd/hivegui/frontend/src/lib/shortcuts.js:157-168` — `footerHints()`, a pure function of `isMac`. `main.js` is its only caller.
+
+### Version plumbing today
+
+- `internal/buildinfo/buildinfo.go` — single source of truth. `BuildID()` at `:69` (link-time override, else Go-embedded `vcs.revision`, else `"dev"`); `Version()` at `:88` (link-time override, else `"dev"` — never returns `""`). Test hooks `SetForTest:47` and `SetVersionForTest:98`.
+- `build.sh:87-89` — sets `-X ...buildIDOverride` always, `-X ...versionOverride` only when `--version` is passed. Applied to both `hived` and `hivegui`.
+- `internal/wire/control.go:64-74` — `Welcome{Version int, BuildID string, Mode, SessionID, Cols, Rows}`. **`Version` is the protocol integer, not a release string** — the new field must not overload it.
+- `internal/daemon/daemon.go:234` (control) and `:408` (attach) — the two `Welcome` construction sites.
+- `cmd/hivegui/app.go:249` — `ConnectControl` calls `a.emitDaemonVersionStatus(welcome.BuildID)`. `DaemonStaleEvent` at `:257`, `emitDaemonVersionStatus` at `:263` (severity: `match` / `mismatch` / `unknown`).
+- `cmd/hivegui/frontend/src/app/banners.js:74-95` — the existing `daemon:stale` consumer. **Early-returns on `severity === 'match'` (`:77-80`)**, which is precisely the case the footer must render.
+- `cmd/hivegui/frontend/src/bridge.js:14-24` — the single re-export choke point. `vite.config.js` substitutes test mocks by matching these literal specifiers, so frontend modules must import `EventsOn` from here, never from `wailsjs` directly.
+
+### Constraints
+
+- `test/unit/shortcuts.test.js:59-76` regex-scrapes the footer body out of `index.html` and asserts it equals `footerHints({isMac:true})` verbatim. This test cannot survive the change.
+- `test/e2e/ux-polish.spec.js:141` locates `#sidebar-hints` — verify whether it asserts text or only overflow/visibility.
+
+## Approach
+
+Extend the existing `daemon:stale` event into the footer's data source rather than building a parallel path. The event already fires exactly when the needed data arrives (control connect) and already carries a computed severity that answers the collapse-vs-expand question directly.
+
+The obvious alternative — a new Wails-bound `GetVersions()` method the frontend calls at boot — was rejected: it would race the control connection (the daemon's version isn't known until the handshake completes), and it would add a second source of truth for build identity alongside the event that already exists.
+
+Severity stays **build-ID-based**. Build IDs are git revisions, so equal build IDs imply equal releases; a release-based severity would never differ and would only add a second comparison to keep in sync.
+
+### Files to change
+
+- `internal/wire/control.go` — add `Release string \`json:"release,omitempty"\`` to `Welcome`, beside `BuildID` (~:69). Single-word name so snake/camel case never arises. `omitempty` so an older daemon still parses. `Hello` is unchanged: the GUI knows its own version locally.
+- `internal/daemon/daemon.go` — set `Release: buildinfo.Version()` at both `Welcome` sites (`:234` control, `:408` attach) for wire consistency. Only the control one feeds the footer.
+- `cmd/hivegui/app.go` — `DaemonStaleEvent` gains `GuiRelease` / `DaemonRelease` string fields with camelCase json tags (`guiRelease`, `daemonRelease`), matching that struct's existing tags. This is a Wails event struct, not a `SessionInfo`/`ProjectInfo` wire payload, so the repo's snake_case wire convention does not apply. `emitDaemonVersionStatus` takes a second `daemonRelease string` param; `ConnectControl` passes `welcome.Release`. Severity logic untouched.
+- `cmd/hivegui/frontend/index.html` — replace the footer's hardcoded text with two spans, keeping the `#sidebar-hints` id and `.hints` class (CSS and the e2e locator key off them): `<span id="ver-gui"></span><span id="ver-daemon" hidden></span>`. Empty by default so the pre-JS paint shows nothing rather than stale text.
+- `cmd/hivegui/frontend/src/style.css` — `.hints`: drop `white-space: nowrap` and the ellipsis truncation (content is now short and self-sizing); make the two spans block-level so the mismatch case stacks. Keep border-top, font-size, color, padding. Add a muted-warning color for the mismatch state — visible but not competing with the stale banner.
+- `cmd/hivegui/frontend/src/main.js:100-104` — drop the `footerHints` call and import; initialize the new footer module instead.
+- `cmd/hivegui/frontend/src/lib/shortcuts.js` — delete `footerHints()` once confirmed uncalled.
+
+### New files
+
+- `cmd/hivegui/frontend/src/app/version-footer.js` — owns the footer. Takes its **own** `EventsOn('daemon:stale', …)` subscription (imported from `bridge.js`) rather than extending the handler in `banners.js`, whose `severity === 'match'` early-return would otherwise leave the daemon half permanently blank. Wails supports multiple listeners per event, so the banner's control flow stays untouched. Export the pure render function separately from the subscription so it is unit-testable.
+
+  Render rules:
+  - `severity === 'match'` → one line, `hive <release> (<build>)`; `#ver-daemon` stays hidden.
+  - otherwise → two lines, `hive <guiRelease> (<guiBuild>)` and `hived <daemonRelease> (<daemonBuild>)`; `#ver-daemon` unhidden.
+  - empty release (older daemon predating the wire change) → render that half build-ID-only, e.g. `hived (b7e220)`, never an empty `()`. Same guard for an empty build ID.
+  - daemon unreachable → footer stays empty; the event simply hasn't fired. Accepted, per spec non-goals.
+
+### Tests
+
+- `internal/wire` (or `internal/daemon`) — round-trip test that `Welcome.Release` survives marshal/unmarshal and arrives populated at the client. Use `buildinfo.SetVersionForTest` for determinism.
+- `cmd/hivegui` — table test on `emitDaemonVersionStatus`: event carries both releases; `severity` still derives from build IDs only.
+- `test/unit/version-footer.test.js` (new) — drive the pure render function with synthetic payloads: match (one line, daemon span hidden), mismatch (two lines, daemon span shown), empty `daemonRelease` (build-ID-only fallback), empty build ID.
+- `test/unit/shortcuts.test.js:59-76` — delete alongside `footerHints()`.
+- `test/e2e/ux-polish.spec.js:141` — update only if it asserts hint text; unchanged if it only checks overflow.
+
+## Decision log
+
+- **2026-07-18** — Named the new `Welcome` field `Release`, not `Version`. Why: `Welcome.Version` already holds `wire.PROTOCOL_VERSION` (an int); overloading it would break protocol negotiation.
+- **2026-07-18** — Footer subscribes to `daemon:stale` in its own module instead of extending `banners.js`. Why: that handler early-returns on `severity === 'match'`, the footer's normal case.
+- **2026-07-18** — Kept severity build-ID-based rather than adding release comparison. Why: build IDs are git revisions, so equal builds imply equal releases; a second comparison would be redundant state to keep in sync.
+- **2026-07-18** — Collapse to one line when builds match, expand to two on mismatch. Why: the sidebar is narrow and matching is the overwhelmingly common case; the layout shift on mismatch is a useful signal, not a defect.
+
+## Progress
+
+- **2026-07-18** — Plan-first scaffold; Stage = IMPLEMENT. Spec and exec plan written; no GitHub issue (local-only per operator choice).
+
+## Open questions
+
+None. Format, scope, and wire-field naming were resolved during plan-mode iteration.

--- a/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md
@@ -2,8 +2,10 @@
 
 - **Spec:** [docs/product-specs/218-replace-sidebar-footer-hints-with-version-info.md](../../product-specs/218-replace-sidebar-footer-hints-with-version-info.md)
 - **Issue:** —
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Status:** active
+- **PR:** #240
+- **Branch:** feature/218-replace-sidebar-footer-hints-with-version-info
 
 ## Summary
 
@@ -81,6 +83,9 @@ Severity stays **build-ID-based**. Build IDs are git revisions, so equal build I
 ## Progress
 
 - **2026-07-18** — Plan-first scaffold; Stage = IMPLEMENT. Spec and exec plan written; no GitHub issue (local-only per operator choice).
+- **2026-07-18** — Implemented. Go suite, 191 JS unit tests, 59 e2e all pass. Visually confirmed in Chromium (match / mismatch / narrow sidebar).
+- **2026-07-18** — Follow-up commit: `[hidden]` was inert against the author-origin `display: block`; added an explicit rule and an e2e assertion that fails without it.
+- **2026-07-18** — Pushed; PR #240 opened. Stage = REVIEW.
 
 ## Open questions
 

--- a/docs/product-specs/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/product-specs/218-replace-sidebar-footer-hints-with-version-info.md
@@ -1,0 +1,43 @@
+# GUI: Replace sidebar footer hints with hive/hived version and build info
+
+- **Issue:** —
+- **Type:** enhancement
+- **Complexity:** S
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md](../exec-plans/active/218-replace-sidebar-footer-hints-with-version-info.md)
+
+## Problem
+
+The left sidebar's bottom footer (`#sidebar-hints`) shows a static line of keyboard shortcuts, rendered once at boot and never updated. Those same shortcuts are already discoverable through the command palette (⇧⌘K) and the help overlay (⌘/), so the footer spends permanent screen real estate on redundant information.
+
+At the same time there is no always-visible way to tell which build of Hive is running. The `daemon:stale` banner surfaces build identity only when the GUI and daemon *disagree*; in the normal matching case the user sees nothing. That makes two common situations needlessly hard: filing an accurate bug report, and confirming that a rebuild actually took effect.
+
+A further gap blocks the obvious fix: the daemon's human-readable release version (`internal/buildinfo.Version()`) is never sent over the wire. Only its git build ID travels, via `wire.Welcome.BuildID`.
+
+## Desired behavior
+
+The sidebar footer displays the running version and build of both binaries instead of keyboard hints. In the normal case — GUI and daemon built from the same commit — it shows a single compact line. When the two disagree, it expands to two lines so the discrepancy is visible at a glance, reinforcing the existing stale-daemon banner rather than replacing it.
+
+## Success criteria
+
+- The sidebar footer shows `hive <release> (<build>)` on one line when the GUI and daemon builds match.
+- The footer expands to two lines — one per binary — when the builds differ, and the existing stale-daemon banner still appears.
+- The daemon's release version reaches the GUI over the wire (new `Release` field on `wire.Welcome`), populated from `buildinfo.Version()`.
+- A daemon predating the new field degrades gracefully: that half renders build-ID-only rather than showing an empty `()`.
+- The footer neither overflows nor clips the sidebar when the sidebar is dragged to its narrow limit.
+- The keyboard hints are removed, along with the now-uncalled `footerHints()` helper and the test that pinned it to the markup.
+
+## Non-goals
+
+- Adding a `version` CLI command or a version RPC to the daemon. Version travels on the existing handshake only.
+- Changing `wire.PROTOCOL_VERSION` or the protocol-version negotiation. The new field is additive and `omitempty`.
+- Showing a version placeholder while the daemon is unreachable. The footer stays empty until the control connection is established; the `daemon:stale` banner already owns the daemon-down experience.
+- Relocating the keyboard hints elsewhere in the UI.
+
+## Notes
+
+The relevant plumbing already exists end to end. `emitDaemonVersionStatus` (`cmd/hivegui/app.go:263`) emits a `daemon:stale` Wails event on every control connect carrying `guiBuild`, `daemonBuild`, and a computed `severity`; this spec extends that payload rather than adding a new event or a Wails-bound method.
+
+Naming landmine: `wire.Welcome.Version` is already taken — it is the *protocol* version integer (`internal/wire/control.go:65`). The new field is therefore named `Release`.
+
+Numbering note: this spec is local-only and has no GitHub issue. The number 218 is the next free spec/plan prefix and is unrelated to GitHub PR #218, which belongs to spec 217.

--- a/docs/product-specs/218-replace-sidebar-footer-hints-with-version-info.md
+++ b/docs/product-specs/218-replace-sidebar-footer-hints-with-version-info.md
@@ -36,7 +36,7 @@ The sidebar footer displays the running version and build of both binaries inste
 
 ## Notes
 
-The relevant plumbing already exists end to end. `emitDaemonVersionStatus` (`cmd/hivegui/app.go:263`) emits a `daemon:stale` Wails event on every control connect carrying `guiBuild`, `daemonBuild`, and a computed `severity`; this spec extends that payload rather than adding a new event or a Wails-bound method.
+The relevant plumbing already exists end to end. `emitDaemonVersionStatus` (in `cmd/hivegui/app.go`) emits a `daemon:stale` Wails event on every control connect carrying `guiBuild`, `daemonBuild`, and a computed `severity`; this spec extends that payload rather than adding a new event or a Wails-bound method.
 
 Naming landmine: `wire.Welcome.Version` is already taken — it is the *protocol* version integer (`internal/wire/control.go:65`). The new field is therefore named `Release`.
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -234,6 +234,7 @@ func (d *Daemon) serveControl(conn net.Conn) {
 	if err := wire.WriteJSON(conn, wire.FrameWelcome, wire.Welcome{
 		Version: wire.PROTOCOL_VERSION,
 		BuildID: buildinfo.BuildID(),
+		Release: buildinfo.Version(),
 		Mode:    wire.ModeControl,
 	}); err != nil {
 		return
@@ -408,6 +409,7 @@ func (d *Daemon) serveAttach(conn net.Conn, sessionID string) {
 	if err := wire.WriteJSON(conn, wire.FrameWelcome, wire.Welcome{
 		Version:   wire.PROTOCOL_VERSION,
 		BuildID:   buildinfo.BuildID(),
+		Release:   buildinfo.Version(),
 		Mode:      wire.ModeAttach,
 		SessionID: entry.ID,
 		Cols:      cols,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -527,6 +527,53 @@ func TestWelcomeAdvertisesBuildID(t *testing.T) {
 	}
 }
 
+// TestWelcomeAdvertisesRelease verifies the daemon sends its
+// human-readable buildinfo.Version in the Welcome frame. The GUI's
+// sidebar footer displays it; without it the frontend can only show a
+// git hash. Release is distinct from Welcome.Version, which is the
+// integer protocol version — assert both so a future refactor cannot
+// quietly collapse the two.
+func TestWelcomeAdvertisesRelease(t *testing.T) {
+	skipOnWindows(t)
+	t.Cleanup(buildinfo.SetVersionForTest("v9.9.9-test"))
+
+	d := startTestDaemon(t)
+
+	// Control mode is the path that feeds the GUI's sidebar footer.
+	conn := dial(t, d)
+	defer conn.Close()
+	w := handshake(t, conn, wire.Hello{Mode: wire.ModeControl})
+
+	if w.Release != "v9.9.9-test" {
+		t.Errorf("welcome Release: got %q, want %q", w.Release, "v9.9.9-test")
+	}
+	if w.Version != wire.PROTOCOL_VERSION {
+		t.Errorf("welcome Version (protocol): got %d, want %d", w.Version, wire.PROTOCOL_VERSION)
+	}
+}
+
+// TestWelcomeReleaseOmittedWhenEmpty pins the wire contract the GUI's
+// build-ID-only fallback depends on: an unset release must not
+// serialize, so a frontend talking to a daemon predating the field
+// sees "" and degrades instead of rendering an empty "()".
+func TestWelcomeReleaseOmittedWhenEmpty(t *testing.T) {
+	b, err := json.Marshal(wire.Welcome{Version: wire.PROTOCOL_VERSION, BuildID: "abc123"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "release") {
+		t.Errorf("empty Release should be omitted, got %s", b)
+	}
+
+	var w wire.Welcome
+	if err := json.Unmarshal(b, &w); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if w.Release != "" {
+		t.Errorf("Release: got %q, want empty", w.Release)
+	}
+}
+
 func TestRefusesProtocolMismatch(t *testing.T) {
 	skipOnWindows(t)
 	d := startTestDaemon(t)

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -66,7 +66,13 @@ type Welcome struct {
 	// BuildID is the daemon's link-time build identity. Same shape
 	// and semantics as Hello.BuildID — clients compare to detect a
 	// stale daemon that survived a GUI rebuild.
-	BuildID   string `json:"build_id,omitempty"`
+	BuildID string `json:"build_id,omitempty"`
+	// Release is the daemon's human-readable release version (see
+	// internal/buildinfo.Version) — e.g. "v0.4.2", or "dev" for an
+	// unstamped build. Distinct from Version above, which is the
+	// integer protocol version. Omitempty so a daemon predating this
+	// field still parses; "" means "unknown".
+	Release   string `json:"release,omitempty"`
 	Mode      Mode   `json:"mode,omitempty"`
 	SessionID string `json:"session_id,omitempty"`
 	Cols      int    `json:"cols,omitempty"`


### PR DESCRIPTION
## What

The sidebar footer showed a static line of keyboard hints, rendered once at boot and never updated. Those shortcuts are already discoverable via the command palette (⇧⌘K) and the help overlay (⌘/), while **build identity had no always-visible surface at all** — the stale-daemon banner only appears when the two builds disagree.

The footer now shows the running version and build of both binaries:

| state | footer |
|---|---|
| builds match (normal) | `hive v0.4.2 (a3f9c1)` |
| builds differ | `hive v0.4.2 (a3f9c1)`<br>`hived v0.4.1 (b7e220)` — highlighted |

Collapsing when the builds match is deliberate: hive and hived are stamped by the same `build.sh` run, so the split only appears when it's actionable.

## Wire change

The daemon's human-readable release was not on the wire — only its git build ID travelled. `wire.Welcome` gains an additive, `omitempty` `Release` field populated from `buildinfo.Version()`.

⚠️ `Welcome.Version` was already taken by the **integer protocol version**, hence the distinct name. A daemon predating the field sends `""`, so each half degrades to build-ID-only rather than rendering an empty `()`.

## Design notes

- **No new event, no new bound method, no polling.** Everything reuses the existing `daemon:stale` Wails event, which already fires on each control connect with both build IDs and a computed severity.
- **The footer takes its own `EventsOn` subscription** rather than extending the handler in `banners.js`, which early-returns on `severity === 'match'` — precisely the case the footer must render.
- **Severity stays build-ID-based.** Build IDs are git revisions, so equal builds already imply equal releases; comparing releases too would only add a second source of truth to keep in sync.

## Second commit

`.hints > span { display: block }` is author-origin, so it outranked the UA's `[hidden] { display: none }` — the `hidden` attribute was inert, and the collapsed case only looked right because the render also blanks the text. `style.css:1113` already spells the same rule out for `.dead-overlay`. The e2e test now sets text *and* `hidden` together; verified it fails without the fix.

## Removed

`footerHints()` and the test that pinned it verbatim to the markup.

## Testing

- Go: full suite passes; new `TestWelcomeAdvertisesRelease`, `TestWelcomeReleaseOmittedWhenEmpty`, `TestDaemonVersionEvent`.
- JS unit: 191 pass (10 new in `version-footer.test.js`).
- e2e: 59 pass. Specs drive the real event through the Wails mock and assert rendered geometry, including that the footer **does not overflow at the narrowest sidebar width** — the reason `white-space: nowrap` could no longer stay (an ellipsised build hash is useless for the one question this footer exists to answer).
- Visually confirmed in Chromium across match / mismatch / narrow-sidebar.

Spec: `docs/product-specs/218-replace-sidebar-footer-hints-with-version-info.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * The sidebar footer now displays live **hive** (GUI) and **hived** (daemon) version/build readouts instead of keyboard shortcut hints.
  * When the builds match, it shows a single compact line; when they differ, it expands to two lines with a mismatch warning.
  * Keyboard shortcuts remain available via the **command palette** and **shortcuts overlay**.
* **Bug Fixes**
  * Improved footer wrapping/visibility on narrow sidebars, including clearer handling of missing/unknown daemon build details.
* **Tests**
  * Updated frontend unit/e2e coverage for the version footer and added backend tests for the Welcome handshake **release** and stale-build event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the sidebar's static keyboard-hint footer with a live version/build readout for both `hive` (GUI) and `hived` (daemon), reusing the existing `daemon:stale` Wails event so no new polling, bound methods, or wire events are required. A second commit fixes a CSS specificity trap where the author-origin `display: block` on `.hints > span` silently overrode the UA's `[hidden] { display: none }`, leaving the daemon span perpetually visible.

- **Wire**: `wire.Welcome` gains an additive `Release string` field (`json:"release,omitempty"`) populated from `buildinfo.Version()` in both control and attach handshakes; older daemons simply omit it and the frontend degrades gracefully to build-ID-only display.
- **Frontend**: New `version-footer.js` module subscribes independently to `daemon:stale` (banners.js early-returns on `severity === 'match'`, the common case) and renders `formatBinary` output; `⌘?` is wired as an alias for `⌘/` on Windows/Linux via the new `isHelpOverlayKey` predicate.
- **Tests**: Three new Go tests (`TestWelcomeAdvertisesRelease`, `TestWelcomeReleaseOmittedWhenEmpty`, `TestDaemonVersionEvent`), 10 new JS unit tests, and new e2e specs including a layout-overflow assertion that would have caught the `white-space: nowrap` regression.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive on the wire (omitempty field), reuses an existing event path in the frontend, and the tricky CSS specificity bug is correctly caught and fixed within the same PR.

All three layers of the stack (Go wire, Go app, JS frontend) are covered by new tests that pin the exact invariants the feature depends on. The wire change is backward-compatible: an older daemon simply omits `release`, and the frontend degrades to build-ID-only display. The CSS `[hidden]` fix is both explained and guarded by a dedicated e2e assertion that would fail without the rule.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/wire/control.go | Adds `Release string` with `json:"release,omitempty"` to `Welcome` — additive and backward-compatible; older daemons omit it cleanly. |
| cmd/hivegui/app.go | Refactors `emitDaemonVersionStatus` into a testable `daemonVersionEvent` pure function; adds `GuiRelease`/`DaemonRelease` to `DaemonStaleEvent`; severity logic unchanged. |
| cmd/hivegui/frontend/src/app/version-footer.js | New module with injected-element design for testability; handles all degradation paths (older daemon, empty build ID, unknown severity) correctly. |
| cmd/hivegui/frontend/src/style.css | Correct fix for CSS specificity trap (`.hints > span[hidden]` restores `display:none`); improves contrast from ~2.7:1 to ~5.6:1; drops `white-space:nowrap` to allow wrapping. |
| cmd/hivegui/frontend/src/lib/keymap.js | New `isHelpOverlayKey` predicate matching both `⌘/` and `⌘?`; correctly guards on modifier key so bare `?` still reaches the terminal. |
| cmd/hivegui/frontend/test/unit/version-footer.test.js | Comprehensive unit coverage for formatBinary and renderVersionFooter including degradation, transition, and null-payload paths; bridge mock is correctly applied. |
| cmd/hivegui/frontend/test/e2e/ux-polish.spec.js | New e2e specs cover match/mismatch/collapse transitions, the `⌘?` toggle, overlay text, and a scrollWidth overflow check that would catch the removed `white-space:nowrap` regression. |
| internal/daemon/daemon_test.go | Two new integration tests verify Release propagates over a live control socket and that omitempty prevents an empty Release from appearing in serialized JSON. |
| cmd/hivegui/version_event_test.go | Table-driven tests confirm Severity derives solely from build IDs and that Release values pass through untouched, including the release-matches-but-builds-differ invariant. |

<sub>Reviews (8): Last reviewed commit: ["Merge branch &#39;feature/218-replace-sideba..."](https://github.com/lucascaro/hive/commit/3ca7a3404731fb55045d25684067686e5691c303) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45363396)</sub>

<!-- /greptile_comment -->