### PR TITLE
fix(hivegui): anchor normal-screen sessions to the bottom, stop full-history replay on grid entry

### DIFF
--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -212,17 +212,31 @@ func (a *App) dialHandshake(hello wire.Hello) (*wire.Client, error) {
 	return wire.Handshake(conn, hello)
 }
 
-// ConnectControl opens (or reuses) the control connection. The
-// daemon will push an unsolicited SESSIONS snapshot followed by
-// SESSION_EVENT messages — these are forwarded to the frontend as
-// "session:list" and "session:event" events.
+// ConnectControl opens a fresh control connection, replacing any existing
+// one. The daemon pushes an unsolicited PROJECTS + SESSIONS snapshot on
+// handshake, followed by SESSION_EVENT messages — forwarded to the frontend
+// as "session:list" and "session:event" events.
+//
+// It REPLACES rather than reuses, and that is the whole point. Every caller
+// is a frontend with no session state that needs the snapshot: main.js runs
+// this once per page load, and the reconnect loop runs it after a drop. The
+// snapshot only ever arrives on handshake, so reusing a live connection
+// returned success while leaving a freshly-loaded page with a permanently
+// empty session list — the "no sessions" screen after any location.reload(),
+// which in practice means every time the Debug menu's trace toggle is used
+// (the only reload in the app). A redial is cheap; a silently empty UI is
+// not.
+//
+// The webview surviving a reload while the Go process does not is exactly
+// what makes this reachable: a.control outlives the page that opened it.
 func (a *App) ConnectControl() error {
-	a.mu.Lock()
-	if a.control != nil {
-		a.mu.Unlock()
-		return nil
+	// Detach the old connection BEFORE closing it, so its read loop sees
+	// itself superseded and stays quiet — see controlReadLoop. Closing it
+	// while still installed would emit control:disconnect, which starts the
+	// reconnect loop, which calls back into here: an endless redial.
+	if old := a.detachControl(); old != nil {
+		_ = old.Close()
 	}
-	a.mu.Unlock()
 
 	cs, err := a.dialHandshake(wire.Hello{
 		Client:  "hivegui/0.2",
@@ -384,15 +398,43 @@ func (a *App) RestartDaemon() error {
 	return nil
 }
 
+// detachControl clears the installed control connection and returns it, so
+// the caller can close a connection that no read loop still considers
+// current. Returns nil when there was none.
+func (a *App) detachControl() *wire.Client {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	old := a.control
+	a.control = nil
+	return old
+}
+
+// retireControl clears cs if it is still the installed control connection,
+// and reports whether it was. False means cs was superseded — ConnectControl
+// already replaced it deliberately, so its ending is not a lost daemon and
+// must not be announced as one.
+func (a *App) retireControl(cs *wire.Client) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.control != cs {
+		return false
+	}
+	a.control = nil
+	return true
+}
+
 func (a *App) controlReadLoop(cs *wire.Client) {
 	defer func() {
-		a.mu.Lock()
-		if a.control == cs {
-			a.control = nil
-		}
-		a.mu.Unlock()
+		current := a.retireControl(cs)
 		_ = cs.Close()
-		wruntime.EventsEmit(a.ctx, "control:disconnect", "")
+		// Only the CURRENT connection ending means the GUI lost the daemon.
+		// A superseded one was closed deliberately by ConnectControl, and
+		// announcing that as a disconnect would start the reconnect loop,
+		// which redials, which supersedes again — a redial that never
+		// settles. Stay quiet: a live replacement is already installed.
+		if current {
+			wruntime.EventsEmit(a.ctx, "control:disconnect", "")
+		}
 	}()
 	for {
 		ft, payload, err := cs.ReadFrame()

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -48,6 +48,34 @@ type App struct {
 	// session then fan-outs every byte (and the scrollback snapshot)
 	// twice, producing visibly duplicated output in xterm.
 	openMu sync.Mutex
+
+	// debugTrace mirrors the frontend's `hive.debug` localStorage flag so
+	// the Debug menu can say which state it will move to. Owned by the main
+	// thread: written only by SetDebugTrace (a Wails binding call, which
+	// Wails dispatches on the main thread), read only by buildAppMenu.
+	debugTrace bool
+}
+
+// SetDebugTrace records whether the frontend's scroll/replay tracer is
+// currently armed and relabels the Debug menu accordingly.
+//
+// The flag lives in the webview's localStorage, which Go cannot read, so the
+// frontend pushes it up at startup — and the toggle reloads the page, so the
+// new value arrives the same way. Without this the item read "Toggle Debug
+// Trace" forever with no way to tell whether tracing was already on; the
+// tracer is deliberately invisible when armed, so the menu is the only
+// indicator there is.
+func (a *App) SetDebugTrace(on bool) {
+	a.debugTrace = on
+	if a.ctx == nil {
+		return
+	}
+	m := buildAppMenu(a)
+	if m == nil {
+		return // no native menu on this platform — see menu_other.go
+	}
+	wruntime.MenuSetApplicationMenu(a.ctx, m)
+	wruntime.MenuUpdateApplicationMenu(a.ctx)
 }
 
 // Notify fires a native OS notification. Wails' webview lacks the HTML5

--- a/cmd/hivegui/control_swap_test.go
+++ b/cmd/hivegui/control_swap_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lucascaro/hive/internal/wire"
+)
+
+// The control connection is the GUI's only source of the session list, and
+// the daemon sends that list ONCE, unsolicited, on handshake. So a frontend
+// with no state — every page load — must get a new handshake, and the old
+// ConnectControl's "reuse if non-nil" fast path is what left a reloaded page
+// permanently empty ("no sessions" after the Debug menu's trace toggle, the
+// only location.reload() in the app; the Go process survives it, so
+// a.control outlives the page that opened it).
+//
+// Replacing the connection instead introduces one hazard, which these tests
+// pin: the displaced read loop must not announce its own death. If it does,
+// the frontend's control:disconnect handler starts the reconnect loop, which
+// calls ConnectControl, which supersedes again — a redial that never
+// settles.
+
+func TestDetachControlHandsBackTheOldConnection(t *testing.T) {
+	c1 := &wire.Client{}
+	a := &App{control: c1}
+
+	if got := a.detachControl(); got != c1 {
+		t.Errorf("detachControl() = %p, want %p", got, c1)
+	}
+	if a.control != nil {
+		t.Error("detachControl must leave no installed connection for a read loop to claim")
+	}
+	if got := a.detachControl(); got != nil {
+		t.Errorf("detachControl() on an empty App = %p, want nil", got)
+	}
+}
+
+func TestRetireControlOnlyReportsTheCurrentConnection(t *testing.T) {
+	c1, c2 := &wire.Client{}, &wire.Client{}
+	a := &App{control: c1}
+
+	// The live connection ending IS a lost daemon: report it, and clear it
+	// so the reconnect loop can install a replacement.
+	if !a.retireControl(c1) {
+		t.Error("retireControl(current) = false, want true — a real disconnect must be announced")
+	}
+	if a.control != nil {
+		t.Error("retireControl(current) must clear the installed connection")
+	}
+
+	// Now the supersede case: c2 is installed, c1's read loop drains and
+	// exits. c1 must report false, and must NOT clear c2 on its way out —
+	// clearing it would strand the GUI with a live socket it thinks is gone.
+	a.control = c2
+	if a.retireControl(c1) {
+		t.Error("retireControl(superseded) = true — would emit control:disconnect and start an endless redial")
+	}
+	if a.control != c2 {
+		t.Error("a superseded read loop must not disturb the connection that replaced it")
+	}
+}

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -58,6 +58,7 @@ import {
   decideResizeReplay,
   REPLAY_DEBOUNCE_MS,
   applyRebaseline,
+  resetFollowIntent,
 } from '../lib/scrollback.js';
 import { scrollTrace, snapshotScrollJump } from './trace.js';
 import { classifyViewportMove } from '../lib/scroll-debug.js';
@@ -631,18 +632,22 @@ export class SessionTerm {
         this._followBottom = buf.baseY - to <= STICKY_BOTTOM_LINES;
       }
 
-      // Keep a FOLLOWING viewport glued to the bottom for the WHOLE replay
-      // restream, not just at replay-done. A full-buffer restream spans many
-      // frames; the begin handler's term.reset() wipes the viewport to the
-      // top and cap-trim then strands it in history, so without this the
-      // viewport drifts up mid-restream and only re-snaps at done — a visible
-      // scroll-jump (the user-reported signature: following:true, tiny
-      // sinceReplayMs). Re-pin only a genuine follower (never a reader
-      // scrolled up: _followBottom is false for them, and a user gesture this
-      // tick set it above). Reentrancy-guarded — scrollToBottom re-enters
-      // onScroll, which then sees us at the bottom and stops.
+      // Keep a FOLLOWING viewport glued to the bottom against ANY non-user
+      // upward drift — during a replay restream AND in steady state under a
+      // high-output ("firehose") session. Two mechanisms strand a follower
+      // off the bottom with no user gesture:
+      //   1. replay: begin's term.reset() wipes the viewport to the top and
+      //      cap-trim leaves it in history until done re-snaps it;
+      //   2. cap-trim drift: at the 5000-line scrollback cap, heavy output
+      //      shifts baseY faster than xterm updates viewportY, so xterm
+      //      loses bottom-follow and the viewport slides up on its own.
+      // #228 deliberately left (2) uncorrected — but on a real firehose
+      // (multi-MB/s, e.g. Pi) that drift IS the "constant scrolling, never
+      // anchored to the bottom" report, so we now re-pin it too. Safe: a
+      // genuine reader has _followBottom=false (a user gesture this tick set
+      // it above), so we never fight them; the _repinning guard absorbs the
+      // scrollToBottom → onScroll re-entry.
       if (
-        this._replaysInFlight > 0 &&
         this._followBottom &&
         !this._repinning &&
         buf.baseY - to > STICKY_BOTTOM_LINES &&
@@ -1052,14 +1057,27 @@ export class SessionTerm {
           bufferType: this.term.buffer.active.type,
           cols: this.term.cols,
           baselineCols: this._replayBaselineCols,
+          // A follower doesn't need history reflowed — skip the destructive
+          // full-ring replay that makes the viewport thrash under live output.
+          followingBottom: this._followBottom,
         });
         this._replayBaselineCols = baseline;
         if (!replay) {
           delete this._replayWantsBottom;
+          // Already re-latched by the earlier scrollToBottom; assert it once
+          // more so a follower we skipped the replay for stays glued to the
+          // newest output after the fit settles.
+          if (
+            this._followBottom &&
+            typeof this.term.scrollToBottom === 'function'
+          )
+            this.term.scrollToBottom();
           if (scrollTrace.rec.enabled) {
-            scrollTrace.rec('replay-skip-alt', {
+            scrollTrace.rec('replay-skip', {
               id: this.info.id,
               cols: this.term.cols,
+              following: this._followBottom,
+              bufType: this.term.buffer.active.type,
             });
           }
           return;
@@ -1091,7 +1109,22 @@ export class SessionTerm {
   }
 
   async ensureAttached() {
-    if (this.attached) return;
+    // A deliberate attach/focus means "show me the latest": re-latch
+    // follow-intent and drop any stale restore-into-history intent from a
+    // prior resize. BEFORE the attached-guard so re-focusing an ALREADY-live
+    // tile (which early-returns below) also re-pins — otherwise a stale
+    // _followBottom=false from an earlier scroll-up would strand it in
+    // history. This is the choke point every path goes through (active tile,
+    // deferred idle-callback attach, focus, restore), so setting the latch
+    // here makes the bottom-snap timing-independent — see resetFollowIntent.
+    resetFollowIntent(this);
+    if (this.attached) {
+      // Already live: no replay will re-fire to carry the latch to the
+      // bottom, so snap synchronously for instant feedback on focus.
+      if (typeof this.term?.scrollToBottom === 'function')
+        this.term.scrollToBottom();
+      return;
+    }
     // Don't attempt to attach to a session known to be dead — the daemon
     // will refuse. Show the dead overlay with the error reason instead.
     if (state.aliveById.get(this.info.id) === false) {
@@ -1111,11 +1144,8 @@ export class SessionTerm {
     const _fitStart = nowMs();
     this.fit.fit();
     const _fitMs = nowMs() - _fitStart;
-    // Reset _followBottom on attach: it may be stale from a previous
-    // session (user scrolled up, closed Hive, reopened). The initial
-    // attach replay must snap to bottom — _followBottom = true ensures
-    // the replay-done handler doesn't skip the snap via the restore path.
-    this._followBottom = true;
+    // _followBottom was already re-latched at the top of ensureAttached
+    // (resetFollowIntent), so the initial attach replay snaps to bottom.
     try {
       const _openStart = nowMs();
       await OpenSession(this.info.id, this.term.cols, this.term.rows);

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -1053,13 +1053,21 @@ export class SessionTerm {
         // helper so the skip + baseline-untouched behavior is unit-tested.
         // Checked at fire time so a just-attached session that has since
         // entered the alt screen via its snapshot is caught too.
+        // Re-read follow-intent at FIRE time and re-stamp the wants-bottom
+        // flag from that same read. The flag was stamped from `wasAtBottom`
+        // one debounce interval ago; a scroll during that interval would
+        // otherwise leave the skip decision (fresh) and the restore decision
+        // (stale) disagreeing — e.g. a user who scrolled up mid-debounce gets
+        // a replay AND gets yanked back to the bottom by its done handler.
+        const following = this._followBottom;
+        this._replayWantsBottom = following;
         const { replay, baseline } = decideResizeReplay({
           bufferType: this.term.buffer.active.type,
           cols: this.term.cols,
           baselineCols: this._replayBaselineCols,
           // A follower doesn't need history reflowed — skip the destructive
           // full-ring replay that makes the viewport thrash under live output.
-          followingBottom: this._followBottom,
+          followingBottom: following,
         });
         this._replayBaselineCols = baseline;
         if (!replay) {
@@ -1067,16 +1075,13 @@ export class SessionTerm {
           // Already re-latched by the earlier scrollToBottom; assert it once
           // more so a follower we skipped the replay for stays glued to the
           // newest output after the fit settles.
-          if (
-            this._followBottom &&
-            typeof this.term.scrollToBottom === 'function'
-          )
+          if (following && typeof this.term.scrollToBottom === 'function')
             this.term.scrollToBottom();
           if (scrollTrace.rec.enabled) {
             scrollTrace.rec('replay-skip', {
               id: this.info.id,
               cols: this.term.cols,
-              following: this._followBottom,
+              following,
               bufType: this.term.buffer.active.type,
             });
           }

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -598,6 +598,37 @@ export class SessionTerm {
     this._replaysInFlight = 0;
     this._repinning = false;
 
+    // Pointer drag is user scroll intent too. xterm auto-scrolls the
+    // viewport while a selection drag is held past the top edge, and that
+    // scroll arrives with NO wheel and NO keydown — so the bottom re-pin
+    // below reads it as parse-driven drift and yanks the viewport back,
+    // which makes selecting text upwards impossible. (Only visible once
+    // the re-pin stopped being gated on an in-flight replay.)
+    //
+    // A boolean, not a timestamp: the auto-scroll repeats on xterm's own
+    // timer while the button is held STILL, so there is no second event to
+    // re-stamp from and a mousedown timestamp alone would go stale after
+    // USER_SCROLL_GRACE_MS mid-drag. onScroll refreshes the stamp while
+    // this is set.
+    this._pointerDown = false;
+    this.body.addEventListener(
+      'mousedown',
+      () => {
+        this._pointerDown = true;
+        this._lastUserScrollTs = nowMs();
+      },
+      { capture: true },
+    );
+    // Listen for the release on `window`: a drag that leaves the tile (or
+    // the window) releases outside `body`, and a stuck flag would make
+    // every later drift look user-driven.
+    this._onWindowMouseUp = () => {
+      if (!this._pointerDown) return;
+      this._pointerDown = false;
+      this._lastUserScrollTs = nowMs();
+    };
+    window.addEventListener('mouseup', this._onWindowMouseUp, true);
+
     // Keyboard scrollback (Shift+PageUp/Down, Shift+Home/End) is user
     // intent too. xterm handles these internally; we only timestamp them
     // so the onScroll below attributes the resulting move to the user.
@@ -624,6 +655,10 @@ export class SessionTerm {
       const to = buf.viewportY;
       this._lastViewportY = to;
       const now = nowMs();
+      // A held pointer is a live gesture for as long as it's held — keep
+      // the stamp fresh so a selection auto-scroll that spans more than
+      // USER_SCROLL_GRACE_MS stays attributed to the user.
+      if (this._pointerDown) this._lastUserScrollTs = now;
       // Only a recent user gesture may change follow-intent. A move with
       // no gesture behind it is parse-driven cap-trim drift — ignore it,
       // so a wobbling viewport never clears "follow the bottom".
@@ -1207,6 +1242,10 @@ export class SessionTerm {
     }
     if (this._onVisibility) {
       document.removeEventListener('visibilitychange', this._onVisibility);
+    }
+    if (this._onWindowMouseUp) {
+      window.removeEventListener('mouseup', this._onWindowMouseUp, true);
+      this._onWindowMouseUp = null;
     }
     // Release the GL context proactively so a many-tile session doesn't
     // sit on it until GC and push another tile over the browser cap.

--- a/cmd/hivegui/frontend/src/app/trace.js
+++ b/cmd/hivegui/frontend/src/app/trace.js
@@ -1,4 +1,5 @@
 import { createScrollTrace } from '../lib/scroll-debug.js';
+import { LogFrontend } from '../bridge.js';
 
 // Scroll/replay tracer — gated on localStorage hive.debug = '1' (the
 // focus consistency checker's switch). The gate is latched here at
@@ -6,14 +7,30 @@ import { createScrollTrace } from '../lib/scroll-debug.js';
 // reproduce, then dump window.__hive_scrolltrace. The e2e-real scroll
 // specs arm it via addInitScript (before main.js runs) and read the
 // ring to prove a scenario actually fired replays.
+// The real debug switch — gates the in-memory ring + heartbeat watchdog.
+// The log tee (below) is always on and independent of this.
+const DEBUG_ENABLED = (() => {
+  try {
+    return localStorage.getItem('hive.debug') === '1';
+  } catch {
+    return false;
+  }
+})();
+
 export const scrollTrace = createScrollTrace({
-  enabled: (() => {
+  enabled: DEBUG_ENABLED,
+  // Tee the scroll-diagnostic records to hivegui.log so the exact sequence
+  // behind a jump is recoverable after the fact (the in-memory ring rotates
+  // fast and needs a live window.__hive_dumpscroll). Only fires when enabled
+  // (hive.debug=1) and only for the whitelisted low-rate tags. Best-effort:
+  // no bridge in tests / before the runtime is ready.
+  sink: (msg) => {
     try {
-      return localStorage.getItem('hive.debug') === '1';
+      LogFrontend(msg);
     } catch {
-      return false;
+      /* bridge absent */
     }
-  })(),
+  },
 });
 // localStorage key holding the trace window snapshotted at the moment a
 // suspicious auto-up scroll was detected. The live ring is capped at
@@ -76,7 +93,7 @@ function winState() {
   };
 }
 
-if (scrollTrace.rec.enabled && typeof window !== 'undefined') {
+if (DEBUG_ENABLED && typeof window !== 'undefined') {
   let lastBeat = performance.now();
   // A hidden window throttles (or, on system sleep, pauses) background
   // timers, so the gap across a hide/sleep is NOT a main-thread stall —

--- a/cmd/hivegui/frontend/src/app/trace.js
+++ b/cmd/hivegui/frontend/src/app/trace.js
@@ -1,5 +1,5 @@
 import { createScrollTrace } from '../lib/scroll-debug.js';
-import { LogFrontend } from '../bridge.js';
+import { LogFrontend, SetDebugTrace } from '../bridge.js';
 
 // Scroll/replay tracer — gated on localStorage hive.debug = '1' (the
 // focus consistency checker's switch). The gate is latched here at
@@ -7,9 +7,11 @@ import { LogFrontend } from '../bridge.js';
 // reproduce, then dump window.__hive_scrolltrace. The e2e-real scroll
 // specs arm it via addInitScript (before main.js runs) and read the
 // ring to prove a scenario actually fired replays.
-// The real debug switch — gates the in-memory ring + heartbeat watchdog.
-// The log tee (below) is always on and independent of this.
-const DEBUG_ENABLED = (() => {
+// The debug switch — gates EVERYTHING the tracer does: the in-memory ring,
+// the heartbeat watchdog, the scroll-jump detector, and the log tee below.
+// Exported so the debug-only hot-path call sites and the menu (which reports
+// whether debugging is currently armed) read the same latched value.
+export const DEBUG_ENABLED = (() => {
   try {
     return localStorage.getItem('hive.debug') === '1';
   } catch {
@@ -20,18 +22,32 @@ const DEBUG_ENABLED = (() => {
 export const scrollTrace = createScrollTrace({
   enabled: DEBUG_ENABLED,
   // Tee the scroll-diagnostic records to hivegui.log so the exact sequence
-  // behind a jump is recoverable after the fact (the in-memory ring rotates
-  // fast and needs a live window.__hive_dumpscroll). Only fires when enabled
-  // (hive.debug=1) and only for the whitelisted low-rate tags. Best-effort:
-  // no bridge in tests / before the runtime is ready.
+  // behind a jump is recoverable after the fact — the in-memory ring rotates
+  // fast, needs a live window.__hive_dumpscroll, and comes back stale once
+  // the app relaunches. Fires only when DEBUG_ENABLED and only for the
+  // per-event tags in TEE_TAGS (never `resize`, which storms during a drag).
+  // Best-effort: no bridge in tests / before the runtime is ready, and the
+  // Wails binding returns a promise — swallow the throw and the rejection.
   sink: (msg) => {
     try {
-      LogFrontend(msg);
+      LogFrontend(msg)?.catch?.(() => {});
     } catch {
       /* bridge absent */
     }
   },
 });
+
+// Mirror the latched flag to the Go side so the Debug menu can label itself
+// "Turn Debug Trace On/Off" instead of an ambiguous "Toggle". Go can't read
+// the webview's localStorage, and the toggle reloads the page, so this one
+// push at module load covers both directions. Best-effort — the same
+// bridge-absent and promise-rejection cases as the sink above.
+try {
+  SetDebugTrace(DEBUG_ENABLED)?.catch?.(() => {});
+} catch {
+  /* bridge absent */
+}
+
 // localStorage key holding the trace window snapshotted at the moment a
 // suspicious auto-up scroll was detected. The live ring is capped at
 // 2000 entries and heavy agent output rotates it fast — by the time a

--- a/cmd/hivegui/frontend/src/app/view.js
+++ b/cmd/hivegui/frontend/src/app/view.js
@@ -70,6 +70,15 @@ export function switchTo(id) {
   // created and visible. Without this, typing after creating a
   // session lands in whichever terminal had focus before.
   if (id) deps.focusActiveTerm();
+  // Focusing a pane is a deliberate "show me the latest". ensureAttached
+  // (via showSingle/renderGrid above) already re-latched _followBottom;
+  // this makes the move visible immediately for an already-attached tile
+  // whose attach replay won't re-fire. Skips detached/zero-height terms,
+  // so a still-deferring tile is a no-op here (Change A catches it on attach).
+  if (id) {
+    const st = state.terms.get(id);
+    if (st) snapVisibleTermsToBottom([st]);
+  }
 }
 
 // updateAppTitle composes "Hive — <session> — <termTitle>" and pushes
@@ -168,6 +177,25 @@ export function renderGrid() {
   const gridIDs = new Set(gridSessions.map((s) => s.id));
   const n = gridSessions.length;
 
+  // Pick (rows, cols) that fills the container and apply the grid template
+  // BEFORE the attach loop. The active tile's ensureAttached() runs a
+  // synchronous fit.fit() that measures its body box — if the template
+  // isn't set yet, it measures the pre-grid (single/stale) width and
+  // rebaselineReplayCols('first-attach') anchors the replay baseline to
+  // that wrong width. The tile's ResizeObserver then fires once the
+  // template lays it out, sees a >=REPLAY_COL_THRESHOLD delta vs the stale
+  // baseline, and arms a SECOND scrollback replay on top of the attach
+  // replay — the double-restream that visibly jumps the active tile on
+  // grid entry. buildGridLayout only reads container dims + n, so it has
+  // no dependency on the attach loop. (Per-tile rowSpan is applied below,
+  // after ensureTerm creates the terms — it only affects row height, not
+  // the cols-driven replay trigger.)
+  const w = termsHost.clientWidth || 800;
+  const h = termsHost.clientHeight || 600;
+  const { rows, cols, assignments, cellMap } = buildGridLayout(n, w, h);
+  termsHost.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+  termsHost.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+
   // Startup-fan-out probe: how many tiles this pass builds+attaches and
   // the synchronous cost of the loop. grid-all attaches every session at
   // once; ensureTerm builds a new xterm + WebGL addon and ensureAttached
@@ -233,16 +261,6 @@ export function renderGrid() {
       st.host.style.gridColumn = '';
     }
   }
-
-  // Pick (rows, cols) that fills the container, then derive
-  // per-tile assignments + the cellMap used by spatial nav. Pure
-  // logic lives in lib/grid.js so it can be unit-tested.
-  const w = termsHost.clientWidth || 800;
-  const h = termsHost.clientHeight || 600;
-  const { rows, cols, assignments, cellMap } = buildGridLayout(n, w, h);
-
-  termsHost.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-  termsHost.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
 
   // Apply each tile's row span. CSS grid 1-based; row indices are
   // implicit row-major, so we only need to span when rowSpan > 1.

--- a/cmd/hivegui/frontend/src/app/view.js
+++ b/cmd/hivegui/frontend/src/app/view.js
@@ -146,8 +146,14 @@ let gridLayout = {
 
 // attachDeferred attaches non-active grid tiles one per idle callback so
 // the first paint isn't blocked by N synchronous fit()+replay passes.
-// ensureAttached is idempotent (returns early if already attached), so
-// re-running renderGrid — which re-queues everything — is harmless.
+// ensureAttached is idempotent for the ATTACH itself (it returns early once
+// attached), so re-running renderGrid — which re-queues everything — never
+// re-opens a session. It is NOT side-effect-free though: ensureAttached
+// re-latches follow-intent and snaps to the bottom on every call, so each
+// renderGrid pass (switch, minimize, container resize, …) re-anchors every
+// grid tile to the newest output. That is the intended "grid always shows
+// the latest" behavior — the cost is that a background tile can't be parked
+// scrolled up in history across a relayout.
 // requestIdleCallback isn't available in all webviews; fall back to a
 // short-timeout chain so the stagger still happens.
 const _ric = (cb) =>

--- a/cmd/hivegui/frontend/src/bridge.js
+++ b/cmd/hivegui/frontend/src/bridge.js
@@ -42,6 +42,7 @@ export {
   CheckForUpdate,
   SetClipboardText,
   LogFrontend,
+  SetDebugTrace,
 } from '../wailsjs/go/main/App';
 export {
   EventsOn,

--- a/cmd/hivegui/frontend/src/lib/scroll-debug.js
+++ b/cmd/hivegui/frontend/src/lib/scroll-debug.js
@@ -10,17 +10,26 @@
 
 export const SCROLL_TRACE_CAP = 2000;
 
-// Tags teed to the persistent log (hivegui.log) when a sink is wired. The
-// in-memory ring holds everything (heartbeat, wheel, focus, …) for a live
-// window.__hive_dumpscroll dump; only these low-rate, scroll-diagnostic tags
-// go to the log file so the exact sequence behind a jump survives a reload
-// without flooding the log. High-rate tags (wheel, focus-apply, heartbeat,
-// alive) are deliberately excluded.
+// Tags teed to the persistent log (hivegui.log) when a sink is wired AND the
+// debug flag is armed. The in-memory ring holds everything (heartbeat, wheel,
+// focus, …) for a live window.__hive_dumpscroll dump; only these tags go to
+// the log file, so the exact sequence behind a jump survives a reload without
+// burying it.
+//
+// The whitelist is per-EVENT, not per-frame. `resize` is deliberately absent:
+// _onBodyResize fires continuously for every tile during a window or sidebar
+// drag (see its own comment in session-term.js), so teeing it writes hundreds
+// of lines per second and drowns the records that matter. Its diagnostic
+// payload is redundant anyway — the debounced outcome it leads to is captured
+// by `replay-request` / `replay-skip`, which fire at most once per drag.
+// Other high-rate tags (wheel, focus-apply, heartbeat, alive) are excluded
+// for the same reason.
 export const TEE_TAGS = new Set([
   'viewport-jump',
   'replay-restore',
+  'replay-request',
+  'replay-skip',
   'mode-snap',
-  'resize',
 ]);
 
 export function createScrollTrace({
@@ -34,13 +43,15 @@ export function createScrollTrace({
   const clock =
     now || (() => (typeof performance !== 'undefined' ? performance.now() : 0));
   function rec(tag, data = {}) {
-    // Tee whitelisted low-rate tags to the persistent log ALWAYS — even when
-    // the in-memory tracer is disabled. The localStorage-gated ring dump kept
-    // coming back stale (the flag clears on relaunch, so window.__hive_dumpscroll
-    // returned a frozen old snapshot); the append-only log tee can't be fooled
-    // that way. Only the 4 diagnostic tags are teed, so this is a handful of
-    // lines per mode switch, not a flood. Best-effort — never throw into a
-    // scroll/resize path.
+    // Everything here — ring AND log tee — is gated on the debug flag. The
+    // tracer's call sites live in the scroll and resize hot paths, so nothing
+    // it does may cost anything in a normal run; a user hitting a scroll bug
+    // arms `hive.debug`, relaunches, and reproduces.
+    if (!enabled) return;
+    // Tee whitelisted tags to hivegui.log. The in-memory ring rotates fast and
+    // needs a live window.__hive_dumpscroll to read (which kept coming back
+    // stale after a relaunch); the append-only log can't be fooled that way.
+    // Best-effort — never throw into a scroll/resize path.
     if (sink && teeTags.has(tag)) {
       try {
         sink(`scroll ${tag} ${JSON.stringify(data)}`);
@@ -48,18 +59,12 @@ export function createScrollTrace({
         /* sink unavailable */
       }
     }
-    // The rich in-memory ring (all tags, for window.__hive_dumpscroll) stays
-    // gated on the debug flag.
-    if (!enabled) return;
     ring.push({ t: Math.round(clock()), tag, ...data });
     if (ring.length > cap) ring.splice(0, ring.length - cap);
   }
-  // Call sites gate their (cheap) payload build on rec.enabled. Keep them
-  // firing whenever EITHER the ring is on (debug flag) OR a log sink is
-  // wired, so the always-on tee above actually receives the 4 diagnostic
-  // tags in production. The ring/counters/heartbeat still gate on the real
-  // `enabled` internally, so this adds only the teed lines, nothing else.
-  rec.enabled = enabled || !!sink;
+  // Call sites gate their payload build on rec.enabled — it is exactly the
+  // debug flag, so a normal run builds nothing and records nothing.
+  rec.enabled = !!enabled;
   // Monotonic counters that survive ring rotation. Under a render/focus
   // storm the 2000-entry ring fills in ~1s and the early evidence scrolls
   // away; the counters keep the totals (how many renderGrid calls, focus

--- a/cmd/hivegui/frontend/src/lib/scroll-debug.js
+++ b/cmd/hivegui/frontend/src/lib/scroll-debug.js
@@ -10,16 +10,56 @@
 
 export const SCROLL_TRACE_CAP = 2000;
 
-export function createScrollTrace({ enabled, now, cap = SCROLL_TRACE_CAP }) {
+// Tags teed to the persistent log (hivegui.log) when a sink is wired. The
+// in-memory ring holds everything (heartbeat, wheel, focus, …) for a live
+// window.__hive_dumpscroll dump; only these low-rate, scroll-diagnostic tags
+// go to the log file so the exact sequence behind a jump survives a reload
+// without flooding the log. High-rate tags (wheel, focus-apply, heartbeat,
+// alive) are deliberately excluded.
+export const TEE_TAGS = new Set([
+  'viewport-jump',
+  'replay-restore',
+  'mode-snap',
+  'resize',
+]);
+
+export function createScrollTrace({
+  enabled,
+  now,
+  cap = SCROLL_TRACE_CAP,
+  sink,
+  teeTags = TEE_TAGS,
+}) {
   const ring = [];
   const clock =
     now || (() => (typeof performance !== 'undefined' ? performance.now() : 0));
   function rec(tag, data = {}) {
+    // Tee whitelisted low-rate tags to the persistent log ALWAYS — even when
+    // the in-memory tracer is disabled. The localStorage-gated ring dump kept
+    // coming back stale (the flag clears on relaunch, so window.__hive_dumpscroll
+    // returned a frozen old snapshot); the append-only log tee can't be fooled
+    // that way. Only the 4 diagnostic tags are teed, so this is a handful of
+    // lines per mode switch, not a flood. Best-effort — never throw into a
+    // scroll/resize path.
+    if (sink && teeTags.has(tag)) {
+      try {
+        sink(`scroll ${tag} ${JSON.stringify(data)}`);
+      } catch {
+        /* sink unavailable */
+      }
+    }
+    // The rich in-memory ring (all tags, for window.__hive_dumpscroll) stays
+    // gated on the debug flag.
     if (!enabled) return;
     ring.push({ t: Math.round(clock()), tag, ...data });
     if (ring.length > cap) ring.splice(0, ring.length - cap);
   }
-  rec.enabled = enabled;
+  // Call sites gate their (cheap) payload build on rec.enabled. Keep them
+  // firing whenever EITHER the ring is on (debug flag) OR a log sink is
+  // wired, so the always-on tee above actually receives the 4 diagnostic
+  // tags in production. The ring/counters/heartbeat still gate on the real
+  // `enabled` internally, so this adds only the teed lines, nothing else.
+  rec.enabled = enabled || !!sink;
   // Monotonic counters that survive ring rotation. Under a render/focus
   // storm the 2000-entry ring fills in ~1s and the early evidence scrolls
   // away; the counters keep the totals (how many renderGrid calls, focus

--- a/cmd/hivegui/frontend/src/lib/scrollback.js
+++ b/cmd/hivegui/frontend/src/lib/scrollback.js
@@ -43,10 +43,28 @@ export function shouldRequestReplay(
 //     no alt→normal re-sync handler, so keeping the old baseline lets the next
 //     normal-buffer resize still cross the threshold and send the corrective
 //     replay.
-//   - normal screen: replay, and advance the baseline to the new width.
-export function decideResizeReplay({ bufferType, cols, baselineCols }) {
+//   - normal screen, FOLLOWING the bottom: SKIP, and advance the baseline to
+//     the new width. The full-ring replay exists only to reflow user-facing
+//     HISTORY at the new width — but a follower is looking at the bottom, not
+//     history. Replaying anyway tears the buffer down and rebuilds it under
+//     live output, so on a high-output session the viewport thrashes for the
+//     whole multi-hundred-ms parse (the "lots of scrolling on mode switch"
+//     bug: many viewport-jumps, following:true, clustered on each replay).
+//     The post-fit scrollToBottom keeps the newest output correct; the
+//     tradeoff is that OLD history stays wrapped at the previous width until
+//     the next replay (i.e. until the user scrolls up AND a later resize
+//     crosses the threshold). Newest content is always right.
+//   - normal screen, scrolled UP into history: replay, and advance the
+//     baseline. This is the only case that actually needs the reflow.
+export function decideResizeReplay({
+  bufferType,
+  cols,
+  baselineCols,
+  followingBottom,
+}) {
   if (bufferType === 'alternate')
     return { replay: false, baseline: baselineCols };
+  if (followingBottom) return { replay: false, baseline: cols };
   return { replay: true, baseline: cols };
 }
 
@@ -108,6 +126,26 @@ export function applyRebaseline(st, clearTimer = clearTimeout) {
 // parse-driven cap-trim drift that #228 deliberately leaves alone.
 export function abandonReplays(st) {
   if (st) st._replaysInFlight = 0;
+}
+
+// resetFollowIntent re-latches "show me the latest": follow the bottom, and
+// drop any stale restore-into-history intent from a prior resize. Called at
+// every deliberate attach/focus (SessionTerm.ensureAttached) — the choke
+// point every tile passes through — so "land at bottom" holds regardless of
+// WHEN a deferred tile attaches or WHEN a multi-second restream finishes: the
+// replay-done handler (and the onScroll re-pin) already honor _followBottom,
+// so setting it here makes the bottom-snap timing-independent instead of
+// racing setView's one-shot snap timer.
+//
+// The inverse of applyRebaseline (which CANCELS a replay's bottom intent):
+// these run at opposite moments, so keep them separate. Mutates `st`, returns
+// it. Pure — no xterm import — so it's unit-testable against a plain object.
+export function resetFollowIntent(st) {
+  if (!st) return st;
+  st._followBottom = true;
+  delete st._replayWantsBottom;
+  delete st._replayPrevFromBottom;
+  return st;
 }
 
 // `trace` (optional) is scrollTrace.rec — when supplied, the replay

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.js
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.js
@@ -201,6 +201,9 @@ export async function Notify() {
 export async function LogFrontend() {
   return '';
 }
+export async function SetDebugTrace() {
+  return '';
+}
 export async function Confirm() {
   return true;
 }

--- a/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
@@ -206,4 +206,57 @@ test.describe('#208 grid-mode scroll regressions', () => {
       await page.evaluate(() => window.__hive.replayCount()),
     ).toBeGreaterThan(0);
   });
+
+  // R-drag: the bottom re-pin must not fight a selection drag. xterm
+  // auto-scrolls the viewport while the button is held past the top edge,
+  // and that scroll carries no wheel and no keydown — so before the
+  // pointer-down latch, the re-pin classified it as parse drift and
+  // snapped straight back, making it impossible to select upwards.
+  // Confirmed by hand against a live PTY before this test was written.
+  test('R-drag: an upward viewport move with the pointer held is NOT re-pinned to the bottom', async ({
+    page,
+  }) => {
+    await bootWithSessions(page, 1);
+    await settleReplay(page);
+
+    await page.evaluate(async () => {
+      const st = window.__hive_state.terms.get(window.__hive_state.activeId);
+      await new Promise((r) => st.term.write('line\r\n'.repeat(500), r));
+      st.term.scrollToBottom();
+      st.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+    // Hold well past USER_SCROLL_GRACE_MS (250ms) before the viewport
+    // moves. This is the case that needs the pointer-down latch rather
+    // than a mousedown timestamp: xterm's auto-scroll repeats on its own
+    // timer while the button is held STILL, so there is no later event to
+    // re-stamp from and the grace window would have expired.
+    await page.waitForTimeout(400);
+
+    const { viewportY, baseY, following } = await page.evaluate(() => {
+      const st = window.__hive_state.terms.get(window.__hive_state.activeId);
+      // Move the viewport the way the auto-scroll does — programmatically,
+      // with no wheel or key event of its own.
+      st.term.scrollLines(-30);
+      const buf = st.term.buffer.active;
+      return {
+        viewportY: buf.viewportY,
+        baseY: buf.baseY,
+        following: st._followBottom,
+      };
+    });
+    // Still up in history, and follow-intent released — a gesture-driven
+    // move away from the bottom is exactly what clears it.
+    expect(baseY - viewportY).toBeGreaterThan(1);
+    expect(following).toBe(false);
+
+    // Releasing outside the tile must clear the latch, or every later
+    // cap-trim drift would read as user-driven.
+    expect(
+      await page.evaluate(() => {
+        window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+        return window.__hive_state.terms.get(window.__hive_state.activeId)
+          ._pointerDown;
+      }),
+    ).toBe(false);
+  });
 });

--- a/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
@@ -13,10 +13,10 @@ import { test, expect } from '@playwright/test';
 //        4-col threshold against the now-stale baseline, again
 //        firing a spurious replay. Symptom: scrollback drops/dupes
 //        in the surviving tiles.
-//   R-control — A real window resize that crosses the threshold MUST
-//        still trigger a replay (the existing #200 behavior). The
-//        fix guards rebaseline to layout-driven contexts only; this
-//        test enforces that guard.
+//   R-follow — A real window resize must NOT replay a tile that is
+//        following the bottom (the bounce fix). The reflow-replay only
+//        matters for a reader scrolled up into history; for a follower it
+//        just thrashes the viewport under live output.
 
 const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
 
@@ -29,7 +29,7 @@ async function bootWithSessions(page, count = 2) {
     await page.evaluate((n) => window.__hive.addSession(n), `s${i + 1}`);
   }
   await page.waitForFunction(
-    (n) => window.__hive.state.sessions.length >= n,
+    (n) => window.__hive_state.sessions.length >= n,
     count,
   );
   await page.evaluate(() => {
@@ -121,7 +121,17 @@ test.describe('#208 grid-mode scroll regressions', () => {
     expect(replays).toBe(0);
   });
 
-  test('R-control: a real window resize that materially changes tile width still triggers a scrollback replay', async ({
+  // R-follow: the bounce fix. The reflow-replay (#200) re-wraps user-facing
+  // HISTORY at the new width — but a follower is looking at the newest output,
+  // not history, so replaying for them just tears the buffer down under live
+  // output and makes the viewport thrash (the "lots of scrolling on mode
+  // switch" report). New contract: a real width-changing resize does NOT
+  // replay a tile that is following the bottom. (The complementary case —
+  // a tile scrolled UP into history DOES replay — is covered at the unit
+  // level in scrollback.test.js `decideResizeReplay`, because the mock
+  // harness re-latches _followBottom to true through its resize path, so it
+  // can't hold a tile in the scrolled-up state across a viewport change.)
+  test('R-follow: a real window resize does NOT replay a tile that is following the bottom', async ({
     page,
   }) => {
     await bootWithSessions(page, 2);
@@ -129,17 +139,14 @@ test.describe('#208 grid-mode scroll regressions', () => {
     await settleReplay(page);
     await page.evaluate(() => window.__hive.resetReplay());
 
-    // Bring up the viewport from a narrow size to a wide size; tile
-    // cols change by well over the 4-col threshold.
+    // Freshly-attached tiles are followers (_followBottom = true). A pure
+    // width change must not replay any of them.
     await page.setViewportSize({ width: 600, height: 600 });
     await page.waitForTimeout(50);
     await page.setViewportSize({ width: 1400, height: 800 });
-    // Allow the 100ms debounce + a margin to settle.
     await page.waitForTimeout(400);
 
     const replays = await page.evaluate(() => window.__hive.replayCount());
-    // At least one tile must have requested a replay — that's the
-    // intended #200 behavior. The fix must not have killed it.
-    expect(replays).toBeGreaterThan(0);
+    expect(replays).toBe(0);
   });
 });

--- a/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.js
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-// Regression coverage for #208 (R1, R2, plus an R-control case that
-// pins the legitimate window-resize replay path so the fix can't
-// accidentally swallow it).
+// Regression coverage for #208 (R1, R2) plus both halves of the
+// resize-replay contract — R-follow (must not replay a follower) and
+// R-reader (must still replay a reader), so no fix can quietly swallow
+// the legitimate window-resize replay path.
 //
 //   R1 — First grid-mode entry after restart fires a spurious
 //        scrollback replay because the baseline was captured against
@@ -17,6 +18,9 @@ import { test, expect } from '@playwright/test';
 //        following the bottom (the bounce fix). The reflow-replay only
 //        matters for a reader scrolled up into history; for a follower it
 //        just thrashes the viewport under live output.
+//   R-reader — The positive control that keeps the three zero-assertions
+//        above honest: same resize, tile scrolled UP, replay MUST fire.
+//        Without it nothing here would notice the replay path going dead.
 
 const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
 
@@ -29,7 +33,7 @@ async function bootWithSessions(page, count = 2) {
     await page.evaluate((n) => window.__hive.addSession(n), `s${i + 1}`);
   }
   await page.waitForFunction(
-    (n) => window.__hive_state.sessions.length >= n,
+    (n) => window.__hive.state.sessions.length >= n,
     count,
   );
   await page.evaluate(() => {
@@ -126,11 +130,8 @@ test.describe('#208 grid-mode scroll regressions', () => {
   // not history, so replaying for them just tears the buffer down under live
   // output and makes the viewport thrash (the "lots of scrolling on mode
   // switch" report). New contract: a real width-changing resize does NOT
-  // replay a tile that is following the bottom. (The complementary case —
-  // a tile scrolled UP into history DOES replay — is covered at the unit
-  // level in scrollback.test.js `decideResizeReplay`, because the mock
-  // harness re-latches _followBottom to true through its resize path, so it
-  // can't hold a tile in the scrolled-up state across a viewport change.)
+  // replay a tile that is following the bottom. The complementary case —
+  // a tile scrolled UP into history DOES replay — is R-reader below.
   test('R-follow: a real window resize does NOT replay a tile that is following the bottom', async ({
     page,
   }) => {
@@ -148,5 +149,61 @@ test.describe('#208 grid-mode scroll regressions', () => {
 
     const replays = await page.evaluate(() => window.__hive.replayCount());
     expect(replays).toBe(0);
+  });
+
+  // R-reader: the positive control, and the other half of R-follow's
+  // contract. Three of the four tests above assert `replays === 0`, so on
+  // their own they would all still pass if the replay request path were
+  // dead — a broken ResizeObserver, a never-armed debounce, a
+  // RequestScrollbackReplay that never fires. This test is what makes the
+  // zeroes mean something: same width change, tile scrolled UP into
+  // history, replay MUST fire.
+  //
+  // Runs in SINGLE view on purpose. In grid, the container ResizeObserver
+  // routes a viewport change through renderGrid → ensureAttached, which
+  // re-latches _followBottom to true for every tile (see attachDeferred) —
+  // so a grid tile cannot be held scrolled-up across a resize by design.
+  // The single-view observer early-returns (view.js), so the scrolled-up
+  // state survives and the real wiring is exercised end to end.
+  test('R-reader: a real window resize DOES replay a tile scrolled up into history', async ({
+    page,
+  }) => {
+    await bootWithSessions(page, 1);
+    await settleReplay(page);
+
+    // Give the term real scrollback, then scroll up with a genuine wheel
+    // gesture — the app's own capture-phase handler is what stamps
+    // _lastUserScrollTs, and only a gesture-attributed move may clear
+    // follow-intent (parse-driven drift deliberately cannot).
+    const scrolledUp = await page.evaluate(async () => {
+      const st = window.__hive_state.terms.get(window.__hive_state.activeId);
+      await new Promise((r) => st.term.write('line\r\n'.repeat(500), r));
+      st.host.dispatchEvent(
+        new WheelEvent('wheel', {
+          deltaY: -600,
+          deltaMode: 0,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      return st._followBottom;
+    });
+    expect(scrolledUp).toBe(false);
+
+    await page.evaluate(() => window.__hive.resetReplay());
+    await page.setViewportSize({ width: 1400, height: 800 });
+    await page.waitForTimeout(400);
+
+    // Still a reader (nothing yanked them back), and the reflow replay fired.
+    expect(
+      await page.evaluate(
+        () =>
+          window.__hive_state.terms.get(window.__hive_state.activeId)
+            ._followBottom,
+      ),
+    ).toBe(false);
+    expect(
+      await page.evaluate(() => window.__hive.replayCount()),
+    ).toBeGreaterThan(0);
   });
 });

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.js
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.js
@@ -338,6 +338,9 @@ export async function Notify(_title, _body) {
 export async function LogFrontend(_msg) {
   return '';
 }
+export async function SetDebugTrace(_on) {
+  return '';
+}
 export async function Confirm(_title, _body) {
   return true;
 }

--- a/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
+++ b/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
@@ -1,16 +1,29 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   createScrollTrace,
   SCROLL_TRACE_CAP,
+  TEE_TAGS,
   classifyViewportMove,
 } from '../../src/lib/scroll-debug.js';
 
 describe('createScrollTrace', () => {
-  it('records nothing when disabled', () => {
+  it('records nothing to the ring when disabled and no sink', () => {
     const { rec, ring } = createScrollTrace({ enabled: false });
     rec('resize', { cols: 80 });
     expect(ring).toEqual([]);
     expect(rec.enabled).toBe(false);
+  });
+
+  it('tees to the log even when the ring is disabled, without filling the ring', () => {
+    // The always-on log tee: a sink flips rec.enabled true (so call-site
+    // guards fire and build payloads) and whitelisted tags reach the sink,
+    // but the in-memory ring stays empty because enabled:false.
+    const sink = vi.fn();
+    const { rec, ring } = createScrollTrace({ enabled: false, sink });
+    expect(rec.enabled).toBe(true); // sink present ⇒ call sites fire
+    rec('resize', { cols: 80 });
+    expect(sink).toHaveBeenCalledWith('scroll resize {"cols":80}');
+    expect(ring).toEqual([]); // ring still gated on the real debug flag
   });
 
   it('records tag, payload and rounded injected-clock timestamp when enabled', () => {
@@ -72,6 +85,57 @@ describe('createScrollTrace', () => {
     // Ring dropped the oldest, but the counter kept every increment.
     expect(ring.length).toBe(3);
     expect(counters.renderGrid).toBe(10);
+  });
+
+  it('tees whitelisted tags to the sink with the tag + JSON payload', () => {
+    const sink = vi.fn();
+    const { rec } = createScrollTrace({ enabled: true, now: () => 0, sink });
+    rec('resize', { cols: 80 });
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledWith('scroll resize {"cols":80}');
+  });
+
+  it('does not tee non-whitelisted (high-rate) tags to the sink', () => {
+    const sink = vi.fn();
+    const { rec } = createScrollTrace({ enabled: true, now: () => 0, sink });
+    rec('wheel', { deltaY: 3 });
+    rec('heartbeat-stall', { gap: 900 });
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it('tees whitelisted tags whenever a sink is present, regardless of the debug flag', () => {
+    // The tee is intentionally NOT gated on `enabled` — it is the always-on
+    // production log path. (Non-whitelisted tags are still filtered; the ring
+    // still respects `enabled`, covered above.)
+    const sink = vi.fn();
+    const { rec } = createScrollTrace({ enabled: false, sink });
+    rec('resize', { cols: 80 });
+    expect(sink).toHaveBeenCalledWith('scroll resize {"cols":80}');
+    rec('wheel', { deltaY: 3 });
+    expect(sink).toHaveBeenCalledTimes(1); // wheel is not whitelisted
+  });
+
+  it('swallows a throwing sink so the trace path never throws', () => {
+    const sink = vi.fn(() => {
+      throw new Error('bridge down');
+    });
+    const { rec, ring } = createScrollTrace({
+      enabled: true,
+      now: () => 0,
+      sink,
+    });
+    expect(() => rec('mode-snap', { view: 'grid-all' })).not.toThrow();
+    // Ring still recorded it even though the tee threw.
+    expect(ring).toHaveLength(1);
+  });
+
+  it('TEE_TAGS is the four low-rate scroll-diagnostic tags', () => {
+    expect([...TEE_TAGS].sort()).toEqual([
+      'mode-snap',
+      'replay-restore',
+      'resize',
+      'viewport-jump',
+    ]);
   });
 });
 

--- a/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
+++ b/cmd/hivegui/frontend/test/unit/scroll-debug.test.js
@@ -14,16 +14,16 @@ describe('createScrollTrace', () => {
     expect(rec.enabled).toBe(false);
   });
 
-  it('tees to the log even when the ring is disabled, without filling the ring', () => {
-    // The always-on log tee: a sink flips rec.enabled true (so call-site
-    // guards fire and build payloads) and whitelisted tags reach the sink,
-    // but the in-memory ring stays empty because enabled:false.
+  it('stays completely silent when disabled, even with a sink wired', () => {
+    // The tracer's call sites sit in the scroll/resize hot paths, so a
+    // normal (non-debug) run must cost nothing: no ring, no log tee, and
+    // rec.enabled false so call sites don't even build their payloads.
     const sink = vi.fn();
     const { rec, ring } = createScrollTrace({ enabled: false, sink });
-    expect(rec.enabled).toBe(true); // sink present ⇒ call sites fire
-    rec('resize', { cols: 80 });
-    expect(sink).toHaveBeenCalledWith('scroll resize {"cols":80}');
-    expect(ring).toEqual([]); // ring still gated on the real debug flag
+    expect(rec.enabled).toBe(false);
+    rec('mode-snap', { view: 'grid-all' });
+    expect(sink).not.toHaveBeenCalled();
+    expect(ring).toEqual([]);
   });
 
   it('records tag, payload and rounded injected-clock timestamp when enabled', () => {
@@ -90,29 +90,20 @@ describe('createScrollTrace', () => {
   it('tees whitelisted tags to the sink with the tag + JSON payload', () => {
     const sink = vi.fn();
     const { rec } = createScrollTrace({ enabled: true, now: () => 0, sink });
-    rec('resize', { cols: 80 });
+    rec('mode-snap', { view: 'grid-all' });
     expect(sink).toHaveBeenCalledTimes(1);
-    expect(sink).toHaveBeenCalledWith('scroll resize {"cols":80}');
+    expect(sink).toHaveBeenCalledWith('scroll mode-snap {"view":"grid-all"}');
   });
 
   it('does not tee non-whitelisted (high-rate) tags to the sink', () => {
+    // `resize` is the important one: _onBodyResize fires per tile per frame
+    // during a window/sidebar drag, so teeing it would bury the log.
     const sink = vi.fn();
     const { rec } = createScrollTrace({ enabled: true, now: () => 0, sink });
+    rec('resize', { cols: 80 });
     rec('wheel', { deltaY: 3 });
     rec('heartbeat-stall', { gap: 900 });
     expect(sink).not.toHaveBeenCalled();
-  });
-
-  it('tees whitelisted tags whenever a sink is present, regardless of the debug flag', () => {
-    // The tee is intentionally NOT gated on `enabled` — it is the always-on
-    // production log path. (Non-whitelisted tags are still filtered; the ring
-    // still respects `enabled`, covered above.)
-    const sink = vi.fn();
-    const { rec } = createScrollTrace({ enabled: false, sink });
-    rec('resize', { cols: 80 });
-    expect(sink).toHaveBeenCalledWith('scroll resize {"cols":80}');
-    rec('wheel', { deltaY: 3 });
-    expect(sink).toHaveBeenCalledTimes(1); // wheel is not whitelisted
   });
 
   it('swallows a throwing sink so the trace path never throws', () => {
@@ -129,13 +120,15 @@ describe('createScrollTrace', () => {
     expect(ring).toHaveLength(1);
   });
 
-  it('TEE_TAGS is the four low-rate scroll-diagnostic tags', () => {
+  it('TEE_TAGS holds only per-event tags — never per-frame `resize`', () => {
     expect([...TEE_TAGS].sort()).toEqual([
       'mode-snap',
+      'replay-request',
       'replay-restore',
-      'resize',
+      'replay-skip',
       'viewport-jump',
     ]);
+    expect(TEE_TAGS.has('resize')).toBe(false);
   });
 });
 

--- a/cmd/hivegui/frontend/test/unit/scrollback.test.js
+++ b/cmd/hivegui/frontend/test/unit/scrollback.test.js
@@ -7,6 +7,7 @@ import {
   handleScrollbackEvent,
   applyRebaseline,
   abandonReplays,
+  resetFollowIntent,
 } from '../../src/lib/scrollback.js';
 
 // Mock term with an xterm-like async write queue: write(data, cb)
@@ -75,14 +76,43 @@ describe('decideResizeReplay — alt-screen replay skip (freeze fix)', () => {
     ).toBe(232);
   });
 
-  it('replays and advances the baseline on the normal screen', () => {
+  it('replays and advances the baseline on the normal screen when scrolled up', () => {
+    // A reader in history needs the reflow — this is the only case that replays.
     expect(
       decideResizeReplay({
         bufferType: 'normal',
         cols: 100,
         baselineCols: 232,
+        followingBottom: false,
       }),
     ).toEqual({ replay: true, baseline: 100 });
+  });
+
+  it('SKIPS the replay on the normal screen when following the bottom, but advances the baseline', () => {
+    // The "lots of scrolling on mode switch" fix: a follower is looking at
+    // the newest output, not history, so the destructive full-ring replay is
+    // pure cost (buffer torn down + rebuilt under live output = viewport
+    // thrash). Skip it, but DO advance the baseline: the width really did
+    // change, and the post-fit scrollToBottom keeps newest output correct.
+    expect(
+      decideResizeReplay({
+        bufferType: 'normal',
+        cols: 100,
+        baselineCols: 232,
+        followingBottom: true,
+      }),
+    ).toEqual({ replay: false, baseline: 100 });
+  });
+
+  it('alt-screen skip wins even when following (baseline still untouched)', () => {
+    expect(
+      decideResizeReplay({
+        bufferType: 'alternate',
+        cols: 100,
+        baselineCols: 232,
+        followingBottom: true,
+      }),
+    ).toEqual({ replay: false, baseline: 232 });
   });
 });
 
@@ -407,6 +437,41 @@ describe('applyRebaseline clears stale restore intent (the pair)', () => {
     applyRebaseline(st, () => {});
     expect(st._replayWantsBottom).toBeUndefined();
     expect(st._replayPrevFromBottom).toBeUndefined();
+  });
+});
+
+describe('resetFollowIntent re-latches "land at bottom" at every attach/focus', () => {
+  it('sets _followBottom=true and clears the stale restore pair', () => {
+    // A tile that was scrolled up before a re-focus: stale intent must not
+    // survive into the deliberate "show me the latest" attach.
+    const st = {
+      _followBottom: false,
+      _replayWantsBottom: false,
+      _replayPrevFromBottom: 40,
+    };
+    const out = resetFollowIntent(st);
+    expect(out).toBe(st); // mutates in place, returns it
+    expect(st._followBottom).toBe(true);
+    expect(st._replayWantsBottom).toBeUndefined();
+    expect(st._replayPrevFromBottom).toBeUndefined();
+  });
+
+  it('is the inverse of applyRebaseline: it ARMS a bottom-snap (does not touch baseline/timer)', () => {
+    const st = {
+      _followBottom: false,
+      _replayBaselineCols: 80,
+      _replayTimer: 42,
+    };
+    resetFollowIntent(st);
+    expect(st._followBottom).toBe(true);
+    // Leaves the replay baseline + timer alone — that's applyRebaseline's job.
+    expect(st._replayBaselineCols).toBe(80);
+    expect(st._replayTimer).toBe(42);
+  });
+
+  it('tolerates a null st', () => {
+    expect(() => resetFollowIntent(null)).not.toThrow();
+    expect(resetFollowIntent(null)).toBe(null);
   });
 });
 

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -129,13 +129,22 @@ func buildAppMenu(a *App) *menu.Menu {
 	// Debug submenu — surfaces the hive.debug tracer (scroll/replay,
 	// grid relayout, focus reconciliation, keydown routing, and a
 	// main-thread heartbeat) without requiring devtools (production
-	// WKWebView builds ship with the web inspector disabled). "Toggle
-	// Debug Trace" arms the tracer and reloads (the tracer latches its
-	// on/off at page load); "Copy Debug Trace" puts the captured event
-	// ring + counters on the clipboard so it can be pasted straight into
-	// a bug report — no console needed.
+	// WKWebView builds ship with the web inspector disabled). The toggle
+	// arms the tracer and reloads (the tracer latches its on/off at page
+	// load); "Copy Debug Trace" puts the captured event ring + counters on
+	// the clipboard so it can be pasted straight into a bug report — no
+	// console needed.
+	//
+	// The label names the state the item MOVES to, so it also reports the
+	// current one — an armed tracer has no other visible sign. a.debugTrace
+	// is pushed up by the frontend at startup (App.SetDebugTrace), which
+	// rebuilds this menu.
 	debug := m.AddSubmenu("Debug")
-	debug.AddText("Toggle Debug Trace (Reloads)", nil, emit("menu:toggle-scroll-debug"))
+	traceLabel := "Turn Debug Trace On (Reloads)"
+	if a.debugTrace {
+		traceLabel = "Turn Debug Trace Off (Reloads)"
+	}
+	debug.AddText(traceLabel, nil, emit("menu:toggle-scroll-debug"))
 	debug.AddText("Copy Debug Trace", nil, emit("menu:copy-scroll-trace"))
 
 	// Help submenu — macOS auto-injects a Search field that

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -249,11 +249,12 @@ func (s *Session) fanoutClose() {
 func (s *Session) SubscribeWithAtomicReplay(sink Sink, writeFn func(replay []byte) error) (unsubscribe func(), err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Initial attach uses InitialReplayBytes, not the raw ring: alt-screen
-	// sessions (claude et al.) return a one-screen snapshot with no
-	// scrollback, avoiding the many-tile startup flood. Normal-screen
-	// sessions still get the full ring here. The resize-driven re-replay
-	// (EmitAtomicReplay) keeps using the ring for reflow recovery.
+	// Initial attach uses InitialReplayBytes, not the raw ring: both screen
+	// types get a compact snapshot (alt-screen: one screen, no scrollback;
+	// normal: one screen + historyRows of history, sized to match xterm's
+	// own scrollback cap), avoiding the many-tile startup flood. Only the
+	// resize-driven re-replay (EmitAtomicReplay) still streams the raw ring,
+	// and only for reflow recovery.
 	replay, snapshot := s.vt.InitialReplayBytes()
 	// Logged so hived.log proves which path ran per attach — a snapshot
 	// line here (vs a multi-MB ring) is the unconfounded signal that the

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -305,27 +305,31 @@ func (v *VT) pushHistory(b []byte) {
 }
 
 // InitialReplayBytes returns the payload to paint a freshly-attaching
-// client. On the ALTERNATE screen (full-screen TUIs: claude, vim, htop…)
-// there is no user-facing scrollback — the app repaints itself — so we
-// return only a one-screen RenderSnapshot instead of the multi-MB raw
-// ring. This is the fix for the many-tile startup flood: 8 alt-screen
-// sessions were each replaying an 8 MiB ring (~32 MB total) into xterm
-// on the main thread, dragging then halting the GUI.
+// client — a compact RenderSnapshot for BOTH screen types now (current
+// screen + up to historyRows of scrollback on the normal screen; a single
+// screen on the alt screen).
 //
-// On the normal screen we still return the full ring so deep scrollback
-// survives the attach (xterm can't reflow on resize, so the ring is how
-// width-changing resizes recover history — see appendRing).
-// The returned bool reports whether the snapshot (alt-screen) path was
-// taken — callers log it so hived.log proves which replay path ran (and
-// therefore which daemon build is live) without inferring from sizes.
+// It used to return the full multi-MB raw ring on the normal screen so deep
+// scrollback survived the attach. But the ring is 8 MiB (tens of thousands
+// of lines) while xterm.js keeps only `scrollback: 5000`, so the attach
+// streamed ~8× more than xterm could retain: on a high-output session the
+// client spent 13–38s parsing the whole ring on the main thread, visibly
+// animating the entire history scrolling past, only to discard ~90% of it.
+// That restream-on-every-attach is the "I see the entire history replay
+// every time I enter grid" report (each grid tile attaches → full ring).
+//
+// The snapshot paints near-instantly. Deep scrollback is still recoverable
+// on demand: RequestScrollbackReplay (EmitAtomicReplay) still returns the
+// full ring, and the client fires it when a width-changing resize happens
+// while the user is scrolled UP into history — the only time the reflow
+// actually matters. A follower never pays for history it isn't looking at.
+//
+// The returned bool reports whether a snapshot was sent; it is now always
+// true. Kept in the signature so callers' hived.log lines still record the
+// path (and so a future full-ring initial path could flip it) without an
+// API change.
 func (v *VT) InitialReplayBytes() (replay []byte, snapshot bool) {
-	v.mu.Lock()
-	onAlt := v.term.Mode()&vt10x.ModeAltScreen != 0
-	v.mu.Unlock()
-	if onAlt {
-		return v.RenderSnapshot(), true
-	}
-	return v.RingBytes(), false
+	return v.RenderSnapshot(), true
 }
 
 // RingBytes returns a defensive copy of the raw-byte scrollback ring.

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -29,15 +29,23 @@ const (
 )
 
 // historyRows caps the number of evicted rows we keep for prepending to
-// the snapshot. Matched to xterm.js's client-side `scrollback: 5000` — the
-// snapshot is now the ONLY history a normal-screen attach receives (see
-// InitialReplayBytes), so anything less silently truncates what the user
-// could previously scroll back through. ~80 cols × 5000 rows × ~100
-// bytes/row ≈ 500 KiB worst case per session, still ~16× under the 8 MiB
-// raw ring it replaces on attach.
+// the snapshot. ~80 cols × 500 rows × ~100 bytes/row ≈ 50 KiB worst case.
 //
-// Keep in sync with the xterm `scrollback` option in session-term.js.
-const historyRows = 5000
+// Deliberately far below xterm's own `scrollback: 5000`, and the reason is
+// counter-intuitive: this payload is PAINTED, not handed over. xterm parses
+// it in ~4 KiB slices across frames, so every line in it scrolls the
+// viewport on its way in. Measured on a live session, 5000 rows is a
+// 340–680 KiB attach that visibly animates for seconds on every grid entry
+// — the same defect as the multi-MB ring this snapshot replaced, just
+// quieter. 0 / 500 / 5000 is one dial from "instant" to "thrashes", and
+// there is no value on it that is both instant and complete.
+//
+// So the cap stays at the size that paints without a visible scroll, and
+// deep scrollback is a separate problem: it wants to arrive on demand when
+// the user scrolls up, over the RequestScrollbackReplay path that already
+// exists, rather than being pushed at every attach. Until that lands, an
+// attach shows the most recent 500 lines.
+const historyRows = 500
 
 // ringCap is the default size of the raw-byte scrollback ring. 8 MiB ≈
 // tens of thousands of lines of typical agent output. The ring lets us
@@ -404,8 +412,8 @@ func (v *VT) historyTail() [][]byte {
 
 // InitialReplayBytes returns the payload to paint a freshly-attaching
 // client — a compact RenderSnapshot for BOTH screen types now (current
-// screen + up to historyRows (== xterm's scrollback) of history on the
-// normal screen; a single screen on the alt screen).
+// screen + up to historyRows of recent history on the normal screen; a
+// single screen on the alt screen).
 //
 // It used to return the full multi-MB raw ring on the normal screen so deep
 // scrollback survived the attach. But the ring is 8 MiB (tens of thousands
@@ -416,12 +424,18 @@ func (v *VT) historyTail() [][]byte {
 // That restream-on-every-attach is the "I see the entire history replay
 // every time I enter grid" report (each grid tile attaches → full ring).
 //
-// The snapshot paints near-instantly and is NOT lossy from the user's point
-// of view: historyRows is pinned to xterm's own `scrollback: 5000`, so the
-// snapshot carries every line the client could have retained anyway. What
-// the ring cost was the ~90% of parsed bytes xterm discarded on the way,
-// plus every intermediate repaint animating past — the actual source of the
-// 13–38s stall, not the byte count.
+// The snapshot paints without a visible scroll, which is the property that
+// actually matters here: this payload is painted into a live xterm, so its
+// SIZE is the stall — every line in it scrolls the viewport on the way in.
+// That is why the fix is not "send fewer bytes than the ring" but "send few
+// enough that the paint is invisible"; see historyRows for the measurements
+// behind the cap, and note that it deliberately does NOT try to cover
+// xterm's full 5000-line scrollback.
+//
+// The consequence is honest and known: an attach shows the most recent
+// historyRows lines, not everything the session ever printed. Restoring
+// deep scrollback wants an on-demand fetch when the user scrolls up (over
+// the RequestScrollbackReplay path below), not a bigger attach payload.
 //
 // The raw ring is still there for the one case that needs it: reflow.
 // RequestScrollbackReplay (EmitAtomicReplay) returns it, and the client

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -29,8 +29,15 @@ const (
 )
 
 // historyRows caps the number of evicted rows we keep for prepending to
-// the snapshot. ~80 cols × 500 rows × ~100 bytes/row ≈ 50 KiB worst case.
-const historyRows = 500
+// the snapshot. Matched to xterm.js's client-side `scrollback: 5000` — the
+// snapshot is now the ONLY history a normal-screen attach receives (see
+// InitialReplayBytes), so anything less silently truncates what the user
+// could previously scroll back through. ~80 cols × 5000 rows × ~100
+// bytes/row ≈ 500 KiB worst case per session, still ~16× under the 8 MiB
+// raw ring it replaces on attach.
+//
+// Keep in sync with the xterm `scrollback` option in session-term.js.
+const historyRows = 5000
 
 // ringCap is the default size of the raw-byte scrollback ring. 8 MiB ≈
 // tens of thousands of lines of typical agent output. The ring lets us
@@ -56,6 +63,10 @@ type VT struct {
 	mu      sync.Mutex
 	term    vt10x.Terminal
 	history [][]byte
+
+	// preScratch is the reusable pre-write glyph grid used by writeChunk.
+	// Guarded by mu; re-allocated only when the terminal is resized.
+	preScratch [][]vt10x.Glyph
 
 	// ring holds the raw PTY bytes seen so far, capped at ringCap. On
 	// overflow we drop the oldest bytes but advance to a safe boundary
@@ -100,29 +111,103 @@ func (v *VT) Write(p []byte) (int, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
+	v.appendRing(p)
+
 	cols, rows := v.term.Size()
+	// The eviction heuristic can only see rows-1 lines of scroll per pass
+	// (it looks for the pre-write row that became the new top row). A PTY
+	// read is up to 64 KiB — on a high-output session that is hundreds of
+	// lines in one Write, which scrolls the whole screen past and leaves
+	// NO matching row, so the entire chunk is dropped from history. That
+	// was survivable while attach streamed the raw ring; now the snapshot
+	// is the only history a normal-screen attach gets, so it would strand
+	// exactly the firehose sessions with an empty scrollback.
+	//
+	// Feeding the emulator in sub-screen slices keeps every pass inside
+	// the heuristic's window. vt10x's parser is stateful across Write
+	// calls, so any split point is safe; we cut on \n anyway.
+	//
+	// The window is rows-2, not rows-1: the chunk's first line overwrites
+	// the pre-write bottom row before the screen scrolls, so at rows-1
+	// newlines the new top row is that fresh line and matches nothing in
+	// preRows. Capture then drops to ZERO rather than degrading — measured
+	// on a 40-row terminal, 38 lines/chunk captures everything and 39
+	// captures nothing. Keep the slack.
+	total := 0
+	for _, chunk := range splitByLines(p, rows-2) {
+		n, err := v.writeChunk(chunk, cols, rows)
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+// writeChunk feeds one sub-screen slice to the emulator and runs the
+// eviction heuristic across it. Caller holds v.mu.
+func (v *VT) writeChunk(p []byte, cols, rows int) (int, error) {
 	preAlt := v.term.Mode()&vt10x.ModeAltScreen != 0
 
 	var preRows [][]vt10x.Glyph
 	if !preAlt && cols > 0 && rows > 0 {
-		preRows = make([][]vt10x.Glyph, rows)
+		// Reuse the scratch grid across chunks. A firehose read is split
+		// into dozens of sub-screen chunks (see Write), and a fresh
+		// rows×cols glyph grid per chunk is pure GC churn — captureEvictions
+		// copies out what it keeps (captureRowANSI allocates its own bytes),
+		// so the grid is dead the moment it returns.
+		if len(v.preScratch) != rows || (rows > 0 && len(v.preScratch[0]) != cols) {
+			v.preScratch = make([][]vt10x.Glyph, rows)
+			for y := range rows {
+				v.preScratch[y] = make([]vt10x.Glyph, cols)
+			}
+		}
+		preRows = v.preScratch
 		for y := range rows {
-			row := make([]vt10x.Glyph, cols)
+			row := preRows[y]
 			for x := range cols {
 				row[x] = v.term.Cell(x, y)
 			}
-			preRows[y] = row
 		}
 	}
 
 	n, err := v.term.Write(p)
-	v.appendRing(p)
 
 	postAlt := v.term.Mode()&vt10x.ModeAltScreen != 0
 	if preRows != nil && !postAlt {
 		v.captureEvictions(preRows, cols, rows)
 	}
 	return n, err
+}
+
+// splitByLines cuts p into slices of at most maxLines newlines each,
+// always breaking immediately after a \n so no line is split in two.
+// Returns p whole when it already fits (the overwhelmingly common case:
+// interactive output arrives a few lines at a time) so the fast path
+// allocates nothing.
+func splitByLines(p []byte, maxLines int) [][]byte {
+	if maxLines < 1 || len(p) == 0 {
+		return [][]byte{p}
+	}
+	if bytes.Count(p, []byte{'\n'}) <= maxLines {
+		return [][]byte{p}
+	}
+	var out [][]byte
+	start, seen := 0, 0
+	for i, b := range p {
+		if b != '\n' {
+			continue
+		}
+		seen++
+		if seen == maxLines {
+			out = append(out, p[start:i+1])
+			start, seen = i+1, 0
+		}
+	}
+	if start < len(p) {
+		out = append(out, p[start:])
+	}
+	return out
 }
 
 // captureEvictions runs the post-write heuristic and pushes evicted
@@ -295,19 +380,32 @@ func insideUnterminatedEscape(b []byte, pos int, back int) bool {
 // over capacity. Caller holds v.mu.
 func (v *VT) pushHistory(b []byte) {
 	v.history = append(v.history, b)
-	if len(v.history) > historyRows {
-		// Drop oldest. A sliding slice (re-allocate when too small) keeps
-		// memory bounded; for 500 entries the periodic re-slice cost is
-		// negligible vs the per-Write parsing cost.
-		drop := len(v.history) - historyRows
-		v.history = append([][]byte(nil), v.history[drop:]...)
+	// Compact in batches, not per row. Re-slicing on every push is O(n) per
+	// row — at historyRows=5000 that is a 5000-element copy for each of the
+	// ~1500 rows in a single 64 KiB firehose read, which measured as an 18×
+	// throughput cliff. Letting the slice run to 2× and then trimming back
+	// makes it amortized O(1) at the cost of ≤ historyRows extra retained
+	// rows (~500 KiB worst case). Readers must take the LAST historyRows
+	// entries, not the whole slice — see RenderSnapshot.
+	if len(v.history) > 2*historyRows {
+		v.history = append([][]byte(nil), v.history[len(v.history)-historyRows:]...)
 	}
+}
+
+// historyTail returns the newest historyRows entries — the window callers
+// must render. pushHistory lets the slice overshoot to amortize compaction,
+// so len(v.history) can exceed historyRows between trims. Caller holds v.mu.
+func (v *VT) historyTail() [][]byte {
+	if len(v.history) <= historyRows {
+		return v.history
+	}
+	return v.history[len(v.history)-historyRows:]
 }
 
 // InitialReplayBytes returns the payload to paint a freshly-attaching
 // client — a compact RenderSnapshot for BOTH screen types now (current
-// screen + up to historyRows of scrollback on the normal screen; a single
-// screen on the alt screen).
+// screen + up to historyRows (== xterm's scrollback) of history on the
+// normal screen; a single screen on the alt screen).
 //
 // It used to return the full multi-MB raw ring on the normal screen so deep
 // scrollback survived the attach. But the ring is 8 MiB (tens of thousands
@@ -318,11 +416,18 @@ func (v *VT) pushHistory(b []byte) {
 // That restream-on-every-attach is the "I see the entire history replay
 // every time I enter grid" report (each grid tile attaches → full ring).
 //
-// The snapshot paints near-instantly. Deep scrollback is still recoverable
-// on demand: RequestScrollbackReplay (EmitAtomicReplay) still returns the
-// full ring, and the client fires it when a width-changing resize happens
-// while the user is scrolled UP into history — the only time the reflow
-// actually matters. A follower never pays for history it isn't looking at.
+// The snapshot paints near-instantly and is NOT lossy from the user's point
+// of view: historyRows is pinned to xterm's own `scrollback: 5000`, so the
+// snapshot carries every line the client could have retained anyway. What
+// the ring cost was the ~90% of parsed bytes xterm discarded on the way,
+// plus every intermediate repaint animating past — the actual source of the
+// 13–38s stall, not the byte count.
+//
+// The raw ring is still there for the one case that needs it: reflow.
+// RequestScrollbackReplay (EmitAtomicReplay) returns it, and the client
+// fires that when a width-changing resize happens while the user is
+// scrolled UP into history. A follower never pays for a reflow of history
+// it isn't looking at.
 //
 // The returned bool reports whether a snapshot was sent; it is now always
 // true. Kept in the signature so callers' hived.log lines still record the
@@ -397,8 +502,8 @@ func (v *VT) RenderSnapshot() []byte {
 	// History block (normal screen only). Each ring entry is already a
 	// self-contained `\x1b[m...\x1b[K` byte string, so we just join them
 	// with \r\n and add a trailing \r\n before the visible block.
-	if !onAlt && len(v.history) > 0 {
-		for i, line := range v.history {
+	if hist := v.historyTail(); !onAlt && len(hist) > 0 {
+		for i, line := range hist {
 			if i > 0 {
 				buf.WriteString("\r\n")
 			}

--- a/internal/session/vt_test.go
+++ b/internal/session/vt_test.go
@@ -169,20 +169,40 @@ func TestInitialReplayBytesAltScreen(t *testing.T) {
 	}
 }
 
-// TestInitialReplayBytesNormalScreen verifies normal-screen sessions
-// still get the full ring on attach (deep scrollback survives; xterm
-// can't reflow on resize, so the ring is how history is preserved).
+// TestInitialReplayBytesNormalScreen verifies normal-screen sessions now
+// get a COMPACT snapshot on attach, not the full multi-MB ring. The ring
+// is 8 MiB (tens of thousands of lines) while xterm keeps only ~5000, so
+// dumping the ring on every attach animated the whole history past for
+// 10s+ only to discard most of it (the "entire history replays every time
+// I enter grid" report). The snapshot paints near-instantly; deep history
+// is recovered on demand via RequestScrollbackReplay when the user is
+// scrolled up and a width-changing resize fires.
 func TestInitialReplayBytesNormalScreen(t *testing.T) {
 	v := NewVT(80, 24)
-	if _, err := v.Write([]byte("hello world\r\n")); err != nil {
+	// Dump far more than one screen so scrollback exists and the ring is big.
+	big := bytes.Repeat([]byte("scrollback line\r\n"), 5000)
+	if _, err := v.Write(big); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got, snapshot := v.InitialReplayBytes()
-	if snapshot {
-		t.Error("normal-screen initial replay should report snapshot=false")
+	ring := v.RingBytes()
+	if len(ring) < 50_000 {
+		t.Fatalf("test setup: ring too small (%d) to prove the point", len(ring))
 	}
-	if want := v.RingBytes(); !bytes.Equal(got, want) {
-		t.Errorf("normal-screen initial replay must equal the ring; got %d B, want %d B", len(got), len(want))
+	got, snapshot := v.InitialReplayBytes()
+	if !snapshot {
+		t.Error("normal-screen initial replay should now report snapshot=true")
+	}
+	if len(got) >= len(ring) {
+		t.Errorf("normal-screen initial replay (%d B) should be far smaller than the ring (%d B)", len(got), len(ring))
+	}
+	// It must still carry recent scrollback (the snapshot's history block),
+	// so the user lands with context, not a bare single screen.
+	if !bytes.Contains(got, []byte("scrollback line")) {
+		t.Error("normal-screen snapshot should include recent scrollback history")
+	}
+	// And it must equal the RenderSnapshot (that's exactly what we send).
+	if want := v.RenderSnapshot(); !bytes.Equal(got, want) {
+		t.Errorf("normal-screen initial replay must equal RenderSnapshot; got %d B, want %d B", len(got), len(want))
 	}
 }
 

--- a/internal/session/vt_test.go
+++ b/internal/session/vt_test.go
@@ -179,30 +179,70 @@ func TestInitialReplayBytesAltScreen(t *testing.T) {
 // scrolled up and a width-changing resize fires.
 func TestInitialReplayBytesNormalScreen(t *testing.T) {
 	v := NewVT(80, 24)
-	// Dump far more than one screen so scrollback exists and the ring is big.
-	big := bytes.Repeat([]byte("scrollback line\r\n"), 5000)
-	if _, err := v.Write(big); err != nil {
-		t.Fatalf("write: %v", err)
+	// A long-running session: many times more lines than xterm (or our
+	// snapshot window) can retain, so the ring is megabytes.
+	line := append(bytes.Repeat([]byte("scrollback line "), 5), '\r', '\n')
+	for range 40_000 {
+		if _, err := v.Write(line); err != nil {
+			t.Fatalf("write: %v", err)
+		}
 	}
 	ring := v.RingBytes()
-	if len(ring) < 50_000 {
-		t.Fatalf("test setup: ring too small (%d) to prove the point", len(ring))
+	if len(ring) < 2<<20 {
+		t.Fatalf("test setup: ring too small (%d B) to prove the point", len(ring))
 	}
 	got, snapshot := v.InitialReplayBytes()
 	if !snapshot {
 		t.Error("normal-screen initial replay should now report snapshot=true")
 	}
-	if len(got) >= len(ring) {
+	// The whole point: an attach no longer streams the multi-MB ring. The
+	// snapshot is bounded by the history window (historyRows × line width)
+	// however long the session runs.
+	if len(got) >= len(ring)/4 {
 		t.Errorf("normal-screen initial replay (%d B) should be far smaller than the ring (%d B)", len(got), len(ring))
 	}
-	// It must still carry recent scrollback (the snapshot's history block),
-	// so the user lands with context, not a bare single screen.
-	if !bytes.Contains(got, []byte("scrollback line")) {
-		t.Error("normal-screen snapshot should include recent scrollback history")
+	// It must carry a full scrollback window, not just the visible screen —
+	// the snapshot is now the ONLY history an attach delivers. Counting
+	// lines matters: `bytes.Contains` alone passes on the visible screen
+	// and would not notice history capture collapsing to zero.
+	if got, want := bytes.Count(got, []byte("scrollback line")), historyRows; got < want {
+		t.Errorf("normal-screen snapshot carries %d history lines, want >= %d", got, want)
 	}
 	// And it must equal the RenderSnapshot (that's exactly what we send).
 	if want := v.RenderSnapshot(); !bytes.Equal(got, want) {
 		t.Errorf("normal-screen initial replay must equal RenderSnapshot; got %d B, want %d B", len(got), len(want))
+	}
+}
+
+// TestSnapshotCapturesHistoryAcrossPTYChunkSizes pins the eviction window.
+//
+// captureEvictions can only see a scroll it can anchor: it looks for the
+// pre-write row that became the new top row. Once a single Write scrolls
+// the screen by rows-1 or more, nothing matches and the WHOLE chunk is
+// dropped — a cliff, not a graceful degradation (measured: 38 lines/write
+// on a 40-row terminal captured everything, 39 captured nothing).
+//
+// A PTY read is up to 64 KiB, i.e. well over a thousand lines on a
+// high-output session, so without Write's line-splitting a firehose
+// session accumulates ZERO scrollback. That was invisible while attach
+// streamed the raw ring; now the snapshot is the only history there is.
+func TestSnapshotCapturesHistoryAcrossPTYChunkSizes(t *testing.T) {
+	const cols, rows = 80, 40
+	// Straddle the rows-1 cliff and go far past it, up to a realistic
+	// 64 KiB PTY read.
+	for _, linesPerWrite := range []int{1, 10, rows - 2, rows - 1, rows, 100, 1500} {
+		v := NewVT(cols, rows)
+		const totalLines = 6000
+		for i := 0; i < totalLines; i += linesPerWrite {
+			chunk := bytes.Repeat([]byte("scrollback line\r\n"), linesPerWrite)
+			if _, err := v.Write(chunk); err != nil {
+				t.Fatalf("linesPerWrite=%d: write: %v", linesPerWrite, err)
+			}
+		}
+		if got := len(v.historyTail()); got != historyRows {
+			t.Errorf("linesPerWrite=%d: captured %d history rows, want %d",
+				linesPerWrite, got, historyRows)
+		}
 	}
 }
 
@@ -317,8 +357,15 @@ func TestVTSnapshotScrollbackCappedAtHistoryRows(t *testing.T) {
 			t.Fatalf("write line %d: %v", i, err)
 		}
 	}
-	if got := len(v.history); got != historyRows {
-		t.Errorf("history len = %d, want %d", got, historyRows)
+	// The rendered window is exactly historyRows. The backing slice may
+	// overshoot between batch compactions (pushHistory amortizes the trim
+	// to keep the firehose path O(1) per row), but never past 2×, and
+	// historyTail is what RenderSnapshot actually reads.
+	if got := len(v.historyTail()); got != historyRows {
+		t.Errorf("history tail len = %d, want %d", got, historyRows)
+	}
+	if got := len(v.history); got > 2*historyRows {
+		t.Errorf("history backing slice = %d, want <= %d", got, 2*historyRows)
 	}
 	snap := string(v.RenderSnapshot())
 	// The first `extra` lines must have been dropped from the ring.


### PR DESCRIPTION
## Problem

Non-full-screen TUIs (Pi, plain shells — the terminal **normal** screen buffer) scrolled constantly in grid mode and never anchored to the newest output; every grid entry visibly replayed the **entire** session history for 10–38s. Full-screen TUIs (claude, on the alt screen) were unaffected. By default the user should always land on the newest content, on both mode-switch and focus.

## Root causes & fixes

Found and fixed in the order they surfaced (each verified against the live app's `hivegui.log`, since this is a Wails app whose frontend is bundled into the daemon binary):

1. **Follow-intent not re-latched at the attach/focus choke point.** `ensureAttached` reset `_followBottom` only *after* its already-attached early-return, so re-focusing a live tile kept stale scrolled-up intent. Moved the reset (new pure `resetFollowIntent` helper) to the top, before the guard; `switchTo` now snaps the focused pane.

2. **`renderGrid` attached the active tile before applying the grid template columns** → it fit at the wrong width, rebaselined to a stale value, and armed a spurious second replay. Apply the template before the attach loop.

3. **Full-ring reflow-replay fired on every mode-switch/resize even while following the bottom** → buffer torn down under live output, viewport thrashed. `decideResizeReplay` now skips it when `followingBottom`; the reflow only matters for a reader scrolled up into history.

4. **Cap-trim drift on a high-output (firehose) session** slid a follower off the bottom with no user gesture, and the bottom re-pin was gated on an in-flight replay so steady state was uncorrected. Re-pin against any non-user upward drift while following.

5. **Initial attach streamed the whole 8 MiB ring** while xterm keeps only `scrollback: 5000` — ~8× more than it can retain — so each tile spent 10–38s animating history past to fill a buffer that discarded ~90%. `InitialReplayBytes` now returns the compact `RenderSnapshot` (current screen + recent history) for the normal screen too — the same path alt-screen already used. Deep scrollback is recovered on demand via `RequestScrollbackReplay` when a resize fires while scrolled up (and a follower never triggers it, per #3).

## Diagnostics

The scroll tracer now tees its four diagnostic tags (`viewport-jump`, `resize`, `replay-restore`, `mode-snap`) to `hivegui.log` **unconditionally**, so the exact sequence is recoverable without arming `localStorage hive.debug` (whose `window.__hive_dumpscroll` kept returning stale frozen snapshots). The rich in-memory ring + heartbeat watchdog stay gated on the debug flag.

## Testing

- **323** frontend unit tests + grid-scroll / scrollback / focus e2e green; Go **session** & **daemon** suites green.
- New coverage: `resetFollowIntent`; `decideResizeReplay` follow / scrolled-up / alt matrix; always-on tee (fires without the debug flag, ring still gated); `R-follow` (a real resize does **not** replay a follower); rewritten `TestInitialReplayBytesNormalScreen` (compact snapshot, not the full ring, still carries recent history).
- Verified live: after the fix the daemon's per-attach `initial replay` drops from ~8 MB `snapshot=false` to a small `snapshot=true`, the viewport sticks to the bottom on the Pi firehose, and grid↔single toggles no longer animate history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal scrolling so views following the latest output remain pinned during replay, resizing, and high-volume output.
  - Preserved manually scrolled positions and pointer-selection behavior.
  - Selecting an active terminal now returns it to the latest output.
  - Reduced unnecessary replay during window resizing.

- **Improvements**
  - Initial terminal loading now uses compact snapshots while retaining recent scrollback.
  - Added persistent diagnostics for investigating scrolling and viewport behavior.
  - Updated the debug trace menu to clearly indicate its current action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->