### PR TITLE
docs: 243 QA verdict + spec the flaky e2e-real suite

### DIFF
--- a/docs/exec-plans/completed/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/exec-plans/completed/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -4,7 +4,8 @@
 - **Issue:** —
 - **PR:** #244
 - **Branch:** feature/243-restart-hive-doesnt-reliably-restart-daemon
-- **Status:** active
+- **Stage:** DONE
+- **Status:** completed
 
 ## Summary
 
@@ -77,6 +78,14 @@ Chosen over the obvious alternative (keep signalling by pid, add an `lsof -t <so
 - **2026-07-19** — Review iter 1 cleared both IMPORTANT findings: RestartDaemon no longer tears down conns before confirming the daemon died (the error path has to leave a working window, and there is no reconnect route), and restartHive is re-entrancy-guarded now that the menu and palette reach it. Both have regression tests; the Go one was mutation-checked against the pre-fix ordering.
 - **2026-07-19** — PR #244 opened; stage = REVIEW.
 - **2026-07-18** — Implemented on `feature/243-restart-hive-doesnt-reliably-restart-daemon`. `./build.sh` green; `internal/daemon` shutdown tests, `cmd/hivegui` restart tests, `cmd/hived` pidfile tests, and 253 frontend vitest tests all pass.
+
+## QA verdict
+
+- **2026-07-19** — **PASS**. Merged as c220c67. Operator ran the decisive manual check on the built bundle: with `<sock>.pid` deleted — the state that pre-fix guaranteed the bug, since `killRunningHived` returns nil having killed nothing and the relaunched GUI dials straight back onto the surviving daemon — Restart Hive replaced the daemon. That covers success criteria 1 and 2, the two the whole change exists for.
+  - build/lint/test — PASS — `./build.sh`, `go test ./...` (every package ok), `go vet ./...`, `GOOS=windows go vet ./cmd/hivegui/`, Vitest 255/255. `gofmt -l` flags only files this PR did not touch. CI green on all three platforms at merge.
+  - acceptance — PASS — criteria 1, 2 operator-verified; 4 (menu + palette entry) exercised as the trigger; 3 (daemon survives both channels → error, no relaunch) covered by `TestRestartDaemon_FailurePreservesConns`, which was mutation-checked against the pre-fix ordering and is impractical to test by hand (needs a daemon that ignores both FrameShutdown and SIGKILL); 5 (no ~5s zombie stall) and 6 (per-step `hivegui.log` lines) follow from the socket probe replacing signal-based liveness and are not separately instrumented.
+  - regression — PASS — `FrameShutdown` (0x15) is client→server and optional; an older daemon ignores it and the SIGTERM fallback still runs. `removePidfile`'s ownership check tightened existing behavior, with `main_test.go` updated rather than weakened.
+  - root cause — **NOT REPRODUCED**. The specific `nil` path that fired on the operator's machine was never identified; the live state at triage was healthy. The fix holds regardless of which path it was, and `hivegui.log` exists so a recurrence is explainable rather than re-guessed. Reopen against this spec if the banner ever returns after a restart.
 
 ## PR convergence ledger
 

--- a/docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md
+++ b/docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md
@@ -2,10 +2,11 @@
 
 - **Issue:** —
 - **PR:** #244
+- **Shipped:** 2026-07-19 (c220c67)
 - **Type:** bug
 - **Complexity:** M
 - **Priority:** P1
-- **Exec plan:** [docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md](../exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md)
+- **Exec plan:** [docs/exec-plans/completed/243-restart-hive-doesnt-reliably-restart-daemon.md](../exec-plans/completed/243-restart-hive-doesnt-reliably-restart-daemon.md)
 
 ## Problem
 

--- a/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
+++ b/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
@@ -1,0 +1,44 @@
+# The e2e-real Playwright suite fails on main and blocks every PR
+
+- **Issue:** —
+- **Type:** bug
+- **Complexity:** M
+- **Priority:** P1
+- **Exec plan:** —
+
+## Problem
+
+`CI (Linux)` and `CI (macOS)` fail on `main` itself, including the current tip (`13121a0`). Over the last 8 runs on `main`: Linux failed 5, macOS failed 4, Windows failed 0 — Windows is clean because `build-windows.yml` runs only `go test ./...` and never invokes Playwright. Every failure is in the `e2e-real` suite (`playwright test --config=playwright.real.config.js`, which drives a real `hived` through `hived-ws-bridge`); the Go suites, the Vitest unit/DOM layers, and the mock-bridge `e2e` suite are all consistently green.
+
+The recurring failures cluster in three spec files:
+
+- `test/e2e-real/wheel-scroll.spec.js` — `:185` pixel-mode, `:194` line-mode, `:203` legacy `wheelDeltaY`, `:215` mouse-tracking forwards the wheel, `:228` alternate-buffer does not swallow the wheel
+- `test/e2e-real/scroll-codex.spec.js` — `:166` markers survive grid↔single toggles, `:203` viewport converges after a mode switch, `:244` unscrolled user not stranded by a resize under load, `:300` scrolled reader not yanked to the bottom
+- `test/e2e-real/scroll-restream-strand.spec.js` — `:59` no transient viewport-jump on threshold crossing
+
+The failures are load- and timing-dependent, not deterministic: `scroll-codex.spec.js:244` fails with `baseY` at 1624 against an `expect(...).toBeGreaterThan(4500)` precondition — the buffer never reached the scrollback cap the assertion depends on, so the test is failing its *setup*, not its invariant. Several of these were introduced alongside the scroll/replay fixes in the current `[Unreleased]` block, which is where the flakiness likely entered.
+
+Observed twice on PR #244 in a way that isolates the cause from any code change: Linux flipped green → red across `b404d1c`, and macOS flipped green → red across `365ec37`. **Both are documentation-only commits.** A subsequent re-run of the identical macOS commit passed with no changes at all.
+
+## Desired behavior
+
+CI is a trustworthy merge gate: a red check means the PR broke something. `e2e-real` either passes deterministically or is explicitly quarantined so it cannot fail a PR for reasons unrelated to that PR's diff. Whichever way it goes, a developer never has to ask "is this red mine?" — which is the state the suite is in today, and the reason it is a P1 despite being test-only.
+
+## Success criteria
+
+- Ten consecutive `CI (Linux)` and `CI (macOS)` runs on unchanged `main` are green.
+- No spec depends on an unbounded "output reached the cap" precondition without either waiting for that condition deterministically or failing with a clear "precondition not met" skip.
+- If any spec is quarantined rather than fixed, it is skipped explicitly with a linked follow-up, not left failing.
+- A developer can tell from the check name alone whether a red gate implicates their diff.
+
+## Non-goals
+
+- Rewriting the scroll/replay behavior the specs cover. The production code may well be correct; this is about the harness.
+- Changing what `e2e-real` tests. Coverage should not shrink as the fix.
+- Windows CI, which does not run Playwright at all (arguably its own gap, but a separate one).
+
+## Notes
+
+Surfaced while driving PR #244 (Restart Hive) through `/hs-review-loop`. That PR's own Windows failure *was* real and was fixed; these are not. Evidence is recorded in `docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md` under `## CI note`.
+
+Root cause is **not** diagnosed here — this spec records the evidence and the impact. The load-dependent `baseY` precondition in `scroll-codex.spec.js:286` is the most concrete starting thread: a runner under CPU contention produces less output in the same wall-clock window, which fits every observation, including why the failure set grows on the slower/busier runs.

--- a/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
+++ b/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
@@ -39,6 +39,6 @@ CI is a trustworthy merge gate: a red check means the PR broke something. `e2e-r
 
 ## Notes
 
-Surfaced while driving PR #244 (Restart Hive) through `/hs-review-loop`. That PR's own Windows failure *was* real and was fixed; these are not. Evidence is recorded in `docs/exec-plans/active/243-restart-hive-doesnt-reliably-restart-daemon.md` under `## CI note`.
+Surfaced while driving PR #244 (Restart Hive) through `/hs-review-loop`. That PR's own Windows failure *was* real and was fixed; these are not. Evidence is recorded in `docs/exec-plans/completed/243-restart-hive-doesnt-reliably-restart-daemon.md` under `## CI note`.
 
 Root cause is **not** diagnosed here — this spec records the evidence and the impact. The load-dependent `baseY` precondition in `scroll-codex.spec.js:286` is the most concrete starting thread: a runner under CPU contention produces less output in the same wall-clock window, which fits every observation, including why the failure set grows on the slower/busier runs.


### PR DESCRIPTION
Docs-only. Two unrelated-but-bundled items, deliberately in one PR so this
takes **one** trip through the flaky CI gate instead of two — which is itself
the subject of half the PR.

## 1. Close out 243 (Restart Hive)

Merged as c220c67 (#244). Records the QA verdict as **PASS** and moves the exec
plan to `completed/`.

The verdict states plainly that **the original root cause was never
reproduced** — the live state at triage was healthy, so the specific `nil` path
that fired on the reporting machine is still unknown. What *is* verified is the
decisive case: with `<sock>.pid` deleted — the state that pre-fix guaranteed the
bug, since `killRunningHived` returns nil having killed nothing and the
relaunched GUI dials straight back onto the surviving daemon — Restart Hive
replaced the daemon. The new `hivegui.log` is the insurance if it recurs.

## 2. Spec 245 — the e2e-real suite fails on main

`CI (Linux)` and `CI (macOS)` fail on `main`'s own tip. Last 8 runs on `main`:
Linux 5 failures, macOS 4, Windows 0 — Windows is clean only because
`build-windows.yml` never invokes Playwright.

Isolated from any code change **twice** while driving #244:

| commit | contents | Linux | macOS |
|---|---|---|---|
| `b404d1c` | **docs only** | ❌ | ✅ |
| `3d68f72` | code | ✅ | ✅ |
| `365ec37` | **docs only** | ✅ | ❌ |

A re-run of the *identical* macOS commit then passed with no changes at all.

Failures cluster in `wheel-scroll.spec.js`, `scroll-codex.spec.js`, and
`scroll-restream-strand.spec.js`. Root cause is **not** diagnosed — the spec
records evidence and impact. The most concrete thread: `scroll-codex.spec.js:286`
asserts `baseY > 4500` as a *precondition* (buffer reached the scrollback cap)
and observed 1624, so the test is failing its setup, not its invariant. A runner
under CPU contention produces less output in the same wall-clock window, which
fits every observation including why the failure set grows on slower runs.

Filed P1 despite being test-only: a gate that fails ~50% of the time on
unchanged `main` means no one can tell whether a red check is theirs.

## Note

This PR must itself pass that flaky gate. If it goes red in one of those three
spec files, that is the bug it documents — re-run rather than debug the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked the daemon restart issue as completed and recorded QA verification results.
  * Updated the related product specification with the shipped date, commit reference, and moved the execution plan to the completed location.
  * Added a product spec documenting intermittent `e2e-real` CI failures, including observed behavior and the desired deterministic/quarantine approach with success criteria and follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Docs-only PR that closes out issue 243 and opens tracking for issue 245. No production code changes.

- Renames the 243 exec plan from `active/` to `completed/`, updates the product spec's cross-reference and adds a Shipped date, and appends a QA verdict (PASS) with build, acceptance, regression, and root-cause detail.
- Adds a new product spec (`245-flaky-e2e-real-suite-blocks-every-pr.md`) documenting the intermittent Playwright `e2e-real` CI failures observed on `main`, with observed failure rates, the three recurring spec files, evidence that the failures are timing/load-dependent rather than diff-induced, and concrete success criteria.

<h3>Confidence Score: 5/5</h3>

All three files are documentation only; no executable code, migrations, or configuration is touched, so there is nothing here that can break at runtime.

The changes are pure markdown: one file rename with an appended QA verdict, one metadata update, and one new spec. Cross-references between the three files are consistent (the completed/ path is correctly used throughout), and the content accurately reflects the described PR #244 outcome and the flaky-CI evidence.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/exec-plans/completed/243-restart-hive-doesnt-reliably-restart-daemon.md | Renamed from active/ to completed/, added QA verdict section with pass/fail verdicts for build, acceptance, regression, and root-cause categories; all accurate and internally consistent. |
| docs/product-specs/243-restart-hive-doesnt-reliably-restart-daemon.md | Added Shipped date and updated exec-plan cross-reference from active/ to completed/ to match the rename; both changes are correct. |
| docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md | New spec documenting the flaky e2e-real CI suite; well-evidenced and actionable, but the Problem section attributes the baseY > 4500 assertion to scroll-codex.spec.js:244 while the Notes section (and PR description) places it at :286 — a minor internal inconsistency that could misdirect a developer searching for the failing assertion. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Op as Operator
    participant GUI as hivegui
    participant Daemon as hived (old)
    participant Socket as Unix Socket
    participant NewGUI as hivegui (new)
    participant NewDaemon as hived (new)

    Op->>GUI: Restart Hive
    GUI->>Daemon: FrameShutdown (0x15) over control conn
    Daemon->>Socket: Close listener → socket goes dead
    GUI->>Socket: socketDead probe — succeeds
    GUI->>NewGUI: spawnNewGUI + Quit
    NewGUI->>Socket: dialOrSpawn — dial fails (socket dead)
    NewGUI->>NewDaemon: spawn new hived
    NewDaemon->>Socket: "bind & listen (new socket)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Op as Operator
    participant GUI as hivegui
    participant Daemon as hived (old)
    participant Socket as Unix Socket
    participant NewGUI as hivegui (new)
    participant NewDaemon as hived (new)

    Op->>GUI: Restart Hive
    GUI->>Daemon: FrameShutdown (0x15) over control conn
    Daemon->>Socket: Close listener → socket goes dead
    GUI->>Socket: socketDead probe — succeeds
    GUI->>NewGUI: spawnNewGUI + Quit
    NewGUI->>Socket: dialOrSpawn — dial fails (socket dead)
    NewGUI->>NewDaemon: spawn new hived
    NewDaemon->>Socket: "bind & listen (new socket)"
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Update docs/product-specs/245-flaky-e2e-..."](https://github.com/lucascaro/hive/commit/429922e3cf4e18202229aae075025955f941f021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45466846)</sub>

<!-- /greptile_comment -->