### PR TITLE
frontend: TypeScript migration wave 3 — src/app leaf modules

### DIFF
--- a/cmd/hivegui/frontend/src/app/dom.ts
+++ b/cmd/hivegui/frontend/src/app/dom.ts
@@ -4,30 +4,39 @@
 
 import { createStatus } from '../lib/status.js';
 
-export const termsHost = document.getElementById('terms');
+// index.html owns these three ids; a missing one means the document and
+// this module have drifted, which is a load-time bug, not a runtime
+// condition to branch on. Throwing here beats `!` — it names the id.
+function mustEl(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`missing #${id} in index.html`);
+  return el;
+}
+
+export const termsHost = mustEl('terms');
 termsHost.classList.add('single');
 
-export const projectsUL = document.getElementById('projects');
-export const status = document.getElementById('status');
+export const projectsUL = mustEl('projects');
+export const status = mustEl('status');
 
 const statusCtl = createStatus({
-  render: (text, isError) => {
+  render: (text: string, isError: boolean) => {
     status.textContent = text;
     status.classList.toggle('error', isError);
   },
-  setTimer: (fn, ms) => window.setTimeout(fn, ms),
-  clearTimer: (id) => window.clearTimeout(id),
+  setTimer: (fn: () => void, ms: number) => window.setTimeout(fn, ms),
+  clearTimer: (id: number) => window.clearTimeout(id),
   now: () => Date.now(),
 });
 
 // setStatus owns the persistent slot: connection state, nav feedback.
-export function setStatus(text, isError = false) {
+export function setStatus(text: string, isError = false): void {
   statusCtl.set(text, isError);
 }
 
 // flashStatus owns transient per-action feedback; it auto-reverts to
 // the persistent slot (errors linger 6s, info 2.5s — see lib/status.js).
-export function flashStatus(text, isError = false) {
+export function flashStatus(text: string, isError = false): void {
   statusCtl.flash(text, isError);
 }
 
@@ -35,5 +44,5 @@ export function flashStatus(text, isError = false) {
 // action in the status bar. Wails mutation promises reject when the
 // daemon connection is down (or the call throws Go-side), which used
 // to be swallowed — the button click just silently did nothing.
-export const reportFailure = (what) => (err) =>
+export const reportFailure = (what: string) => (err: unknown) =>
   flashStatus(`${what} failed: ${err}`, true);

--- a/cmd/hivegui/frontend/src/app/inline-rename.ts
+++ b/cmd/hivegui/frontend/src/app/inline-rename.ts
@@ -19,6 +19,16 @@
 //                      non-empty, changed value)
 //   onDone()        — called after every finish, commit or cancel
 //   beforeFocus()   — optional, run after mount but before focus/select
+export interface InlineRenameOpts {
+  mount: (input: HTMLInputElement) => void;
+  unmount: (input: HTMLInputElement) => void;
+  value: string;
+  className: string;
+  onCommit: (next: string) => void;
+  onDone?: () => void;
+  beforeFocus?: () => void;
+}
+
 export function beginInlineRename({
   mount,
   unmount,
@@ -27,7 +37,7 @@ export function beginInlineRename({
   onCommit,
   onDone,
   beforeFocus,
-}) {
+}: InlineRenameOpts): HTMLInputElement {
   const input = document.createElement('input');
   input.type = 'text';
   input.className = className;
@@ -37,7 +47,7 @@ export function beginInlineRename({
   input.focus();
   input.select();
   let done = false;
-  const finish = (commit) => {
+  const finish = (commit: boolean) => {
     if (done) return;
     done = true;
     const next = input.value.trim();

--- a/cmd/hivegui/frontend/src/app/modals/registry.ts
+++ b/cmd/hivegui/frontend/src/app/modals/registry.ts
@@ -6,12 +6,12 @@
 // replaces an explicit four-element classList check with the same
 // check over the registered set).
 
-const modals = [];
+const modals: Element[] = [];
 
-export function registerModal(el) {
+export function registerModal(el: Element | null | undefined): void {
   if (el) modals.push(el);
 }
 
-export function anyModalOpen() {
+export function anyModalOpen(): boolean {
   return modals.some((el) => !el.classList.contains('hidden'));
 }

--- a/cmd/hivegui/frontend/src/app/selectors.ts
+++ b/cmd/hivegui/frontend/src/app/selectors.ts
@@ -1,11 +1,11 @@
 // Read-only derivations over the shared state object. No DOM, no
 // bridge calls — pure lookups modules can share without cycles.
 
-import { state } from './state.js';
+import { state, type SessionInfo } from './state.js';
 
 // orderedSessions returns sessions sorted by (project order, session order)
 // so navigation always matches what the user sees.
-export function orderedSessions() {
+export function orderedSessions(): SessionInfo[] {
   const projOrder = new Map(state.projects.map((p, i) => [p.id, i]));
   return [...state.sessions].sort((a, b) => {
     const pa = projOrder.get(a.projectId ?? a.project_id ?? '') ?? 1e9;
@@ -21,7 +21,7 @@ export function orderedSessions() {
 // explicitly — the full-circle walk ends back on it, and ⌘B must always
 // move you somewhere new (a flag on the session you're already looking
 // at is stale; setActive clears it on focus anyway).
-export function nextAttentionId() {
+export function nextAttentionId(): string | null {
   const ord = orderedSessions();
   const n = ord.length;
   if (n === 0) return null;
@@ -37,7 +37,7 @@ export function nextAttentionId() {
 // view: a session's worktree (preferred), otherwise the owning
 // project's cwd, otherwise the user's currently-selected project.
 // Empty string means "let the Go side fall back to launchDir".
-export function activeCwd() {
+export function activeCwd(): string {
   const id = state.activeId;
   const s = id ? state.sessions.find((x) => x.id === id) : null;
   if (s?.worktree_path) return s.worktree_path;
@@ -46,7 +46,7 @@ export function activeCwd() {
   return p?.cwd ?? '';
 }
 
-export function activeProjectId() {
+export function activeProjectId(): string {
   // currentProjectId is the user's explicit "I'm here" — set by
   // ⌘[/], project-header click, switchTo (synced to session's
   // project), and project events. Empty projects work because they
@@ -73,7 +73,9 @@ export function activeProjectId() {
 // internal/wire/control.go), so prefer those and fall back to the
 // camelCase variants for safety — this matches `s.projectId ??
 // s.project_id` used elsewhere in this file.
-export function resolveSessionCwd(sess) {
+export function resolveSessionCwd(
+  sess: SessionInfo | null | undefined,
+): string {
   if (!sess) return '';
   const wt = sess.worktree_path ?? sess.worktreePath;
   if (wt) return wt;

--- a/cmd/hivegui/frontend/src/app/selectors.ts
+++ b/cmd/hivegui/frontend/src/app/selectors.ts
@@ -40,7 +40,12 @@ export function nextAttentionId(): string | null {
 export function activeCwd(): string {
   const id = state.activeId;
   const s = id ? state.sessions.find((x) => x.id === id) : null;
-  if (s?.worktree_path) return s.worktree_path;
+  // Both spellings, like resolveSessionCwd below — a camelCase-only
+  // session used to fall through to the project cwd here, so ⌘N landed
+  // in the repo root instead of the worktree. Not delegating to
+  // resolveSessionCwd: its project fallback skips activeProjectId().
+  const wt = s?.worktree_path ?? s?.worktreePath;
+  if (wt) return wt;
   const pid = (s?.projectId ?? s?.project_id) || activeProjectId();
   const p = pid ? state.projects.find((x) => x.id === pid) : null;
   return p?.cwd ?? '';
@@ -71,8 +76,10 @@ export function activeProjectId(): string {
 //
 // Wire payloads from the daemon use snake_case (see
 // internal/wire/control.go), so prefer those and fall back to the
-// camelCase variants for safety — this matches `s.projectId ??
-// s.project_id` used elsewhere in this file.
+// camelCase variants for safety. Both spellings are read everywhere in
+// this file; only the ordering varies, and it doesn't matter — no
+// payload carries both (test/e2e/payload-shapes.spec.js pins the two
+// shapes separately).
 export function resolveSessionCwd(
   sess: SessionInfo | null | undefined,
 ): string {

--- a/cmd/hivegui/frontend/src/app/state.ts
+++ b/cmd/hivegui/frontend/src/app/state.ts
@@ -31,6 +31,10 @@ export interface SessionInfo {
   worktreePath?: string;
   worktree_branch?: string;
   worktreeBranch?: string;
+  // Why the dead-session overlay reads: events.js:131 and
+  // session-term.js:1173 both fall back off it.
+  last_error?: string;
+  lastError?: string;
 }
 
 export interface ProjectInfo {

--- a/cmd/hivegui/frontend/src/app/state.ts
+++ b/cmd/hivegui/frontend/src/app/state.ts
@@ -10,9 +10,59 @@ import {
   serializeCollapsed,
   COLLAPSED_STORAGE_KEY,
 } from '../lib/collapsed.js';
-import { createNavHistory } from '../lib/nav-history.js';
+import { createNavHistory, type NavHistory } from '../lib/nav-history.js';
+import type { ViewMode } from '../lib/view.js';
 
-export const state = {
+// Wire payloads from the daemon (internal/wire/control.go) are
+// snake_case; some paths also carry camelCase, so both spellings are
+// optional and call sites read `x_y ?? xY` (see selectors.ts). These
+// are NOT the generated wailsjs models — sessions/projects arrive over
+// EventsOn as raw JSON, so there is nothing generated to import.
+export interface SessionInfo {
+  id: string;
+  name?: string;
+  agent?: string;
+  color?: string;
+  order?: number;
+  alive?: boolean;
+  project_id?: string;
+  projectId?: string;
+  worktree_path?: string;
+  worktreePath?: string;
+  worktree_branch?: string;
+  worktreeBranch?: string;
+}
+
+export interface ProjectInfo {
+  id: string;
+  name?: string;
+  cwd?: string;
+  color?: string;
+  order?: number;
+}
+
+// SessionTerm (app/session-term.js) is still JS — wave 6. Until then the
+// registry is typed `unknown`, so wave-3 files can't pretend to know it.
+export interface AppState {
+  projects: ProjectInfo[];
+  sessions: SessionInfo[];
+  collapsed: Set<string>;
+  attention: Set<string>;
+  attentionReturnId: string | null;
+  attentionRestored: Set<string>;
+  nav: NavHistory;
+  minimized: Set<string>;
+  aliveById: Map<string, boolean>;
+  dismissedDead: Set<string>;
+  terms: Map<string, unknown>;
+  activeId: string | null;
+  currentProjectId: string | null;
+  view: ViewMode;
+  gridProjectId: string | null;
+  fontSize: number;
+}
+
+export const state: AppState = {
   projects: [], // ProjectInfo[] in display order
   sessions: [], // SessionInfo[] in display order
   collapsed: loadSavedCollapsed(), // project ids that are collapsed — persisted
@@ -60,7 +110,7 @@ if (
   window.__hive_state = state;
 }
 
-export function loadSavedView() {
+export function loadSavedView(): ViewMode {
   try {
     return normalizeView(localStorage.getItem(VIEW_STORAGE_KEY));
   } catch {
@@ -68,7 +118,7 @@ export function loadSavedView() {
   }
 }
 
-export function loadSavedCollapsed() {
+export function loadSavedCollapsed(): Set<string> {
   try {
     return loadCollapsed(localStorage.getItem(COLLAPSED_STORAGE_KEY));
   } catch {
@@ -76,7 +126,7 @@ export function loadSavedCollapsed() {
   }
 }
 
-export function saveCollapsed() {
+export function saveCollapsed(): void {
   try {
     localStorage.setItem(
       COLLAPSED_STORAGE_KEY,

--- a/cmd/hivegui/frontend/src/app/trace.ts
+++ b/cmd/hivegui/frontend/src/app/trace.ts
@@ -28,7 +28,7 @@ export const scrollTrace = createScrollTrace({
   // per-event tags in TEE_TAGS (never `resize`, which storms during a drag).
   // Best-effort: no bridge in tests / before the runtime is ready, and the
   // Wails binding returns a promise — swallow the throw and the rejection.
-  sink: (msg) => {
+  sink: (msg: string) => {
     try {
       LogFrontend(msg)?.catch?.(() => {});
     } catch {
@@ -61,7 +61,7 @@ const LASTJUMP_KEY = 'hive.scrolltrace.lastjump';
 // scroll-jump detector (SessionTerm.onScroll) when it records an
 // unexplained upward viewport move. Best-effort: storage may be full or
 // disabled — never throw into the scroll path.
-export function snapshotScrollJump() {
+export function snapshotScrollJump(): void {
   try {
     localStorage.setItem(
       LASTJUMP_KEY,
@@ -98,7 +98,7 @@ let _maxStallMs = 0;
 // throttled to ~1fps — the signature of an OS-occluded / unfocused window
 // rather than a busy loop. So every freeze probe now carries whether the
 // page is visible and whether the webview actually holds OS key focus.
-function winState() {
+function winState(): Record<string, unknown> {
   const ae = document.activeElement;
   return {
     vis: document.visibilityState,
@@ -162,7 +162,7 @@ if (typeof window !== 'undefined') {
   // observed main-thread stall. Best-effort copies the JSON to the
   // clipboard so a user hitting the bug can paste it straight back.
   window.__hive_dumpscroll = () => {
-    let lastJump = null;
+    let lastJump: unknown = null;
     try {
       lastJump = JSON.parse(localStorage.getItem(LASTJUMP_KEY) || 'null');
     } catch {

--- a/cmd/hivegui/frontend/src/globals.d.ts
+++ b/cmd/hivegui/frontend/src/globals.d.ts
@@ -1,0 +1,23 @@
+// Debug/e2e-only globals. None of these exist in a normal production
+// build: `__hive_state` is gated on the Vite mock/real env vars
+// (app/state.ts), the scrolltrace pair is gated on localStorage
+// `hive.debug` (app/trace.ts), and `__hive` is injected by the
+// Playwright mock bridge (test/e2e/wails-mock.js).
+
+import type { AppState } from './app/state.js';
+import type { ScrollTraceEntry } from './lib/scroll-debug.js';
+
+declare global {
+  interface Window {
+    __hive_state?: AppState;
+    __hive_scrolltrace?: ScrollTraceEntry[];
+    __hive_dumpscroll?: () => {
+      enabled: boolean;
+      ring: ScrollTraceEntry[];
+      lastJump: unknown;
+      counters: Record<string, number>;
+      maxStallMs: number;
+    };
+    __hive?: unknown;
+  }
+}

--- a/cmd/hivegui/frontend/tsconfig.json
+++ b/cmd/hivegui/frontend/tsconfig.json
@@ -4,10 +4,19 @@
   // still pulled into the program transitively by imports, but never checked.
   //
   // `include` is scoped to the directories already converted and widens one
-  // wave at a time — see docs/exec-plans/active/typescript-migration.md. Note
-  // that `include` does NOT bound the program (imports pull files in
-  // regardless); the green build comes from `checkJs: false`, with `include`
-  // as belt-and-braces. Don't widen it ahead of a wave.
+  // wave at a time — see docs/exec-plans/active/typescript-migration.md.
+  //
+  // EVERY WAVE MUST WIDEN `include` WITH THE FILES IT CONVERTS. `include` does
+  // bound the program for any subtree nothing already in it imports, and the
+  // failure is silent: a converted file left outside never enters the program,
+  // so it goes unchecked while `tsc` stays green and the coverage claim reads
+  // as true. Wave 3 hit exactly this — `src/lib/**` are leaves, so nothing in
+  // the program reached `src/app/**`. Test dirs are the same trap: nothing
+  // imports a test file at all.
+  //
+  // The mixed tree stays green because of `checkJs: false` — un-migrated .js
+  // pulled in by imports is never checked — NOT because of `include`. So don't
+  // widen it ahead of a wave either; that just costs the belt-and-braces.
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],

--- a/cmd/hivegui/frontend/tsconfig.json
+++ b/cmd/hivegui/frontend/tsconfig.json
@@ -13,7 +13,9 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "types": [],
+    // vite/client supplies ImportMetaEnv (state.ts gates the __hive_state
+    // e2e affordance on import.meta.env.VITE_WAILS_*).
+    "types": ["vite/client"],
     "allowJs": true,
     "checkJs": false,
     "noEmit": true,
@@ -25,6 +27,11 @@
   // test/unit is safe to include wholesale from wave 1: the un-converted
   // *.test.js files land in the program but `checkJs: false` skips them, so
   // each test starts being checked exactly when it's renamed to .ts.
-  "include": ["src/lib/**/*", "test/unit/**/*"],
+  "include": [
+    "src/lib/**/*",
+    "src/app/**/*",
+    "src/globals.d.ts",
+    "test/unit/**/*"
+  ],
   "exclude": ["node_modules", "dist", "wailsjs"]
 }

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -2,7 +2,7 @@
 
 - **Spec:** [docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md](../../analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md) §2c
 - **Issue:** TBD
-- **Stage:** IMPLEMENT (wave 1 done, unmerged)
+- **Stage:** IMPLEMENT (waves 1–3 merged; wave 4 next)
 - **Status:** active
 
 ## Summary
@@ -159,7 +159,11 @@ each split across waves.
 5. **Never widen `tsconfig.include` ahead of a wave.** The real mechanism: `include` does
    *not* bound the program — imported `.js` files enter it regardless — so the green `tsc`
    comes from `checkJs: false`, with `include` as belt-and-braces. The pair is what keeps
-   the staging honest.
+   the staging honest. **Corrected in wave 3:** "imported `.js` files enter it regardless"
+   only holds for files something in `include` actually imports. `src/lib/**` are leaves,
+   so nothing already in the program reaches `src/app/**` — it had to be added explicitly
+   (wave 3) or the converted files would be silently unchecked. Treat 6 as the general
+   rule and 5 as the narrow one.
 6. **But DO widen `include` in the same wave that converts a test directory.** The inverse
    of 5, and the sharper hazard: nothing imports a test file, so a `test/dom/*.test.ts`
    outside `include` never enters the program at all — it is silently unchecked, and `tsc`
@@ -312,6 +316,35 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
     carries three: `ReplayFlags` (bookkeeping only), `RebaselineTerm`
     (+ `term.cols`), `ReplayXterm` (`reset()` required). Optional means
     "the code branches on its absence" — nothing else.
+
+- **2026-08-08** — Wave 3 complete: `state`, `dom`, `selectors`, `trace`,
+  `inline-rename`, `modals/registry`, plus `src/globals.d.ts`. Two config
+  changes the plan didn't anticipate:
+  - **`include` had to gain `src/app/**/*`.** Invariant 5's "src/** is safe,
+    imports pull it in" is wrong for `src/app/`: the program roots are
+    `src/lib/**` + `test/unit/**`, and lib is leaves — nothing under them
+    imports app, so the wave-3 files would have sat outside the program,
+    silently unchecked with `tsc` green. Same trap as invariant 6, one
+    directory over. Every later wave must widen `include` with it.
+  - **`"types": []` → `["vite/client"]`.** `state.ts:57` gates the
+    `__hive_state` e2e affordance on `import.meta.env.VITE_WAILS_*`, which is
+    `TS2339` without it.
+  - `dom.ts` gained a 4-line `mustEl(id)` that throws: `getElementById`
+    returns `HTMLElement | null` and the three ids are index.html's contract,
+    not a runtime branch. Preferred over `!` because the throw names the id.
+  - `state.ts` now declares `SessionInfo` / `ProjectInfo` / `AppState`. These
+    are hand-written on purpose — sessions and projects arrive over `EventsOn`
+    as raw JSON and are **not** in the generated `wailsjs/go/models.ts` (which
+    holds only `AgentInfo`, `AttachInfo`, `CustomAgent`, `UpdateInfo`), so
+    invariant 3 doesn't apply. Both `snake_case` and `camelCase` spellings are
+    optional fields, matching the `x_y ?? xY` reads. `state.terms` is
+    `Map<string, unknown>` until `SessionTerm` is typed in wave 6.
+
+  Gates: typecheck/build/biome green, vitest 322 in 32 files (unchanged),
+  Playwright mock 79 passed + 1 skipped (unchanged). e2e-real fails 5 locally
+  — `main` at `1e82220` fails 6 of the same specs unstashed, so it's the known
+  local flake, not the diff. Non-vacuity re-proved with a planted
+  `const _probe: string = state.fontSize` in `selectors.ts` (TS2322).
 
 ## Open questions
 


### PR DESCRIPTION
Wave 3 of docs/exec-plans/active/typescript-migration.md: `state`, `dom`, `selectors`, `trace`, `inline-rename`, `modals/registry`, plus `src/globals.d.ts`.

## Two config changes the plan didn't anticipate

- **`include` gains `src/app/**/*`.** Invariant 5 assumed imports pull `src/**` into the program. They don't here — the roots are `src/lib/**` + `test/unit/**`, and lib is leaves, so nothing reaches `src/app`. Without this the converted files sit outside the program: unchecked, `tsc` green, coverage claim false. Same trap as invariant 6, one directory over. Plan updated to say so.
- **`"types": []` → `["vite/client"]`.** `state.ts` gates the `__hive_state` e2e affordance on `import.meta.env.VITE_WAILS_*`; TS2339 without it.

## Notes

- `SessionInfo` / `ProjectInfo` / `AppState` are hand-written. Sessions and projects arrive over `EventsOn` as raw JSON and are **not** in the generated `wailsjs/go/models.ts` (which has only `AgentInfo`, `AttachInfo`, `CustomAgent`, `UpdateInfo`), so the no-hand-written-bindings invariant doesn't apply. Both `snake_case` and `camelCase` spellings stay optional, matching the `x_y ?? xY` reads.
- `state.terms` is `Map<string, unknown>` until `SessionTerm` is typed in wave 6.
- `dom.ts` gains a 4-line `mustEl(id)` that throws — `getElementById` is nullable and those three ids are index.html's contract, not a runtime branch. The throw names the missing id, `!` wouldn't.

## Gates

typecheck / build / biome green. vitest 322 in 32 files and Playwright mock 79 passed + 1 skipped — both unchanged. e2e-real fails 5 locally; `main` at 1e82220 fails 6 of the same specs with the branch stashed, so it's the known local flake. Non-vacuity re-proved with a planted `const _probe: string = state.fontSize` (TS2322).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved frontend reliability by detecting missing required interface elements during application startup with clearer error messages.
  - Strengthened type safety across navigation, session, project, modal, status, and inline-renaming functionality without changing user-facing behavior.
  - Expanded development and testing support for application state, diagnostics, and browser-based checks.

- **Documentation**
  - Updated the TypeScript migration plan with completed work, configuration details, testing results, and remaining milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->