### PR TITLE
fix(gui): stop grid-view startup slowdown that freezes with many sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Thumbs.db
 
 # hivesmith local tooling config
 .hivesmith/
+
+# stray daemon/gui log dumped into the repo root during debugging
+/hive.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- GUI: fixed a startup slowdown that degraded to a freeze when several
+  full-screen agent sessions (Claude, etc.) were open in grid view. On
+  attach the daemon replayed each session's entire multi-MB scrollback
+  ring into the terminal — tens of MB parsed on the main thread across
+  all tiles at once, ballooning webview memory until it stalled.
+  Full-screen (alt-screen) sessions now replay only a one-screen snapshot
+  (no scrollback, which they don't use anyway); normal-screen sessions
+  still get their full history. Grid tiles also now attach lazily (active
+  tile first, the rest on idle) instead of all at once.
+- GUI: recover the control connection automatically. A dropped
+  connection to the daemon (sleep/wake, a daemon upgrade) previously left
+  the window frozen with no way back except a full restart; it now
+  reconnects with backoff and re-syncs.
+- GUI: cap repeated WebGL context-loss recovery so a flapping GPU context
+  can't spin into a busy loop that freezes the window; the tile falls back
+  to the DOM renderer instead. Also bound the number of simultaneous WebGL
+  contexts so a many-tile grid can't exhaust the browser limit (which
+  showed as magenta blocks in place of terminal text).
+
+### Changed
+
+- Logs: `hived.log` and `hivegui.log` now rotate at 8 MiB (one prior
+  generation kept) instead of growing unbounded. Added always-on
+  diagnostic breadcrumbs — a main-thread heartbeat plus per-attach
+  replay/timing lines — to make future freezes diagnosable from the logs.
+
 ## [2.3.0] — 2026-07-19
 
 ### Added

