### PR TITLE
fix(gui): make Restart Hive actually replace the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GUI: "Restart Hive" now actually replaces the daemon — or says why it
+  can't. It asks `hived` to exit over the control connection Hive
+  already holds, then confirms the socket has gone quiet before
+  relaunching, so the new window can no longer come back attached to
+  the daemon it was supposed to replace (the stale-build banner
+  returning immediately after a "restart" was this bug). Signalling the
+  pid recorded in `<sock>.pid` remains as a fallback, but the pidfile is
+  no longer trusted as proof: three of its paths could report success
+  having killed nothing. If the daemon survives both attempts, the
+  restart fails visibly in the banner instead of quitting into a broken
+  state. Restarts are also no longer stalled ~5s by a liveness check
+  that could never observe the daemon exiting.
+- GUI: `hived` exiting no longer deletes a *newer* daemon's pidfile,
+  which left Restart Hive with no handle on the running daemon at all.
+- GUI: **Restart Hive…** is now in the File menu and the command
+  palette. It was previously reachable only from the daemon-stale
+  banner, so when the GUI and daemon builds matched there was no way to
+  restart Hive from inside the app.
+- GUI: errors are written to `hivegui.log` in the Hive state directory,
+  next to `hived.log`. Under LaunchServices the GUI's stderr goes to
+  `/dev/null`, so failures previously left no trace anywhere on disk.
 - GUI: renaming a session from its tile header no longer throws a
   `ReferenceError` and silently discards the new name. The tile
   rename's commit handler called `UpdateSession` without it being

--- a/cmd/hived/main.go
+++ b/cmd/hived/main.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/lucascaro/hive/internal/agent"
@@ -82,7 +84,7 @@ func main() {
 	// race doesn't clobber the running daemon's pidfile and then leave
 	// it stale (log.Fatalf below skips defers).
 	pidPath := d.SocketPath() + ".pid"
-	if err := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600); err != nil {
+	if err := os.WriteFile(pidPath, fmt.Appendf(nil, "%d", os.Getpid()), 0o600); err != nil {
 		log.Printf("hived: write pidfile: %v", err)
 	}
 	defer removePidfile(pidPath)
@@ -101,11 +103,27 @@ func main() {
 	}
 }
 
-// removePidfile deletes the pidfile, logging any failure other than
-// "already gone" — a stale pidfile makes the GUI's Restart action
-// signal the wrong process, so a failed cleanup must be diagnosable
-// from hived.log.
+// removePidfile deletes the pidfile, but only when it still names
+// this process. A daemon that exits slowly (or is killed after its
+// replacement is already up) would otherwise delete the *live*
+// daemon's pidfile on the way out, leaving the GUI's Restart action
+// with no handle on the running daemon at all.
+//
+// Logs any failure other than "already gone" — a stale pidfile makes
+// the GUI's Restart action signal the wrong process, so a failed
+// cleanup must be diagnosable from hived.log.
 func removePidfile(path string) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("hived: read pidfile %s before removal: %v", path, err)
+		}
+		return
+	}
+	if owner := strings.TrimSpace(string(raw)); owner != strconv.Itoa(os.Getpid()) {
+		log.Printf("hived: pidfile %s now owned by pid %s, leaving it alone", path, owner)
+		return
+	}
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Printf("hived: remove pidfile %s: %v", path, err)
 	}

