### PR TITLE
registry: split registry.go + thread caller ctx through git work (improvement plan 3b + 3d)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -113,7 +113,9 @@ func New(cfg Config) (*Daemon, error) {
 	// Bootstrap session only if the registry is still empty after revive
 	// (i.e. truly first run on this machine).
 	if len(reg.List()) == 0 && bootstrapWanted(cfg.BootstrapSession) {
-		_, err := reg.Create(wire.CreateSpec{
+		// Pre-Run: no daemon context exists yet, so this one-shot
+		// bootstrap create is rooted at Background.
+		_, err := reg.Create(context.Background(), wire.CreateSpec{
 			Name:  "main",
 			Cols:  cfg.BootstrapSession.Cols,
 			Rows:  cfg.BootstrapSession.Rows,
@@ -153,7 +155,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 			log.Printf("hived: accept: %v", err)
 			continue
 		}
-		go d.serve(conn)
+		go d.serve(ctx, conn)
 	}
 }
 
@@ -193,8 +195,10 @@ func (d *Daemon) Close() error {
 	return nil
 }
 
-// serve dispatches on the HELLO mode.
-func (d *Daemon) serve(conn net.Conn) {
+// serve dispatches on the HELLO mode. ctx is the daemon's Run context
+// (not a per-connection one): registry work it reaches — the post-spawn
+// agent-session-id capture in particular — outlives this connection.
+func (d *Daemon) serve(ctx context.Context, conn net.Conn) {
 	d.mu.Lock()
 	if d.clients == nil {
 		d.mu.Unlock()
@@ -236,7 +240,7 @@ func (d *Daemon) serve(conn net.Conn) {
 
 	switch hello.Mode {
 	case wire.ModeControl:
-		d.serveControl(conn)
+		d.serveControl(ctx, conn)
 	case wire.ModeAttach:
 		d.serveAttach(conn, hello.SessionID)
 	case wire.ModeCreate:
@@ -244,7 +248,7 @@ func (d *Daemon) serve(conn net.Conn) {
 		if hello.Create != nil {
 			spec = *hello.Create
 		}
-		e, err := d.reg.Create(spec)
+		e, err := d.reg.Create(ctx, spec)
 		if err != nil {
 			_ = wire.WriteJSON(conn, wire.FrameError, wire.Error{Code: "create_failed", Message: err.Error()})
 			return
@@ -259,7 +263,7 @@ func (d *Daemon) serve(conn net.Conn) {
 }
 
 // serveControl handles a session-management connection.
-func (d *Daemon) serveControl(conn net.Conn) {
+func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 	if err := wire.WriteJSON(conn, wire.FrameWelcome, wire.Welcome{
 		Version: wire.PROTOCOL_VERSION,
 		BuildID: buildinfo.BuildID(),
@@ -339,7 +343,7 @@ func (d *Daemon) serveControl(conn net.Conn) {
 				sendError("bad_payload", err.Error())
 				continue
 			}
-			if _, err := d.reg.Create(spec); err != nil {
+			if _, err := d.reg.Create(ctx, spec); err != nil {
 				sendError("create_failed", err.Error())
 			}
 		case wire.FrameKillSession:

--- a/internal/registry/colors.go
+++ b/internal/registry/colors.go
@@ -1,0 +1,42 @@
+package registry
+
+import (
+	"math/rand/v2"
+	"slices"
+)
+
+// colorPalette is the curated set of "good" hues used for auto-
+// assigned project and session colors. All are readable as text on
+// the dark sidebar. Users can override via Update.
+var colorPalette = []string{
+	"#f59e0b", // amber
+	"#f97316", // orange
+	"#ef4444", // red
+	"#ec4899", // pink
+	"#d946ef", // fuchsia
+	"#a855f7", // purple
+	"#8b5cf6", // violet
+	"#6366f1", // indigo
+	"#3b82f6", // sky
+	"#06b6d4", // cyan
+	"#14b8a6", // teal
+	"#10b981", // emerald
+	"#84cc16", // lime
+	"#eab308", // yellow
+}
+
+// pickColor returns a random palette color, excluding any entry
+// listed in avoid. Uses math/rand/v2 top-level helpers so it's
+// goroutine-safe without needing a lock at the call site.
+func pickColor(avoid ...string) string {
+	n := len(colorPalette)
+	idx := rand.IntN(n)
+	for i := range n {
+		c := colorPalette[(idx+i)%n]
+		if !slices.Contains(avoid, c) {
+			return c
+		}
+	}
+	// Every palette entry is in avoid — fall back to a uniform pick.
+	return colorPalette[idx]
+}

--- a/internal/registry/create.go
+++ b/internal/registry/create.go
@@ -49,7 +49,8 @@ type createPlan struct {
 // the session starts so a crash mid-Create still surfaces the entry.
 //
 // ctx bounds the git and post-spawn-capture work; it must be
-// daemon-scoped, not per-connection (see attachSessionLocked).
+// daemon-scoped, not per-connection (see
+// startAgentSessionIDCaptureLocked).
 func (r *Registry) Create(ctx context.Context, spec wire.CreateSpec) (*Entry, error) {
 	p := r.resolveCreateTarget(spec)
 	r.planWorktreeAndName(spec, &p)
@@ -81,13 +82,16 @@ func (r *Registry) Create(ctx context.Context, spec wire.CreateSpec) (*Entry, er
 		// or kill it. Store the error so the GUI can surface it.
 		r.mu.Lock()
 		e.LastError = err.Error()
+		info := e.Info()
 		r.mu.Unlock()
-		r.broadcast(wire.SessionEventAdded, e.Info())
+		r.broadcast(wire.SessionEventAdded, info)
 		return e, err
 	}
 
-	r.attachSession(ctx, e, sess, spec, p)
-	r.broadcast(wire.SessionEventAdded, e.Info())
+	// Snapshot under the lock: attachSession starts the capture
+	// goroutine, which mutates AgentSessionID on this same entry.
+	info := r.attachSession(ctx, e, sess, spec, p)
+	r.broadcast(wire.SessionEventAdded, info)
 	go r.watchSessionExit(p.id, sess)
 	return e, nil
 }
@@ -280,8 +284,8 @@ func (r *Registry) renameAfterWorktreeFailure(e *Entry, spec wire.CreateSpec) {
 
 // attachSession binds the freshly spawned PTY to the entry, records
 // the worktree and agent-session ids, and kicks off the post-spawn
-// capture. Takes r.mu.
-func (r *Registry) attachSession(ctx context.Context, e *Entry, sess *session.Session, spec wire.CreateSpec, p createPlan) {
+// capture, and returns the info snapshot to broadcast. Takes r.mu.
+func (r *Registry) attachSession(ctx context.Context, e *Entry, sess *session.Session, spec wire.CreateSpec, p createPlan) wire.SessionInfo {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -313,6 +317,7 @@ func (r *Registry) attachSession(ctx context.Context, e *Entry, sess *session.Se
 	// caller-chosen ids (Codex). The cancel func is stored so
 	// watchSessionExit can stop the poll if the session dies first.
 	r.startAgentSessionIDCaptureLocked(ctx, e, p.cwd)
+	return e.Info()
 }
 
 // startAgentSessionIDCaptureLocked launches the per-agent capture

--- a/internal/registry/create.go
+++ b/internal/registry/create.go
@@ -1,0 +1,361 @@
+package registry
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/lucascaro/hive/internal/agent"
+	"github.com/lucascaro/hive/internal/session"
+	"github.com/lucascaro/hive/internal/wire"
+	"github.com/lucascaro/hive/internal/worktree"
+)
+
+// createPlan carries values resolved by one step of Create into the
+// next. Create's lock/unlock boundaries are load-bearing (a concurrent
+// KillProject can invalidate projectID across one; the PTY fork and
+// `git worktree add` must not run under r.mu), so every step below
+// either takes r.mu for its whole body or never takes it at all.
+type createPlan struct {
+	id        string
+	projectID string
+	color     string
+	cwd       string
+
+	// adoptedPath/adoptedBranch are set when cwd already lives in a
+	// worktree owned by a sibling session in the same project (e.g. ⌘P
+	// duplicate): the new entry joins that worktree instead of creating
+	// one.
+	adoptedPath   string
+	adoptedBranch string
+
+	// wtPath/wtBranch are the worktree this session should end up in,
+	// pre-resolved before naming and cleared if `git worktree add`
+	// later fails.
+	wtPath   string
+	wtBranch string
+
+	name string
+	// nameFromBranch records whether name was derived from wtBranch. If
+	// `git worktree add` later fails we rename to a random label so the
+	// persisted name doesn't claim a worktree that doesn't exist.
+	nameFromBranch bool
+}
+
+// Create adds a new session and starts it. Metadata persists before
+// the session starts so a crash mid-Create still surfaces the entry.
+//
+// ctx bounds the git and post-spawn-capture work; it must be
+// daemon-scoped, not per-connection (see attachSessionLocked).
+func (r *Registry) Create(ctx context.Context, spec wire.CreateSpec) (*Entry, error) {
+	p := r.resolveCreateTarget(spec)
+	r.planWorktreeAndName(spec, &p)
+
+	e, err := r.insertEntry(spec, p)
+	if err != nil {
+		return nil, err
+	}
+
+	// Everything below runs outside the lock so neither `git worktree
+	// add` nor the PTY fork blocks the registry.
+	cmd := resolveAgentCmd(spec, p.id)
+	r.materializeWorktree(ctx, &p)
+	if p.nameFromBranch && p.wtBranch == "" {
+		r.renameAfterWorktreeFailure(e, spec)
+	}
+
+	sess, err := startSession(session.Options{
+		Shell: spec.Shell,
+		Cmd:   cmd,
+		Cwd:   p.cwd,
+		Cols:  spec.Cols,
+		Rows:  spec.Rows,
+	})
+	if err != nil {
+		log.Printf("registry: session.Start failed for %s (agent=%q cmd=%v): %v",
+			e.ID, spec.Agent, cmd, err)
+		// Strand the metadata as a dead entry. The user can recreate
+		// or kill it. Store the error so the GUI can surface it.
+		r.mu.Lock()
+		e.LastError = err.Error()
+		r.mu.Unlock()
+		r.broadcast(wire.SessionEventAdded, e.Info())
+		return e, err
+	}
+
+	r.attachSession(ctx, e, sess, spec, p)
+	r.broadcast(wire.SessionEventAdded, e.Info())
+	go r.watchSessionExit(p.id, sess)
+	return e, nil
+}
+
+// resolveCreateTarget picks the id, owning project, color and cwd for
+// a new session, and detects an adoptable sibling worktree. Takes r.mu.
+func (r *Registry) resolveCreateTarget(spec wire.CreateSpec) createPlan {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p := createPlan{id: uuid.NewString()}
+	// Resolve owning project first so we can avoid its color when
+	// auto-picking the session color (otherwise the gradient could
+	// collapse to a flat hue).
+	p.projectID = spec.ProjectID
+	if p.projectID == "" {
+		p.projectID = r.defaultProjectIDLocked()
+	}
+	var projectColor string
+	if proj, ok := r.projects[p.projectID]; ok {
+		projectColor = proj.Color
+	}
+	// Color is reserved for project/session identity; agent identity
+	// is conveyed by the badge/icon. So skip the agent-default tier
+	// and pick a random palette color when the caller didn't choose.
+	p.color = spec.Color
+	if p.color == "" {
+		p.color = pickColor(r.lastSessionColor, projectColor)
+		r.lastSessionColor = p.color
+	}
+	// Resolve cwd up front (under the same lock) so we can decide on a
+	// worktree branch BEFORE naming the session — the session name is
+	// derived from the worktree branch when one is in play, so the
+	// user can find the worktree directory from the session label.
+	p.cwd = spec.Cwd
+	if p.cwd == "" {
+		if proj, ok := r.projects[p.projectID]; ok && proj.Cwd != "" {
+			p.cwd = proj.Cwd
+		}
+	}
+	// Detect when cwd already lives in a worktree owned by another
+	// session in the same project (e.g. ⌘P duplicate). The new entry
+	// adopts that worktree's path+branch so the sidebar shows the
+	// worktree badge and Kill can keep the worktree alive until the
+	// last session in it goes away.
+	if !spec.UseWorktree && p.cwd != "" {
+		for _, other := range r.entries {
+			if other.ProjectID == p.projectID && other.WorktreePath != "" && other.WorktreePath == p.cwd {
+				p.adoptedPath = other.WorktreePath
+				p.adoptedBranch = other.WorktreeBranch
+				break
+			}
+		}
+	}
+	return p
+}
+
+// planWorktreeAndName pre-resolves the worktree branch+path so the
+// session name can match the worktree directory, then picks the name.
+// ResolveBranchAndPath only picks a free name; the actual `git worktree
+// add` happens in materializeWorktree. Does not take r.mu.
+func (r *Registry) planWorktreeAndName(spec wire.CreateSpec, p *createPlan) {
+	if p.adoptedPath != "" {
+		p.wtPath, p.wtBranch = p.adoptedPath, p.adoptedBranch
+	}
+	if spec.UseWorktree && p.cwd != "" && worktree.IsGitRepo(p.cwd) {
+		if root, err := worktree.Root(p.cwd); err == nil {
+			if b, path, rerr := worktree.ResolveBranchAndPath(root, spec.Branch); rerr == nil {
+				p.wtBranch, p.wtPath = b, path
+			} else {
+				log.Printf("registry: worktree.ResolveBranchAndPath: %v", rerr)
+			}
+		}
+	}
+
+	p.name = spec.Name
+	if p.name != "" {
+		return
+	}
+	if p.wtBranch == "" {
+		p.name = agent.RandomName(agent.ID(spec.Agent))
+		return
+	}
+	// Tie the session name to the worktree directory so the user can
+	// find the worktree from the session label. Slashes (e.g.
+	// `feature/foo`) get folded to `-` so the name is safe to use in
+	// paths and shell-quoted contexts.
+	suffix := spec.Agent
+	if suffix == "" {
+		suffix = "shell"
+	}
+	p.name = strings.ReplaceAll(p.wtBranch, "/", "-") + " " + suffix
+	p.nameFromBranch = true
+}
+
+// insertEntry registers the entry and persists it before the session
+// starts, rolling both back if either write fails. Takes r.mu.
+func (r *Registry) insertEntry(spec wire.CreateSpec, p createPlan) (*Entry, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Re-validate projectID after the unlock window above: a concurrent
+	// KillProject could have removed it. Fall back to the default
+	// project rather than persisting a dangling reference.
+	projectID := p.projectID
+	if _, ok := r.projects[projectID]; !ok {
+		projectID = r.defaultProjectIDLocked()
+	}
+	e := &Entry{
+		ID: p.id, Name: p.name, Color: p.color,
+		Order: len(r.order), Created: time.Now().UTC(),
+		Agent: spec.Agent, ProjectID: projectID,
+	}
+	r.entries[p.id] = e
+	r.order = append(r.order, p.id)
+	rollback := func() {
+		delete(r.entries, p.id)
+		r.order = r.order[:len(r.order)-1]
+	}
+	if err := r.persistEntryLocked(e); err != nil {
+		rollback()
+		return nil, err
+	}
+	if err := r.persistIndexLocked(); err != nil {
+		rollback()
+		return nil, err
+	}
+	return e, nil
+}
+
+// resolveAgentCmd returns the argv to spawn. If the spec names an
+// agent (and no explicit Cmd), look up its default command and use it.
+func resolveAgentCmd(spec wire.CreateSpec, id string) []string {
+	cmd := spec.Cmd
+	if len(cmd) > 0 || spec.Agent == "" {
+		return cmd
+	}
+	def, ok := agent.Get(agent.ID(spec.Agent))
+	if !ok || len(def.Cmd) == 0 {
+		return cmd
+	}
+	cmd = def.Cmd
+	// Pin the agent's conversation to our entry id so Restart can
+	// resume by id even when sibling sessions share this cwd. Skipped
+	// when the caller passed an explicit spec.Cmd (we don't mutate
+	// user-supplied argv).
+	if def.SessionIDFlag != "" {
+		cmd = append(append([]string(nil), cmd...), def.SessionIDFlag, id)
+	}
+	return cmd
+}
+
+// materializeWorktree runs the heavy `git worktree add` and promotes
+// the plan's cwd into the new worktree. Failure is non-fatal — the
+// session falls back to the plain project cwd. Aborting create on
+// worktree failure would block users on marginal repos (shallow
+// clones, sandbox restrictions, slow filesystems). Does not take r.mu.
+func (r *Registry) materializeWorktree(ctx context.Context, p *createPlan) {
+	// Skip the create when we're adopting an existing worktree from a
+	// sibling session — the directory is already on disk and `git
+	// worktree add` would fail.
+	if p.wtBranch == "" || p.adoptedPath != "" {
+		return
+	}
+	root, err := worktree.Root(p.cwd)
+	if err != nil {
+		p.wtPath, p.wtBranch = "", ""
+		return
+	}
+	if cerr := worktree.CreateWorktree(ctx, root, p.wtBranch, p.wtPath); cerr != nil {
+		log.Printf("registry: worktree create failed (falling back to plain session): %v", cerr)
+		p.wtPath, p.wtBranch = "", ""
+		return
+	}
+	p.cwd = p.wtPath
+	worktree.EnsureGitignore(root)
+	log.Printf("registry: created worktree %s on branch %s", p.wtPath, p.wtBranch)
+}
+
+// renameAfterWorktreeFailure relabels an entry whose name was derived
+// from a worktree branch that failed to materialize — the persisted
+// name would otherwise lie about reality ("feature-foo claude" with no
+// worktree). Takes r.mu.
+func (r *Registry) renameAfterWorktreeFailure(e *Entry, spec wire.CreateSpec) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e.Name = agent.RandomName(agent.ID(spec.Agent))
+	r.persistEntryLoggedLocked(e, "create (rename fallback)")
+}
+
+// attachSession binds the freshly spawned PTY to the entry, records
+// the worktree and agent-session ids, and kicks off the post-spawn
+// capture. Takes r.mu.
+func (r *Registry) attachSession(ctx context.Context, e *Entry, sess *session.Session, spec wire.CreateSpec, p createPlan) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// The session.Session uses its own UUID; we override with the
+	// registry id so the registry id is the public identity.
+	sess.ID = p.id
+	e.sess = sess
+	if p.wtPath != "" {
+		e.WorktreePath = p.wtPath
+		e.WorktreeBranch = p.wtBranch
+	}
+	// Pin the agent session id when the agent's first-launch flag let
+	// us choose it (Claude). Persist alongside the worktree fields
+	// above so the entry on disk matches what we just spawned. Skip
+	// when the caller passed an explicit spec.Cmd — we never injected
+	// SessionIDFlag in that branch (we don't mutate user-supplied
+	// argv), so the agent did NOT record its conversation under our
+	// id. Pretending otherwise would make Restart resume the wrong
+	// conversation (or fail to find one).
+	if len(spec.Cmd) == 0 {
+		if def, ok := agent.Get(agent.ID(spec.Agent)); ok && def.SessionIDFlag != "" {
+			e.AgentSessionID = p.id
+		}
+	}
+	if p.wtPath != "" || e.AgentSessionID != "" {
+		r.persistEntryLoggedLocked(e, "create")
+	}
+	// Kick off the post-spawn capture for agents that don't support
+	// caller-chosen ids (Codex). The cancel func is stored so
+	// watchSessionExit can stop the poll if the session dies first.
+	r.startAgentSessionIDCaptureLocked(ctx, e, p.cwd)
+}
+
+// startAgentSessionIDCaptureLocked launches the per-agent capture
+// goroutine when the agent's Def opts into post-spawn id capture.
+// Caller must hold r.mu so the cancel func is wired before
+// watchSessionExit can race with it.
+//
+// ctx must be daemon-scoped: this goroutine outlives Create, so a
+// per-connection ctx would silently kill Codex id capture whenever a
+// create-mode client disconnects within the timeout.
+func (r *Registry) startAgentSessionIDCaptureLocked(ctx context.Context, e *Entry, cwd string) {
+	def, ok := agent.Get(agent.ID(e.Agent))
+	if !ok || def.CaptureSessionIDFn == nil {
+		return
+	}
+	// 30s is a generous upper bound. Codex writes the rollout file
+	// well within a second of spawn in practice; the long tail is
+	// only for sandboxed/cold-start scenarios.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	e.captureCancel = cancel
+	id := e.ID
+	go func() {
+		defer cancel()
+		captured, err := def.CaptureSessionIDFn(ctx, cwd, time.Now())
+		if err != nil || captured == "" {
+			return
+		}
+		r.mu.Lock()
+		e2, ok := r.entries[id]
+		if !ok {
+			r.mu.Unlock()
+			return
+		}
+		// If the session already exited and was reaped, or another
+		// path has already populated AgentSessionID, leave it alone.
+		if e2.AgentSessionID != "" {
+			r.mu.Unlock()
+			return
+		}
+		e2.AgentSessionID = captured
+		r.persistEntryLoggedLocked(e2, "agent-session-id capture")
+		info := e2.Info()
+		r.mu.Unlock()
+		r.broadcast(wire.SessionEventUpdated, info)
+	}()
+}

--- a/internal/registry/custom_agent_test.go
+++ b/internal/registry/custom_agent_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -35,7 +36,7 @@ func TestCreateResolvesCustomAgentCmd(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	if _, err := r.Create(wire.CreateSpec{
+	if _, err := r.Create(context.Background(), wire.CreateSpec{
 		Name: "lite", Agent: "claude-lite", Shell: "/bin/bash",
 	}); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -63,7 +64,7 @@ func TestReviveResolvesCustomAgentFromPersistedID(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{Name: "t1", Agent: "mytool", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "t1", Agent: "mytool", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestRestartCustomAgentFallsBackToCmd(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{Name: "t1", Agent: "mytool", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "t1", Agent: "mytool", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -130,7 +131,7 @@ func TestCreateWithUnknownAgentFallsBackToShell(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	if _, err := r.Create(wire.CreateSpec{
+	if _, err := r.Create(context.Background(), wire.CreateSpec{
 		Name: "ghost", Agent: "no-such-agent", Shell: "/bin/bash",
 	}); err != nil {
 		t.Fatalf("Create: %v", err)

--- a/internal/registry/events.go
+++ b/internal/registry/events.go
@@ -1,0 +1,58 @@
+package registry
+
+import (
+	"log"
+
+	"github.com/lucascaro/hive/internal/wire"
+)
+
+// Listener is a channel that receives SessionEvent notifications.
+type Listener chan wire.SessionEvent
+
+// ProjectListener is a channel that receives ProjectEvent.
+type ProjectListener chan wire.ProjectEvent
+
+// Subscribe returns a channel that receives every SessionEvent. The
+// returned cleanup function unsubscribes and closes the channel.
+// Slow consumers are dropped — listeners must drain promptly.
+func (r *Registry) Subscribe() (Listener, func()) {
+	// 64, not 16: Update with an order change broadcasts one event per
+	// session while holding r.mu (see renumberLocked), so a listener
+	// that's merely a beat behind on a many-session registry could
+	// overflow a small buffer and get dropped.
+	ch := make(Listener, 64)
+	r.mu.Lock()
+	r.listeners[ch] = struct{}{}
+	r.mu.Unlock()
+	return ch, func() {
+		r.mu.Lock()
+		if _, ok := r.listeners[ch]; ok {
+			delete(r.listeners, ch)
+			close(ch)
+		}
+		r.mu.Unlock()
+	}
+}
+
+func (r *Registry) broadcast(kind string, info wire.SessionInfo) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.broadcastLocked(kind, info)
+}
+
+func (r *Registry) broadcastLocked(kind string, info wire.SessionInfo) {
+	ev := wire.SessionEvent{Kind: kind, Session: info}
+	for ch := range r.listeners {
+		select {
+		case ch <- ev:
+		default:
+			// Listener can't keep up. Dropping it silently would leave
+			// the client permanently desynced with no trace — warn so
+			// "the GUI went stale" can be correlated with this moment.
+			log.Printf("registry: dropping slow session-event listener (buffer %d full, %d listeners); client is desynced until it resubscribes",
+				cap(ch), len(r.listeners))
+			delete(r.listeners, ch)
+			close(ch)
+		}
+	}
+}

--- a/internal/registry/projects_test.go
+++ b/internal/registry/projects_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"runtime"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestSessionInheritsProjectCwd(t *testing.T) {
 	skipNonPosix(t)
 	r := freshRegistry(t)
 	p, _ := r.CreateProject(wire.CreateProjectReq{Name: "p", Color: "#abc", Cwd: "/tmp"})
-	e, err := r.Create(wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
+	e, err := r.Create(context.Background(), wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create session: %v", err)
 	}
@@ -58,8 +59,8 @@ func TestKillProjectReassign(t *testing.T) {
 	def, _ := r.EnsureDefaultProject("/tmp")
 	p, _ := r.CreateProject(wire.CreateProjectReq{Name: "extra"})
 	// Two sessions in p.
-	a, _ := r.Create(wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
-	b, _ := r.Create(wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
+	a, _ := r.Create(context.Background(), wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
+	b, _ := r.Create(context.Background(), wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
 	if err := r.KillProject(p.ID, false); err != nil {
 		t.Fatalf("KillProject reassign: %v", err)
 	}
@@ -78,7 +79,7 @@ func TestKillProjectKillSessions(t *testing.T) {
 	r := freshRegistry(t)
 	_, _ = r.EnsureDefaultProject("/tmp")
 	p, _ := r.CreateProject(wire.CreateProjectReq{Name: "doomed"})
-	a, _ := r.Create(wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
+	a, _ := r.Create(context.Background(), wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
 	if err := r.KillProject(p.ID, true); err != nil {
 		t.Fatalf("KillProject killSessions: %v", err)
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,8 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/lucascaro/hive/internal/agent"
 	"github.com/lucascaro/hive/internal/session"
 	"github.com/lucascaro/hive/internal/wire"
@@ -272,269 +270,6 @@ func (r *Registry) Get(id string) *Entry {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.entries[id]
-}
-
-// Create adds a new session and starts it. Metadata persists before
-// the session starts so a crash mid-Create still surfaces the entry.
-func (r *Registry) Create(spec wire.CreateSpec) (*Entry, error) {
-	r.mu.Lock()
-	id := uuid.NewString()
-	// Resolve owning project first so we can avoid its color when
-	// auto-picking the session color (otherwise the gradient could
-	// collapse to a flat hue).
-	projectID := spec.ProjectID
-	if projectID == "" {
-		projectID = r.defaultProjectIDLocked()
-	}
-	var projectColor string
-	if p, ok := r.projects[projectID]; ok {
-		projectColor = p.Color
-	}
-	// Color is reserved for project/session identity; agent identity
-	// is conveyed by the badge/icon. So skip the agent-default tier
-	// and pick a random palette color when the caller didn't choose.
-	color := spec.Color
-	if color == "" {
-		color = pickColor(r.lastSessionColor, projectColor)
-		r.lastSessionColor = color
-	}
-	// Resolve cwd up front (under the same lock) so we can decide on a
-	// worktree branch BEFORE naming the session — the session name is
-	// derived from the worktree branch when one is in play, so the
-	// user can find the worktree directory from the session label.
-	cwd := spec.Cwd
-	if cwd == "" {
-		if p, ok := r.projects[projectID]; ok && p.Cwd != "" {
-			cwd = p.Cwd
-		}
-	}
-	// Detect when cwd already lives in a worktree owned by another
-	// session in the same project (e.g. ⌘P duplicate). The new entry
-	// adopts that worktree's path+branch so the sidebar shows the
-	// worktree badge and Kill can keep the worktree alive until the
-	// last session in it goes away.
-	var adoptedPath, adoptedBranch string
-	if !spec.UseWorktree && cwd != "" {
-		for _, other := range r.entries {
-			if other.ProjectID == projectID && other.WorktreePath != "" && other.WorktreePath == cwd {
-				adoptedPath = other.WorktreePath
-				adoptedBranch = other.WorktreeBranch
-				break
-			}
-		}
-	}
-	r.mu.Unlock()
-
-	// Pre-resolve the worktree branch+path so the session name can
-	// match the worktree directory. ResolveBranchAndPath only picks a
-	// free name; the actual `git worktree add` happens further down.
-	var wtPath, wtBranch string
-	if adoptedPath != "" {
-		wtPath, wtBranch = adoptedPath, adoptedBranch
-	}
-	if spec.UseWorktree && cwd != "" && worktree.IsGitRepo(cwd) {
-		if root, err := worktree.Root(cwd); err == nil {
-			if b, p, rerr := worktree.ResolveBranchAndPath(root, spec.Branch); rerr == nil {
-				wtBranch, wtPath = b, p
-			} else {
-				log.Printf("registry: worktree.ResolveBranchAndPath: %v", rerr)
-			}
-		}
-	}
-
-	name := spec.Name
-	// nameFromBranch records whether the name was derived from the
-	// pre-resolved worktree branch. If `git worktree add` later fails
-	// we'll rename to a random label so the persisted name doesn't
-	// claim a worktree that doesn't exist.
-	nameFromBranch := false
-	if name == "" {
-		if wtBranch != "" {
-			// Tie the session name to the worktree directory so the
-			// user can find the worktree from the session label.
-			// Slashes (e.g. `feature/foo`) get folded to `-` so the
-			// name is safe to use in paths and shell-quoted contexts.
-			suffix := spec.Agent
-			if suffix == "" {
-				suffix = "shell"
-			}
-			name = strings.ReplaceAll(wtBranch, "/", "-") + " " + suffix
-			nameFromBranch = true
-		} else {
-			name = agent.RandomName(agent.ID(spec.Agent))
-		}
-	}
-
-	r.mu.Lock()
-	// Re-validate projectID after the unlock window above: a concurrent
-	// KillProject could have removed it. Fall back to the default
-	// project rather than persisting a dangling reference.
-	if _, ok := r.projects[projectID]; !ok {
-		projectID = r.defaultProjectIDLocked()
-	}
-	e := &Entry{
-		ID: id, Name: name, Color: color,
-		Order: len(r.order), Created: time.Now().UTC(),
-		Agent: spec.Agent, ProjectID: projectID,
-	}
-	r.entries[id] = e
-	r.order = append(r.order, id)
-	if err := r.persistEntryLocked(e); err != nil {
-		delete(r.entries, id)
-		r.order = r.order[:len(r.order)-1]
-		r.mu.Unlock()
-		return nil, err
-	}
-	if err := r.persistIndexLocked(); err != nil {
-		delete(r.entries, id)
-		r.order = r.order[:len(r.order)-1]
-		r.mu.Unlock()
-		return nil, err
-	}
-	r.mu.Unlock()
-
-	// Start the session outside the lock so the PTY fork doesn't block
-	// the registry. If the spec names an agent (and no explicit Cmd),
-	// look up its default command and use it.
-	cmd := spec.Cmd
-	if len(cmd) == 0 && spec.Agent != "" {
-		if def, ok := agent.Get(agent.ID(spec.Agent)); ok && len(def.Cmd) > 0 {
-			cmd = def.Cmd
-			// Pin the agent's conversation to our entry id so Restart
-			// can resume by id even when sibling sessions share this
-			// cwd. Skipped when the caller passed an explicit spec.Cmd
-			// (we don't mutate user-supplied argv).
-			if def.SessionIDFlag != "" {
-				cmd = append(append([]string(nil), cmd...), def.SessionIDFlag, id)
-			}
-		}
-	}
-
-	// Now actually create the worktree (heavy `git worktree add`).
-	// Failure here is non-fatal — the session falls back to the plain
-	// project cwd. Aborting create on worktree failure would block
-	// users on marginal repos (shallow clones, sandbox restrictions,
-	// slow filesystems).
-	// Skip the create when we're adopting an existing worktree from a
-	// sibling session — the directory is already on disk and `git
-	// worktree add` would fail.
-	if wtBranch != "" && adoptedPath == "" {
-		if root, err := worktree.Root(cwd); err == nil {
-			if cerr := worktree.CreateWorktree(root, wtBranch, wtPath); cerr != nil {
-				log.Printf("registry: worktree create failed (falling back to plain session): %v", cerr)
-				wtPath, wtBranch = "", ""
-			} else {
-				cwd = wtPath
-				worktree.EnsureGitignore(root)
-				log.Printf("registry: created worktree %s on branch %s", wtPath, wtBranch)
-			}
-		} else {
-			wtPath, wtBranch = "", ""
-		}
-	}
-	// If the name was derived from a worktree branch but the worktree
-	// failed to materialize, the persisted name would lie about reality
-	// ("feature-foo claude" with no worktree). Rename to a random label
-	// and re-persist so the session label matches what actually exists.
-	if nameFromBranch && wtBranch == "" {
-		r.mu.Lock()
-		e.Name = agent.RandomName(agent.ID(spec.Agent))
-		r.persistEntryLoggedLocked(e, "create (rename fallback)")
-		r.mu.Unlock()
-	}
-
-	sess, err := startSession(session.Options{
-		Shell: spec.Shell,
-		Cmd:   cmd,
-		Cwd:   cwd,
-		Cols:  spec.Cols,
-		Rows:  spec.Rows,
-	})
-	if err != nil {
-		log.Printf("registry: session.Start failed for %s (agent=%q cmd=%v): %v",
-			e.ID, spec.Agent, cmd, err)
-		// Strand the metadata as a dead entry. The user can recreate
-		// or kill it. Store the error so the GUI can surface it.
-		r.mu.Lock()
-		e.LastError = err.Error()
-		r.mu.Unlock()
-		r.broadcast(wire.SessionEventAdded, e.Info())
-		return e, err
-	}
-	r.mu.Lock()
-	// The session.Session uses its own UUID; we override with the
-	// registry id so the registry id is the public identity.
-	sess.ID = id
-	e.sess = sess
-	if wtPath != "" {
-		e.WorktreePath = wtPath
-		e.WorktreeBranch = wtBranch
-	}
-	// Pin the agent session id when the agent's first-launch flag let
-	// us choose it (Claude). Persist alongside the worktree fields
-	// above so the entry on disk matches what we just spawned. Skip
-	// when the caller passed an explicit spec.Cmd — we never injected
-	// SessionIDFlag in that branch (we don't mutate user-supplied
-	// argv), so the agent did NOT record its conversation under our
-	// id. Pretending otherwise would make Restart resume the wrong
-	// conversation (or fail to find one).
-	if len(spec.Cmd) == 0 {
-		if def, ok := agent.Get(agent.ID(spec.Agent)); ok && def.SessionIDFlag != "" {
-			e.AgentSessionID = id
-		}
-	}
-	if wtPath != "" || e.AgentSessionID != "" {
-		r.persistEntryLoggedLocked(e, "create")
-	}
-	// Kick off the post-spawn capture for agents that don't support
-	// caller-chosen ids (Codex). The cancel func is stored so
-	// watchSessionExit can stop the poll if the session dies first.
-	r.startAgentSessionIDCaptureLocked(e, cwd)
-	r.mu.Unlock()
-	r.broadcast(wire.SessionEventAdded, e.Info())
-	go r.watchSessionExit(id, sess)
-	return e, nil
-}
-
-// startAgentSessionIDCaptureLocked launches the per-agent capture
-// goroutine when the agent's Def opts into post-spawn id capture.
-// Caller must hold r.mu so the cancel func is wired before
-// watchSessionExit can race with it.
-func (r *Registry) startAgentSessionIDCaptureLocked(e *Entry, cwd string) {
-	def, ok := agent.Get(agent.ID(e.Agent))
-	if !ok || def.CaptureSessionIDFn == nil {
-		return
-	}
-	// 30s is a generous upper bound. Codex writes the rollout file
-	// well within a second of spawn in practice; the long tail is
-	// only for sandboxed/cold-start scenarios.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	e.captureCancel = cancel
-	id := e.ID
-	go func() {
-		defer cancel()
-		captured, err := def.CaptureSessionIDFn(ctx, cwd, time.Now())
-		if err != nil || captured == "" {
-			return
-		}
-		r.mu.Lock()
-		e2, ok := r.entries[id]
-		if !ok {
-			r.mu.Unlock()
-			return
-		}
-		// If the session already exited and was reaped, or another
-		// path has already populated AgentSessionID, leave it alone.
-		if e2.AgentSessionID != "" {
-			r.mu.Unlock()
-			return
-		}
-		e2.AgentSessionID = captured
-		r.persistEntryLoggedLocked(e2, "agent-session-id capture")
-		info := e2.Info()
-		r.mu.Unlock()
-		r.broadcast(wire.SessionEventUpdated, info)
-	}()
 }
 
 // Revive starts a fresh process on the existing entry. No-op if the
@@ -975,6 +710,14 @@ func (r *Registry) renumberLocked() {
 	}
 }
 
+// ponytail: disk I/O runs under r.mu, so persist latency blocks every
+// session op; renumberLocked makes it len(order) writes per reorder,
+// not one. Not fixed by snapshot-under-lock + write-outside: r.mu is
+// also what serializes the writes, so releasing it before the write
+// lets a slow writer land a stale snapshot on top of a newer one.
+// Upgrade path if it ever hurts: a persist-ordering lock acquired
+// under r.mu and released after the write, threaded through every
+// *Locked persist call site.
 func (r *Registry) persistEntryLocked(e *Entry) error {
 	path := filepath.Join(SessionsDir(r.stateDir), e.ID, "session.json")
 	return writeJSON(path, MetaFile{
@@ -1033,4 +776,3 @@ func (r *Registry) persistProjectIndexLoggedLocked(op string) {
 		log.Printf("registry: %s: persist project index failed (on-disk order now stale): %v", op, err)
 	}
 }
-

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"slices"
@@ -114,9 +113,6 @@ func (e *Entry) Info() wire.SessionInfo {
 	}
 }
 
-// Listener is a channel that receives SessionEvent notifications.
-type Listener chan wire.SessionEvent
-
 // Registry is the daemon-side authoritative store of sessions and
 // the projects they belong to.
 type Registry struct {
@@ -142,9 +138,6 @@ type Registry struct {
 	// streams without filtering.
 	projectListeners map[ProjectListener]struct{}
 }
-
-// ProjectListener is a channel that receives ProjectEvent.
-type ProjectListener chan wire.ProjectEvent
 
 // Open creates or loads a Registry rooted at stateDir. Existing
 // metadata on disk is loaded; live sessions are not auto-started.
@@ -917,28 +910,6 @@ func (r *Registry) Update(req wire.UpdateSessionReq) (*Entry, error) {
 	return e, nil
 }
 
-// Subscribe returns a channel that receives every SessionEvent. The
-// returned cleanup function unsubscribes and closes the channel.
-// Slow consumers are dropped — listeners must drain promptly.
-func (r *Registry) Subscribe() (Listener, func()) {
-	// 64, not 16: Update with an order change broadcasts one event per
-	// session while holding r.mu (see renumberLocked), so a listener
-	// that's merely a beat behind on a many-session registry could
-	// overflow a small buffer and get dropped.
-	ch := make(Listener, 64)
-	r.mu.Lock()
-	r.listeners[ch] = struct{}{}
-	r.mu.Unlock()
-	return ch, func() {
-		r.mu.Lock()
-		if _, ok := r.listeners[ch]; ok {
-			delete(r.listeners, ch)
-			close(ch)
-		}
-		r.mu.Unlock()
-	}
-}
-
 // Close terminates every live session and clears listeners. The on-disk
 // metadata is preserved.
 func (r *Registry) Close() error {
@@ -1063,61 +1034,3 @@ func (r *Registry) persistProjectIndexLoggedLocked(op string) {
 	}
 }
 
-func (r *Registry) broadcast(kind string, info wire.SessionInfo) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.broadcastLocked(kind, info)
-}
-
-func (r *Registry) broadcastLocked(kind string, info wire.SessionInfo) {
-	ev := wire.SessionEvent{Kind: kind, Session: info}
-	for ch := range r.listeners {
-		select {
-		case ch <- ev:
-		default:
-			// Listener can't keep up. Dropping it silently would leave
-			// the client permanently desynced with no trace — warn so
-			// "the GUI went stale" can be correlated with this moment.
-			log.Printf("registry: dropping slow session-event listener (buffer %d full, %d listeners); client is desynced until it resubscribes",
-				cap(ch), len(r.listeners))
-			delete(r.listeners, ch)
-			close(ch)
-		}
-	}
-}
-
-// colorPalette is the curated set of "good" hues used for auto-
-// assigned project and session colors. All are readable as text on
-// the dark sidebar. Users can override via Update.
-var colorPalette = []string{
-	"#f59e0b", // amber
-	"#f97316", // orange
-	"#ef4444", // red
-	"#ec4899", // pink
-	"#d946ef", // fuchsia
-	"#a855f7", // purple
-	"#8b5cf6", // violet
-	"#6366f1", // indigo
-	"#3b82f6", // sky
-	"#06b6d4", // cyan
-	"#14b8a6", // teal
-	"#10b981", // emerald
-	"#84cc16", // lime
-	"#eab308", // yellow
-}
-
-// pickColor returns a random palette color, excluding any entry
-// listed in avoid. Uses math/rand/v2 top-level helpers so it's
-// goroutine-safe without needing a lock at the call site.
-func pickColor(avoid ...string) string {
-	n := len(colorPalette)
-	idx := rand.IntN(n)
-	for i := range n {
-		c := colorPalette[(idx+i)%n]
-		if !slices.Contains(avoid, c) {
-			return c
-		}
-	}
-	// Every palette entry is in avoid — fall back to a uniform pick.
-	return colorPalette[idx]
-}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"runtime"
 	"slices"
 	"sync"
@@ -62,11 +63,11 @@ func TestCreateListKill(t *testing.T) {
 	listener, unsub := r.Subscribe()
 	defer unsub()
 
-	a, err := r.Create(wire.CreateSpec{Name: "alpha", Color: "#abc", Cols: 80, Rows: 24, Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "alpha", Color: "#abc", Cols: 80, Rows: 24, Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create alpha: %v", err)
 	}
-	b, err := r.Create(wire.CreateSpec{Name: "beta", Color: "#def", Cols: 80, Rows: 24, Shell: "/bin/bash"})
+	b, err := r.Create(context.Background(), wire.CreateSpec{Name: "beta", Color: "#def", Cols: 80, Rows: 24, Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create beta: %v", err)
 	}
@@ -117,7 +118,7 @@ func TestSessionExitBroadcastsDead(t *testing.T) {
 	listener, unsub := r.Subscribe()
 	defer unsub()
 
-	a, err := r.Create(wire.CreateSpec{Name: "dying", Cols: 80, Rows: 24, Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "dying", Cols: 80, Rows: 24, Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -157,7 +158,7 @@ func TestRestart_PreservesEntry(t *testing.T) {
 	skipOnWindows(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{Name: "alpha", Color: "#abc", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "alpha", Color: "#abc", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -198,7 +199,7 @@ func TestRestart_PreservesEntry(t *testing.T) {
 func TestUpdateRenameAndColor(t *testing.T) {
 	skipOnWindows(t)
 	r := freshRegistry(t)
-	a, _ := r.Create(wire.CreateSpec{Name: "x", Shell: "/bin/bash"})
+	a, _ := r.Create(context.Background(), wire.CreateSpec{Name: "x", Shell: "/bin/bash"})
 
 	newName := "renamed"
 	newColor := "#fedcba"
@@ -220,9 +221,9 @@ func TestUpdateRenameAndColor(t *testing.T) {
 func TestReorder(t *testing.T) {
 	skipOnWindows(t)
 	r := freshRegistry(t)
-	a, _ := r.Create(wire.CreateSpec{Name: "a", Shell: "/bin/bash"})
-	b, _ := r.Create(wire.CreateSpec{Name: "b", Shell: "/bin/bash"})
-	c, _ := r.Create(wire.CreateSpec{Name: "c", Shell: "/bin/bash"})
+	a, _ := r.Create(context.Background(), wire.CreateSpec{Name: "a", Shell: "/bin/bash"})
+	b, _ := r.Create(context.Background(), wire.CreateSpec{Name: "b", Shell: "/bin/bash"})
+	c, _ := r.Create(context.Background(), wire.CreateSpec{Name: "c", Shell: "/bin/bash"})
 
 	// Move c to position 0.
 	zero := 0
@@ -247,8 +248,8 @@ func TestPersistenceAcrossOpen(t *testing.T) {
 	dir := t.TempDir()
 
 	r1, _ := Open(dir)
-	a, _ := r1.Create(wire.CreateSpec{Name: "first", Color: "#111", Shell: "/bin/bash"})
-	b, _ := r1.Create(wire.CreateSpec{Name: "second", Color: "#222", Shell: "/bin/bash"})
+	a, _ := r1.Create(context.Background(), wire.CreateSpec{Name: "first", Color: "#111", Shell: "/bin/bash"})
+	b, _ := r1.Create(context.Background(), wire.CreateSpec{Name: "second", Color: "#222", Shell: "/bin/bash"})
 	_ = a
 	_ = b
 	_ = r1.Close()
@@ -348,7 +349,7 @@ func TestCreateAppendsSessionIDForClaude(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -373,7 +374,7 @@ func TestRestartUsesResumeArgsForClaude(t *testing.T) {
 	// transcript jsonl for the pinned id. Restart must use --resume.
 	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return true }))
 
-	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -403,7 +404,7 @@ func TestCreatePinsAgentSessionIDForClaude(t *testing.T) {
 	captureStartSession(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -421,7 +422,7 @@ func TestRestartUsesCapturedAgentSessionIDForCodex(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{Name: "x", Agent: "codex", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "x", Agent: "codex", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -457,7 +458,7 @@ func TestRestartFallsBackToResumeCmdForCodex(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{Name: "x", Agent: "codex", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "x", Agent: "codex", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -495,11 +496,11 @@ func TestTwoClaudeSessionsRestartUseDistinctIDs(t *testing.T) {
 	r := freshRegistry(t)
 	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return true }))
 
-	a, err := r.Create(wire.CreateSpec{Name: "a", Agent: "claude", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "a", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create a: %v", err)
 	}
-	b, err := r.Create(wire.CreateSpec{Name: "b", Agent: "claude", Shell: "/bin/bash"})
+	b, err := r.Create(context.Background(), wire.CreateSpec{Name: "b", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create b: %v", err)
 	}
@@ -549,7 +550,7 @@ func TestAgentSessionIDPersistsAcrossReload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	a, err := r1.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
+	a, err := r1.Create(context.Background(), wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -581,7 +582,7 @@ func TestReviveUsesResumeArgsForPinnedClaude(t *testing.T) {
 	r := freshRegistry(t)
 	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return true }))
 
-	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -628,7 +629,7 @@ func TestRestartEmptyClaudeSessionRepinsBySessionID(t *testing.T) {
 	// No transcript on disk: the session was never used.
 	t.Cleanup(agent.SetClaudeSessionExistsForTest(func(id, cwd string) bool { return false }))
 
-	a, err := r.Create(wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
+	a, err := r.Create(context.Background(), wire.CreateSpec{Name: "c1", Agent: "claude", Shell: "/bin/bash"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -661,7 +662,7 @@ func TestCreateWithExplicitCmdSkipsAgentSessionIDPin(t *testing.T) {
 	rec := captureStartSession(t)
 	r := freshRegistry(t)
 
-	a, err := r.Create(wire.CreateSpec{
+	a, err := r.Create(context.Background(), wire.CreateSpec{
 		Name:  "c1",
 		Agent: "claude",
 		Cmd:   []string{"claude", "--print", "hi"},
@@ -687,4 +688,3 @@ func TestCreateWithExplicitCmdSkipsAgentSessionIDPin(t *testing.T) {
 		t.Errorf("AgentSessionID = %q, want empty (caller-supplied Cmd was not pinned)", got)
 	}
 }
-

--- a/internal/registry/worktree_test.go
+++ b/internal/registry/worktree_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,7 +55,7 @@ func TestCreate_WorktreeNonGitCwd(t *testing.T) {
 	r := freshRegistry(t)
 	p, _ := r.CreateProject(wire.CreateProjectReq{Name: "plain", Cwd: t.TempDir()})
 
-	e, err := r.Create(wire.CreateSpec{
+	e, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID:   p.ID,
 		Shell:       "/bin/bash",
 		UseWorktree: true,
@@ -73,7 +74,7 @@ func TestCreate_WorktreeHappyPath(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
 
-	e, err := r.Create(wire.CreateSpec{
+	e, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID:   p.ID,
 		Shell:       "/bin/bash",
 		Agent:       "claude",
@@ -123,7 +124,7 @@ func TestKill_WorktreeRemoved(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
 
-	e, err := r.Create(wire.CreateSpec{
+	e, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID:   p.ID,
 		Shell:       "/bin/bash",
 		UseWorktree: true,
@@ -153,7 +154,7 @@ func TestKill_WorktreeRemoved(t *testing.T) {
 func TestKill_DirtyWorktree_NoForce_ErrsAndPreserves(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
-	e, err := r.Create(wire.CreateSpec{
+	e, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID:   p.ID,
 		Shell:       "/bin/bash",
 		UseWorktree: true,
@@ -186,7 +187,7 @@ func TestKill_DirtyWorktree_NoForce_ErrsAndPreserves(t *testing.T) {
 func TestKill_DirtyWorktree_ForceRemoves(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
-	e, _ := r.Create(wire.CreateSpec{
+	e, _ := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
 	})
 	time.Sleep(80 * time.Millisecond)
@@ -212,7 +213,7 @@ func TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree(t *testing.T) {
 	r, p := freshRegistryWithProject(t)
 
 	// Source session: spawns a worktree under p.Cwd/.worktrees/<branch>.
-	src, err := r.Create(wire.CreateSpec{
+	src, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash", Agent: "claude", UseWorktree: true,
 	})
 	if err != nil {
@@ -227,7 +228,7 @@ func TestCreate_ExplicitCwdInsideWorktree_NoNestedWorktree(t *testing.T) {
 
 	// Duplicate: explicit cwd inside the existing worktree, UseWorktree
 	// off. This is exactly the wire payload the GUI sends on ⌘P.
-	dup, err := r.Create(wire.CreateSpec{
+	dup, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash", Agent: "claude",
 		Cwd: wtPath, UseWorktree: false,
 	})
@@ -268,7 +269,7 @@ func TestKill_SharedWorktree_KeepsWorktreeUntilLast(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
 
-	src, err := r.Create(wire.CreateSpec{
+	src, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
 	})
 	if err != nil {
@@ -280,7 +281,7 @@ func TestKill_SharedWorktree_KeepsWorktreeUntilLast(t *testing.T) {
 	}
 	time.Sleep(80 * time.Millisecond)
 
-	dup, err := r.Create(wire.CreateSpec{
+	dup, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash",
 		Cwd: wtPath, UseWorktree: false,
 	})
@@ -315,7 +316,7 @@ func TestRevive_StaleWorktreePath_SelfHeals(t *testing.T) {
 	// Create a worktree session, drop the live PTY without going
 	// through Kill (which would also delete the worktree), and then
 	// nuke the worktree dir to simulate the user wiping it.
-	e, _ := r.Create(wire.CreateSpec{
+	e, _ := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
 	})
 	time.Sleep(80 * time.Millisecond)
@@ -357,7 +358,7 @@ func TestRevive_UsesProjectCwd_NotCallerOpts(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
 
-	e, err := r.Create(wire.CreateSpec{
+	e, err := r.Create(context.Background(), wire.CreateSpec{
 		ProjectID: p.ID, Shell: "/bin/bash",
 	})
 	if err != nil {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -55,8 +55,8 @@ func WorktreePath(gitRoot, branch string) string {
 // When no upstream is configured or the remote is unreachable, falls
 // back to creating the branch from local HEAD. Bounded by a 30-second
 // timeout so a slow / hung filesystem can't lock up session creation
-// forever.
-func CreateWorktree(repoDir, branch, worktreePath string) error {
+// forever, and by ctx so daemon shutdown cancels in-flight git work.
+func CreateWorktree(ctx context.Context, repoDir, branch, worktreePath string) error {
 	if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
 		return fmt.Errorf("create worktree parent dir: %w", err)
 	}
@@ -67,8 +67,8 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 	// between this probe and the add.) Probed before upstreamBaseRef:
 	// checking out an existing branch never branches from upstream, so
 	// it must not pay the fetch's network latency.
-	if branchExists(repoDir, branch) {
-		out, err := gitWorktreeAdd(repoDir, worktreePath, branch)
+	if branchExists(ctx, repoDir, branch) {
+		out, err := gitWorktreeAdd(ctx, repoDir, worktreePath, branch)
 		if err != nil {
 			return fmt.Errorf("git worktree add (existing branch %s): %s: %w",
 				branch, strings.TrimSpace(string(out)), err)
@@ -79,7 +79,7 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 	// Best-effort: refresh `origin` so the upstream tip we branch from
 	// reflects the latest remote state. Failures are logged via the
 	// returned base ref staying empty (callers fall back to HEAD).
-	upstream := upstreamBaseRef(repoDir)
+	upstream := upstreamBaseRef(ctx, repoDir)
 
 	var attempts []error
 
@@ -89,7 +89,7 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 	if upstream != "" {
 		args = append(args, upstream)
 	}
-	out, err := gitWorktreeAdd(repoDir, args...)
+	out, err := gitWorktreeAdd(ctx, repoDir, args...)
 	if err == nil {
 		return nil
 	}
@@ -100,7 +100,7 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 	// fall back to checking it out. gitWorktreeAdd pins LC_ALL=C, so
 	// these substrings are stable across user locales.
 	if strings.Contains(string(out), "already exists") || strings.Contains(string(out), "fatal: A branch named") {
-		out2, err2 := gitWorktreeAdd(repoDir, worktreePath, branch)
+		out2, err2 := gitWorktreeAdd(ctx, repoDir, worktreePath, branch)
 		if err2 == nil {
 			return nil
 		}
@@ -114,7 +114,7 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 	// the explicit base ref so HEAD is used. This keeps creation robust
 	// in offline / shallow / sandboxed environments.
 	if upstream != "" {
-		out3, err3 := gitWorktreeAdd(repoDir, "-b", branch, worktreePath)
+		out3, err3 := gitWorktreeAdd(ctx, repoDir, "-b", branch, worktreePath)
 		if err3 == nil {
 			return nil
 		}
@@ -127,8 +127,8 @@ func CreateWorktree(repoDir, branch, worktreePath string) error {
 // gitWorktreeAdd runs `git -C repoDir worktree add <args…>` with a 30s
 // timeout and a C locale. The locale pin keeps CreateWorktree's
 // error-text fallback meaningful on non-English systems.
-func gitWorktreeAdd(repoDir string, args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+func gitWorktreeAdd(ctx context.Context, repoDir string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	full := append([]string{"-C", repoDir, "worktree", "add"}, args...)
 	cmd := exec.CommandContext(ctx, "git", full...)
@@ -141,8 +141,8 @@ func gitWorktreeAdd(repoDir string, args ...string) ([]byte, error) {
 }
 
 // branchExists reports whether refs/heads/<branch> exists in repoDir.
-func branchExists(repoDir, branch string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+func branchExists(ctx context.Context, repoDir, branch string) bool {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	return exec.CommandContext(ctx, "git", "-C", repoDir,
 		"rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil
@@ -153,9 +153,9 @@ func branchExists(repoDir, branch string) bool {
 // resolving, it best-effort fetches `origin` so the returned ref points
 // at the latest remote tip. Bounded by short timeouts; never blocks
 // worktree creation for long.
-func upstreamBaseRef(repoDir string) string {
+func upstreamBaseRef(ctx context.Context, repoDir string) string {
 	// Confirm `origin` exists before spending time on a fetch.
-	checkCtx, checkCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	checkCtx, checkCancel := context.WithTimeout(ctx, 3*time.Second)
 	defer checkCancel()
 	if err := exec.CommandContext(checkCtx, "git", "-C", repoDir, "remote", "get-url", "origin").Run(); err != nil {
 		return ""
@@ -165,14 +165,14 @@ func upstreamBaseRef(repoDir string) string {
 	// we'll still resolve whatever `origin/HEAD` already points at locally.
 	// Warn so a stale cached origin/HEAD doesn't silently base new
 	// worktrees on outdated upstream — the very failure mode #192 fixed.
-	fetchCtx, fetchCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	fetchCtx, fetchCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer fetchCancel()
 	if fetchOut, fetchErr := exec.CommandContext(fetchCtx, "git", "-C", repoDir, "fetch", "--quiet", "origin").CombinedOutput(); fetchErr != nil {
 		log.Printf("worktree: fetch origin failed (%v); new worktree may be based on stale origin/HEAD: %s", fetchErr, strings.TrimSpace(string(fetchOut)))
 	}
 
 	// Resolve origin/HEAD -> origin/<default-branch>.
-	resolveCtx, resolveCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	resolveCtx, resolveCancel := context.WithTimeout(ctx, 3*time.Second)
 	defer resolveCancel()
 	out, err := exec.CommandContext(resolveCtx, "git", "-C", repoDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD").Output()
 	if err != nil {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"os/exec"
@@ -63,11 +64,11 @@ func TestIsGitRepoAndRoot(t *testing.T) {
 
 func TestWorktreePathSanitizes(t *testing.T) {
 	cases := map[string]string{
-		"feature/x":  "feature-x",
-		"hot fix":    "hot-fix",
-		"a:b":        "a-b",
-		"win\\path":  "win-path",
-		"plain":      "plain",
+		"feature/x": "feature-x",
+		"hot fix":   "hot-fix",
+		"a:b":       "a-b",
+		"win\\path": "win-path",
+		"plain":     "plain",
 	}
 	for in, wantSeg := range cases {
 		got := WorktreePath("/r", in)
@@ -156,7 +157,7 @@ func TestCreateWorktree_PrefersUpstreamBase(t *testing.T) {
 
 	branch := "feature-x"
 	wtPath := WorktreePath(local, branch)
-	if err := CreateWorktree(local, branch, wtPath); err != nil {
+	if err := CreateWorktree(context.Background(), local, branch, wtPath); err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
 	defer Cleanup(local, wtPath)
@@ -174,7 +175,7 @@ func TestCreateWorktree_NoRemoteFallsBackToHEAD(t *testing.T) {
 
 	branch := "no-remote-feature"
 	wtPath := WorktreePath(repo, branch)
-	if err := CreateWorktree(repo, branch, wtPath); err != nil {
+	if err := CreateWorktree(context.Background(), repo, branch, wtPath); err != nil {
 		t.Fatalf("CreateWorktree on repo without remote: %v", err)
 	}
 	defer Cleanup(repo, wtPath)
@@ -201,7 +202,7 @@ func TestCreateWorktree_UnreachableRemoteWarnsAndFallsBack(t *testing.T) {
 	headBefore := revParse(t, repo, "HEAD")
 	branch := "offline-feature"
 	wtPath := WorktreePath(repo, branch)
-	if err := CreateWorktree(repo, branch, wtPath); err != nil {
+	if err := CreateWorktree(context.Background(), repo, branch, wtPath); err != nil {
 		t.Fatalf("CreateWorktree with unreachable remote: %v", err)
 	}
 	defer Cleanup(repo, wtPath)
@@ -229,7 +230,7 @@ func TestCreateWorktree_BranchAlreadyExists(t *testing.T) {
 	}
 	topicSHA := revParse(t, repo, "topic")
 	wt := WorktreePath(repo, "topic")
-	if err := CreateWorktree(repo, "topic", wt); err != nil {
+	if err := CreateWorktree(context.Background(), repo, "topic", wt); err != nil {
 		t.Fatalf("CreateWorktree should check out an existing branch: %v", err)
 	}
 	defer Cleanup(repo, wt)
@@ -245,7 +246,7 @@ func TestCreateWorktree_ExistingBranchCheckedOutElsewhereReportsContext(t *testi
 	repo := initRepo(t)
 	mustGit(t, repo, "branch", "topic")
 	wtA := WorktreePath(repo, "topic")
-	if err := CreateWorktree(repo, "topic", wtA); err != nil {
+	if err := CreateWorktree(context.Background(), repo, "topic", wtA); err != nil {
 		t.Fatalf("first CreateWorktree: %v", err)
 	}
 	defer Cleanup(repo, wtA)
@@ -253,7 +254,7 @@ func TestCreateWorktree_ExistingBranchCheckedOutElsewhereReportsContext(t *testi
 	// A second worktree for the same branch must fail (git refuses), and
 	// the error must say which strategy failed instead of a bare git dump.
 	wtB := filepath.Join(repo, ".worktrees", "topic-second")
-	err := CreateWorktree(repo, "topic", wtB)
+	err := CreateWorktree(context.Background(), repo, "topic", wtB)
 	if err == nil {
 		t.Fatal("second CreateWorktree for same branch should fail")
 	}
@@ -267,7 +268,7 @@ func TestCreateWorktree_AllAttemptsFailJoinsErrors(t *testing.T) {
 	// ".." is invalid in ref names, so both the with-base and no-base
 	// attempts fail. The joined error must carry context from each.
 	bad := "bad..name"
-	err := CreateWorktree(repo, bad, filepath.Join(repo, ".worktrees", "bad-name"))
+	err := CreateWorktree(context.Background(), repo, bad, filepath.Join(repo, ".worktrees", "bad-name"))
 	if err == nil {
 		t.Fatal("CreateWorktree with invalid branch name should fail")
 	}
@@ -298,7 +299,7 @@ func TestHasUncommitted(t *testing.T) {
 	skipNoGit(t)
 	repo := initRepo(t)
 	wt := WorktreePath(repo, "wip")
-	if err := CreateWorktree(repo, "wip", wt); err != nil {
+	if err := CreateWorktree(context.Background(), repo, "wip", wt); err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
 	defer Cleanup(repo, wt)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -149,6 +149,25 @@ func revParseRemote(t *testing.T, bareRepo, branch string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// TestCreateWorktree_CancelledContext pins the cancellation contract
+// added when the git helpers stopped rooting their own
+// context.Background() timeouts: a cancelled caller ctx must abort the
+// add and leave no worktree behind.
+func TestCreateWorktree_CancelledContext(t *testing.T) {
+	skipNoGit(t)
+	repo := initRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	wtPath := WorktreePath(repo, "cancelled")
+	if err := CreateWorktree(ctx, repo, "cancelled", wtPath); err == nil {
+		t.Fatal("CreateWorktree with a cancelled ctx: want error, got nil")
+	}
+	if _, err := os.Stat(wtPath); err == nil {
+		t.Errorf("worktree dir %s exists after a cancelled create", wtPath)
+	}
+}
+
 func TestCreateWorktree_PrefersUpstreamBase(t *testing.T) {
 	local, stale, fresh := initRepoWithUpstream(t)
 	if stale == fresh {


### PR DESCRIPTION
Phases **3b** and **3d** of `docs/analysis/2026-07-19-improvement-plan/phase-3-go-consolidation.md`, done together as the plan suggests ("do it while touching registry in 3b"). Refactor only — no intended behavior change.

## 3b — split `internal/registry/registry.go` (1123 → 779 lines)

Two commits so the mechanical part is verifiable on its own:

1. **Pure file moves** (`e00a840`): `events.go` (`Listener`/`ProjectListener` types, `Subscribe`, `broadcast`, `broadcastLocked`) and `colors.go` (`colorPalette`, `pickColor`), following the existing `projects.go` / `persist.go` pattern. Cut-paste only, zero test edits.
2. **`Create` decomposition** (`create.go`): the 225-line body becomes six named straight-line steps — `resolveCreateTarget` → `planWorktreeAndName` → `insertEntry` → `resolveAgentCmd` → `materializeWorktree` → `renameAfterWorktreeFailure` → `attachSession` — plus `startAgentSessionIDCaptureLocked`. No new abstractions, same package.

The invariant driving the split: **every step either takes `r.mu` for its whole body or never takes it at all.** Nothing was extracted across an unlock boundary, so the three load-bearing lock windows stay visible in `Create` itself:

- the project re-validation after the first unlock (a concurrent `KillProject` can invalidate `projectID`) stays paired with the window that makes it necessary;
- insert + rollback stay in one step (the rollback's `r.order[:len(r.order)-1]` assumes the new entry is last);
- `broadcast` takes `r.mu` itself, so it stays at the `Create` top level on both the error and success paths.

State flows through an explicit local `createPlan` struct — no new `Registry` fields.

### `persistEntryLocked` — claim verified, fix deliberately deferred

The claim is real: `writeJSON` = `MkdirAll` + `WriteFile` + `Rename`, all under `r.mu`; `renumberLocked` makes that `len(order)` writes per reorder, not one.

But the plan's suggested fix (snapshot under lock, write outside) is **not** safe here: `r.mu` is also what serializes the writes. Snapshot-outside lets writer A (v1) and B (v2) reorder so v1 lands on disk last. Shipping that in a refactor PR would trade a latency smell for a data-correctness bug. Left as-is with a `ponytail:` comment naming the ceiling and the upgrade path (a persist-ordering lock acquired under `r.mu` and released after the write, threaded through every `*Locked` call site) — that's its own PR.

## 3d — context propagation

- `internal/worktree/worktree.go`: the five `context.Background()` timeouts (`gitWorktreeAdd`, `branchExists`, `upstreamBaseRef`'s three) now derive from a caller ctx; `CreateWorktree` takes `ctx` as its first arg.
- `registry.go:518` (now `create.go`): the post-spawn agent-session-id capture derives its 30s timeout from the caller ctx.
- `internal/daemon`: `Run`'s ctx threads through `serve` → `serveControl` → `Registry.Create`. Commented at both ends that this ctx **must stay daemon-scoped** — a per-connection ctx would silently kill Codex id capture whenever a create-mode client disconnects inside 30s. `New`'s pre-`Run` bootstrap create keeps `context.Background()`, which is correct there.
- `cmd/hivegui/update.go:81` needed **no change**: it already derives from `a.ctx` and only falls back to `Background()` before `startup()` has run.

Scoped out (noted, not built): `worktree.Root` / `IsGitRepo` / `Cleanup` / `HasUncommitted` / `EnsureGitignore` shell out via bare `exec.Command` with no timeout at all. Not in the plan's list; separate follow-up.

One behavior consequence worth naming: shutdown can now cancel an in-flight `git worktree add`, which may leave partial worktree admin state. `ReclaimOrphanWorktrees` already reclaims that on the next boot.

## Verification

- `go build` / `go vet` on `./internal/...`, `./cmd/hived/...`, `./cmd/hived-ws-bridge/...` — clean.
- `go test ./internal/...` — all green.
- `go test -tags=e2e ./cmd/hived/...` with `HOME` / `HIVE_STATE_DIR` / `HIVE_SOCKET` pointed at `mktemp -d` dirs — green (12.4s). Never touched real state.
- `git diff origin/main -- '*_test.go'` is **ctx-argument churn only** — zero assertion changes. The existing registry/daemon tests are the characterization net; if one had needed its expectations edited, that would have meant a behavior change, not a wrong test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced session creation with improved project/branch/worktree/color selection and agent session support.
  * Added registry event subscriptions for session and project updates.
* **Bug Fixes**
  * Improved shutdown/cancellation behavior: session/worktree creation now respects caller or daemon lifetime and can abort in-flight git operations.
  * Improved reliability of worktree/session state updates on start failures and late agent session-id capture.
* **Tests**
  * Updated session and worktree tests to use context-aware creation APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->