--- a/cmd/hived/main.go
+++ b/cmd/hived/main.go
@@ -53,12 +53,9 @@ func main() {
 	// command through agent.Get.
 	agent.SetCustomDir(stateDir)
 
-	if err := os.MkdirAll(stateDir, 0o700); err == nil {
-		logPath := filepath.Join(stateDir, "hived.log")
-		if f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600); err == nil {
-			log.SetOutput(io.MultiWriter(os.Stderr, f))
-			log.Printf("hived: log tee to %s", logPath)
-		}
+	if f, err := registry.OpenLogFile("hived.log"); err == nil {
+		log.SetOutput(io.MultiWriter(os.Stderr, f))
+		log.Printf("hived: log tee to %s", filepath.Join(stateDir, "hived.log"))
 	}
 
 	d, err := daemon.New(daemon.Config{

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -99,6 +99,14 @@ func (a *App) Notify(title, subtitle, body, tag string) error {
 	return nil
 }
 
+// LogFrontend tees a frontend diagnostic line to hivegui.log. The webview's
+// own console goes to /dev/null under LaunchServices, so freeze/renderer
+// hypotheses (WebGL context-loss storms, reconnect loops) have nowhere to
+// land otherwise. Kept dead simple: one prefixed line per call.
+func (a *App) LogFrontend(msg string) {
+	log.Printf("hivegui[fe]: %s", msg)
+}
+
 func NewApp(launchDir string) *App {
 	// Point the agent catalog at the user's agents.json. hived does
 	// the same with the same directory; each process reloads on mtime
@@ -762,6 +770,7 @@ func (a *App) OpenSession(id string, cols, rows int) (*AttachInfo, error) {
 	}
 	a.mu.Unlock()
 
+	dialStart := time.Now()
 	conn, welcome, err := a.dialHandshake(wire.Hello{
 		Version:   wire.PROTOCOL_VERSION,
 		Client:    "hivegui/0.2",
@@ -771,6 +780,11 @@ func (a *App) OpenSession(id string, cols, rows int) (*AttachInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("attach failed: %w", err)
 	}
+	// Startup-latency probe: dial+handshake is a network round-trip to
+	// hived per session. On a many-session grid launch these run behind
+	// openMu (serialized), so a slow daemon shows here as the sum that
+	// stalls startup. Logged to hivegui.log next to the frontend probes.
+	log.Printf("hivegui[fe]: OpenSession id=%s dialHandshake=%dms", id, time.Since(dialStart).Milliseconds())
 
 	cs := &connState{conn: conn}
 	a.mu.Lock()
@@ -799,6 +813,23 @@ func (a *App) attachReadLoop(id string, cs *connState) {
 		_ = cs.conn.Close()
 		wruntime.EventsEmit(a.ctx, "pty:disconnect", id)
 	}()
+	// Startup-flood probe: sum the FrameData bytes in the first second
+	// after attach and log once. The initial subscribe replays the
+	// session's scrollback ring (up to a few MB); many sessions doing
+	// this at once floods pty:data events into the webview and can stall
+	// its main thread. This quantifies the initial burst per session.
+	loopStart := time.Now()
+	var initBytes int
+	var initFrames int
+	initLogged := false
+	logInitBurst := func() {
+		if initLogged {
+			return
+		}
+		initLogged = true
+		log.Printf("hivegui[fe]: attach id=%s initial burst frames=%d bytes=%d in %dms",
+			id, initFrames, initBytes, time.Since(loopStart).Milliseconds())
+	}
 	for {
 		ft, payload, err := wire.ReadFrame(cs.conn)
 		if err != nil {
@@ -806,6 +837,17 @@ func (a *App) attachReadLoop(id string, cs *connState) {
 				log.Printf("hivegui: attach %s read: %v", id, err)
 			}
 			return
+		}
+		if !initLogged {
+			if ft == wire.FrameData {
+				initFrames++
+				initBytes += len(payload)
+			}
+			// Flush the burst summary once the initial replay settles
+			// (1s quiet-ish window) or on the first non-data frame.
+			if time.Since(loopStart) > time.Second || ft == wire.FrameEvent {
+				logInitBurst()
+			}
 		}
 		switch ft {
 		case wire.FrameData:

--- a/cmd/hivegui/frontend/src/app/events.js
+++ b/cmd/hivegui/frontend/src/app/events.js
@@ -4,7 +4,7 @@
 // EventsOn handler; view/focus callbacks and the scroll tracer are
 // injected because they live in main.js until later stages.
 
-import { EventsOn, Notify, Confirm, KillSession } from '../bridge.js';
+import { EventsOn, Notify, Confirm, KillSession, ConnectControl, LogFrontend } from '../bridge.js';
 import { state, saveCollapsed } from './state.js';
 import { setStatus, flashStatus, reportFailure } from './dom.js';
 import { orderedSessions } from './selectors.js';
@@ -21,6 +21,35 @@ let deps = {
   isDaemonRestarting: () => false,
   scrollTrace: { rec: Object.assign(() => {}, { enabled: false }) },
 };
+
+// Control-connection reconnect loop. Guarded so overlapping disconnect
+// events don't spawn parallel loops. Backoff climbs 500ms → 5s cap so a
+// daemon that's slow to come back doesn't get hammered. Stops if a
+// RestartDaemon takes over (that path spawns a fresh GUI) or once
+// ConnectControl succeeds — the daemon then re-pushes the session list.
+let _reconnecting = false;
+async function reconnectControl() {
+  if (_reconnecting) return;
+  _reconnecting = true;
+  let delay = 500;
+  try {
+    for (;;) {
+      if (deps.isDaemonRestarting()) return; // fresh GUI is taking over
+      try {
+        await ConnectControl();
+        setStatus('connected');
+        try { LogFrontend('control reconnected'); } catch { /* bridge absent in tests */ }
+        return;
+      } catch (err) {
+        try { LogFrontend(`control reconnect failed: ${err}`); } catch { /* ignore */ }
+        await new Promise((r) => setTimeout(r, delay));
+        delay = Math.min(delay * 2, 5000);
+      }
+    }
+  } finally {
+    _reconnecting = false;
+  }
+}
 
 // onSessionBell is fired by SessionTerm whenever its xterm receives
 // BEL. Active + window-focused session: ignore. Otherwise: mark
@@ -344,7 +373,15 @@ export function wireDaemonEvents(injected) {
     // control conn; the banner already says "Restarting hived…". Don't
     // also flash an alarming red status line in that window.
     if (deps.isDaemonRestarting()) return;
-    setStatus('control disconnected', true);
+    // The control conn is the GUI's only channel for session/project
+    // state and commands. Before, a drop (macOS sleep/wake, a daemon
+    // replaced by an upgrade) was terminal: ConnectControl ran once at
+    // boot and nothing reconnected, so the UI sat frozen until the user
+    // restarted. Retry with backoff — ConnectControl is idempotent and
+    // the daemon re-pushes a full SESSIONS snapshot on connect, so the
+    // UI re-syncs automatically once it's back.
+    setStatus('reconnecting…', true);
+    reconnectControl();
   });
 
   // User clicked a notification toast. Route to that session in the

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -21,6 +21,19 @@ import { DEFAULT_FONT_SIZE, clampFont } from '../lib/font.js';
 import {
   shouldRefreshOnVisibility, recoverFromContextLoss, bindDprWatcher,
 } from '../lib/renderer-recovery.js';
+import { acquireWebglSlot, releaseWebglSlot, recordWebglLoss } from '../lib/webgl-budget.js';
+import { LogFrontend } from '../bridge.js';
+
+// A WebGL context that dies, gets reattached, and dies again in a tight
+// loop pins a CPU core and freezes the whole GUI (the "works for days
+// then locks up" report). After this many losses within the window we
+// stop reattaching and leave the tile on the DOM renderer for good.
+const WEBGL_LOSS_STORM_MAX = 3;
+const WEBGL_LOSS_STORM_WINDOW_MS = 10000;
+
+// Best-effort disk log — the webview console is /dev/null under
+// LaunchServices, so renderer/freeze evidence has nowhere else to land.
+function feLog(msg) { try { LogFrontend(msg); } catch { /* bridge absent in tests */ } }
 import {
   shouldRequestReplay, decideResizeReplay, REPLAY_DEBOUNCE_MS, applyRebaseline,
 } from '../lib/scrollback.js';
@@ -571,15 +584,36 @@ export class SessionTerm {
     // context-loss recovery. After a fresh attach the renderer's atlas
     // is empty, so force a full repaint to overwrite whatever stale
     // pixels were left behind by the lost context.
+    //
+    // A tile that lost its context repeatedly (loss storm) has sworn off
+    // WebGL — never reattach, or the refresh paths (DPR / visibility)
+    // would restart the loop.
+    if (this._webglGaveUp) return false;
+
+    // Gate on a process-wide context budget first: past the browser's
+    // simultaneous-WebGL-context cap the atlas unbinds and tiles fill
+    // with magenta. Over budget → stay on the DOM renderer and just
+    // repaint so nothing stale is left frozen.
+    if (!acquireWebglSlot()) {
+      this.webgl = null;
+      this._hasWebglSlot = false;
+      try { this.term.refresh(0, this.term.rows - 1); } catch {}
+      return false;
+    }
     try {
       const webgl = new WebglAddon();
       webgl.onContextLoss(() => this._onWebglContextLoss());
       this.term.loadAddon(webgl);
       this.webgl = webgl;
+      this._hasWebglSlot = true;
       try { this.term.refresh(0, this.term.rows - 1); } catch {}
       return true;
     } catch {
+      // Construct failed (no GPU / driver) — hand the slot back so a
+      // healthier tile can claim it.
+      releaseWebglSlot();
       this.webgl = null;
+      this._hasWebglSlot = false;
       return false;
     }
   }
@@ -591,7 +625,33 @@ export class SessionTerm {
     // unit-tested without xterm or a real WebGL context.
     const dead = this.webgl;
     this.webgl = null;
-    if (scrollTrace.rec.enabled) scrollTrace.rec('webgl-context-loss', { id: this.info.id });
+    // Release this tile's slot before reattaching, or _attachWebgl's
+    // budget check would see the dead context still counted and refuse
+    // to bring the tile back up.
+    if (this._hasWebglSlot) { releaseWebglSlot(); this._hasWebglSlot = false; }
+
+    // Storm guard: count losses in a sliding window. A context that keeps
+    // dying immediately after reattach would loop dispose→reattach→loss
+    // forever, pinning a core and freezing the GUI. Past the threshold we
+    // stop trying WebGL for this tile and stay on the DOM renderer.
+    this._webglLoss ||= { start: 0, count: 0 };
+    const { count, stormed } = recordWebglLoss(
+      this._webglLoss, nowMs(), WEBGL_LOSS_STORM_MAX, WEBGL_LOSS_STORM_WINDOW_MS,
+    );
+    feLog(`webgl-context-loss id=${this.info.id} count=${count}`);
+    if (scrollTrace.rec.enabled) scrollTrace.rec('webgl-context-loss', { id: this.info.id, count });
+
+    if (stormed) {
+      // Give up on WebGL for this tile. Dispose the dead addon, don't
+      // reattach, force one repaint so the DOM renderer takes over cleanly.
+      this._webglGaveUp = true;
+      try { dead?.dispose(); } catch { /* best-effort */ }
+      try { this.term.refresh(0, this.term.rows - 1); } catch {}
+      feLog(`webgl-give-up id=${this.info.id} — DOM renderer (loss storm)`);
+      if (scrollTrace.rec.enabled) scrollTrace.rec('webgl-give-up', { id: this.info.id });
+      return;
+    }
+
     const { reattached } = recoverFromContextLoss({
       dispose: () => dead?.dispose(),
       reattach: () => this._attachWebgl(),
@@ -878,14 +938,22 @@ export class SessionTerm {
       this._pendingAttach = true;
       return;
     }
+    const _fitStart = nowMs();
     this.fit.fit();
+    const _fitMs = nowMs() - _fitStart;
     // Reset _followBottom on attach: it may be stale from a previous
     // session (user scrolled up, closed Hive, reopened). The initial
     // attach replay must snap to bottom — _followBottom = true ensures
     // the replay-done handler doesn't skip the snap via the restore path.
     this._followBottom = true;
     try {
+      const _openStart = nowMs();
       await OpenSession(this.info.id, this.term.cols, this.term.rows);
+      // Startup-latency probe: fit.fit() is synchronous DOM measurement
+      // (blocks the main thread); OpenSession awaits the Go dial+handshake.
+      // On a many-tile grid launch these run per tile — this line pins
+      // which half of each attach is slow.
+      feLog(`ensureAttached id=${this.info.id} fit=${Math.round(_fitMs)}ms open=${Math.round(nowMs() - _openStart)}ms`);
       this.attached = true;
       // Anchor the replay baseline to the actual fitted cols for this
       // tile. Without this, a later _onBodyResize would initialize the
@@ -902,6 +970,17 @@ export class SessionTerm {
     const bin = atob(b64);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    // Startup-flood probe: xterm.write parses on the main thread, so a
+    // large initial scrollback replay blocks it. Sum bytes/writes for the
+    // first ~2s after this tile's first byte and log once — pairs with the
+    // Go-side "initial burst" line to show flood → main-thread stall.
+    this._wroteBytes = (this._wroteBytes || 0) + bin.length;
+    this._wroteCount = (this._wroteCount || 0) + 1;
+    if (this._writeWindowStart === undefined) this._writeWindowStart = nowMs();
+    if (!this._writeBurstLogged && nowMs() - this._writeWindowStart > 2000) {
+      this._writeBurstLogged = true;
+      feLog(`writeData burst id=${this.info.id} writes=${this._wroteCount} bytes=${this._wroteBytes} in ${Math.round(nowMs() - this._writeWindowStart)}ms`);
+    }
     this.term.write(this.decoder.decode(bytes, { stream: true }));
   }
 
@@ -921,6 +1000,7 @@ export class SessionTerm {
     // Release the GL context proactively so a many-tile session doesn't
     // sit on it until GC and push another tile over the browser cap.
     try { this.webgl?.dispose(); } catch {}
+    if (this._hasWebglSlot) { releaseWebglSlot(); this._hasWebglSlot = false; }
     this.webgl = null;
     this.term.dispose();
     this.host.remove();

--- a/cmd/hivegui/frontend/src/app/view.js
+++ b/cmd/hivegui/frontend/src/app/view.js
@@ -189,10 +189,15 @@ export function renderGrid() {
     termsHost.appendChild(st.host); // re-order to keep DOM == nav order
   }
   attachDeferred(_deferred);
-  try {
-    const _ms = (() => { try { return Math.round(performance.now() - _fanoutStart); } catch { return -1; } })();
-    LogFrontend(`renderGrid fanout tiles=${n} built=${_built} sync=${_ms}ms view=${state.view}`);
-  } catch { /* bridge absent in tests */ }
+  // Only log when the pass built new tiles — renderGrid runs on every
+  // repaint (switch, minimize, resize, …), and an unconditional line
+  // would spam the log with built=0 sync=0ms noise on every grid touch.
+  if (_built > 0) {
+    try {
+      const _ms = (() => { try { return Math.round(performance.now() - _fanoutStart); } catch { return -1; } })();
+      LogFrontend(`renderGrid fanout tiles=${n} built=${_built} sync=${_ms}ms view=${state.view}`);
+    } catch { /* bridge absent in tests */ }
+  }
   // Hide / unmark tiles outside the scope.
   for (const [sid, st] of state.terms) {
     if (!gridIDs.has(sid)) {

--- a/cmd/hivegui/frontend/src/app/view.js
+++ b/cmd/hivegui/frontend/src/app/view.js
@@ -5,7 +5,7 @@
 // initView(deps) — they live in session-term/focus modules (stage 6)
 // and main.js.
 
-import { WindowSetTitle } from '../bridge.js';
+import { WindowSetTitle, LogFrontend } from '../bridge.js';
 import { state } from './state.js';
 import { termsHost, setStatus } from './dom.js';
 import { orderedSessions, activeProjectId } from './selectors.js';
@@ -125,6 +125,27 @@ export function switchToProject(pid) {
 // current Hive's behavior). cellMap[row*cols + col] = session index.
 let gridLayout = { rows: 1, cols: 1, sessions: [], assignments: [], cellMap: [] };
 
+// attachDeferred attaches non-active grid tiles one per idle callback so
+// the first paint isn't blocked by N synchronous fit()+replay passes.
+// ensureAttached is idempotent (returns early if already attached), so
+// re-running renderGrid — which re-queues everything — is harmless.
+// requestIdleCallback isn't available in all webviews; fall back to a
+// short-timeout chain so the stagger still happens.
+const _ric = (cb) => (typeof requestIdleCallback === 'function'
+  ? requestIdleCallback(cb, { timeout: 500 })
+  : setTimeout(cb, 16));
+function attachDeferred(terms) {
+  let i = 0;
+  const step = () => {
+    if (i >= terms.length) return;
+    const st = terms[i++];
+    // Skip tiles that left the grid before their turn came up.
+    if (st.host.classList.contains('in-grid')) st.ensureAttached();
+    if (i < terms.length) _ric(step);
+  };
+  if (terms.length) _ric(step);
+}
+
 // renderGrid lays out every tile that should be visible in the
 // current grid scope. Tiles for other sessions are hidden but kept
 // alive (so their xterm scrollback persists across mode switches).
@@ -136,18 +157,42 @@ export function renderGrid() {
   const gridIDs = new Set(gridSessions.map((s) => s.id));
   const n = gridSessions.length;
 
-  // Ensure every grid session has a SessionTerm and is attached.
+  // Startup-fan-out probe: how many tiles this pass builds+attaches and
+  // the synchronous cost of the loop. grid-all attaches every session at
+  // once; ensureTerm builds a new xterm + WebGL addon and ensureAttached
+  // runs a synchronous fit() per tile — the suspected slow-startup stall.
+  // (ensureAttached's await is fire-and-forget here, so this captures the
+  // synchronous DOM/construction cost; the per-tile open latency lands in
+  // the "ensureAttached" feLog lines.)
+  const _fanoutStart = (() => { try { return performance.now(); } catch { return 0; } })();
+  let _built = 0;
+
+  // Ensure every grid session has a SessionTerm; attach lazily. Every
+  // grid tile is on-screen (the grid fits all N into the viewport), but
+  // attaching all N synchronously runs N fit()s + kicks off N replays in
+  // one main-thread pass — the startup drag. Attach the ACTIVE tile now
+  // so the user's focus is live immediately; defer the rest to idle
+  // callbacks so they stream in without blocking the first paint.
   // Move tiles into the desired DOM order (row-major) so that flexbox
   // / CSS grid honors the navigation order without us having to set
   // grid-row/column explicitly.
+  const _deferred = [];
   for (const info of gridSessions) {
+    const existed = state.terms.has(info.id);
     const st = deps.ensureTerm(info);
+    if (!existed) _built += 1;
     st.host.classList.add('in-grid');
     st.host.classList.toggle('active', info.id === state.activeId);
     st.host.classList.toggle('attention', state.attention.has(info.id));
-    st.ensureAttached();
+    if (info.id === state.activeId) st.ensureAttached();
+    else _deferred.push(st);
     termsHost.appendChild(st.host); // re-order to keep DOM == nav order
   }
+  attachDeferred(_deferred);
+  try {
+    const _ms = (() => { try { return Math.round(performance.now() - _fanoutStart); } catch { return -1; } })();
+    LogFrontend(`renderGrid fanout tiles=${n} built=${_built} sync=${_ms}ms view=${state.view}`);
+  } catch { /* bridge absent in tests */ }
   // Hide / unmark tiles outside the scope.
   for (const [sid, st] of state.terms) {
     if (!gridIDs.has(sid)) {

--- a/cmd/hivegui/frontend/src/bridge.js
+++ b/cmd/hivegui/frontend/src/bridge.js
@@ -19,6 +19,6 @@ export {
   CreateProject, KillProject, UpdateProject,
   LaunchDir, PickDirectory, OpenNewWindow, CloseWindow,
   IsGitRepo, OpenURL, OpenTerminalAt, Notify, Confirm,
-  RestartDaemon, CheckForUpdate, SetClipboardText,
+  RestartDaemon, CheckForUpdate, SetClipboardText, LogFrontend,
 } from '../wailsjs/go/main/App';
 export { EventsOn, WindowSetTitle, ClipboardGetText } from '../wailsjs/runtime/runtime';

--- a/cmd/hivegui/frontend/src/lib/freeze-heartbeat.js
+++ b/cmd/hivegui/frontend/src/lib/freeze-heartbeat.js
@@ -1,0 +1,62 @@
+// Always-on freeze classifier (idle vs blocked), logged to disk.
+//
+// The WebGL-storm freeze pinned a CPU core and left a fingerprint. The
+// *other* freeze does the opposite: the webview main thread goes idle,
+// 0% CPU, and nothing in the app's instrumented paths fires — so it
+// leaves no trace on disk. A user-reported "irresponsive" then has zero
+// evidence to work from.
+//
+// A setInterval callback can only run when the main thread yields, so the
+// gap between ticks measures how long the thread was blocked. This helper
+// is the pure decision half (what, if anything, to log for a given gap);
+// the caller owns the timer and the LogFrontend sink so this stays
+// trivially unit-testable.
+
+// classifyBeat returns a log line string, or null to stay silent.
+//   - gap  : ms since the previous tick.
+//   - nominalMs : the timer's configured interval.
+//   - visible   : document.visibilityState === 'visible'.
+//   - state     : arbitrary extra fields ({hasFocus, view, ...}) appended.
+//   - beat      : monotonically increasing tick counter.
+//   - aliveEvery: emit a low-rate "alive" line every N beats (0 = never).
+//
+// A gap far past nominal means the thread was BLOCKED (busy loop or a
+// synchronous stall) — always worth logging. A hidden window legitimately
+// throttles timers, so a large gap while hidden is not a stall and is
+// suppressed. The periodic "alive" line proves the loop is still running
+// (and carries window state) so a totally silent log = process wedged or
+// killed, not merely quiet.
+export function classifyBeat({ gap, nominalMs, visible, state, beat, aliveEvery }) {
+  const stall = visible && gap > nominalMs * 2;
+  if (stall) {
+    return `hb STALL gap=${Math.round(gap)}ms ${fmtState(state)}`;
+  }
+  if (aliveEvery > 0 && beat % aliveEvery === 0) {
+    return `hb alive vis=${visible ? 1 : 0} ${fmtState(state)}`;
+  }
+  return null;
+}
+
+function fmtState(state) {
+  if (!state) return '';
+  return Object.entries(state)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+}
+
+// jsHeapMB reads the JS heap size (MB, rounded) from performance.memory
+// when the engine exposes it. Chromium/WebView2 do; WebKit/Safari's
+// WebContent (what the Mac app uses) generally does NOT — returns null
+// there, and the heartbeat line simply omits the field. It measures the
+// JS heap only, not the process RSS that ballooned to ~1 GB (that lives
+// in the separate WebContent/GPU process), but a climbing JS heap is
+// still a useful leak signal where available.
+export function jsHeapMB(perf) {
+  try {
+    const m = perf && perf.memory;
+    if (m && typeof m.usedJSHeapSize === 'number') {
+      return Math.round(m.usedJSHeapSize / (1024 * 1024));
+    }
+  } catch { /* not exposed */ }
+  return null;
+}

--- a/cmd/hivegui/frontend/src/lib/webgl-budget.js
+++ b/cmd/hivegui/frontend/src/lib/webgl-budget.js
@@ -1,0 +1,53 @@
+// Process-wide WebGL context budget (#magenta-blocks).
+//
+// Every SessionTerm wants its own xterm WebGL renderer, but browsers /
+// WebView2 cap simultaneous WebGL contexts (~16 in Chromium). A grid of
+// many tiles blows past that cap on startup: contexts get force-lost,
+// the glyph texture-atlas unbinds, and the shader samples uninitialized
+// texture memory — the tiles fill with solid magenta blocks.
+//
+// We cap ourselves well under the browser limit. The first N tiles get
+// GPU rendering; the rest fall back to xterm's DOM renderer (visually
+// identical, just slower) instead of thrashing the GL context pool.
+
+// ponytail: fixed budget below the Chromium/WebView2 simultaneous-context
+// cap (~16). Lower it if magenta still appears on low-end GPUs.
+export const WEBGL_CONTEXT_BUDGET = 8;
+
+let active = 0;
+
+// Try to reserve a GL context slot. Returns true if the caller may build
+// a WebglAddon, false if the budget is exhausted (caller uses DOM renderer).
+export function acquireWebglSlot(budget = WEBGL_CONTEXT_BUDGET) {
+  if (active >= budget) return false;
+  active++;
+  return true;
+}
+
+// Release a previously-acquired slot. Floors at 0 so an over-release
+// (double dispose) can't hand out phantom slots.
+export function releaseWebglSlot() {
+  if (active > 0) active--;
+}
+
+export function activeWebglSlots() { return active; }
+
+// Test-only: reset the module-level counter between cases.
+export function _resetWebglBudget() { active = 0; }
+
+// Sliding-window loss counter for the context-loss storm guard. A WebGL
+// context that dies immediately after every reattach loops forever and
+// freezes the GUI; this decides when a tile should stop reattaching.
+//
+// `s` is the tile's mutable state ({ start, count }); `now` is a
+// monotonic ms clock. Returns { count, stormed } — stormed=true means
+// the tile has lost its context more than `max` times within `windowMs`
+// and should give up on WebGL.
+export function recordWebglLoss(s, now, max, windowMs) {
+  if (now - (s.start || 0) > windowMs) {
+    s.start = now;
+    s.count = 0;
+  }
+  s.count = (s.count || 0) + 1;
+  return { count: s.count, stormed: s.count > max };
+}

--- a/cmd/hivegui/frontend/src/main.js
+++ b/cmd/hivegui/frontend/src/main.js
@@ -8,7 +8,9 @@ import '@xterm/xterm/css/xterm.css';
 
 import {
   ConnectControl, KillSession, OpenNewWindow, CloseWindow, OpenTerminalAt,
+  LogFrontend,
 } from './bridge.js';
+import { classifyBeat, jsHeapMB } from './lib/freeze-heartbeat.js';
 import { isMac } from './lib/platform.js';
 import { paletteShortcuts } from './lib/shortcuts.js';
 import { state } from './app/state.js';
@@ -174,14 +176,59 @@ initVersionFooter();
   });
 })();
 
+// ---------- freeze heartbeat ----------
+//
+// Always-on, low-rate main-thread heartbeat teed to hivegui.log. The
+// idle-freeze (thread parked, 0% CPU, no magenta) leaves no other trace
+// on disk, so a "went irresponsive" report has nothing to work from.
+// A STALL line means the thread was blocked (busy loop / sync stall); a
+// silent log across a freeze means the thread was idle-blocked or the
+// process wedged. The periodic "alive" line carries window state so an
+// occluded/unfocused window is distinguishable from a real block. The
+// first STALL after boot also quantifies the slow-startup hang.
+(function startFreezeHeartbeat() {
+  const NOMINAL_MS = 1000;
+  const ALIVE_EVERY = 3; // ~every 3s — tight enough to watch a mem/gap ramp
+  let last = (() => { try { return performance.now(); } catch { return 0; } })();
+  let beat = 0;
+  setInterval(() => {
+    let now;
+    try { now = performance.now(); } catch { now = last + NOMINAL_MS; }
+    const gap = now - last;
+    last = now;
+    beat += 1;
+    const heap = jsHeapMB(typeof performance !== 'undefined' ? performance : null);
+    const st = {
+      vis: document.visibilityState,
+      focus: typeof document.hasFocus === 'function' ? (document.hasFocus() ? 1 : 0) : '?',
+      terms: state.terms.size,
+      view: state.view,
+    };
+    if (heap !== null) st.heapMB = heap;
+    const line = classifyBeat({
+      gap, nominalMs: NOMINAL_MS,
+      visible: document.visibilityState === 'visible',
+      beat, aliveEvery: ALIVE_EVERY, state: st,
+    });
+    if (line) { try { LogFrontend(line); } catch { /* bridge absent in tests */ } }
+  }, NOMINAL_MS);
+})();
+
 // ---------- bootstrap ----------
 
 (async () => {
+  const t0 = (() => { try { return performance.now(); } catch { return 0; } })();
+  try { LogFrontend('boot: connecting control'); } catch { /* ignore */ }
   setStatus('connecting…');
   try {
     await ConnectControl();
     setStatus('connected');
+    try {
+      const dt = (() => { try { return Math.round(performance.now() - t0); } catch { return -1; } })();
+      LogFrontend(`boot: control connected in ${dt}ms`);
+    } catch { /* ignore */ }
   } catch (err) {
     setStatus(`connect failed: ${err}`, true);
+    try { LogFrontend(`boot: control connect failed: ${err}`); } catch { /* ignore */ }
   }
 })();

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.js
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.js
@@ -135,6 +135,7 @@ export async function IsGitRepo() { return false; }
 export async function OpenURL() { return ''; }
 export async function OpenTerminalAt() { return ''; }
 export async function Notify() { return ''; }
+export async function LogFrontend() { return ''; }
 export async function Confirm() { return true; }
 export async function RestartDaemon() { return ''; }
 export async function CheckForUpdate() { return null; }

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -239,6 +239,7 @@ export async function IsGitRepo(_dir) { return false; }
 export async function OpenURL(_url) { maybeFail('OpenURL'); return ''; }
 export async function OpenTerminalAt(_dir) { maybeFail('OpenTerminalAt'); return ''; }
 export async function Notify(_title, _body) { return ''; }
+export async function LogFrontend(_msg) { return ''; }
 export async function Confirm(_title, _body) { return true; }
 export async function RestartDaemon() { return ''; }
 export async function CheckForUpdate() { return null; }

--- a/cmd/hivegui/frontend/test/unit/freeze-heartbeat.test.js
+++ b/cmd/hivegui/frontend/test/unit/freeze-heartbeat.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { classifyBeat, jsHeapMB } from '../../src/lib/freeze-heartbeat.js';
+
+const base = { nominalMs: 1000, visible: true, beat: 1, aliveEvery: 0, state: null };
+
+describe('classifyBeat', () => {
+  it('logs a STALL when the visible thread was blocked past 2x nominal', () => {
+    const line = classifyBeat({ ...base, gap: 5000 });
+    expect(line).toMatch(/^hb STALL gap=5000ms/);
+  });
+
+  it('stays silent on a normal-cadence tick', () => {
+    expect(classifyBeat({ ...base, gap: 1010 })).toBeNull();
+  });
+
+  it('does NOT treat a large gap while hidden as a stall (timers throttle)', () => {
+    expect(classifyBeat({ ...base, gap: 60000, visible: false })).toBeNull();
+  });
+
+  it('emits a periodic alive line carrying window state', () => {
+    const line = classifyBeat({
+      ...base, gap: 1000, beat: 15, aliveEvery: 15,
+      state: { vis: 'visible', focus: 1, terms: 12 },
+    });
+    expect(line).toMatch(/^hb alive vis=1 /);
+    expect(line).toContain('terms=12');
+  });
+
+  it('a stall wins over the alive cadence and includes state', () => {
+    const line = classifyBeat({
+      ...base, gap: 9000, beat: 15, aliveEvery: 15, state: { view: 'grid-all' },
+    });
+    expect(line).toMatch(/^hb STALL/);
+    expect(line).toContain('view=grid-all');
+  });
+});
+
+describe('jsHeapMB', () => {
+  it('returns rounded MB when performance.memory is exposed', () => {
+    expect(jsHeapMB({ memory: { usedJSHeapSize: 100 * 1024 * 1024 } })).toBe(100);
+  });
+  it('returns null when the engine does not expose memory (WebKit)', () => {
+    expect(jsHeapMB({})).toBeNull();
+    expect(jsHeapMB(null)).toBeNull();
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/webgl-budget.test.js
+++ b/cmd/hivegui/frontend/test/unit/webgl-budget.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  acquireWebglSlot, releaseWebglSlot, activeWebglSlots, _resetWebglBudget,
+  recordWebglLoss,
+} from '../../src/lib/webgl-budget.js';
+
+describe('webgl context budget', () => {
+  beforeEach(() => _resetWebglBudget());
+
+  it('grants slots up to the budget, then refuses', () => {
+    expect(acquireWebglSlot(3)).toBe(true);
+    expect(acquireWebglSlot(3)).toBe(true);
+    expect(acquireWebglSlot(3)).toBe(true);
+    expect(acquireWebglSlot(3)).toBe(false); // over budget → DOM renderer
+    expect(activeWebglSlots()).toBe(3);
+  });
+
+  it('release frees a slot for the next tile', () => {
+    acquireWebglSlot(1);
+    expect(acquireWebglSlot(1)).toBe(false);
+    releaseWebglSlot();
+    expect(acquireWebglSlot(1)).toBe(true);
+  });
+
+  it('over-release floors at 0 (double dispose is safe)', () => {
+    releaseWebglSlot();
+    releaseWebglSlot();
+    expect(activeWebglSlots()).toBe(0);
+    expect(acquireWebglSlot(1)).toBe(true); // still only 1 real slot
+  });
+});
+
+describe('recordWebglLoss (context-loss storm guard)', () => {
+  const MAX = 3;
+  const WIN = 10000;
+
+  it('does not storm at or below the threshold', () => {
+    const s = { start: 0, count: 0 };
+    expect(recordWebglLoss(s, 1000, MAX, WIN).stormed).toBe(false); // 1
+    expect(recordWebglLoss(s, 1100, MAX, WIN).stormed).toBe(false); // 2
+    expect(recordWebglLoss(s, 1200, MAX, WIN).stormed).toBe(false); // 3
+  });
+
+  it('storms once losses exceed the threshold within the window', () => {
+    const s = { start: 0, count: 0 };
+    for (let i = 0; i < MAX; i++) recordWebglLoss(s, 1000 + i, MAX, WIN);
+    const r = recordWebglLoss(s, 1000 + MAX, MAX, WIN); // 4th
+    expect(r.count).toBe(4);
+    expect(r.stormed).toBe(true);
+  });
+
+  it('resets the counter after the window elapses (slow flapping is fine)', () => {
+    const s = { start: 0, count: 0 };
+    recordWebglLoss(s, 1000, MAX, WIN);
+    recordWebglLoss(s, 2000, MAX, WIN);
+    recordWebglLoss(s, 3000, MAX, WIN);
+    // Next loss is past the window → counter restarts, no storm.
+    const r = recordWebglLoss(s, 3000 + WIN + 1, MAX, WIN);
+    expect(r.count).toBe(1);
+    expect(r.stormed).toBe(false);
+  });
+});

--- a/cmd/hivegui/main.go
+++ b/cmd/hivegui/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/lucascaro/hive/internal/registry"
 	"github.com/wailsapp/wails/v2"
@@ -53,12 +52,7 @@ func resolveLaunchDir() string {
 // "Restart Hive doesn't restart the daemon" report could not be
 // diagnosed from the machine it happened on.
 func setupLogFile() {
-	stateDir := registry.StateDir()
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return
-	}
-	f, err := os.OpenFile(filepath.Join(stateDir, "hivegui.log"),
-		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	f, err := registry.OpenLogFile("hivegui.log")
 	if err != nil {
 		return
 	}

--- a/internal/registry/logfile.go
+++ b/internal/registry/logfile.go
@@ -1,0 +1,34 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// maxLogBytes caps a log file before it's rotated. The GUI/daemon logs
+// are diagnostic breadcrumbs, not an audit trail — an 8 MiB window is
+// tens of thousands of lines, plenty to catch a freeze, while bounding
+// disk use. (A prior unbounded log reached 54 MiB.)
+const maxLogBytes = 8 << 20
+
+// OpenLogFile opens name under the state dir for appending, rotating it
+// first if it already exceeds maxLogBytes. Rotation is a single-slot
+// rename to name+".1" (overwriting any previous .1), so at most ~2x the
+// cap is ever on disk. Best-effort: on any error the caller gets a nil
+// file and should fall back to stderr-only logging.
+//
+// ponytail: single-slot size rotation, no compression or dated archives.
+// Add generations only if one prior window ever proves too little.
+func OpenLogFile(name string) (*os.File, error) {
+	dir := StateDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, name)
+	if fi, err := os.Stat(path); err == nil && fi.Size() >= maxLogBytes {
+		// Rotate. Ignore rename errors — worst case we keep appending to
+		// the oversized file, which is still better than losing logging.
+		_ = os.Rename(path, path+".1")
+	}
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -249,7 +249,17 @@ func (s *Session) fanoutClose() {
 func (s *Session) SubscribeWithAtomicReplay(sink Sink, writeFn func(replay []byte) error) (unsubscribe func(), err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := writeFn(s.vt.RingBytes()); err != nil {
+	// Initial attach uses InitialReplayBytes, not the raw ring: alt-screen
+	// sessions (claude et al.) return a one-screen snapshot with no
+	// scrollback, avoiding the many-tile startup flood. Normal-screen
+	// sessions still get the full ring here. The resize-driven re-replay
+	// (EmitAtomicReplay) keeps using the ring for reflow recovery.
+	replay, snapshot := s.vt.InitialReplayBytes()
+	// Logged so hived.log proves which path ran per attach — a snapshot
+	// line here (vs a multi-MB ring) is the unconfounded signal that the
+	// fixed daemon build is live, independent of the days-long freeze.
+	log.Printf("session %s: initial replay %d bytes snapshot=%v", s.ID, len(replay), snapshot)
+	if err := writeFn(replay); err != nil {
 		return nil, err
 	}
 	s.sinks[sink] = struct{}{}

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -304,6 +304,30 @@ func (v *VT) pushHistory(b []byte) {
 	}
 }
 
+// InitialReplayBytes returns the payload to paint a freshly-attaching
+// client. On the ALTERNATE screen (full-screen TUIs: claude, vim, htop…)
+// there is no user-facing scrollback — the app repaints itself — so we
+// return only a one-screen RenderSnapshot instead of the multi-MB raw
+// ring. This is the fix for the many-tile startup flood: 8 alt-screen
+// sessions were each replaying an 8 MiB ring (~32 MB total) into xterm
+// on the main thread, dragging then halting the GUI.
+//
+// On the normal screen we still return the full ring so deep scrollback
+// survives the attach (xterm can't reflow on resize, so the ring is how
+// width-changing resizes recover history — see appendRing).
+// The returned bool reports whether the snapshot (alt-screen) path was
+// taken — callers log it so hived.log proves which replay path ran (and
+// therefore which daemon build is live) without inferring from sizes.
+func (v *VT) InitialReplayBytes() (replay []byte, snapshot bool) {
+	v.mu.Lock()
+	onAlt := v.term.Mode()&vt10x.ModeAltScreen != 0
+	v.mu.Unlock()
+	if onAlt {
+		return v.RenderSnapshot(), true
+	}
+	return v.RingBytes(), false
+}
+
 // RingBytes returns a defensive copy of the raw-byte scrollback ring.
 // Callers can stream the result to a client that wants to repaint
 // xterm.js from a clean slate after a width-changing resize.

--- a/internal/session/vt_test.go
+++ b/internal/session/vt_test.go
@@ -136,6 +136,56 @@ func TestVTAltScreenSnapshot(t *testing.T) {
 	}
 }
 
+// TestInitialReplayBytesAltScreen verifies the startup-flood fix: an
+// alt-screen session (claude et al.) returns a compact one-screen
+// snapshot on initial attach, NOT the raw scrollback ring. Feeding the
+// ring's worth of bytes and confirming the initial replay is far smaller
+// (and is a snapshot, i.e. starts by entering alt screen) guards against
+// regressing back to the multi-MB per-tile flood.
+func TestInitialReplayBytesAltScreen(t *testing.T) {
+	v := NewVT(80, 24)
+	// Enter alt screen, then dump a lot of output (as a full-screen TUI
+	// repainting would). All of it lands in the ring.
+	if _, err := v.Write([]byte("\x1b[?1049h")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	big := bytes.Repeat([]byte("claude output line\r\n"), 5000)
+	if _, err := v.Write(big); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	ring := v.RingBytes()
+	initial, snapshot := v.InitialReplayBytes()
+	if len(ring) < 50_000 {
+		t.Fatalf("test setup: ring too small (%d) to prove the point", len(ring))
+	}
+	if !snapshot {
+		t.Error("alt-screen initial replay should report snapshot=true")
+	}
+	if len(initial) >= len(ring) {
+		t.Errorf("alt-screen initial replay (%d B) should be far smaller than the ring (%d B)", len(initial), len(ring))
+	}
+	if !bytes.HasPrefix(initial, []byte("\x1b[?1049h")) {
+		t.Errorf("alt-screen initial replay should be a snapshot entering alt screen; got prefix %q", initial[:min(20, len(initial))])
+	}
+}
+
+// TestInitialReplayBytesNormalScreen verifies normal-screen sessions
+// still get the full ring on attach (deep scrollback survives; xterm
+// can't reflow on resize, so the ring is how history is preserved).
+func TestInitialReplayBytesNormalScreen(t *testing.T) {
+	v := NewVT(80, 24)
+	if _, err := v.Write([]byte("hello world\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, snapshot := v.InitialReplayBytes()
+	if snapshot {
+		t.Error("normal-screen initial replay should report snapshot=false")
+	}
+	if want := v.RingBytes(); !bytes.Equal(got, want) {
+		t.Errorf("normal-screen initial replay must equal the ring; got %d B, want %d B", len(got), len(want))
+	}
+}
+
 // TestWriteColorRGBForeground verifies RGB-encoded colors emit a
 // truecolor SGR fragment instead of being dropped to default.
 func TestWriteColorRGBForeground(t *testing.T) {


### PR DESCRIPTION
## Problem

Opening several full-screen agent sessions (Claude et al.) in **grid view** dragged at startup and then degraded to an unresponsive window. Restarting the daemon was a known mitigation but not a fix — it recurred after a few days of uptime.

## Diagnosis (from added instrumentation)

The daemon/attach path was fast (`dialHandshake=0–11ms`). The cost was the **scrollback replay**: on attach the daemon streamed each session's entire multi-MB raw ring into xterm. Captured on an 8-session grid:

- **~32 MB** of `writeData` parsed on the webview main thread in the first ~3s (`bytes=8,340,481 in 3206ms`, ×8 tiles).
- WebContent process RSS **~1 GB** → WebKit backing-store/GC thrashing → "slows to a halt."

All the sessions were `claude` (alt-screen), which has **no user-facing scrollback** — the multi-MB replay was pure waste.

## Fixes

- **Daemon** (`internal/session`): alt-screen sessions replay a one-screen snapshot on initial attach instead of the raw ring. Normal-screen sessions keep full history; resize-driven re-replay is unchanged.
- **GUI**: grid tiles attach lazily (active tile first, rest on idle) instead of all synchronously.
- **GUI**: auto-reconnect the control connection on drop (previously terminal — `ConnectControl` ran once at boot and never retried, leaving the window frozen after sleep/wake or a daemon upgrade).
- **GUI**: cap WebGL context-loss recovery so a flapping GPU context can't busy-loop into a freeze; bound simultaneous WebGL contexts so a many-tile grid can't exhaust the browser limit (the magenta-blocks symptom).

## Diagnosability

- Rotate `hived.log` / `hivegui.log` at 8 MiB (were unbounded — one reached 54 MiB).
- Always-on main-thread heartbeat + per-attach replay/timing breadcrumbs. The daemon logs the replay path (`snapshot=true/false` + size) per attach, so which code path ran is verifiable from the logs.

## Testing

- `scripts/test.sh go unit dom` — all green.
- New unit tests: WebGL budget + context-loss storm guard, freeze-heartbeat classifier, and alt-screen vs normal-screen initial-replay routing (`vt_test.go`).

## Verification note

A daemon restart clears accumulated state, so "freeze went away" is confounded. The unconfounded signal is the per-attach replay size: **let sessions accumulate scrollback, then restart only the GUI** (same long-running daemon). The fix is proven when `hived.log` shows `initial replay … snapshot=true` at a small size on a non-empty ring — the exact input that previously produced 8 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid-view performance by attaching only the active tile immediately and deferring the rest.
  * Reduced full-screen startup replay overhead by sending the appropriate initial payload.
  * Added automatic control-connection recovery with exponential backoff.
  * Improved WebGL stability using context budgeting, storm-guarded recovery, and DOM-renderer fallback.
  * Prevented log files from growing indefinitely via bounded rotation.
* **Diagnostics**
  * Added freeze-heartbeat and richer frontend/backend timing breadcrumbs (including startup latency and replay/write “flood” probes).
* **Tests**
  * Added unit/e2e coverage for heartbeat classification, WebGL budgeting, and initial replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a startup freeze in grid view caused by the daemon streaming entire multi-MB scrollback rings to every alt-screen tile simultaneously, overwhelming the webview main thread. It also adds control-connection auto-reconnect, a WebGL context budget, and a context-loss storm guard.

- **Core fix (daemon side)**: `InitialReplayBytes` returns a compact `RenderSnapshot` for alt-screen sessions instead of the raw ring, cutting the per-tile replay from ~8 MB to one screen's worth. Normal-screen sessions keep full-ring replay unchanged.
- **Core fix (GUI side)**: Grid tiles now attach lazily via idle callbacks (active tile first, deferred rest), eliminating the synchronous N-tile `fit()+replay` on the main thread at startup.
- **WebGL budget + storm guard**: A process-wide slot counter caps simultaneous WebGL contexts at 8 (preventing magenta-block artefacts); a sliding-window loss counter detects rapid context-loss loops and falls back to the DOM renderer to stop busy-loop freezes.
- **Control reconnect**: `reconnectControl` retries with exponential backoff (500 ms → 5 s) after a disconnect, replacing the previous one-shot `ConnectControl` call that left the window frozen after sleep/wake or daemon upgrade.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fixes are well-scoped, the core alt-screen replay path is covered by new unit tests, and the slot/storm tracking is correctly paired with WebGL lifecycle in all observable code paths.

The daemon change (InitialReplayBytes) is verified by two targeted Go tests. The WebGL budget and storm guard are pure-function modules with full unit-test coverage. The lazy-attach and reconnect logic rely on idempotent helpers that were already battle-tested. The one concern noted — _attachWebgl missing an explicit already-held-slot guard — is a defensive hardening suggestion; current call sites (init, context-loss recovery) properly release before re-acquiring, so no budget corruption occurs today.

**Files Needing Attention:** internal/session/vt.go — the TOCTOU window between reading the alt-screen flag and calling RenderSnapshot()/RingBytes() was flagged in a prior review thread and is still present; worth a follow-up if sessions are observed to receive the wrong replay type at high attach concurrency.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/session/vt.go | Adds InitialReplayBytes() which reads the alt-screen flag under v.mu then releases the lock before calling RenderSnapshot()/RingBytes() — the core startup-flood fix, with a known TOCTOU race window already flagged in previous review threads. |
| internal/session/session.go | Switches SubscribeWithAtomicReplay from RingBytes to InitialReplayBytes, adding a log line that proves which replay path ran per attach. Change is small and correct; resize-driven re-replay still uses the full ring via EmitAtomicReplay. |
| internal/registry/logfile.go | New single-slot log rotation helper: stat the file, rename to .1 if ≥ 8 MiB, open fresh. Clean, minimal, handles the unbounded-log problem. Each binary writes to its own file so there is no concurrent-rename race. |
| cmd/hivegui/frontend/src/app/session-term.js | Integrates WebGL budget (acquireWebglSlot/releaseWebglSlot) and context-loss storm guard into _attachWebgl and _onWebglContextLoss. Slot tracking is correctly paired with webgl reference in every code path; minor concern that _attachWebgl has no guard for the (currently unreachable) case where _hasWebglSlot is already true on entry. |
| cmd/hivegui/frontend/src/lib/webgl-budget.js | Process-wide WebGL context counter and sliding-window storm detector. Pure functions, well-unit-tested, floor-at-0 on over-release is safe. No issues. |
| cmd/hivegui/frontend/src/app/view.js | Introduces lazy attachDeferred that attaches the active tile immediately and defers the rest via requestIdleCallback with a 500 ms timeout fallback. ensureAttached idempotency makes the approach safe even when renderGrid fires repeatedly. |
| cmd/hivegui/frontend/src/app/events.js | Replaces the one-shot ConnectControl call on disconnect with reconnectControl() — an exponential-backoff loop (500 ms → 5 s) guarded by a _reconnecting flag to prevent parallel loops. finally block correctly resets the flag on all exit paths. |
| cmd/hivegui/frontend/src/lib/freeze-heartbeat.js | New classifyBeat helper: emits STALL when visible thread gap exceeds 2× nominal, suppresses large gaps while hidden (timer throttling), emits periodic alive lines. Clean design, pure functions, well-tested. |
| cmd/hivegui/app.go | Adds LogFrontend RPC, dial-latency probe around dialHandshake, and initial-burst byte counter in the read loop. Burst log is only emitted mid-loop (no defer); this is a pre-existing note in previous review threads. |
| internal/session/vt_test.go | New tests for InitialReplayBytes: alt-screen path verifies snapshot is far smaller than the ring and starts with the 1049h escape; normal-screen path verifies byte-for-byte equality with RingBytes. Good coverage of the core fix. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GU as GUI (main.js)
    participant VW as view.js
    participant ST as SessionTerm
    participant WB as webgl-budget.js
    participant AP as app.go (Go)
    participant VT as vt.go (daemon)

    GU->>AP: ConnectControl()
    AP-->>GU: connected → SESSIONS snapshot

    GU->>VW: renderGrid()
    VW->>ST: ensureAttached() [active tile, immediate]
    ST->>AP: OpenSession(id, cols, rows)
    AP->>VT: SubscribeWithAtomicReplay()
    VT->>VT: InitialReplayBytes()
    alt alt-screen (claude, vim…)
        VT-->>AP: RenderSnapshot() [~one screen, small]
    else normal screen
        VT-->>AP: RingBytes() [full scrollback]
    end
    AP-->>ST: FrameData stream (compact)
    ST->>WB: acquireWebglSlot()
    WB-->>ST: "true (if budget < 8)"
    ST->>ST: WebglAddon created

    VW->>VW: attachDeferred([non-active tiles])
    loop requestIdleCallback per tile
        VW->>ST: ensureAttached() [deferred]
        ST->>AP: OpenSession(id, cols, rows)
        AP-->>ST: FrameData stream
    end

    Note over AP,ST: control disconnect (sleep/wake)
    AP-->>GU: pty:ctrl-disconnect event
    GU->>GU: reconnectControl() with backoff
    loop 500ms→5s backoff
        GU->>AP: ConnectControl()
        AP-->>GU: success → SESSIONS snapshot re-pushed
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix: only log renderGrid fanout when til..."](https://github.com/lucascaro/hive/commit/49af31b6b92b9a460fa9014f7f1ccf79cbde273c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47090289)</sub>

<!-- /greptile_comment -->