--- a/cmd/hived/main_test.go
+++ b/cmd/hived/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -23,7 +24,7 @@ func TestRemovePidfile(t *testing.T) {
 	t.Run("removes existing file silently", func(t *testing.T) {
 		buf := capture(t)
 		path := filepath.Join(t.TempDir(), "hived.sock.pid")
-		if err := os.WriteFile(path, []byte("123"), 0o600); err != nil {
+		if err := os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
 		removePidfile(path)
@@ -43,6 +44,25 @@ func TestRemovePidfile(t *testing.T) {
 		}
 	})
 
+	// The pidfile is the GUI restart path's fallback handle on the
+	// daemon. A daemon exiting after its replacement is already up
+	// must not delete the live daemon's pidfile — doing so leaves
+	// Restart Hive with nothing to signal.
+	t.Run("foreign pid is left alone", func(t *testing.T) {
+		buf := capture(t)
+		path := filepath.Join(t.TempDir(), "hived.sock.pid")
+		if err := os.WriteFile(path, []byte("999999"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		removePidfile(path)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("pidfile owned by another pid was removed: %v", err)
+		}
+		if !strings.Contains(buf.String(), "owned by pid 999999") {
+			t.Errorf("expected an ownership log line; got %q", buf.String())
+		}
+	})
+
 	t.Run("undeletable file logs a warning", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("chmod-based failure injection requires POSIX permissions")
@@ -56,7 +76,7 @@ func TestRemovePidfile(t *testing.T) {
 			t.Fatalf("Mkdir: %v", err)
 		}
 		path := filepath.Join(dir, "hived.sock.pid")
-		if err := os.WriteFile(path, []byte("123"), 0o600); err != nil {
+		if err := os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
 		if err := os.Chmod(dir, 0o500); err != nil {

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -306,34 +306,73 @@ func (a *App) emitDaemonVersionStatus(daemonBuild, daemonRelease string) {
 	wruntime.EventsEmit(a.ctx, "daemon:stale", daemonVersionEvent(daemonBuild, daemonRelease))
 }
 
-// RestartDaemon kills the running hived and relaunches the GUI as a
-// detached child, then quits this process. Reconnecting in-place left
+// restartKillBudget bounds each of the two kill channels' wait for
+// the socket to go quiet. hived's shutdown is a listener close plus a
+// registry flush, so this is generous.
+const restartKillBudget = 3 * time.Second
+
+// RestartDaemon stops the running hived, relaunches the GUI as a
+// detached child, and quits this process. Reconnecting in-place left
 // the existing window holding stale session state (xterm buffers,
 // attach conns) that no longer matched the fresh daemon; a full GUI
 // restart sidesteps that by starting from a clean slate.
 //
-// killRunningHived blocks until the previous daemon is actually gone
-// so the relaunched GUI's dialOrSpawn binds a fresh socket. We kill
-// before spawning the child for the same reason — otherwise the new
-// GUI would happily reconnect to the old daemon.
+// The daemon is stopped over the control connection we already hold
+// (FrameShutdown) and, failing that, by signalling the pid recorded
+// in <sock>.pid. Either way the socket is probed afterwards: only
+// once nothing answers do we relaunch and quit. That ordering is the
+// whole point — killRunningHived can return nil without having killed
+// anything (missing pidfile, unrecognised process name), and the
+// relaunched GUI's dialOrSpawn would then reconnect to the very
+// daemon the user asked to replace, silently.
+//
+// If the daemon survives both channels we return an error and stay
+// put. A visible failure in a working window beats quitting into a
+// window that looks restarted and isn't.
 func (a *App) RestartDaemon() error {
+	sock := hdaemon.SocketPath()
+
 	a.mu.Lock()
-	if a.control != nil {
-		_ = a.control.conn.Close()
-		a.control = nil
-	}
+	control := a.control
+	a.control = nil
 	for _, c := range a.attaches {
 		_ = c.conn.Close()
 	}
 	a.attaches = make(map[string]*connState)
 	a.mu.Unlock()
 
-	if err := killRunningHived(hdaemon.SocketPath()); err != nil {
-		return fmt.Errorf("kill stale hived: %w", err)
+	if control != nil {
+		if err := wire.WriteFrame(control.conn, wire.FrameShutdown, nil); err != nil {
+			log.Printf("hivegui: restart: send shutdown frame: %v", err)
+		}
+		_ = control.conn.Close()
+	} else {
+		log.Printf("hivegui: restart: no control conn, skipping in-band shutdown")
 	}
+
+	dead := control != nil && socketDead(sock, restartKillBudget)
+	log.Printf("hivegui: restart: in-band shutdown left socket dead=%v", dead)
+
+	if !dead {
+		// A kill error is logged, not returned: hived is a child the
+		// GUI never Wait()s on, so a SIGTERM'd daemon lingers as a
+		// zombie and the signal-based wait reports "still alive" for a
+		// process that has already released the socket. The socket
+		// probe below is the arbiter.
+		if err := killRunningHived(sock); err != nil {
+			log.Printf("hivegui: restart: kill hived: %v", err)
+		}
+		dead = socketDead(sock, restartKillBudget)
+		log.Printf("hivegui: restart: signal path left socket dead=%v", dead)
+	}
+	if !dead {
+		return fmt.Errorf("hived still answering on %s after shutdown and signal; not restarting", sock)
+	}
+
 	if err := spawnNewGUI(a.launchDir); err != nil {
 		return fmt.Errorf("relaunch GUI: %w", err)
 	}
+	log.Printf("hivegui: restart: relaunched, quitting")
 	wruntime.Quit(a.ctx)
 	return nil
 }

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -334,18 +334,21 @@ func (a *App) RestartDaemon() error {
 
 	a.mu.Lock()
 	control := a.control
-	a.control = nil
-	for _, c := range a.attaches {
-		_ = c.conn.Close()
-	}
-	a.attaches = make(map[string]*connState)
 	a.mu.Unlock()
 
+	// Nothing is torn down until the daemon is confirmed gone. The
+	// error path below has to leave a *working* window behind, and
+	// there is no recovery route back: ConnectControl runs once from
+	// the frontend's boot path, and the control:disconnect handler
+	// only sets a status line (and is suppressed outright while a
+	// restart is in flight). Closing conns up front would strand the
+	// user in a dead window on exactly the path meant to protect
+	// them. Sending FrameShutdown does not require closing the conn,
+	// and socketDead dials its own.
 	if control != nil {
 		if err := wire.WriteFrame(control.conn, wire.FrameShutdown, nil); err != nil {
 			log.Printf("hivegui: restart: send shutdown frame: %v", err)
 		}
-		_ = control.conn.Close()
 	} else {
 		log.Printf("hivegui: restart: no control conn, skipping in-band shutdown")
 	}
@@ -366,8 +369,24 @@ func (a *App) RestartDaemon() error {
 		log.Printf("hivegui: restart: signal path left socket dead=%v", dead)
 	}
 	if !dead {
+		// Everything is still wired up — the window the user is
+		// looking at keeps working, and the banner shows why.
 		return fmt.Errorf("hived still answering on %s after shutdown and signal; not restarting", sock)
 	}
+
+	// The daemon is gone; these conns are dead sockets now. Release
+	// them before the relaunch so the outgoing process isn't holding
+	// half-open fds while the new GUI comes up.
+	a.mu.Lock()
+	if a.control != nil {
+		_ = a.control.conn.Close()
+		a.control = nil
+	}
+	for _, c := range a.attaches {
+		_ = c.conn.Close()
+	}
+	a.attaches = make(map[string]*connState)
+	a.mu.Unlock()
 
 	if err := spawnNewGUI(a.launchDir); err != nil {
 		return fmt.Errorf("relaunch GUI: %w", err)

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -345,16 +345,19 @@ func (a *App) RestartDaemon() error {
 	// user in a dead window on exactly the path meant to protect
 	// them. Sending FrameShutdown does not require closing the conn,
 	// and socketDead dials its own.
+	dead := false
 	if control != nil {
-		if err := wire.WriteFrame(control.conn, wire.FrameShutdown, nil); err != nil {
+		// writeFrame, not wire.WriteFrame: the header and payload are
+		// two Write calls, and the frontend can be writing to this
+		// same conn concurrently. Every other writer takes writeMu.
+		if err := control.writeFrame(wire.FrameShutdown, nil); err != nil {
 			log.Printf("hivegui: restart: send shutdown frame: %v", err)
 		}
+		dead = socketDead(sock, restartKillBudget)
+		log.Printf("hivegui: restart: in-band shutdown left socket dead=%v", dead)
 	} else {
 		log.Printf("hivegui: restart: no control conn, skipping in-band shutdown")
 	}
-
-	dead := control != nil && socketDead(sock, restartKillBudget)
-	log.Printf("hivegui: restart: in-band shutdown left socket dead=%v", dead)
 
 	if !dead {
 		// A kill error is logged, not returned: hived is a child the

--- a/cmd/hivegui/frontend/src/app/banners.js
+++ b/cmd/hivegui/frontend/src/app/banners.js
@@ -45,27 +45,37 @@ function hideDaemonBanner() {
 // restart Hive at all. File ▸ Restart Hive… and the command palette
 // call this directly.
 export async function restartHive() {
-  // Restart kills hived AND relaunches Hive itself, so every running
-  // session ends. Warn first.
-  const ok = await Confirm(
-    'Restart Hive?',
-    'This will close Hive, terminate every running shell and agent, ' +
-    'and reopen Hive with a fresh daemon. Save your work first.\n\n' +
-    'Continue?',
-  );
-  if (!ok) return;
-  daemonBannerRestart.disabled = true;
+  // Re-entrancy guard. The banner button disables itself, but the
+  // menu item and palette entry bypass that — and the probe window
+  // is seconds long, plenty of time to invoke it twice and reach
+  // spawnNewGUI twice.
+  if (daemonRestarting) return;
+  // Claimed before the first await: the confirm dialog is itself a
+  // window during which a second invocation would otherwise slip
+  // past the check above.
   daemonRestarting = true;
-  showDaemonBanner('Restarting Hive…');
+  daemonBannerRestart.disabled = true;
   try {
-    await RestartDaemon();
-    // RestartDaemon quits this process on success; control returns
-    // here only on failure paths — including the daemon refusing to
-    // die, which now surfaces here instead of silently relaunching
-    // into the old daemon.
-  } catch (err) {
-    flashStatus(`restart failed: ${err}`, true);
-    showDaemonBanner(`Restart failed: ${err}`);
+    // Restart kills hived AND relaunches Hive itself, so every
+    // running session ends. Warn first.
+    const ok = await Confirm(
+      'Restart Hive?',
+      'This will close Hive, terminate every running shell and agent, ' +
+      'and reopen Hive with a fresh daemon. Save your work first.\n\n' +
+      'Continue?',
+    );
+    if (!ok) return;
+    showDaemonBanner('Restarting Hive…');
+    try {
+      await RestartDaemon();
+      // RestartDaemon quits this process on success; control returns
+      // here only on failure paths — including the daemon refusing to
+      // die, which now surfaces here instead of silently relaunching
+      // into the old daemon.
+    } catch (err) {
+      flashStatus(`restart failed: ${err}`, true);
+      showDaemonBanner(`Restart failed: ${err}`);
+    }
   } finally {
     daemonBannerRestart.disabled = false;
     daemonRestarting = false;

--- a/cmd/hivegui/frontend/src/app/banners.js
+++ b/cmd/hivegui/frontend/src/app/banners.js
@@ -38,6 +38,40 @@ function showDaemonBanner(text) {
 function hideDaemonBanner() {
   daemonBannerEl.classList.add('hidden');
 }
+// restartHive confirms, then asks Go to replace the daemon and
+// relaunch. Exported (like manualUpdateCheck below) because the
+// daemon-stale banner used to be the *only* way to reach it: with
+// matching builds the banner never appears, so there was no way to
+// restart Hive at all. File ▸ Restart Hive… and the command palette
+// call this directly.
+export async function restartHive() {
+  // Restart kills hived AND relaunches Hive itself, so every running
+  // session ends. Warn first.
+  const ok = await Confirm(
+    'Restart Hive?',
+    'This will close Hive, terminate every running shell and agent, ' +
+    'and reopen Hive with a fresh daemon. Save your work first.\n\n' +
+    'Continue?',
+  );
+  if (!ok) return;
+  daemonBannerRestart.disabled = true;
+  daemonRestarting = true;
+  showDaemonBanner('Restarting Hive…');
+  try {
+    await RestartDaemon();
+    // RestartDaemon quits this process on success; control returns
+    // here only on failure paths — including the daemon refusing to
+    // die, which now surfaces here instead of silently relaunching
+    // into the old daemon.
+  } catch (err) {
+    flashStatus(`restart failed: ${err}`, true);
+    showDaemonBanner(`Restart failed: ${err}`);
+  } finally {
+    daemonBannerRestart.disabled = false;
+    daemonRestarting = false;
+  }
+}
+
 function wireDaemonBanner() {
   daemonBannerDismiss.addEventListener('click', () => {
     // Dismissals are per-daemon-build: re-show if a different build
@@ -45,31 +79,7 @@ function wireDaemonBanner() {
     daemonBannerDismissedFor = daemonBannerEl.dataset.daemonBuild || '';
     hideDaemonBanner();
   });
-  daemonBannerRestart.addEventListener('click', async () => {
-    // Restart kills hived AND relaunches Hive itself, so every running
-    // session ends. Warn first.
-    const ok = await Confirm(
-      'Restart Hive?',
-      'This will close Hive, terminate every running shell and agent, ' +
-      'and reopen Hive with a fresh daemon. Save your work first.\n\n' +
-      'Continue?',
-    );
-    if (!ok) return;
-    daemonBannerRestart.disabled = true;
-    daemonRestarting = true;
-    showDaemonBanner('Restarting Hive…');
-    try {
-      await RestartDaemon();
-      // RestartDaemon quits this process on success; control returns
-      // here only on failure paths.
-    } catch (err) {
-      flashStatus(`restart failed: ${err}`, true);
-      showDaemonBanner(`Restart failed: ${err}`);
-    } finally {
-      daemonBannerRestart.disabled = false;
-      daemonRestarting = false;
-    }
-  });
+  daemonBannerRestart.addEventListener('click', restartHive);
 
   EventsOn('daemon:stale', (ev) => {
     if (!ev) return;

--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -28,7 +28,7 @@ import {
   switchTo, setView, gridSpatialMove, shiftActiveProject,
   restoreSession, minimizeSession,
 } from './view.js';
-import { manualUpdateCheck } from './banners.js';
+import { manualUpdateCheck, restartHive } from './banners.js';
 import { clearAttention } from './events.js';
 import { updateSidebarSelection } from './sidebar.js';
 import { scrollTrace } from './trace.js';
@@ -463,6 +463,7 @@ const menuActions = {
   'menu:next-project': () => shiftActiveProject(+1),
   'menu:prev-project': () => shiftActiveProject(-1),
   'menu:check-for-updates': () => manualUpdateCheck(),
+  'menu:restart-hive': () => restartHive(),
   // Must toggle, not just open: the native ⌘/ accelerator intercepts
   // the key before the webview on macOS, so the keydown close path
   // (Escape/⌘/ in the window listener) never sees ⌘/ while the menu

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -25,7 +25,7 @@ import { initSettings, openSettings } from './app/modals/settings.js';
 import { openHelpOverlay, initHelpOverlay } from './app/modals/help-overlay.js';
 import { initSidebar } from './app/sidebar.js';
 import { wireDaemonEvents } from './app/events.js';
-import { isDaemonRestarting, initBanners } from './app/banners.js';
+import { isDaemonRestarting, initBanners, restartHive } from './app/banners.js';
 import { initVersionFooter } from './app/version-footer.js';
 import {
   switchTo, switchToProject, updateAppTitle, renderMinimizedTray,
@@ -75,6 +75,7 @@ const paletteCommands = [
   { id: 'prev-project',         name: 'Previous Project',            run: () => shiftActiveProject(-1) },
   { id: 'keyboard-shortcuts',   name: 'Keyboard Shortcuts',          run: () => openHelpOverlay() },
   { id: 'settings',             name: 'Settings…',                   run: () => openSettings() },
+  { id: 'restart-hive',         name: 'Restart Hive…',               run: () => restartHive() },
   ...Array.from({ length: 9 }, (_, i) => ({
     id: `switch-${i + 1}`,
     name: `Switch to Session ${i + 1}`,

--- a/cmd/hivegui/frontend/test/dom/restart-hive.test.js
+++ b/cmd/hivegui/frontend/test/dom/restart-hive.test.js
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+//
+// restartHive (src/app/banners.js) used to be an anonymous click
+// handler on the daemon-stale banner's button — the only trigger in
+// the whole app. With matching GUI/daemon builds the banner never
+// renders, so there was no way to restart Hive at all. It is now an
+// exported action the File menu and command palette call directly,
+// and these tests pin the behaviour that made it safe to expose:
+// confirm first, and surface a refusal instead of swallowing it.
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const bridge = vi.hoisted(() => ({
+  Confirm: vi.fn(() => Promise.resolve(true)),
+  RestartDaemon: vi.fn(() => Promise.resolve()),
+  CheckForUpdate: vi.fn(() => Promise.resolve()),
+  OpenURL: vi.fn(() => Promise.resolve()),
+  EventsOn: vi.fn(),
+}));
+
+vi.mock('../../src/bridge.js', () => bridge);
+
+let restartHive, isDaemonRestarting, bannerEl, bannerText;
+
+beforeAll(async () => {
+  // dom.js runs side effects on import (it decorates #terms), and
+  // banners.js pulls it in for flashStatus — so the scaffold needs
+  // those elements even though this file never touches them.
+  document.body.innerHTML = `
+    <div id="terms"></div><ul id="projects"></ul>
+    <div id="daemon-banner" class="hidden">
+      <span id="daemon-banner-text"></span>
+      <button id="daemon-banner-restart"></button>
+      <button id="daemon-banner-dismiss"></button>
+    </div>
+    <div id="update-banner" class="hidden">
+      <span id="update-banner-text"></span>
+      <button id="update-banner-download"></button>
+      <button id="update-banner-dismiss"></button>
+    </div>
+    <div id="status"></div>`;
+  ({ restartHive, isDaemonRestarting } = await import('../../src/app/banners.js'));
+  bannerEl = document.getElementById('daemon-banner');
+  bannerText = document.getElementById('daemon-banner-text');
+});
+
+beforeEach(() => {
+  bridge.Confirm.mockClear().mockResolvedValue(true);
+  bridge.RestartDaemon.mockClear().mockResolvedValue(undefined);
+});
+
+describe('restartHive', () => {
+  it('asks for confirmation before touching the daemon', async () => {
+    bridge.Confirm.mockResolvedValue(false);
+    await restartHive();
+    expect(bridge.Confirm).toHaveBeenCalled();
+    expect(bridge.RestartDaemon).not.toHaveBeenCalled();
+  });
+
+  it('calls RestartDaemon once confirmed', async () => {
+    await restartHive();
+    expect(bridge.RestartDaemon).toHaveBeenCalledTimes(1);
+  });
+
+  // The daemon now refuses to "restart" when it cannot actually
+  // replace hived, rather than relaunching into the old one. That
+  // rejection has to reach the user.
+  it('surfaces a refusal in the banner', async () => {
+    bridge.RestartDaemon.mockRejectedValue(new Error('hived still answering'));
+    await restartHive();
+    expect(bannerEl.classList.contains('hidden')).toBe(false);
+    expect(bannerText.textContent).toMatch(/Restart failed.*hived still answering/);
+  });
+
+  // events.js reads this to suppress the red "control disconnected"
+  // status while a restart is deliberately tearing the conn down.
+  it('clears the restarting flag when the call settles', async () => {
+    await restartHive();
+    expect(isDaemonRestarting()).toBe(false);
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/restart-hive.test.js
+++ b/cmd/hivegui/frontend/test/dom/restart-hive.test.js
@@ -78,3 +78,35 @@ describe('restartHive', () => {
     expect(isDaemonRestarting()).toBe(false);
   });
 });
+
+// The banner button disabled itself, but the menu item and palette
+// entry bypass that — and the daemon probe window is seconds long.
+// Two invocations must not both reach RestartDaemon (which would
+// spawn the replacement GUI twice).
+describe('restartHive re-entrancy', () => {
+  it('ignores a second invocation while one is in flight', async () => {
+    let releaseConfirm;
+    bridge.Confirm.mockImplementation(
+      () => new Promise((resolve) => { releaseConfirm = () => resolve(true); }),
+    );
+
+    const first = restartHive();
+    const second = restartHive();   // must be a no-op, not a second run
+    releaseConfirm();
+    await Promise.all([first, second]);
+
+    expect(bridge.Confirm).toHaveBeenCalledTimes(1);
+    expect(bridge.RestartDaemon).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the guard when the user cancels', async () => {
+    bridge.Confirm.mockResolvedValue(false);
+    await restartHive();
+    expect(isDaemonRestarting()).toBe(false);
+
+    // A cancel must not wedge the action permanently.
+    bridge.Confirm.mockResolvedValue(true);
+    await restartHive();
+    expect(bridge.RestartDaemon).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cmd/hivegui/main.go
+++ b/cmd/hivegui/main.go
@@ -92,6 +92,9 @@ func main() {
 		Bind:             []interface{}{app},
 	})
 	if err != nil {
-		println("hivegui:", err.Error())
+		// log, not println: println writes to stderr only, which
+		// LaunchServices sends to /dev/null — a startup failure would
+		// leave no trace in the very logfile setupLogFile just opened.
+		log.Printf("hivegui: wails.Run: %v", err)
 	}
 }

--- a/cmd/hivegui/main.go
+++ b/cmd/hivegui/main.go
@@ -4,8 +4,12 @@ package main
 
 import (
 	"embed"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
 
+	"github.com/lucascaro/hive/internal/registry"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
@@ -42,7 +46,27 @@ func resolveLaunchDir() string {
 	return ""
 }
 
+// setupLogFile tees the standard logger to $STATE/hivegui.log,
+// mirroring what hived does with hived.log. Under LaunchServices the
+// GUI's stderr goes to /dev/null, so until now a failed restart (or
+// any other error) left no trace anywhere on disk — the reason the
+// "Restart Hive doesn't restart the daemon" report could not be
+// diagnosed from the machine it happened on.
+func setupLogFile() {
+	stateDir := registry.StateDir()
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(stateDir, "hivegui.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	log.SetOutput(io.MultiWriter(os.Stderr, f))
+}
+
 func main() {
+	setupLogFile()
 	launchDir := resolveLaunchDir()
 	app := NewApp(launchDir)
 

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -59,6 +59,9 @@ func buildAppMenu(a *App) *menu.Menu {
 		emit("menu:delete-project"))
 	file.AddSeparator()
 	file.AddText("Check for Updates…", nil, emit("menu:check-for-updates"))
+	// No accelerator: this terminates every running shell and agent,
+	// which is not something to leave one fat-finger away.
+	file.AddText("Restart Hive…", nil, emit("menu:restart-hive"))
 	// macOS convention puts Settings in the app menu, but Wails v2
 	// builds that menu entirely in Objective-C from a role enum
 	// (WailsMenu.m's appendRole) — processMenuItem returns as soon as

--- a/cmd/hivegui/restart.go
+++ b/cmd/hivegui/restart.go
@@ -19,14 +19,30 @@ import (
 func socketDead(sock string, budget time.Duration) bool {
 	deadline := time.Now().Add(budget)
 	for {
-		c, err := net.DialTimeout("unix", sock, 500*time.Millisecond)
+		// Clamp the dial timeout to what's left, so the call as a
+		// whole honours budget instead of overrunning it by up to a
+		// full dial timeout on the last iteration.
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return false
+		}
+		if remaining > dialTimeout {
+			remaining = dialTimeout
+		}
+		c, err := net.DialTimeout("unix", sock, remaining)
 		if err != nil {
 			return true
 		}
 		_ = c.Close()
-		if !time.Now().Before(deadline) {
-			return false
-		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(pollInterval)
 	}
 }
+
+const (
+	dialTimeout = 500 * time.Millisecond
+	// Every probe dial costs the daemon an accepted connection that
+	// hangs up without a HELLO. 200ms keeps the restart responsive
+	// while keeping that chatter to a handful of entries over the
+	// fallback window.
+	pollInterval = 200 * time.Millisecond
+)

--- a/cmd/hivegui/restart.go
+++ b/cmd/hivegui/restart.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"net"
+	"time"
+)
+
+// socketDead reports whether nothing answers on sock, polling until
+// budget expires.
+//
+// This is the authoritative liveness test for the restart path, and
+// deliberately replaces signal-based probing. hived runs as a direct
+// child of the GUI that never Wait()s on it, so a SIGTERM'd daemon
+// lingers as a zombie: signal(0) keeps succeeding long after the
+// process has stopped serving. A zombie holds no socket, so dialing
+// answers the question we actually care about — "can a relaunched GUI
+// still reach the old daemon?" — which is exactly the failure this
+// whole change exists to prevent.
+func socketDead(sock string, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for {
+		c, err := net.DialTimeout("unix", sock, 500*time.Millisecond)
+		if err != nil {
+			return true
+		}
+		_ = c.Close()
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/cmd/hivegui/restart_test.go
+++ b/cmd/hivegui/restart_test.go
@@ -71,6 +71,11 @@ func TestSocketDead_MissingPath(t *testing.T) {
 // there is no recovery route, since ConnectControl only runs from the
 // frontend's boot path. The error path must leave everything wired up.
 func TestRestartDaemon_FailurePreservesConns(t *testing.T) {
+	// NewApp calls agent.SetCustomDir(registry.StateDir()). Without
+	// this the test reads the developer's real Hive state directory
+	// and leaves the package-level customDir pointing at it for the
+	// rest of the binary.
+	isolateState(t)
 	sock := filepath.Join(shortTempDir(t), "s")
 	// A daemon that ignores FrameShutdown and never dies.
 	ln, err := net.Listen("unix", sock)

--- a/cmd/hivegui/restart_test.go
+++ b/cmd/hivegui/restart_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -11,9 +12,17 @@ import (
 // shortTempDir keeps socket paths well clear of sun_path's 104-byte
 // limit on macOS, which t.TempDir() gets uncomfortably close to.
 // Mirrors the helper of the same name in internal/daemon.
+//
+// The /tmp base is unix-only — there is no such directory on Windows,
+// and sun_path is not a constraint there either, so fall back to the
+// default temp location.
 func shortTempDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "hg")
+	base := "/tmp"
+	if runtime.GOOS == "windows" {
+		base = ""
+	}
+	dir, err := os.MkdirTemp(base, "hg")
 	if err != nil {
 		t.Fatalf("mkdir temp: %v", err)
 	}

--- a/cmd/hivegui/restart_test.go
+++ b/cmd/hivegui/restart_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// socketDead is the restart path's liveness authority, replacing the
+// signal-based probe that reports a zombie hived as alive forever.
+// These two tests pin both answers.
+
+func TestSocketDead_LiveListener(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "s")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	start := time.Now()
+	if socketDead(sock, 300*time.Millisecond) {
+		t.Fatal("socketDead reported dead while a listener is accepting")
+	}
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Errorf("gave up after %v, want at least the full 300ms budget", elapsed)
+	}
+}
+
+func TestSocketDead_AfterClose(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "s")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_ = ln.Close()
+
+	if !socketDead(sock, time.Second) {
+		t.Fatal("socketDead reported alive after the listener closed")
+	}
+}
+
+// A socket path that never existed must read as dead, not as an
+// error the caller has to interpret — RestartDaemon treats "cannot
+// dial" as "nothing to reconnect to", which is the whole point.
+func TestSocketDead_MissingPath(t *testing.T) {
+	if !socketDead(filepath.Join(t.TempDir(), "nope"), time.Second) {
+		t.Fatal("socketDead reported alive for a nonexistent socket path")
+	}
+}

--- a/cmd/hivegui/restart_test.go
+++ b/cmd/hivegui/restart_test.go
@@ -2,17 +2,31 @@ package main
 
 import (
 	"net"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+// shortTempDir keeps socket paths well clear of sun_path's 104-byte
+// limit on macOS, which t.TempDir() gets uncomfortably close to.
+// Mirrors the helper of the same name in internal/daemon.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "hg")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
 
 // socketDead is the restart path's liveness authority, replacing the
 // signal-based probe that reports a zombie hived as alive forever.
 // These two tests pin both answers.
 
 func TestSocketDead_LiveListener(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "s")
+	sock := filepath.Join(shortTempDir(t), "s")
 	ln, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -29,7 +43,7 @@ func TestSocketDead_LiveListener(t *testing.T) {
 }
 
 func TestSocketDead_AfterClose(t *testing.T) {
-	sock := filepath.Join(t.TempDir(), "s")
+	sock := filepath.Join(shortTempDir(t), "s")
 	ln, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -45,7 +59,63 @@ func TestSocketDead_AfterClose(t *testing.T) {
 // error the caller has to interpret — RestartDaemon treats "cannot
 // dial" as "nothing to reconnect to", which is the whole point.
 func TestSocketDead_MissingPath(t *testing.T) {
-	if !socketDead(filepath.Join(t.TempDir(), "nope"), time.Second) {
+	if !socketDead(filepath.Join(shortTempDir(t), "nope"), time.Second) {
 		t.Fatal("socketDead reported alive for a nonexistent socket path")
+	}
+}
+
+// TestRestartDaemon_FailurePreservesConns is the regression test for
+// the ordering bug: RestartDaemon used to tear down the control and
+// attach conns before it knew whether the daemon would actually die.
+// On the "hived survived" path that left the user in a dead window —
+// there is no recovery route, since ConnectControl only runs from the
+// frontend's boot path. The error path must leave everything wired up.
+func TestRestartDaemon_FailurePreservesConns(t *testing.T) {
+	sock := filepath.Join(shortTempDir(t), "s")
+	// A daemon that ignores FrameShutdown and never dies.
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = c // hold it open, read nothing, exit never
+		}
+	}()
+	t.Setenv("HIVE_SOCKET", sock)
+
+	control, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial control: %v", err)
+	}
+	defer control.Close()
+	attach, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial attach: %v", err)
+	}
+	defer attach.Close()
+
+	app := NewApp("")
+	app.control = &connState{conn: control}
+	app.attaches["sess-1"] = &connState{conn: attach}
+
+	if err := app.RestartDaemon(); err == nil {
+		t.Fatal("RestartDaemon should fail while the daemon is still answering")
+	}
+
+	if app.control == nil {
+		t.Error("control conn was dropped on the failure path")
+	}
+	if len(app.attaches) != 1 {
+		t.Errorf("attach conns were dropped on the failure path: %d left", len(app.attaches))
+	}
+	// Still usable, not a closed fd.
+	if _, err := control.Write([]byte{}); err != nil {
+		t.Errorf("control conn is no longer writable: %v", err)
 	}
 }

--- a/cmd/hivegui/restart_unix.go
+++ b/cmd/hivegui/restart_unix.go
@@ -5,6 +5,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -13,26 +14,40 @@ import (
 	"time"
 )
 
+// Package-level seams so tests can drive the branches without
+// shelling out or needing a real hived, mirroring probeFn in
+// restart_windows.go.
+var (
+	looksLikeHivedFn = pidLooksLikeHived
+	waitForExitFn    = waitForExit
+)
+
 // killRunningHived sends SIGTERM to the hived recorded in <sock>.pid,
-// waits for it to exit, and escalates to SIGKILL on a 3s budget. On
-// SIGKILL, also waits for the process to actually exit so the caller
-// can rely on "killRunningHived returned nil ⇒ socket is free."
+// waits for it to exit, and escalates to SIGKILL on a 3s budget.
+//
+// This is the *fallback* kill channel. RestartDaemon prefers an
+// in-band FrameShutdown over the control conn, because everything
+// below depends on the pidfile being present and accurate — and a
+// nil return here does NOT mean the socket is free. Three branches
+// return nil having killed nothing (no pidfile, unrecognised process
+// name, already-gone pid), which is exactly how a "restarted" GUI
+// ended up reconnecting to the daemon it meant to replace. The caller
+// probes the socket afterwards and treats that as the truth.
 //
 // The pidfile is scoped to the socket the daemon owns (sibling file,
 // "<sock>.pid"). That way a user running a second hived with a custom
 // --socket can't be accidentally signaled by the GUI's restart action,
 // which only ever talks to the default socket.
 //
-// Returns nil if the pidfile is missing, the recorded pid no longer
-// exists, or the recorded pid does not look like a hived (a stale
-// pidfile whose pid was recycled to an unrelated user process). The
-// last case is the safety-critical one: the OS hands recycled pids to
-// editors, shells, anything; we must not SIGTERM them.
+// The unrecognised-name branch is the safety-critical one: the OS
+// hands recycled pids to editors, shells, anything; we must not
+// SIGTERM them.
 func killRunningHived(sock string) error {
 	pidPath := sock + ".pid"
 	raw, err := os.ReadFile(pidPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("hivegui: kill hived: no pidfile at %s; nothing to signal", pidPath)
 			return nil
 		}
 		return fmt.Errorf("read pidfile: %w", err)
@@ -50,14 +65,17 @@ func killRunningHived(sock string) error {
 	// recycled is the "alive but not hived" case — guard with a comm
 	// check below before any destructive signal.
 	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		log.Printf("hivegui: kill hived: pid %d already gone", pid)
 		return nil // already gone, nothing to do
 	}
-	if !pidLooksLikeHived(pid) {
+	if !looksLikeHivedFn(pid) {
 		// Stale pidfile pointing at a recycled, unrelated pid. Drop
 		// the file and bail; do NOT signal an unknown process.
+		log.Printf("hivegui: kill hived: pid %d is not a hived; removing stale pidfile %s", pid, pidPath)
 		_ = os.Remove(pidPath)
 		return nil
 	}
+	log.Printf("hivegui: kill hived: SIGTERM pid %d", pid)
 
 	if err := proc.Signal(syscall.SIGTERM); err != nil {
 		if errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH) {
@@ -65,13 +83,21 @@ func killRunningHived(sock string) error {
 		}
 		return fmt.Errorf("signal pid %d: %w", pid, err)
 	}
-	if waitForExit(proc, 3*time.Second) {
+	if waitForExitFn(proc, 3*time.Second) {
 		return nil
 	}
 	// Still alive after 3s — escalate, then wait for the kernel to
 	// reap it so the caller's reconnect doesn't race the dying socket.
+	log.Printf("hivegui: kill hived: pid %d survived SIGTERM, escalating to SIGKILL", pid)
 	_ = proc.Signal(syscall.SIGKILL)
-	waitForExit(proc, 2*time.Second)
+	if !waitForExitFn(proc, 2*time.Second) {
+		// Mirrors the Windows path, which has always reported this.
+		// Note the caller does not rely on this error alone: it probes
+		// the socket either way, because a zombie child (hived is
+		// spawned by the GUI and never Wait()ed on) keeps answering
+		// signal(0) forever while holding no socket.
+		return fmt.Errorf("pid %d still alive 2s after SIGKILL", pid)
+	}
 	return nil
 }
 

--- a/cmd/hivegui/restart_unix_test.go
+++ b/cmd/hivegui/restart_unix_test.go
@@ -1,0 +1,128 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// These mirror restart_windows_test.go. They exist because the unix
+// path had zero coverage while carrying three branches that return
+// nil without killing anything — the class of bug that let "Restart
+// Hive" relaunch into the daemon it was supposed to replace.
+
+func writePidfile(t *testing.T, pid int) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "s")
+	if err := os.WriteFile(sock+".pid", []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+	return sock
+}
+
+// sleeper starts a long-lived child we own, so tests can signal a
+// real pid without touching anything else on the machine. The
+// returned channel closes when the child is reaped — the only
+// reliable exit signal here, since signal(0) keeps succeeding on an
+// unreaped zombie (the same trap that broke waitForExit in
+// production).
+func sleeper(t *testing.T) (int, <-chan struct{}) {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	reaped := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(reaped) }()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	return cmd.Process.Pid, reaped
+}
+
+func stubSeams(t *testing.T, looksLikeHived bool, exits bool) {
+	t.Helper()
+	origName, origWait := looksLikeHivedFn, waitForExitFn
+	looksLikeHivedFn = func(int) bool { return looksLikeHived }
+	waitForExitFn = func(*os.Process, time.Duration) bool { return exits }
+	t.Cleanup(func() { looksLikeHivedFn, waitForExitFn = origName, origWait })
+}
+
+func TestKillRunningHived_NoPidfile(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "s")
+	if err := killRunningHived(sock); err != nil {
+		t.Fatalf("missing pidfile should be a no-op, got %v", err)
+	}
+}
+
+func TestKillRunningHived_InvalidPid(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "s")
+	if err := os.WriteFile(sock+".pid", []byte("not-a-pid"), 0o600); err != nil {
+		t.Fatalf("write pidfile: %v", err)
+	}
+	if err := killRunningHived(sock); err == nil {
+		t.Fatal("unparseable pidfile should error, got nil")
+	}
+}
+
+func TestKillRunningHived_DeadPidNoError(t *testing.T) {
+	// A pid we know is gone: start a child and reap it.
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run true: %v", err)
+	}
+	sock := writePidfile(t, cmd.Process.Pid)
+
+	if err := killRunningHived(sock); err != nil {
+		t.Fatalf("dead pid should be a no-op, got %v", err)
+	}
+}
+
+func TestKillRunningHived_StalePidfileRemoved(t *testing.T) {
+	pid, reaped := sleeper(t)
+	sock := writePidfile(t, pid)
+	stubSeams(t, false, true) // alive, but not a hived
+
+	if err := killRunningHived(sock); err != nil {
+		t.Fatalf("recycled pid should be a no-op, got %v", err)
+	}
+	if _, err := os.Stat(sock + ".pid"); !os.IsNotExist(err) {
+		t.Errorf("stale pidfile should have been removed, stat err = %v", err)
+	}
+	// And the innocent bystander must still be running.
+	select {
+	case <-reaped:
+		t.Errorf("unrelated pid %d was killed", pid)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestKillRunningHived_StillAliveAfterKillErrors(t *testing.T) {
+	pid, _ := sleeper(t)
+	sock := writePidfile(t, pid)
+	stubSeams(t, true, false) // a hived that never appears to exit
+
+	err := killRunningHived(sock)
+	if err == nil {
+		t.Fatal("a process that outlives SIGKILL must be reported, got nil")
+	}
+}
+
+func TestKillRunningHived_HappyPath(t *testing.T) {
+	pid, reaped := sleeper(t)
+	sock := writePidfile(t, pid)
+	stubSeams(t, true, true)
+
+	if err := killRunningHived(sock); err != nil {
+		t.Fatalf("killRunningHived: %v", err)
+	}
+	// SIGTERM was really delivered — `sleep` dies on it.
+	select {
+	case <-reaped:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("pid %d still alive; SIGTERM was not delivered", pid)
+	}
+}

--- a/cmd/hivegui/restart_windows.go
+++ b/cmd/hivegui/restart_windows.go
@@ -6,6 +6,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -47,6 +48,7 @@ func killRunningHived(sock string) error {
 	raw, err := os.ReadFile(pidPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("hivegui: kill hived: no pidfile at %s; nothing to terminate", pidPath)
 			return nil
 		}
 		return fmt.Errorf("read pidfile: %w", err)
@@ -61,13 +63,16 @@ func killRunningHived(sock string) error {
 		return fmt.Errorf("probe pid %d: %w", pid, err)
 	}
 	if !alive {
+		log.Printf("hivegui: kill hived: pid %d already gone", pid)
 		return nil // already gone
 	}
 	if !isHived {
 		// Stale pidfile pointing at a recycled, unrelated pid.
+		log.Printf("hivegui: kill hived: pid %d is not a hived; removing stale pidfile %s", pid, pidPath)
 		_ = os.Remove(pidPath)
 		return nil
 	}
+	log.Printf("hivegui: kill hived: terminating pid %d", pid)
 
 	proc, err := os.FindProcess(pid)
 	if err != nil {

--- a/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -73,6 +73,7 @@ Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <so
 ## Progress
 
 - **2026-07-18** — Plan-first scaffold; stage = IMPLEMENT.
+- **2026-07-19** — Review iter 2 cleared four IMPORTANT items (writeMu bypass on the shutdown frame, a log line claiming an in-band attempt that never happened, `println` bypassing the new logfile, and a test reading the real state dir) plus the two Greptile MINORs (socketDead budget overrun, probe-dial EOF spam in hived.log). All three bot review threads replied to and resolved.
 - **2026-07-19** — Review iter 1 cleared both IMPORTANT findings: RestartDaemon no longer tears down conns before confirming the daemon died (the error path has to leave a working window, and there is no reconnect route), and restartHive is re-entrancy-guarded now that the menu and palette reach it. Both have regression tests; the Go one was mutation-checked against the pre-fix ordering.
 - **2026-07-19** — PR #244 opened; stage = REVIEW.
 - **2026-07-18** — Implemented on `feature/243-restart-hive-doesnt-reliably-restart-daemon`. `./build.sh` green; `internal/daemon` shutdown tests, `cmd/hivegui` restart tests, `cmd/hived` pidfile tests, and 253 frontend vitest tests all pass.
@@ -81,6 +82,7 @@ Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <so
 
 <!-- Append-only. One line per /hs-review-loop iteration. -->
 
+- **2026-07-19 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: (4 IMPORTANT, distinct from iter 1); threads_open: 0 (3 bot threads replied + resolved); action: autofix+push; head_sha: 69ef50a.
 - **2026-07-19 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 495bdfec73271419d2f24d2560fdb9f0290d885f1efa99fb4bad82abac6f883c; threads_open: 0; action: autofix+push (2 IMPORTANT applied despite COMMENT-stop, per AGENTS.md boil-the-lake); head_sha: 8a0e349.
 
 ## Open questions

--- a/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -1,0 +1,78 @@
+# Restart Hive doesn't reliably restart the daemon
+
+- **Spec:** [docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md](../../product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md)
+- **Issue:** —
+- **Status:** active
+
+## Summary
+
+Make the Restart Hive action verifiable, recoverable, and reachable. The GUI asks the daemon to exit over the control connection it already holds, confirms the socket is dead before relaunching, falls back to the existing SIGTERM-by-pid path, and fails loudly instead of quitting into a state where the new GUI reattaches to the old daemon. Adds a File-menu and palette entry so restart is invokable without a build mismatch, and a `hivegui.log` so the next failure is diagnosable.
+
+## Research
+
+Authored via plan-first mode; findings from tracing the full path.
+
+- `cmd/hivegui/frontend/src/app/banners.js:41-72` — `wireDaemonBanner`; the click handler (`Confirm` → `RestartDaemon` → catch/`showDaemonBanner`) is the **only** trigger for `RestartDaemon` in the whole frontend. `manualUpdateCheck` (`:202`) is the precedent for exporting a banner action and wiring it to a menu + palette entry.
+- `cmd/hivegui/app.go:319-341` — `RestartDaemon`: close conns → `killRunningHived` → `spawnNewGUI` → `wruntime.Quit`. No verification between kill and relaunch.
+- `cmd/hivegui/restart_unix.go:31-105` — pidfile-only kill. Returns `nil` on missing pidfile (`:36`), name mismatch after deleting the pidfile (`:55-60`), and a discarded post-SIGKILL wait (`:73-75`). Windows returns an error in the equivalent spot (`restart_windows.go:83-86`).
+- `cmd/hivegui/app.go:836-851` — `dialOrSpawn`: dials first, only spawns `hived` on dial failure. A surviving daemon is silently reused.
+- `cmd/hived/main.go:84-88,101-105` — pidfile written after `daemon.New` wins the bind race; `removePidfile` deletes unconditionally, so a late-exiting daemon can delete a live one's pidfile.
+- `internal/daemon/daemon.go:37-45,129-146,298-370` — `Daemon` struct, `Run`'s ctx-cancel → `ln.Close()` goroutine, and the existing inbound control-frame dispatch. Adding a shutdown frame is a small extension of machinery that already exists.
+- `internal/wire/frame.go:40-71` — frame type table; next free discriminator is `0x15`.
+- Observed via `ps -Ao pid,ppid,command`: `hived` (63467) is a **direct child** of `hivegui` (63452), and `startDetached` (`window_unix.go:56-64`) never `Wait()`s. After SIGTERM the daemon is a zombie, `proc.Signal(0)` keeps succeeding, and `waitForExit` (`restart_unix.go:96`) always burns its full budget. A zombie holds no socket, so a socket probe is the correct liveness test.
+- Test precedent: `internal/daemon/daemon_test.go:454` drives control frames over a real socket; `cmd/hivegui/restart_windows_test.go:69-140` shows the `probeFn` seam pattern for testing `killRunningHived`; `cmd/hivegui/frontend/test/dom/attention-jump.test.js:22` shows the DOM-test bridge stub.
+- Ruled out during triage: `ps -o comm=` path truncation (single-column output is untruncated at 85 chars) and `hived` ignoring SIGTERM (`hived.log` shows clean `shutting down`).
+
+## Approach
+
+Stop treating the pidfile as authoritative. The **socket** is the liveness authority; the existing control connection is the primary kill channel; the pidfile/signal path is demoted to a fallback.
+
+`RestartDaemon` becomes: send `FrameShutdown` → `socketDead`? → else `killRunningHived` → `socketDead`? → else return an error **without** relaunching or quitting. `spawnNewGUI` + `Quit` are reached only once the socket is confirmed dead, which makes it structurally impossible for the new GUI to reattach to the old daemon.
+
+Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <sock>` fallback to find the listener when the pidfile is gone) because in-band shutdown removes the pid/name/pidfile guesswork from the happy path entirely, reuses control-frame machinery that already exists, and does not shell out. Verify-only — probing the socket and reporting failure without a recovery channel — was rejected: in exactly the broken state it turns the button into a guaranteed dead-end and relabels the bug instead of fixing it.
+
+### Files to change
+
+- `internal/wire/frame.go` — add `FrameShutdown FrameType = 0x15` (C → S, control, empty payload) and its `String()` case.
+- `internal/daemon/daemon.go` — add `shutdown chan struct{}` + `sync.Once` to `Daemon`; `Shutdown()` closes it; `Run`'s goroutine waits on `ctx.Done()` **or** `shutdown` before `ln.Close()` (`Accept` then returns `net.ErrClosed` and `Run` returns nil, so `d.Close()` and `removePidfile` still run); dispatch `wire.FrameShutdown` → `d.Shutdown()`.
+- `cmd/hivegui/app.go` — rewrite `RestartDaemon` per the sequence above; send the frame on the live control conn before closing it; `log.Printf` each step.
+- `cmd/hivegui/restart_unix.go` — per-branch `log.Printf`; still-alive after the SIGKILL wait returns an error instead of `nil`.
+- `cmd/hivegui/restart_windows.go` — per-branch `log.Printf` only.
+- `cmd/hived/main.go` — `removePidfile` reads the file and deletes only when the contents match `os.Getpid()`.
+- `cmd/hivegui/main.go` — tee `log` output to `filepath.Join(registry.StateDir(), "hivegui.log")`, mirroring `cmd/hived/main.go:54-59`.
+- `cmd/hivegui/frontend/src/app/banners.js` — extract the click-handler body into an exported `restartHive()`; the button calls it.
+- `cmd/hivegui/menu_darwin.go` — `file.AddText("Restart Hive…", nil, emit("menu:restart-hive"))` next to "Check for Updates…" (`:61`). No accelerator — too destructive for a hotkey.
+- `cmd/hivegui/frontend/src/main.js` — palette command `{ id: 'restart-hive', name: 'Restart Hive…', run: restartHive }` + the `menu:restart-hive` binding.
+- `CHANGELOG.md` — via `/hs-changelog-update`.
+
+`banners.js:62-67` already renders a `RestartDaemon` rejection in the banner, which is exactly what the new failure path produces — no change needed there.
+
+### New files
+
+- `cmd/hivegui/restart.go` — `socketDead(sock string, budget time.Duration) bool`, polling `net.Dial("unix", sock)`. Platform-neutral (Go supports unix sockets on Win10+); if it proves unreliable on Windows, gate the probe to unix and keep the existing Windows error path.
+
+### Tests
+
+- `internal/daemon/daemon_test.go` — `TestShutdownFrameStopsDaemon`: send `FrameShutdown` over a real socket, assert `Run` returns nil and the socket stops accepting.
+- `cmd/hivegui/restart_test.go` (new) — `TestSocketDead_LiveListener`, `TestSocketDead_AfterClose`.
+- `cmd/hivegui/restart_unix_test.go` (new) — mirror `restart_windows_test.go` via a name/probe seam: no pidfile, stale pidfile removed, dead pid, invalid pid, plus `TestKillRunningHived_StillAliveAfterKillErrors`.
+- `cmd/hived/main_test.go` — `TestRemovePidfileKeepsForeignPid`.
+- `cmd/hivegui/frontend/test/dom/restart-hive-palette.test.js` (new) — palette entry invokes the mocked `RestartDaemon`.
+
+## Decision log
+
+- **2026-07-18** — In-band `FrameShutdown` over the control conn as the primary kill channel, pidfile/SIGTERM demoted to fallback. Why: the pidfile is the thing that fails, and the daemon already dispatches inbound control frames.
+- **2026-07-18** — Numbered 243 rather than max-prefix+1 (241). Why: this repo's spec numbers mirror GitHub PR numbers, and 241/242 are shipped PRs.
+- **2026-07-18** — `RestartDaemon` logs a `killRunningHived` error instead of returning it. Why: with hived as an unreaped child, the signal-based wait reports "still alive" for a zombie that has already released the socket, so returning that error would abort every restart. The socket probe is the arbiter; the kill error is diagnostic only.
+- **2026-07-18** — `removePidfile`'s ownership check changed existing test expectations (`main_test.go` wrote a hardcoded `"123"`). Updated them to write `os.Getpid()` and added the foreign-pid case, rather than weakening the check.
+
+## Progress
+
+- **2026-07-18** — Plan-first scaffold; stage = IMPLEMENT.
+- **2026-07-18** — Implemented on `feature/243-restart-hive-doesnt-reliably-restart-daemon`. `./build.sh` green; `internal/daemon` shutdown tests, `cmd/hivegui` restart tests, `cmd/hived` pidfile tests, and 253 frontend vitest tests all pass.
+
+## Open questions
+
+- None blocking.
+- Windows `net.Dial("unix", …)` reliability is the one unknown; the fallback (gate the probe to unix) is identified and cheap. `GOOS=windows go vet ./cmd/hivegui/` is clean.
+- Theoretical restart-path race, judged unreachable and deliberately not guarded: `socketDead` returns true when the listener closes, but the old daemon's `os.Remove(d.sock)` runs slightly later in `Daemon.Close()`'s deferred teardown. If a *new* hived ever bound before those defers finished, the old daemon's `os.Remove` would delete the new socket file. New-GUI startup (Wails + WebView + JS, seconds) dwarfs the old daemon's teardown (~100ms), and `daemon.New`'s stale-socket handling compensates. Revisit only if a restart ever comes up with no socket.

--- a/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md](../../product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md)
 - **Issue:** —
+- **PR:** #244
+- **Branch:** feature/243-restart-hive-doesnt-reliably-restart-daemon
 - **Status:** active
 
 ## Summary
@@ -69,6 +71,7 @@ Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <so
 ## Progress
 
 - **2026-07-18** — Plan-first scaffold; stage = IMPLEMENT.
+- **2026-07-19** — PR #244 opened; stage = REVIEW.
 - **2026-07-18** — Implemented on `feature/243-restart-hive-doesnt-reliably-restart-daemon`. `./build.sh` green; `internal/daemon` shutdown tests, `cmd/hivegui` restart tests, `cmd/hived` pidfile tests, and 253 frontend vitest tests all pass.
 
 ## Open questions

--- a/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -63,6 +63,8 @@ Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <so
 
 ## Decision log
 
+- **2026-07-19** — Applied both IMPORTANT review findings rather than stopping on the COMMENT verdict. Why: AGENTS.md requires auto-fixing high-confidence low-risk findings in the same PR, and finding #1 falsified a claim in the code's own doc comment.
+
 - **2026-07-18** — In-band `FrameShutdown` over the control conn as the primary kill channel, pidfile/SIGTERM demoted to fallback. Why: the pidfile is the thing that fails, and the daemon already dispatches inbound control frames.
 - **2026-07-18** — Numbered 243 rather than max-prefix+1 (241). Why: this repo's spec numbers mirror GitHub PR numbers, and 241/242 are shipped PRs.
 - **2026-07-18** — `RestartDaemon` logs a `killRunningHived` error instead of returning it. Why: with hived as an unreaped child, the signal-based wait reports "still alive" for a zombie that has already released the socket, so returning that error would abort every restart. The socket probe is the arbiter; the kill error is diagnostic only.
@@ -71,8 +73,15 @@ Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <so
 ## Progress
 
 - **2026-07-18** — Plan-first scaffold; stage = IMPLEMENT.
+- **2026-07-19** — Review iter 1 cleared both IMPORTANT findings: RestartDaemon no longer tears down conns before confirming the daemon died (the error path has to leave a working window, and there is no reconnect route), and restartHive is re-entrancy-guarded now that the menu and palette reach it. Both have regression tests; the Go one was mutation-checked against the pre-fix ordering.
 - **2026-07-19** — PR #244 opened; stage = REVIEW.
 - **2026-07-18** — Implemented on `feature/243-restart-hive-doesnt-reliably-restart-daemon`. `./build.sh` green; `internal/daemon` shutdown tests, `cmd/hivegui` restart tests, `cmd/hived` pidfile tests, and 253 frontend vitest tests all pass.
+
+## PR convergence ledger
+
+<!-- Append-only. One line per /hs-review-loop iteration. -->
+
+- **2026-07-19 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 495bdfec73271419d2f24d2560fdb9f0290d885f1efa99fb4bad82abac6f883c; threads_open: 0; action: autofix+push (2 IMPORTANT applied despite COMMENT-stop, per AGENTS.md boil-the-lake); head_sha: 8a0e349.
 
 ## Open questions
 

--- a/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -85,6 +85,20 @@ Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <so
 - **2026-07-19 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: (4 IMPORTANT, distinct from iter 1); threads_open: 0 (3 bot threads replied + resolved); action: autofix+push; head_sha: 69ef50a.
 - **2026-07-19 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 495bdfec73271419d2f24d2560fdb9f0290d885f1efa99fb4bad82abac6f883c; threads_open: 0; action: autofix+push (2 IMPORTANT applied despite COMMENT-stop, per AGENTS.md boil-the-lake); head_sha: 8a0e349.
 
+## CI note (not caused by this PR)
+
+`CI (Linux)` fails on `main` itself, including tip `13121a0`, with the same three
+`e2e-real` specs that fail on this branch:
+
+- `wheel-scroll.spec.js:215` — mouse-tracking session forwards the wheel to the app
+- `wheel-scroll.spec.js:228` — alternate-buffer session does not swallow the wheel
+- `scroll-codex.spec.js:244` — unscrolled user not stranded by a resize under load (flaky, passes on retry)
+
+Confirmed pre-existing two ways: the identical set fails on `main`, and on this
+branch Linux flipped success → failure across `69ef50a` → `b404d1c`, a
+**docs-only** commit. Worth its own spec — it will block Gate 6 on every PR
+until fixed.
+
 ## Open questions
 
 - None blocking.

--- a/docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -1,0 +1,38 @@
+# Restart Hive doesn't reliably restart the daemon
+
+- **Issue:** —
+- **Type:** bug
+- **Complexity:** M
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md](../exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md)
+
+## Problem
+
+Clicking **Restart Hive** in the daemon-stale banner relaunches the GUI but leaves the original `hived` running: the stale-build banner reappears immediately, the sidebar version footer is unchanged, and the old daemon PID is still alive. The restart path (`RestartDaemon`, `cmd/hivegui/app.go:319`) treats a pidfile at `<sock>.pid` as its only handle on the daemon and treats `killRunningHived` returning `nil` as proof the socket is free — but three of that function's `nil` returns (missing pidfile, process-name mismatch, discarded post-SIGKILL wait) are compatible with a daemon that is still listening. Nothing probes the socket afterward, so the relaunched GUI's `dialOrSpawn` reconnects to the very daemon the user asked to replace, and the failure is completely silent: the GUI writes no log file at all under LaunchServices.
+
+Two further defects compound it. `hived` runs as a direct child of `hivegui` and is never `Wait()`ed on, so after SIGTERM it becomes a zombie — `proc.Signal(0)` still succeeds, `waitForExit` can never observe the exit, and every restart burns its full 5s escalation budget for nothing. And the daemon-stale banner is the *only* trigger for `RestartDaemon` anywhere in the app, so when the GUI and daemon builds match there is no way to restart Hive at all — no menu item, no palette entry, no shortcut.
+
+## Desired behavior
+
+Restarting Hive actually restarts the daemon, or says so plainly when it cannot. The GUI asks the running daemon to shut down over the control connection it already holds, confirms the socket has gone quiet, and only then relaunches itself — so the new window can never come up attached to the old daemon. When shutdown over the wire is not possible the existing SIGTERM-by-pid path remains as a fallback, and if the daemon is *still* alive after both attempts the restart fails loudly in the banner and leaves the current window working rather than quitting into a broken state. Restart is reachable at any time from **File ▸ Restart Hive…** and the command palette, not only when a build mismatch happens to raise the banner. Every restart step is recorded in a `hivegui.log` next to the existing `hived.log`, so a recurrence can be diagnosed instead of re-guessed.
+
+## Success criteria
+
+- Invoking Restart Hive replaces the running daemon: `<sock>.pid` holds a new PID afterward, and the sidebar version footer reflects the newly spawned `hived`.
+- Restart still works with the pidfile deleted (`rm /tmp/hive-$UID/hived.sock.pid`) — the in-band shutdown path does not depend on it.
+- When the daemon survives both the in-band and signal paths, `RestartDaemon` returns an error, the banner shows it, and the GUI does **not** relaunch or quit.
+- **Restart Hive…** appears in the File menu and the command palette regardless of whether the GUI and daemon builds match.
+- A restart completes promptly rather than stalling ~5s on the zombie-liveness timeout.
+- `~/Library/Application Support/Hive/hivegui.log` contains one readable line per restart step, including which kill channel succeeded and the socket-probe result.
+
+## Non-goals
+
+- Having `RestartDaemon` spawn the replacement `hived` itself; respawn stays a side effect of the relaunched GUI's `dialOrSpawn`.
+- Hardening the macOS `open -n` relaunch (`cmd/hivegui/window_unix.go:33-45`), whose failure is currently unobservable. Real, but a separate bug.
+- Reaping the daemon child properly (`cmd/hivegui` never `Wait()`s); the socket probe makes the zombie irrelevant to this fix.
+
+## Notes
+
+Root cause was **not** reproduced — the live state during triage was healthy, so the bad state is state-dependent. Two hypotheses were tested and ruled out: `ps -o comm=` truncating the long bundle path (single-column output is not truncated), and `hived` ignoring SIGTERM (`hived.log` shows clean `shutting down` handling). The fix is therefore designed to hold regardless of which `nil` path fires, and the new GUI log exists so the next occurrence is explainable.
+
+Prior art: [177-windows-restart-button-and-grid-mode-bugs](177-windows-restart-button-and-grid-mode-bugs.md) fixed the Windows stub, and `CHANGELOG.md:250` fixed the macOS `open -n` relaunch. Both patched the same function without making its "returned nil ⇒ socket is free" contract verifiable.

--- a/docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -1,6 +1,7 @@
 # Restart Hive doesn't reliably restart the daemon
 
 - **Issue:** —
+- **PR:** #244
 - **Type:** bug
 - **Complexity:** M
 - **Priority:** P1

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -42,6 +42,14 @@ type Daemon struct {
 
 	mu      sync.Mutex
 	clients map[net.Conn]struct{}
+
+	// shutdown is closed by Shutdown to stop Run the same way a
+	// cancelled context does. A client asking to exit in-band (the
+	// GUI's Restart action) has no handle on the daemon's context,
+	// and signalling by pid is exactly the fragile path this exists
+	// to avoid.
+	shutdown     chan struct{}
+	shutdownOnce sync.Once
 }
 
 // New binds the socket, opens the registry, and (if configured)
@@ -117,11 +125,12 @@ func New(cfg Config) (*Daemon, error) {
 	}
 
 	return &Daemon{
-		cfg:     cfg,
-		sock:    sock,
-		reg:     reg,
-		ln:      ln,
-		clients: make(map[net.Conn]struct{}),
+		cfg:      cfg,
+		sock:     sock,
+		reg:      reg,
+		ln:       ln,
+		clients:  make(map[net.Conn]struct{}),
+		shutdown: make(chan struct{}),
 	}, nil
 }
 
@@ -129,7 +138,10 @@ func New(cfg Config) (*Daemon, error) {
 func (d *Daemon) Run(ctx context.Context) error {
 	log.Printf("hived: listening on %s, %d session(s)", d.sock, len(d.reg.List()))
 	go func() {
-		<-ctx.Done()
+		select {
+		case <-ctx.Done():
+		case <-d.shutdown:
+		}
 		_ = d.ln.Close()
 	}()
 	for {
@@ -143,6 +155,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 		go d.serve(conn)
 	}
+}
+
+// Shutdown asks Run to stop accepting and return, exactly as a
+// cancelled context would. Safe to call more than once and from any
+// goroutine — a client can send FrameShutdown twice, and the pidfile
+// removal + registry flush that follow Run must happen once.
+func (d *Daemon) Shutdown() {
+	d.shutdownOnce.Do(func() {
+		log.Printf("hived: shutdown requested by client")
+		close(d.shutdown)
+	})
 }
 
 // SocketPath returns the path the daemon is bound to.
@@ -295,6 +318,13 @@ func (d *Daemon) serveControl(conn net.Conn) {
 			return
 		}
 		switch ft {
+		case wire.FrameShutdown:
+			// Return afterwards: the listener is about to close and
+			// this conn is going away with it. Nothing is written
+			// back — the client's proof of shutdown is the socket
+			// going quiet, not an ack it would have to trust.
+			d.Shutdown()
+			return
 		case wire.FrameListSessions:
 			_ = writeJSON(wire.FrameSessions, wire.SessionsResp{Sessions: d.reg.List()})
 		case wire.FrameCreateSession:

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -213,7 +213,13 @@ func (d *Daemon) serve(conn net.Conn) {
 	var hello wire.Hello
 	ft, err := wire.ReadJSON(conn, &hello)
 	if err != nil {
-		log.Printf("hived: read hello: %v", err)
+		// A connect-then-hang-up with no HELLO is a liveness probe,
+		// not an error — the GUI's restart path dials this socket
+		// repeatedly to find out whether the daemon is still up.
+		// Logging those buries real handshake failures in noise.
+		if !errors.Is(err, io.EOF) {
+			log.Printf("hived: read hello: %v", err)
+		}
 		return
 	}
 	if ft != wire.FrameHello {

--- a/internal/daemon/shutdown_test.go
+++ b/internal/daemon/shutdown_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lucascaro/hive/internal/session"
+	"github.com/lucascaro/hive/internal/wire"
+)
+
+// TestShutdownFrameStopsDaemon covers the GUI's primary restart
+// channel: a control client asks the daemon to exit in-band, and the
+// socket must stop answering. This is what lets RestartDaemon replace
+// the daemon without depending on the pidfile — the handle that goes
+// missing in the bug this test exists for.
+func TestShutdownFrameStopsDaemon(t *testing.T) {
+	skipOnWindows(t)
+	tmp := shortTempDir(t)
+	sock := filepath.Join(tmp, "s")
+
+	d, err := New(Config{
+		SocketPath: sock,
+		StateDir:   filepath.Join(tmp, "state"),
+		BootstrapSession: session.Options{
+			Shell: "/bin/bash",
+			Cols:  80,
+			Rows:  24,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	// Run with a context that is never cancelled, so a clean return
+	// can only have come from the shutdown frame.
+	runErr := make(chan error, 1)
+	go func() { runErr <- d.Run(context.Background()) }()
+
+	conn := dial(t, d)
+	handshake(t, conn, wire.Hello{Mode: wire.ModeControl})
+
+	if err := wire.WriteFrame(conn, wire.FrameShutdown, nil); err != nil {
+		t.Fatalf("write shutdown: %v", err)
+	}
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run after shutdown: got %v, want nil", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return within 3s of FrameShutdown")
+	}
+
+	// The listener is closed, so nothing may answer on the socket —
+	// this is precisely the condition RestartDaemon probes for before
+	// it relaunches the GUI.
+	if c, err := net.DialTimeout("unix", sock, time.Second); err == nil {
+		_ = c.Close()
+		t.Fatalf("socket %s still accepting after shutdown", sock)
+	}
+}
+
+// TestShutdownIsIdempotent guards the sync.Once: a client may send
+// the frame twice (or two clients may race), and the second close of
+// the shutdown channel would panic without it.
+func TestShutdownIsIdempotent(t *testing.T) {
+	skipOnWindows(t)
+	tmp := shortTempDir(t)
+	d, err := New(Config{
+		SocketPath: filepath.Join(tmp, "s"),
+		StateDir:   filepath.Join(tmp, "state"),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	d.Shutdown()
+	d.Shutdown()
+}

--- a/internal/wire/frame.go
+++ b/internal/wire/frame.go
@@ -69,6 +69,15 @@ const (
 	// all written atomically with respect to live PTY fanout, so the
 	// client sees a clean buffer-reset boundary.
 	FrameRequestReplay FrameType = 0x14 // C → S, empty payload, attach
+
+	// FrameShutdown asks the daemon to stop accepting connections and
+	// exit, the same way SIGTERM does. The GUI's Restart action uses
+	// it as the primary kill channel: it already holds a control conn,
+	// so shutting down in-band needs no pidfile, no pid lookup, and no
+	// process-name heuristic — all of which can silently fail and
+	// leave the "restarted" GUI attached to the daemon it meant to
+	// replace.
+	FrameShutdown FrameType = 0x15 // C → S, empty payload, control
 )
 
 func (t FrameType) String() string {
@@ -113,6 +122,8 @@ func (t FrameType) String() string {
 		return "RESTART_SESSION"
 	case FrameRequestReplay:
 		return "REQUEST_REPLAY"
+	case FrameShutdown:
+		return "SHUTDOWN"
 	default:
 		return fmt.Sprintf("UNKNOWN(0x%02x)", byte(t))
 	}


### PR DESCRIPTION
## Problem

Clicking **Restart Hive** relaunched the GUI but could leave the old `hived` running: the stale-build banner came straight back, the sidebar version footer was unchanged, and the original daemon PID was still alive.

`RestartDaemon` treated `killRunningHived` returning `nil` as proof the socket was free. Three of its paths return `nil` having killed nothing — missing pidfile, unrecognised process name, and a discarded post-SIGKILL wait. Nothing probed the socket afterwards, so the relaunched GUI's `dialOrSpawn` dialled successfully and reconnected to the very daemon the user asked to replace, silently.

## Approach

The socket is now the liveness authority and the control connection is the primary kill channel:

1. Send the new `wire.FrameShutdown` on the control conn the GUI already holds.
2. Probe the socket. Dead → relaunch and quit.
3. Otherwise fall back to SIGTERM-by-pid, probe again.
4. Still alive → return an error and **stay put**. A visible failure in a working window beats quitting into a window that looks restarted and isn't.

Chosen over keeping pid-signalling with an `lsof` fallback because in-band shutdown removes the pid/name/pidfile guesswork from the happy path entirely and reuses control-frame machinery that already exists.

### Supporting fixes

- **Zombie liveness.** `hived` is a child the GUI never `Wait()`s on, so a SIGTERM'd daemon lingers as a zombie and `signal(0)` keeps succeeding — `waitForExit` could never observe the exit and burned its full 5s budget on every restart. A zombie holds no socket, so the socket probe is both correct and fast. The kill error is now diagnostic only.
- **Self-destructing pidfile.** `removePidfile` deleted unconditionally, so a daemon exiting after its replacement was up destroyed the *live* daemon's pidfile. It now only removes a pidfile naming its own pid.
- **Unreachable action.** The daemon-stale banner was the only trigger for `RestartDaemon` anywhere in the app — with matching builds there was no way to restart Hive at all. Added **File ▸ Restart Hive…** and a command-palette entry (no accelerator: it kills every running session).
- **No diagnostics.** The GUI now writes to `hivegui.log` beside `hived.log`. Under LaunchServices its stderr goes to `/dev/null`, which is why this could not be diagnosed from the machine it happened on.

## Honest caveat

The root cause was **not** reproduced — the live state during triage was healthy, so the bad state is state-dependent. Two hypotheses were tested and ruled out: `ps -o comm=` truncating the long bundle path, and `hived` ignoring SIGTERM. The fix is designed to hold regardless of which `nil` path fires, and the new log exists so a recurrence is explainable rather than re-guessed.

## Tests

- `internal/daemon`: `TestShutdownFrameStopsDaemon`, `TestShutdownIsIdempotent`
- `cmd/hivegui`: `TestSocketDead_*` (live listener / after close / missing path), and a new `restart_unix_test.go` mirroring the Windows suite — no pidfile, invalid pid, dead pid, stale pidfile removed (with a bystander-not-killed assertion), still-alive-after-SIGKILL errors, happy path
- `cmd/hived`: `removePidfile` foreign-pid case; existing cases updated to write a real pid rather than a hardcoded `123`
- `frontend/test/dom/restart-hive.test.js`: confirm-first, calls through, surfaces a refusal in the banner

## Verification

- `./build.sh` green (macOS universal .app)
- `go test ./...` — every package `ok`
- `go vet ./...` clean; `gofmt -l` flags only pre-existing files
- `GOOS=windows go vet ./cmd/hivegui/` clean
- `vitest run` — 28 files, 253 tests passing

Manual check worth doing before merge: `rm /tmp/hive-$UID/hived.sock.pid`, then **File ▸ Restart Hive…** — it must still restart, since the in-band path no longer needs the pidfile.

Spec: `docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Restart Hive…** to the File menu and command palette, with confirmation, re-entrancy protection, and clear restart-progress UI.
  * Enabled in-band daemon shutdown as part of the restart flow.
  * Added persistent GUI diagnostics logging to **hivegui.log**.

* **Bug Fixes**
  * Restart relaunches only after the old daemon is verified stopped (prevents stale-daemon relaunch/quit issues).
  * Improved pidfile safety to avoid deleting a newer/foreign daemon’s pidfile.

* **Documentation**
  * Added restart verification and behavior spec documents.

* **Tests**
  * Added/expanded tests for shutdown idempotency, socket liveness probing, pidfile ownership, and restart failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the \"Restart Hive\" action so it actually replaces the running `hived` daemon instead of silently reconnecting to it. The root cause was that `killRunningHived` had three paths returning `nil` without killing anything, and the restart logic treated that `nil` as proof the socket was free before relaunching.

- **Primary fix**: sends `wire.FrameShutdown` over the existing control connection as the kill channel, then probes the socket directly — a zombie daemon passes `signal(0)` forever but cannot hold a socket, so the socket is now the liveness authority.
- **Supporting fixes**: `removePidfile` now guards against deleting a live replacement daemon's pidfile; the daemon-stale banner is no longer the only restart entry point (File → Restart Hive… and command palette added); GUI errors are teed to `hivegui.log` beside `hived.log` since LaunchServices routes stderr to `/dev/null`.
- **Tests**: new `TestShutdownFrameStopsDaemon`, `TestSocketDead_*`, `restart_unix_test.go`, and a JS DOM test for the re-entrancy guard all exercise the changed paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the restart path is well-hardened and the failure mode (daemon survives) is explicitly handled by keeping the window working rather than quitting into a broken state.

The fix correctly makes the socket the liveness authority throughout: socketDead replaces signal-based probing, FrameShutdown is a direct in-band kill that needs no pidfile, and connection teardown is deferred until after the socket is confirmed dead. The removePidfile ownership check closes the race that could destroy a replacement daemon's pidfile. Test coverage pins every branch that previously returned nil without killing anything.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/hivegui/app.go | RestartDaemon rewritten: sends FrameShutdown in-band first, uses socketDead as liveness authority, and only tears down connections after confirmed success. |
| cmd/hivegui/restart.go | New socketDead helper polls the socket by dialing rather than via signal(0), correctly handling zombie hived processes; dial timeout is clamped to remaining budget. |
| cmd/hivegui/restart_unix.go | killRunningHived demoted to fallback path; SIGKILL error is now diagnostic only. |
| cmd/hived/main.go | removePidfile now checks pidfile ownership before deleting, preventing a slow-exiting old daemon from destroying the replacement daemon's pidfile. |
| internal/daemon/daemon.go | Added Shutdown() with sync.Once; serveControl handles FrameShutdown; EOF from liveness probes silently dropped. |
| internal/wire/frame.go | Added FrameShutdown (0x15) with String() support. |
| cmd/hivegui/frontend/src/app/banners.js | restartHive exported; re-entrancy guard set before Confirm await; finally block resets guard correctly. |
| cmd/hivegui/menu_darwin.go | Added Restart Hive to File menu with no accelerator. |
| cmd/hivegui/restart_unix_test.go | Full coverage of killRunningHived branches including bystander-not-killed assertion. |
| cmd/hivegui/restart_test.go | Tests socketDead and connection-preservation invariant on the failure path. |

<sub>Reviews (4): Last reviewed commit: ["docs(243): note the pre-existing Linux C..."](https://github.com/lucascaro/hive/commit/365ec3794802ddf19d020d39e7ec725d73bdf345) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45418936)</sub>

<!-- /greptile_comment -->