### PR TITLE
Shared daemon wire client (improvement plan 3a)

### DIFF
--- a/cmd/hived-ws-bridge/main.go
+++ b/cmd/hived-ws-bridge/main.go
@@ -96,35 +96,9 @@ type session struct {
 	sockPath string
 
 	mu       sync.Mutex
-	control  *lockedConn
-	attaches map[string]*lockedConn // session id → attach conn
+	control  *wire.Client
+	attaches map[string]*wire.Client // session id → attach conn
 }
-
-// lockedConn serializes frame writes to one daemon connection.
-// wire.WriteFrame issues two Writes (header, then payload), so two
-// goroutines writing the same conn unserialized interleave mid-frame
-// and corrupt the stream. Reads stay lock-free: each conn has exactly
-// one reader goroutine, and socket reads never contend with writes.
-type lockedConn struct {
-	mu sync.Mutex
-	c  net.Conn
-}
-
-func (lc *lockedConn) writeFrame(t wire.FrameType, p []byte) error {
-	lc.mu.Lock()
-	defer lc.mu.Unlock()
-	return wire.WriteFrame(lc.c, t, p)
-}
-
-func (lc *lockedConn) writeJSON(t wire.FrameType, v any) error {
-	lc.mu.Lock()
-	defer lc.mu.Unlock()
-	return wire.WriteJSON(lc.c, t, v)
-}
-
-// Close is intentionally not guarded by lc.mu: net.Conn.Close is safe
-// concurrently with a blocked Write and must be able to unblock one.
-func (lc *lockedConn) Close() error { return lc.c.Close() }
 
 func serveWS(w http.ResponseWriter, r *http.Request, sockPath string) {
 	c, err := upgrader.Upgrade(w, r, nil)
@@ -133,7 +107,7 @@ func serveWS(w http.ResponseWriter, r *http.Request, sockPath string) {
 		return
 	}
 	defer c.Close()
-	s := &session{ws: c, sockPath: sockPath, attaches: make(map[string]*lockedConn)}
+	s := &session{ws: c, sockPath: sockPath, attaches: make(map[string]*wire.Client)}
 	defer s.closeAll()
 	for {
 		_, raw, err := c.ReadMessage()
@@ -290,48 +264,37 @@ func (s *session) connectControl() error {
 	}
 	s.mu.Unlock()
 
-	conn, welcome, err := dialHandshake(s.sockPath, wire.Hello{Mode: wire.ModeControl, Client: "ws-bridge/control"})
+	cli, err := dialHandshake(s.sockPath, wire.Hello{Mode: wire.ModeControl, Client: "ws-bridge/control"})
 	if err != nil {
 		return err
 	}
-	_ = welcome // build-id is irrelevant for tests
-	lc := &lockedConn{c: conn}
 	s.mu.Lock()
-	s.control = lc
+	s.control = cli
 	s.mu.Unlock()
-	go s.controlReadLoop(lc)
+	go s.controlReadLoop(cli)
 	return nil
 }
 
-func (s *session) controlReadLoop(conn *lockedConn) {
+func (s *session) controlReadLoop(cli *wire.Client) {
 	defer func() {
 		s.mu.Lock()
-		if s.control == conn {
+		if s.control == cli {
 			s.control = nil
 		}
 		s.mu.Unlock()
-		_ = conn.Close()
+		_ = cli.Close()
 		s.emit("control:disconnect", "")
 	}()
 	for {
-		ft, payload, err := wire.ReadFrame(conn.c)
+		ft, payload, err := cli.ReadFrame()
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				log.Printf("ws-bridge: control read: %v", err)
 			}
 			return
 		}
-		switch ft {
-		case wire.FrameSessions:
-			s.emit("session:list", string(payload))
-		case wire.FrameSessionEvent:
-			s.emit("session:event", string(payload))
-		case wire.FrameProjects:
-			s.emit("project:list", string(payload))
-		case wire.FrameProjectEvent:
-			s.emit("project:event", string(payload))
-		case wire.FrameError:
-			s.emit("control:error", string(payload))
+		if name, ok := wire.ControlEventName(ft); ok {
+			s.emit(name, string(payload))
 		}
 	}
 }
@@ -350,47 +313,48 @@ func (s *session) openSession(id string, cols, rows int) (*attachInfo, error) {
 	}
 	s.mu.Unlock()
 
-	conn, welcome, err := dialHandshake(s.sockPath, wire.Hello{
+	cli, err := dialHandshake(s.sockPath, wire.Hello{
 		Mode: wire.ModeAttach, SessionID: id, Client: "ws-bridge/attach",
 	})
 	if err != nil {
 		return nil, err
 	}
-	lc := &lockedConn{c: conn}
+	welcome := cli.Welcome()
 	s.mu.Lock()
-	s.attaches[id] = lc
+	s.attaches[id] = cli
 	s.mu.Unlock()
-	go s.attachReadLoop(id, lc)
+	go s.attachReadLoop(id, cli)
 	// Issue preferred size if non-zero and differs from welcome. Routed
 	// through the locked writer — it races with WriteStdin dispatches.
 	if cols > 0 && rows > 0 && (cols != welcome.Cols || rows != welcome.Rows) {
-		_ = lc.writeJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
+		_ = cli.WriteJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
 	}
 	return &attachInfo{SessionID: id, Cols: welcome.Cols, Rows: welcome.Rows}, nil
 }
 
-func (s *session) attachReadLoop(id string, conn *lockedConn) {
+func (s *session) attachReadLoop(id string, cli *wire.Client) {
 	defer func() {
 		s.mu.Lock()
-		if s.attaches[id] == conn {
+		if s.attaches[id] == cli {
 			delete(s.attaches, id)
 		}
 		s.mu.Unlock()
-		_ = conn.Close()
+		_ = cli.Close()
 		s.emit("pty:disconnect", id)
 	}()
 	for {
-		ft, payload, err := wire.ReadFrame(conn.c)
+		ft, payload, err := cli.ReadFrame()
 		if err != nil {
 			return
 		}
-		switch ft {
-		case wire.FrameData:
-			s.emit("pty:data", id, base64.StdEncoding.EncodeToString(payload))
-		case wire.FrameEvent:
-			s.emit("pty:event", id, string(payload))
-		case wire.FrameError:
-			s.emit("pty:error", id, string(payload))
+		name, ok := wire.AttachEventName(ft)
+		if !ok {
+			continue
+		}
+		if ft == wire.FrameData {
+			s.emit(name, id, base64.StdEncoding.EncodeToString(payload))
+		} else {
+			s.emit(name, id, string(payload))
 		}
 	}
 }
@@ -436,7 +400,7 @@ func (s *session) controlWriteJSON(t wire.FrameType, v any) error {
 	if c == nil {
 		return errors.New("no control connection")
 	}
-	return c.writeJSON(t, v)
+	return c.WriteJSON(t, v)
 }
 
 func (s *session) attachWriteFrame(id string, t wire.FrameType, p []byte) error {
@@ -446,7 +410,7 @@ func (s *session) attachWriteFrame(id string, t wire.FrameType, p []byte) error 
 	if c == nil {
 		return fmt.Errorf("no attach for %s", id)
 	}
-	return c.writeFrame(t, p)
+	return c.WriteFrame(t, p)
 }
 
 func (s *session) attachWriteJSON(id string, t wire.FrameType, v any) error {
@@ -456,38 +420,16 @@ func (s *session) attachWriteJSON(id string, t wire.FrameType, v any) error {
 	if c == nil {
 		return fmt.Errorf("no attach for %s", id)
 	}
-	return c.writeJSON(t, v)
+	return c.WriteJSON(t, v)
 }
 
 // --- helpers ---
 
-func dialHandshake(sockPath string, hello wire.Hello) (net.Conn, wire.Welcome, error) {
-	hello.Version = wire.PROTOCOL_VERSION
+func dialHandshake(sockPath string, hello wire.Hello) (*wire.Client, error) {
 	d := net.Dialer{Timeout: 3 * time.Second}
 	conn, err := d.DialContext(context.Background(), "unix", sockPath)
 	if err != nil {
-		return nil, wire.Welcome{}, fmt.Errorf("dial %s: %w", sockPath, err)
+		return nil, fmt.Errorf("dial %s: %w", sockPath, err)
 	}
-	if err := wire.WriteJSON(conn, wire.FrameHello, hello); err != nil {
-		_ = conn.Close()
-		return nil, wire.Welcome{}, fmt.Errorf("hello: %w", err)
-	}
-	ft, payload, err := wire.ReadFrame(conn)
-	if err != nil {
-		_ = conn.Close()
-		return nil, wire.Welcome{}, fmt.Errorf("welcome read: %w", err)
-	}
-	if ft == wire.FrameError {
-		_ = conn.Close()
-		var werr wire.Error
-		_ = json.Unmarshal(payload, &werr)
-		return nil, wire.Welcome{}, fmt.Errorf("handshake refused: %s", werr.Message)
-	}
-	if ft != wire.FrameWelcome {
-		_ = conn.Close()
-		return nil, wire.Welcome{}, fmt.Errorf("unexpected frame %s", ft)
-	}
-	var w wire.Welcome
-	_ = json.Unmarshal(payload, &w)
-	return conn, w, nil
+	return wire.Handshake(conn, hello)
 }

--- a/cmd/hived-ws-bridge/main_test.go
+++ b/cmd/hived-ws-bridge/main_test.go
@@ -107,9 +107,10 @@ func TestDispatchEmptyParamsStillPermissive(t *testing.T) {
 }
 
 // TestConcurrentAttachWritesAreSerialized proves frame writes from
-// concurrent goroutines cannot interleave mid-frame. Before lockedConn,
-// wire.WriteFrame's two Writes (header, payload) from racing goroutines
-// corrupted the stream; this test fails on that code.
+// concurrent goroutines cannot interleave mid-frame. Without the write
+// mutex in wire.Client, wire.WriteFrame's two Writes (header, payload)
+// from racing goroutines corrupted the stream; this test fails on that
+// code.
 func TestConcurrentAttachWritesAreSerialized(t *testing.T) {
 	client, server := net.Pipe()
 	defer server.Close()

--- a/cmd/hived-ws-bridge/main_test.go
+++ b/cmd/hived-ws-bridge/main_test.go
@@ -113,7 +113,7 @@ func TestDispatchEmptyParamsStillPermissive(t *testing.T) {
 func TestConcurrentAttachWritesAreSerialized(t *testing.T) {
 	client, server := net.Pipe()
 	defer server.Close()
-	s := &session{attaches: map[string]*lockedConn{"sid": {c: client}}}
+	s := &session{attaches: map[string]*wire.Client{"sid": wire.NewClient(client)}}
 
 	const goroutines, frames = 10, 50
 	got := make(map[string]int)

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -40,8 +39,8 @@ type App struct {
 	haveInitialPos     bool
 
 	mu       sync.Mutex
-	control  *connState            // control connection (or nil)
-	attaches map[string]*connState // session id → attach connection
+	control  *wire.Client            // control connection (or nil)
+	attaches map[string]*wire.Client // session id → attach connection
 
 	// openMu serializes OpenSession calls. Without it, two concurrent
 	// OpenSession(id) calls both observe an empty attaches[id], both
@@ -49,25 +48,6 @@ type App struct {
 	// session then fan-outs every byte (and the scrollback snapshot)
 	// twice, producing visibly duplicated output in xterm.
 	openMu sync.Mutex
-}
-
-// connState wraps a connection with a write mutex so multiple goroutines
-// (frontend writes vs. internal pings) don't interleave bytes.
-type connState struct {
-	conn    net.Conn
-	writeMu sync.Mutex
-}
-
-func (c *connState) writeJSON(t wire.FrameType, v any) error {
-	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
-	return wire.WriteJSON(c.conn, t, v)
-}
-
-func (c *connState) writeFrame(t wire.FrameType, p []byte) error {
-	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
-	return wire.WriteFrame(c.conn, t, p)
 }
 
 // Notify fires a native OS notification. Wails' webview lacks the HTML5
@@ -115,7 +95,7 @@ func NewApp(launchDir string) *App {
 	agent.SetCustomDir(registry.StateDir())
 	return &App{
 		launchDir: launchDir,
-		attaches:  make(map[string]*connState),
+		attaches:  make(map[string]*wire.Client),
 	}
 }
 
@@ -146,10 +126,10 @@ func (a *App) shutdown(ctx context.Context) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.control != nil {
-		_ = a.control.conn.Close()
+		_ = a.control.Close()
 	}
 	for _, c := range a.attaches {
-		_ = c.conn.Close()
+		_ = c.Close()
 	}
 }
 
@@ -194,43 +174,14 @@ func (a *App) saveGeometry() {
 
 // ----------------------------- control conn -----------------------------
 
-// dialHandshake dials the daemon socket (spawning hived if needed), sends
-// the given HELLO frame, and waits for WELCOME, closing the connection on
-// any failure. Mirrors the shape of hived-ws-bridge's dialHandshake helper
-// for the GUI's own control/attach call sites.
-func (a *App) dialHandshake(hello wire.Hello) (net.Conn, wire.Welcome, error) {
-	hello.Version = wire.PROTOCOL_VERSION
+// dialHandshake dials the daemon socket (spawning hived if needed) and
+// performs the HELLO/WELCOME handshake via the shared wire client.
+func (a *App) dialHandshake(hello wire.Hello) (*wire.Client, error) {
 	conn, err := dialOrSpawn(hdaemon.SocketPath(), a.launchDir)
 	if err != nil {
-		return nil, wire.Welcome{}, err
+		return nil, err
 	}
-	if err := wire.WriteJSON(conn, wire.FrameHello, hello); err != nil {
-		_ = conn.Close()
-		return nil, wire.Welcome{}, fmt.Errorf("hello: %w", err)
-	}
-	ft, payload, err := wire.ReadFrame(conn)
-	if err != nil {
-		_ = conn.Close()
-		return nil, wire.Welcome{}, fmt.Errorf("welcome: %w", err)
-	}
-	if ft == wire.FrameError {
-		_ = conn.Close()
-		var werr wire.Error
-		if json.Unmarshal(payload, &werr) == nil && werr.Message != "" {
-			return nil, wire.Welcome{}, errors.New(werr.Message)
-		}
-		return nil, wire.Welcome{}, errors.New("daemon rejected connection")
-	}
-	if ft != wire.FrameWelcome {
-		_ = conn.Close()
-		return nil, wire.Welcome{}, fmt.Errorf("expected WELCOME, got %s", ft)
-	}
-	var welcome wire.Welcome
-	if err := json.Unmarshal(payload, &welcome); err != nil {
-		_ = conn.Close()
-		return nil, wire.Welcome{}, fmt.Errorf("welcome: %w", err)
-	}
-	return conn, welcome, nil
+	return wire.Handshake(conn, hello)
 }
 
 // ConnectControl opens (or reuses) the control connection. The
@@ -245,8 +196,7 @@ func (a *App) ConnectControl() error {
 	}
 	a.mu.Unlock()
 
-	conn, welcome, err := a.dialHandshake(wire.Hello{
-		Version: wire.PROTOCOL_VERSION,
+	cs, err := a.dialHandshake(wire.Hello{
 		Client:  "hivegui/0.2",
 		BuildID: buildinfo.BuildID(),
 		Mode:    wire.ModeControl,
@@ -255,12 +205,11 @@ func (a *App) ConnectControl() error {
 		return fmt.Errorf("control: %w", err)
 	}
 
-	cs := &connState{conn: conn}
 	a.mu.Lock()
 	a.control = cs
 	a.mu.Unlock()
 	go a.controlReadLoop(cs)
-	a.emitDaemonVersionStatus(welcome.BuildID, welcome.Release)
+	a.emitDaemonVersionStatus(cs.Welcome().BuildID, cs.Welcome().Release)
 	return nil
 }
 
@@ -358,7 +307,7 @@ func (a *App) RestartDaemon() error {
 		// writeFrame, not wire.WriteFrame: the header and payload are
 		// two Write calls, and the frontend can be writing to this
 		// same conn concurrently. Every other writer takes writeMu.
-		if err := control.writeFrame(wire.FrameShutdown, nil); err != nil {
+		if err := control.WriteFrame(wire.FrameShutdown, nil); err != nil {
 			log.Printf("hivegui: restart: send shutdown frame: %v", err)
 		}
 		dead = socketDead(sock, restartKillBudget)
@@ -390,13 +339,13 @@ func (a *App) RestartDaemon() error {
 	// half-open fds while the new GUI comes up.
 	a.mu.Lock()
 	if a.control != nil {
-		_ = a.control.conn.Close()
+		_ = a.control.Close()
 		a.control = nil
 	}
 	for _, c := range a.attaches {
-		_ = c.conn.Close()
+		_ = c.Close()
 	}
-	a.attaches = make(map[string]*connState)
+	a.attaches = make(map[string]*wire.Client)
 	a.mu.Unlock()
 
 	if err := spawnNewGUI(a.launchDir); err != nil {
@@ -407,36 +356,27 @@ func (a *App) RestartDaemon() error {
 	return nil
 }
 
-func (a *App) controlReadLoop(cs *connState) {
+func (a *App) controlReadLoop(cs *wire.Client) {
 	defer func() {
 		a.mu.Lock()
 		if a.control == cs {
 			a.control = nil
 		}
 		a.mu.Unlock()
-		_ = cs.conn.Close()
+		_ = cs.Close()
 		wruntime.EventsEmit(a.ctx, "control:disconnect", "")
 	}()
 	for {
-		ft, payload, err := wire.ReadFrame(cs.conn)
+		ft, payload, err := cs.ReadFrame()
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				log.Printf("hivegui: control read: %v", err)
 			}
 			return
 		}
-		switch ft {
-		case wire.FrameSessions:
-			wruntime.EventsEmit(a.ctx, "session:list", string(payload))
-		case wire.FrameSessionEvent:
-			wruntime.EventsEmit(a.ctx, "session:event", string(payload))
-		case wire.FrameProjects:
-			wruntime.EventsEmit(a.ctx, "project:list", string(payload))
-		case wire.FrameProjectEvent:
-			wruntime.EventsEmit(a.ctx, "project:event", string(payload))
-		case wire.FrameError:
-			wruntime.EventsEmit(a.ctx, "control:error", string(payload))
-		default:
+		if name, ok := wire.ControlEventName(ft); ok {
+			wruntime.EventsEmit(a.ctx, name, string(payload))
+		} else {
 			log.Printf("hivegui: control unexpected frame %s", ft)
 		}
 	}
@@ -527,7 +467,7 @@ func (a *App) CreateSession(agentID, projectID, name, color string, cols, rows i
 	if err != nil {
 		return err
 	}
-	return cs.writeJSON(wire.FrameCreateSession, wire.CreateSpec{
+	return cs.WriteJSON(wire.FrameCreateSession, wire.CreateSpec{
 		Agent:       agentID,
 		ProjectID:   projectID,
 		Name:        name,
@@ -552,7 +492,7 @@ func (a *App) DuplicateSession(agentID, projectID, cwd string) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeJSON(wire.FrameCreateSession, wire.CreateSpec{
+	return cs.WriteJSON(wire.FrameCreateSession, wire.CreateSpec{
 		Agent:       agentID,
 		ProjectID:   projectID,
 		Cwd:         cwd,
@@ -566,7 +506,7 @@ func (a *App) CreateProject(name, color, cwd string) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeJSON(wire.FrameCreateProject, wire.CreateProjectReq{
+	return cs.WriteJSON(wire.FrameCreateProject, wire.CreateProjectReq{
 		Name: name, Color: color, Cwd: cwd,
 	})
 }
@@ -579,7 +519,7 @@ func (a *App) KillProject(id string, killSessions bool) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeJSON(wire.FrameKillProject, wire.KillProjectReq{
+	return cs.WriteJSON(wire.FrameKillProject, wire.KillProjectReq{
 		ProjectID: id, KillSessions: killSessions,
 	})
 }
@@ -604,7 +544,7 @@ func (a *App) UpdateProject(id, name, color, cwd string, order int) error {
 	if order >= 0 {
 		req.Order = &order
 	}
-	return cs.writeJSON(wire.FrameUpdateProject, req)
+	return cs.WriteJSON(wire.FrameUpdateProject, req)
 }
 
 // LaunchDir returns the cwd captured at GUI startup; useful for the
@@ -679,7 +619,7 @@ func (a *App) KillSession(id string, force bool) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeJSON(wire.FrameKillSession, wire.KillSessionReq{
+	return cs.WriteJSON(wire.FrameKillSession, wire.KillSessionReq{
 		SessionID: id, Force: force,
 	})
 }
@@ -694,7 +634,7 @@ func (a *App) RestartSession(id string) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeJSON(wire.FrameRestartSession, wire.RestartSessionReq{
+	return cs.WriteJSON(wire.FrameRestartSession, wire.RestartSessionReq{
 		SessionID: id,
 	})
 }
@@ -731,10 +671,10 @@ func (a *App) UpdateSession(id, name, color string, order int) error {
 	if order >= 0 {
 		req.Order = &order
 	}
-	return cs.writeJSON(wire.FrameUpdateSession, req)
+	return cs.WriteJSON(wire.FrameUpdateSession, req)
 }
 
-func (a *App) requireControl() (*connState, error) {
+func (a *App) requireControl() (*wire.Client, error) {
 	a.mu.Lock()
 	cs := a.control
 	a.mu.Unlock()
@@ -771,8 +711,7 @@ func (a *App) OpenSession(id string, cols, rows int) (*AttachInfo, error) {
 	a.mu.Unlock()
 
 	dialStart := time.Now()
-	conn, welcome, err := a.dialHandshake(wire.Hello{
-		Version:   wire.PROTOCOL_VERSION,
+	cs, err := a.dialHandshake(wire.Hello{
 		Client:    "hivegui/0.2",
 		Mode:      wire.ModeAttach,
 		SessionID: id,
@@ -780,13 +719,13 @@ func (a *App) OpenSession(id string, cols, rows int) (*AttachInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("attach failed: %w", err)
 	}
+	welcome := cs.Welcome()
 	// Startup-latency probe: dial+handshake is a network round-trip to
 	// hived per session. On a many-session grid launch these run behind
 	// openMu (serialized), so a slow daemon shows here as the sum that
 	// stalls startup. Logged to hivegui.log next to the frontend probes.
 	log.Printf("hivegui[fe]: OpenSession id=%s dialHandshake=%dms", id, time.Since(dialStart).Milliseconds())
 
-	cs := &connState{conn: conn}
 	a.mu.Lock()
 	a.attaches[id] = cs
 	a.mu.Unlock()
@@ -795,7 +734,7 @@ func (a *App) OpenSession(id string, cols, rows int) (*AttachInfo, error) {
 	// Issue the frontend's preferred size right after the handshake;
 	// the daemon's WELCOME reports its current size which may differ.
 	if cols > 0 && rows > 0 && (cols != welcome.Cols || rows != welcome.Rows) {
-		_ = cs.writeJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
+		_ = cs.WriteJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
 	}
 
 	return &AttachInfo{
@@ -803,14 +742,14 @@ func (a *App) OpenSession(id string, cols, rows int) (*AttachInfo, error) {
 	}, nil
 }
 
-func (a *App) attachReadLoop(id string, cs *connState) {
+func (a *App) attachReadLoop(id string, cs *wire.Client) {
 	defer func() {
 		a.mu.Lock()
 		if a.attaches[id] == cs {
 			delete(a.attaches, id)
 		}
 		a.mu.Unlock()
-		_ = cs.conn.Close()
+		_ = cs.Close()
 		wruntime.EventsEmit(a.ctx, "pty:disconnect", id)
 	}()
 	// Startup-flood probe: sum the FrameData bytes in the first second
@@ -831,7 +770,7 @@ func (a *App) attachReadLoop(id string, cs *connState) {
 			id, initFrames, initBytes, time.Since(loopStart).Milliseconds())
 	}
 	for {
-		ft, payload, err := wire.ReadFrame(cs.conn)
+		ft, payload, err := cs.ReadFrame()
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				log.Printf("hivegui: attach %s read: %v", id, err)
@@ -849,15 +788,14 @@ func (a *App) attachReadLoop(id string, cs *connState) {
 				logInitBurst()
 			}
 		}
-		switch ft {
-		case wire.FrameData:
-			wruntime.EventsEmit(a.ctx, "pty:data", id, base64.StdEncoding.EncodeToString(payload))
-		case wire.FrameEvent:
-			wruntime.EventsEmit(a.ctx, "pty:event", id, string(payload))
-		case wire.FrameError:
-			wruntime.EventsEmit(a.ctx, "pty:error", id, string(payload))
-		default:
+		name, ok := wire.AttachEventName(ft)
+		switch {
+		case !ok:
 			log.Printf("hivegui: attach %s unexpected frame %s", id, ft)
+		case ft == wire.FrameData:
+			wruntime.EventsEmit(a.ctx, name, id, base64.StdEncoding.EncodeToString(payload))
+		default:
+			wruntime.EventsEmit(a.ctx, name, id, string(payload))
 		}
 	}
 }
@@ -875,7 +813,7 @@ func (a *App) CloseAttach(id string) error {
 	if !ok {
 		return nil
 	}
-	return cs.conn.Close()
+	return cs.Close()
 }
 
 // WriteStdin forwards keystrokes to the attached session.
@@ -888,7 +826,7 @@ func (a *App) WriteStdin(id, b64 string) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeFrame(wire.FrameData, data)
+	return cs.WriteFrame(wire.FrameData, data)
 }
 
 // ResizeSession sends a RESIZE control frame on the attach connection.
@@ -897,7 +835,7 @@ func (a *App) ResizeSession(id string, cols, rows int) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
+	return cs.WriteJSON(wire.FrameResize, wire.Resize{Cols: cols, Rows: rows})
 }
 
 // RequestScrollbackReplay asks the daemon to re-stream the session's
@@ -917,10 +855,10 @@ func (a *App) RequestScrollbackReplay(id string) error {
 	if err != nil {
 		return err
 	}
-	return cs.writeFrame(wire.FrameRequestReplay, nil)
+	return cs.WriteFrame(wire.FrameRequestReplay, nil)
 }
 
-func (a *App) attachFor(id string) (*connState, error) {
+func (a *App) attachFor(id string) (*wire.Client, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	cs, ok := a.attaches[id]

--- a/cmd/hivegui/restart_test.go
+++ b/cmd/hivegui/restart_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/lucascaro/hive/internal/wire"
 )
 
 // shortTempDir keeps socket paths well clear of sun_path's 104-byte
@@ -115,8 +117,8 @@ func TestRestartDaemon_FailurePreservesConns(t *testing.T) {
 	defer attach.Close()
 
 	app := NewApp("")
-	app.control = &connState{conn: control}
-	app.attaches["sess-1"] = &connState{conn: attach}
+	app.control = wire.NewClient(control)
+	app.attaches["sess-1"] = wire.NewClient(attach)
 
 	if err := app.RestartDaemon(); err == nil {
 		t.Fatal("RestartDaemon should fail while the daemon is still answering")

--- a/internal/wire/client.go
+++ b/internal/wire/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 )
 
 // Client is one handshaken connection to hived in a single wire mode.
@@ -22,16 +23,23 @@ type Client struct {
 	welcome Welcome
 }
 
+// handshakeTimeout bounds the wait for WELCOME. A daemon that accepts
+// the socket but never answers must fail the caller, not hang it —
+// the GUI's ConnectControl/OpenSession have no other watchdog. A var,
+// not a const, so tests can shrink it.
+var handshakeTimeout = 5 * time.Second
+
 // Handshake sends HELLO on an established conn, waits for WELCOME and
 // returns the wrapped Client. The conn is closed on any failure.
 // hello.Version is filled with PROTOCOL_VERSION when zero (left alone
-// otherwise so tests can probe version rejection). Callers that need a
-// handshake timeout set a read deadline on conn beforehand and clear
-// it afterwards.
+// otherwise so tests can probe version rejection). The WELCOME wait is
+// bounded by handshakeTimeout; any caller-set read deadline is
+// overwritten and cleared on success.
 func Handshake(conn net.Conn, hello Hello) (*Client, error) {
 	if hello.Version == 0 {
 		hello.Version = PROTOCOL_VERSION
 	}
+	_ = conn.SetReadDeadline(time.Now().Add(handshakeTimeout))
 	if err := WriteJSON(conn, FrameHello, hello); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("hello: %w", err)
@@ -48,6 +56,7 @@ func Handshake(conn net.Conn, hello Hello) (*Client, error) {
 			_ = conn.Close()
 			return nil, fmt.Errorf("welcome: %w", err)
 		}
+		_ = conn.SetReadDeadline(time.Time{})
 		return &Client{conn: conn, welcome: w}, nil
 	case FrameError:
 		_ = conn.Close()

--- a/internal/wire/client.go
+++ b/internal/wire/client.go
@@ -55,7 +55,7 @@ func Handshake(conn net.Conn, hello Hello) (*Client, error) {
 		if json.Unmarshal(payload, &werr) == nil && werr.Message != "" {
 			return nil, fmt.Errorf("daemon refused connection: %s", werr.Message)
 		}
-		return nil, fmt.Errorf("daemon rejected connection")
+		return nil, fmt.Errorf("daemon refused connection")
 	default:
 		_ = conn.Close()
 		return nil, fmt.Errorf("expected WELCOME, got %s", ft)

--- a/internal/wire/client.go
+++ b/internal/wire/client.go
@@ -1,0 +1,130 @@
+package wire
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+)
+
+// Client is one handshaken connection to hived in a single wire mode.
+// It is the shared protocol client used by the GUI, the ws-bridge and
+// the e2e testclient — the dial policy (spawn-on-miss, timeouts) stays
+// with the caller, everything after the socket exists lives here.
+//
+// Writes are serialized: WriteFrame issues two Writes (header, then
+// payload), so unserialized concurrent writers would interleave
+// mid-frame and corrupt the stream. Reads are lock-free — each Client
+// has exactly one reader goroutine by contract.
+type Client struct {
+	conn    net.Conn
+	wmu     sync.Mutex
+	welcome Welcome
+}
+
+// Handshake sends HELLO on an established conn, waits for WELCOME and
+// returns the wrapped Client. The conn is closed on any failure.
+// hello.Version is filled with PROTOCOL_VERSION when zero (left alone
+// otherwise so tests can probe version rejection). Callers that need a
+// handshake timeout set a read deadline on conn beforehand and clear
+// it afterwards.
+func Handshake(conn net.Conn, hello Hello) (*Client, error) {
+	if hello.Version == 0 {
+		hello.Version = PROTOCOL_VERSION
+	}
+	if err := WriteJSON(conn, FrameHello, hello); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("hello: %w", err)
+	}
+	ft, payload, err := ReadFrame(conn)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("welcome: %w", err)
+	}
+	switch ft {
+	case FrameWelcome:
+		var w Welcome
+		if err := json.Unmarshal(payload, &w); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("welcome: %w", err)
+		}
+		return &Client{conn: conn, welcome: w}, nil
+	case FrameError:
+		_ = conn.Close()
+		var werr Error
+		if json.Unmarshal(payload, &werr) == nil && werr.Message != "" {
+			return nil, fmt.Errorf("daemon refused connection: %s", werr.Message)
+		}
+		return nil, fmt.Errorf("daemon rejected connection")
+	default:
+		_ = conn.Close()
+		return nil, fmt.Errorf("expected WELCOME, got %s", ft)
+	}
+}
+
+// NewClient wraps an already-handshaken (or test) conn without
+// performing the HELLO/WELCOME exchange. Welcome() is zero.
+func NewClient(conn net.Conn) *Client { return &Client{conn: conn} }
+
+// Welcome returns the WELCOME frame received during Handshake.
+func (c *Client) Welcome() Welcome { return c.welcome }
+
+// WriteJSON marshals v and writes it as a frame of type t, serialized
+// against other writers on this Client.
+func (c *Client) WriteJSON(t FrameType, v any) error {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	return WriteJSON(c.conn, t, v)
+}
+
+// WriteFrame writes a raw frame, serialized against other writers.
+func (c *Client) WriteFrame(t FrameType, payload []byte) error {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	return WriteFrame(c.conn, t, payload)
+}
+
+// ReadFrame reads the next frame. Single-reader contract: only one
+// goroutine may call ReadFrame.
+func (c *Client) ReadFrame() (FrameType, []byte, error) {
+	return ReadFrame(c.conn)
+}
+
+// Close is deliberately not guarded by the write mutex: net.Conn.Close
+// is safe concurrently with a blocked Write and must be able to
+// unblock one.
+func (c *Client) Close() error { return c.conn.Close() }
+
+// controlEvents and attachEvents are the shared frame → UI-event
+// dispatch tables. The GUI (Wails EventsEmit) and the ws-bridge (WS
+// notifications) emit identical event names; a new fanout frame is
+// added here once and every client picks it up.
+var controlEvents = map[FrameType]string{
+	FrameSessions:     "session:list",
+	FrameSessionEvent: "session:event",
+	FrameProjects:     "project:list",
+	FrameProjectEvent: "project:event",
+	FrameError:        "control:error",
+}
+
+var attachEvents = map[FrameType]string{
+	FrameData:  "pty:data",
+	FrameEvent: "pty:event",
+	FrameError: "pty:error",
+}
+
+// ControlEventName maps a control-mode frame to its client event name.
+// ok is false for frames that are not part of the control fanout.
+func ControlEventName(t FrameType) (string, bool) {
+	n, ok := controlEvents[t]
+	return n, ok
+}
+
+// AttachEventName maps an attach-mode frame to its client event name.
+// ok is false for frames not part of the attach fanout. "pty:data"
+// payloads are raw PTY bytes (callers base64 them for JS transport);
+// the others are JSON.
+func AttachEventName(t FrameType) (string, bool) {
+	n, ok := attachEvents[t]
+	return n, ok
+}

--- a/internal/wire/client_test.go
+++ b/internal/wire/client_test.go
@@ -1,0 +1,184 @@
+package wire
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// handshakeServer answers one HELLO on the server side of a pipe with
+// the given reply frame, then returns the HELLO it saw.
+func handshakeServer(t *testing.T, srv net.Conn, replyType FrameType, reply any) *Hello {
+	t.Helper()
+	var hello Hello
+	if ft, err := ReadJSON(srv, &hello); err != nil || ft != FrameHello {
+		t.Errorf("server: expected HELLO, got %s err=%v", ft, err)
+		return nil
+	}
+	if err := WriteJSON(srv, replyType, reply); err != nil {
+		t.Errorf("server: write reply: %v", err)
+	}
+	return &hello
+}
+
+func TestHandshake_Welcome(t *testing.T) {
+	cli, srv := net.Pipe()
+	var gotHello *Hello
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		gotHello = handshakeServer(t, srv, FrameWelcome, Welcome{
+			Version: PROTOCOL_VERSION, Mode: ModeAttach, SessionID: "s1", Cols: 80, Rows: 24,
+		})
+	}()
+
+	c, err := Handshake(cli, Hello{Mode: ModeAttach, SessionID: "s1", Client: "test/0"})
+	if err != nil {
+		t.Fatalf("Handshake: %v", err)
+	}
+	defer c.Close()
+	<-done
+
+	// Version is filled when zero — every production client relies on this.
+	if gotHello == nil || gotHello.Version != PROTOCOL_VERSION {
+		t.Errorf("sent hello version = %+v, want %d", gotHello, PROTOCOL_VERSION)
+	}
+	w := c.Welcome()
+	if w.SessionID != "s1" || w.Cols != 80 || w.Rows != 24 {
+		t.Errorf("welcome = %+v", w)
+	}
+}
+
+func TestHandshake_PreservesNonZeroVersion(t *testing.T) {
+	// The e2e suite probes version rejection by sending Version: 999;
+	// Handshake must not overwrite it.
+	cli, srv := net.Pipe()
+	done := make(chan struct{})
+	var gotHello *Hello
+	go func() {
+		defer close(done)
+		gotHello = handshakeServer(t, srv, FrameError, Error{Code: "version_mismatch", Message: "go away"})
+	}()
+
+	_, err := Handshake(cli, Hello{Version: 999, Mode: ModeControl})
+	<-done
+	if err == nil {
+		t.Fatal("expected error on refused handshake")
+	}
+	if !strings.Contains(err.Error(), "go away") {
+		t.Errorf("refusal error should carry daemon message, got: %v", err)
+	}
+	if gotHello == nil || gotHello.Version != 999 {
+		t.Errorf("hello version = %+v, want 999", gotHello)
+	}
+}
+
+func TestHandshake_RefusalWithoutMessage(t *testing.T) {
+	cli, srv := net.Pipe()
+	go handshakeServer(t, srv, FrameError, Error{})
+	if _, err := Handshake(cli, Hello{Mode: ModeControl}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestHandshake_UnexpectedFrame(t *testing.T) {
+	cli, srv := net.Pipe()
+	go handshakeServer(t, srv, FrameData, nil)
+	_, err := Handshake(cli, Hello{Mode: ModeControl})
+	if err == nil || !strings.Contains(err.Error(), "expected WELCOME") {
+		t.Fatalf("err = %v", err)
+	}
+	// Conn must be closed on failure: a subsequent server read fails.
+	if err := WriteFrame(srv, FrameData, []byte("x")); err == nil {
+		var b [1]byte
+		if _, rerr := srv.Read(b[:]); rerr == nil {
+			t.Error("conn still open after failed handshake")
+		}
+	}
+}
+
+func TestHandshake_HonorsReadDeadline(t *testing.T) {
+	cli, srv := net.Pipe()
+	defer srv.Close()
+	// Server reads HELLO but never answers.
+	go func() {
+		var hello Hello
+		_, _ = ReadJSON(srv, &hello)
+	}()
+	_ = cli.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	if _, err := Handshake(cli, Hello{Mode: ModeControl}); err == nil {
+		t.Fatal("expected deadline error")
+	}
+}
+
+// TestClient_ConcurrentWritesDoNotInterleave pins the reason the write
+// mutex exists: header and payload are two Writes, and two goroutines
+// writing the same conn unserialized corrupt the stream.
+func TestClient_ConcurrentWritesDoNotInterleave(t *testing.T) {
+	cli, srv := net.Pipe()
+	go handshakeServer(t, srv, FrameWelcome, Welcome{Version: PROTOCOL_VERSION})
+	c, err := Handshake(cli, Hello{Mode: ModeAttach, SessionID: "x"})
+	if err != nil {
+		t.Fatalf("Handshake: %v", err)
+	}
+	defer c.Close()
+
+	const writers, frames = 8, 50
+	payload := bytes.Repeat([]byte("ab"), 100)
+	var wg sync.WaitGroup
+	for range writers {
+		wg.Go(func() {
+			for range frames {
+				if err := c.WriteFrame(FrameData, payload); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		})
+	}
+	go func() { wg.Wait(); _ = srv.Close() }()
+
+	got := 0
+	for {
+		ft, p, err := ReadFrame(srv)
+		if err != nil {
+			break
+		}
+		if ft != FrameData || !bytes.Equal(p, payload) {
+			t.Fatalf("corrupt frame: type=%s len=%d", ft, len(p))
+		}
+		got++
+	}
+	if got != writers*frames {
+		t.Errorf("frames received = %d, want %d", got, writers*frames)
+	}
+}
+
+func TestEventNameTables(t *testing.T) {
+	cases := []struct {
+		fn    func(FrameType) (string, bool)
+		t     FrameType
+		want  string
+		known bool
+	}{
+		{ControlEventName, FrameSessions, "session:list", true},
+		{ControlEventName, FrameSessionEvent, "session:event", true},
+		{ControlEventName, FrameProjects, "project:list", true},
+		{ControlEventName, FrameProjectEvent, "project:event", true},
+		{ControlEventName, FrameError, "control:error", true},
+		{ControlEventName, FrameData, "", false},
+		{AttachEventName, FrameData, "pty:data", true},
+		{AttachEventName, FrameEvent, "pty:event", true},
+		{AttachEventName, FrameError, "pty:error", true},
+		{AttachEventName, FrameSessions, "", false},
+	}
+	for _, tc := range cases {
+		got, ok := tc.fn(tc.t)
+		if got != tc.want || ok != tc.known {
+			t.Errorf("event name for %s: got (%q,%v), want (%q,%v)", tc.t, got, ok, tc.want, tc.known)
+		}
+	}
+}

--- a/internal/wire/client_test.go
+++ b/internal/wire/client_test.go
@@ -100,17 +100,20 @@ func TestHandshake_UnexpectedFrame(t *testing.T) {
 	}
 }
 
-func TestHandshake_HonorsReadDeadline(t *testing.T) {
+func TestHandshake_TimesOutOnMuteServer(t *testing.T) {
+	old := handshakeTimeout
+	handshakeTimeout = 50 * time.Millisecond
+	defer func() { handshakeTimeout = old }()
+
 	cli, srv := net.Pipe()
 	defer srv.Close()
-	// Server reads HELLO but never answers.
+	// Server reads HELLO but never answers WELCOME.
 	go func() {
 		var hello Hello
 		_, _ = ReadJSON(srv, &hello)
 	}()
-	_ = cli.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
 	if _, err := Handshake(cli, Hello{Mode: ModeControl}); err == nil {
-		t.Fatal("expected deadline error")
+		t.Fatal("expected timeout error on mute server")
 	}
 }
 

--- a/internal/wire/testclient/client.go
+++ b/internal/wire/testclient/client.go
@@ -39,14 +39,14 @@ import (
 //   - sessions / projects: control-mode broadcast channels.
 //   - snaps:    one-shot frames (WELCOME, ERROR, SESSIONS, PROJECTS).
 type Client struct {
-	conn net.Conn
+	conn net.Conn        // raw conn; owned by cli after Handshake
+	cli  *wire.Client    // shared protocol client; nil until Handshake
 
 	stream   chan frameMsg
 	sessions chan wire.SessionEvent
 	projects chan wire.ProjectEvent
 	snaps    chan frameMsg
 	errs     chan error
-	welcome  wire.Welcome
 
 	closeOnce sync.Once
 	closed    chan struct{}
@@ -57,16 +57,16 @@ type frameMsg struct {
 	payload []byte
 }
 
-// Dial opens a connection to the daemon's unix socket and starts the
-// reader goroutine. Handshake is a separate call so the caller can
-// fail fast on missing isolation env vars before opening sockets.
+// Dial opens a connection to the daemon's unix socket. Handshake is a
+// separate call so the caller can fail fast on missing isolation env
+// vars before opening sockets.
 func Dial(ctx context.Context, sockPath string) (*Client, error) {
 	var d net.Dialer
 	conn, err := d.DialContext(ctx, "unix", sockPath)
 	if err != nil {
 		return nil, fmt.Errorf("testclient: dial %s: %w", sockPath, err)
 	}
-	c := &Client{
+	return &Client{
 		conn:     conn,
 		stream:   make(chan frameMsg, 256),
 		sessions: make(chan wire.SessionEvent, 32),
@@ -74,65 +74,43 @@ func Dial(ctx context.Context, sockPath string) (*Client, error) {
 		snaps:    make(chan frameMsg, 8),
 		errs:     make(chan error, 1),
 		closed:   make(chan struct{}),
-	}
-	go c.readLoop()
-	return c, nil
+	}, nil
 }
 
-// Handshake sends HELLO and reads the WELCOME (or ERROR) reply.
-// The client version is filled in for the caller.
+// Handshake sends HELLO and reads the WELCOME (or ERROR) reply via the
+// shared wire.Client, then starts the demux reader goroutine.
 func (c *Client) Handshake(hello wire.Hello) (wire.Welcome, error) {
-	if hello.Version == 0 {
-		hello.Version = wire.PROTOCOL_VERSION
-	}
 	if hello.Client == "" {
 		hello.Client = "testclient/0"
 	}
-	if err := wire.WriteJSON(c.conn, wire.FrameHello, hello); err != nil {
-		return wire.Welcome{}, fmt.Errorf("testclient: write HELLO: %w", err)
+	// wire.Handshake reads synchronously; bound it with a deadline so a
+	// mute daemon fails the test in 5s instead of hanging it.
+	_ = c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	cli, err := wire.Handshake(c.conn, hello)
+	if err != nil {
+		return wire.Welcome{}, fmt.Errorf("testclient: %w", err)
 	}
-	// The reader goroutine is already running. WELCOME / ERROR arrive
-	// via the snapshot channel (anything that isn't DATA/EVENT/
-	// SESSION_EVENT/PROJECT_EVENT lands there).
-	select {
-	case msg := <-c.snaps:
-		switch msg.t {
-		case wire.FrameWelcome:
-			var w wire.Welcome
-			if err := json.Unmarshal(msg.payload, &w); err != nil {
-				return wire.Welcome{}, fmt.Errorf("testclient: decode WELCOME: %w", err)
-			}
-			c.welcome = w
-			return w, nil
-		case wire.FrameError:
-			var e wire.Error
-			_ = json.Unmarshal(msg.payload, &e)
-			return wire.Welcome{}, fmt.Errorf("testclient: daemon refused handshake: %s: %s", e.Code, e.Message)
-		default:
-			return wire.Welcome{}, fmt.Errorf("testclient: unexpected frame during handshake: %s", msg.t)
-		}
-	case err := <-c.errs:
-		return wire.Welcome{}, fmt.Errorf("testclient: handshake read: %w", err)
-	case <-time.After(5 * time.Second):
-		return wire.Welcome{}, errors.New("testclient: handshake timeout")
-	}
+	_ = c.conn.SetReadDeadline(time.Time{})
+	c.cli = cli
+	go c.readLoop()
+	return cli.Welcome(), nil
 }
 
 // WriteStdin sends raw PTY bytes (an attach-mode DATA frame).
 func (c *Client) WriteStdin(b []byte) error {
-	return wire.WriteFrame(c.conn, wire.FrameData, b)
+	return c.cli.WriteFrame(wire.FrameData, b)
 }
 
 // CreateSession sends a CREATE_SESSION control frame. Caller must be
 // in control mode.
 func (c *Client) CreateSession(spec wire.CreateSpec) error {
-	return wire.WriteJSON(c.conn, wire.FrameCreateSession, spec)
+	return c.cli.WriteJSON(wire.FrameCreateSession, spec)
 }
 
 // ListSessions sends LIST_SESSIONS. Use AwaitSessionsSnapshot to
 // consume the response.
 func (c *Client) ListSessions() error {
-	return wire.WriteJSON(c.conn, wire.FrameListSessions, wire.ListSessionsReq{})
+	return c.cli.WriteJSON(wire.FrameListSessions, wire.ListSessionsReq{})
 }
 
 // WaitForData reads from the stream until the accumulated DATA bytes
@@ -314,7 +292,7 @@ func (c *Client) readLoop() {
 			return
 		default:
 		}
-		ft, payload, err := wire.ReadFrame(c.conn)
+		ft, payload, err := c.cli.ReadFrame()
 		if err != nil {
 			// When Close was called explicitly, drop the error — it
 			// is just the read-side seeing our own conn.Close. In any

--- a/internal/wire/testclient/client.go
+++ b/internal/wire/testclient/client.go
@@ -85,14 +85,12 @@ func (c *Client) Handshake(hello wire.Hello) (wire.Welcome, error) {
 	if hello.Client == "" {
 		hello.Client = "testclient/0"
 	}
-	// wire.Handshake reads synchronously; bound it with a deadline so a
-	// mute daemon fails the test in 5s instead of hanging it.
-	_ = c.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	// wire.Handshake bounds the WELCOME wait itself, so a mute daemon
+	// fails the test instead of hanging it.
 	cli, err := wire.Handshake(c.conn, hello)
 	if err != nil {
 		return wire.Welcome{}, fmt.Errorf("testclient: %w", err)
 	}
-	_ = c.conn.SetReadDeadline(time.Time{})
 	c.cli = cli
 	go c.readLoop()
 	return cli.Welcome(), nil

--- a/internal/wire/testclient/client.go
+++ b/internal/wire/testclient/client.go
@@ -38,6 +38,8 @@ import (
 //     the Begin → DATA → Done replay envelope.
 //   - sessions / projects: control-mode broadcast channels.
 //   - snaps:    one-shot frames (WELCOME, ERROR, SESSIONS, PROJECTS).
+// Write and Await methods require a successful Handshake first; they
+// panic on a client that has only been dialed.
 type Client struct {
 	conn net.Conn        // raw conn; owned by cli after Handshake
 	cli  *wire.Client    // shared protocol client; nil until Handshake


### PR DESCRIPTION
Phase 3a of `docs/analysis/2026-07-19-improvement-plan` — the plan's top-ranked remaining item.

## Problem
The daemon wire-client logic (dial+HELLO/WELCOME handshake, write-mutex conn wrapper, control/attach read-loop dispatch) existed **three times**: `cmd/hivegui/app.go`, `cmd/hived-ws-bridge/main.go`, and `internal/wire/testclient`. The two production copies had zero tests, and protocol changes needed three synchronized edits.

## Change
- **`internal/wire.Client`** — the one shared client: handshake (closes conn on failure, fills protocol version, preserves non-zero versions for rejection tests), mutex-serialized `WriteJSON`/`WriteFrame`, single-reader `ReadFrame`, mutex-free `Close`.
- **`wire.ControlEventName` / `wire.AttachEventName`** — the frame→UI-event dispatch tables. GUI (Wails events) and bridge (WS notifications) emit identical event names, so a new fanout frame is added once and both pick it up.
- GUI/bridge keep only app-specific glue: spawn-on-miss dialing, emit targets, the attach burst probe. `testclient` keeps its public API and channel demux but delegates the protocol layer.

## Test-first, per the plan
- New `internal/wire/client_test.go`: handshake happy/refusal/unexpected-frame/deadline paths + a concurrency test proving frames can't interleave mid-write.
- `testclient`'s existing tests and the `cmd/hived` Go e2e suite ran **unchanged** as the characterization net.

## Validation
- `go build/vet/test ./...` green
- `go test -tags=e2e ./cmd/hived/...` against a real spawned hived: green
- Playwright **real** suite (real hived through the migrated bridge): green (2 passed, 10 skipped — matches main's phase-1 quarantine state)

Net: production code −12 lines with the three copies collapsed into one 130-line implementation; +190 lines of new unit tests for the previously untested client logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Unified transport handling across the web bridge, GUI, and client tools with a shared wire-mode protocol client for reliable JSON/frame messaging.
  * Standardized the handshake flow (including timeout behavior and daemon refusal messaging) and improved control/session event dispatch using consistent event-name mapping.
  * Updated session resizing and lifecycle handling to use the negotiated connection context.
* **Bug Fixes**
  * Improved connection cleanup and shutdown behavior on setup failures.
  * Ensured concurrent outgoing frames do not interleave.
* **Tests**
  * Added coverage for handshake edge cases, event-name mapping, and concurrent write integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->