### PR TITLE
frontend: TypeScript migration wave 4 — Wails bridge + both test harnesses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ scripts/test.sh go          # just Go
 scripts/test.sh unit dom    # frontend only, no browser
 ```
 
-The frontend layers live in `cmd/hivegui/frontend/test/`. E2E tests run against `vite dev` with `VITE_WAILS_MOCK=1`, which swaps the generated Wails bindings for an in-browser fake (`test/e2e/wails-mock.js`). No native Wails build is required to run them.
+The frontend layers live in `cmd/hivegui/frontend/test/`. E2E tests run against `vite dev` with `VITE_WAILS_MOCK=1`, which swaps the generated Wails bindings for an in-browser fake (`test/e2e/wails-mock.ts`). No native Wails build is required to run them.
 
 ### Lint / Vet
 

--- a/cmd/hivegui/frontend/playwright.config.js
+++ b/cmd/hivegui/frontend/playwright.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 // Boots `vite dev` with VITE_WAILS_MOCK=1, so the frontend loads
 // against the in-browser fake of the Wails bridge defined in
-// test/e2e/wails-mock.js. Tests drive the UI and can inject daemon
+// test/e2e/wails-mock.ts. Tests drive the UI and can inject daemon
 // events through window.__hive.
 export default defineConfig({
   testDir: './test/e2e',

--- a/cmd/hivegui/frontend/playwright.real.config.js
+++ b/cmd/hivegui/frontend/playwright.real.config.js
@@ -5,7 +5,7 @@ import { defineConfig } from '@playwright/test';
 // fully isolated temp paths (HOME / HIVE_STATE_DIR / HIVE_SOCKET) and
 // writes the bridge URL to process.env.WS_BRIDGE_URL. The Vite dev
 // server boots with VITE_WAILS_REAL=1, which makes vite resolve the
-// Wails App + runtime imports to test/e2e-real/wails-bridge.js
+// Wails App + runtime imports to test/e2e-real/wails-bridge.ts
 // instead of the in-browser mock.
 //
 // Specs read process.env.WS_BRIDGE_URL inside a Playwright addInitScript

--- a/cmd/hivegui/frontend/src/bridge.ts
+++ b/cmd/hivegui/frontend/src/bridge.ts
@@ -1,7 +1,7 @@
 // Single re-export point for the Wails bridge surface.
 //
 // MUST stay a sibling of main.js: the vite plugin in vite.config.js
-// substitutes the test harnesses (wails-mock.js / wails-bridge.js) by
+// substitutes the test harnesses (wails-mock.ts / wails-bridge.ts) by
 // matching the EXACT literal specifiers '../wailsjs/go/main/App' and
 // '../wailsjs/runtime/runtime' — moving this file changes the relative
 // specifier and silently breaks both Playwright harnesses.

--- a/cmd/hivegui/frontend/src/globals.d.ts
+++ b/cmd/hivegui/frontend/src/globals.d.ts
@@ -2,7 +2,7 @@
 // build: `__hive_state` is gated on the Vite mock/real env vars
 // (app/state.ts), the scrolltrace pair is gated on localStorage
 // `hive.debug` (app/trace.ts), and `__hive` is injected by the
-// Playwright mock bridge (test/e2e/wails-mock.js).
+// Playwright bridges (test/e2e/wails-mock.ts, test/e2e-real/wails-bridge.ts).
 
 import type { AppState } from './app/state.js';
 import type { ScrollTraceEntry } from './lib/scroll-debug.js';
@@ -19,5 +19,8 @@ declare global {
       maxStallMs: number;
     };
     __hive?: unknown;
+    // Injected by playwright.real.config's addInitScript before page.goto,
+    // read by test/e2e-real/wails-bridge.ts.
+    __WS_BRIDGE_URL?: string;
   }
 }

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
@@ -1,6 +1,6 @@
 // Real-daemon Wails bridge for Layer B Playwright tests.
 //
-// Mirrors the export surface of test/e2e/wails-mock.js so the same
+// Mirrors the export surface of test/e2e/wails-mock.ts so the same
 // Vite resolveId substitution can pick this module when
 // VITE_WAILS_REAL=1 is set. Instead of running a fake state machine
 // in the browser, each method round-trips a JSON-RPC call to
@@ -10,11 +10,28 @@
 // The WS URL is read from window.__WS_BRIDGE_URL — Playwright injects
 // it via addInitScript before page.goto.
 
-const listeners = new Map();
-const pending = new Map();
+type Handler = (...args: unknown[]) => void;
+
+// One in-flight JSON-RPC call. `result` is whatever the bridge sends back —
+// each binding below narrows it (or ignores it).
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error | Event) => void;
+}
+
+// Frames from cmd/hived-ws-bridge: either an event push or a call reply.
+interface Frame {
+  event?: string;
+  args?: unknown[];
+  id?: number;
+  error?: string;
+  result?: unknown;
+}
+
+const listeners = new Map<string, Handler[]>();
+const pending = new Map<number, Pending>();
 let nextId = 1;
-let ws = null;
-let wsReady = null;
+let wsReady: Promise<WebSocket> | null = null;
 
 function getWsUrl() {
   if (typeof window === 'undefined') return null;
@@ -23,17 +40,17 @@ function getWsUrl() {
 
 function ensureWS() {
   if (wsReady) return wsReady;
-  wsReady = new Promise((resolve, reject) => {
+  wsReady = new Promise<WebSocket>((resolve, reject) => {
     const url = getWsUrl();
     if (!url) {
       reject(new Error('no WS bridge URL'));
       return;
     }
-    ws = new WebSocket(url);
-    ws.addEventListener('open', () => resolve(ws));
-    ws.addEventListener('error', (e) => reject(e));
-    ws.addEventListener('message', (m) => {
-      let msg;
+    const sock = new WebSocket(url);
+    sock.addEventListener('open', () => resolve(sock));
+    sock.addEventListener('error', (e) => reject(e));
+    sock.addEventListener('message', (m: MessageEvent) => {
+      let msg: Frame;
       try {
         msg = JSON.parse(m.data);
       } catch {
@@ -50,13 +67,14 @@ function ensureWS() {
         }
         return;
       }
+      if (msg.id === undefined) return;
       const p = pending.get(msg.id);
       if (!p) return;
       pending.delete(msg.id);
       if (msg.error) p.reject(new Error(msg.error));
       else p.resolve(msg.result);
     });
-    ws.addEventListener('close', () => {
+    sock.addEventListener('close', () => {
       for (const [, p] of pending) p.reject(new Error('ws closed'));
       pending.clear();
     });
@@ -64,30 +82,30 @@ function ensureWS() {
   return wsReady;
 }
 
-async function call(method, params) {
-  await ensureWS();
+async function call(method: string, params?: Record<string, unknown>) {
+  const sock = await ensureWS();
   const id = nextId++;
-  return new Promise((resolve, reject) => {
+  return new Promise<unknown>((resolve, reject) => {
     pending.set(id, { resolve, reject });
-    ws.send(JSON.stringify({ id, method, params: params || {} }));
+    sock.send(JSON.stringify({ id, method, params: params || {} }));
   });
 }
 
-// --- runtime surface (matches wails-mock.js / wailsjs/runtime) ---
+// --- runtime surface (matches wails-mock.ts / wailsjs/runtime) ---
 
-export function EventsOn(name, handler) {
-  if (!listeners.has(name)) listeners.set(name, []);
-  listeners.get(name).push(handler);
+export function EventsOn(name: string, handler: Handler) {
+  const arr = listeners.get(name) ?? [];
+  if (!listeners.has(name)) listeners.set(name, arr);
+  arr.push(handler);
   return () => {
-    const arr = listeners.get(name) || [];
     const i = arr.indexOf(handler);
     if (i >= 0) arr.splice(i, 1);
   };
 }
-export function EventsOff(name) {
+export function EventsOff(name: string) {
   listeners.delete(name);
 }
-export function WindowSetTitle(t) {
+export function WindowSetTitle(t: string) {
   document.title = t;
 }
 
@@ -96,15 +114,15 @@ export function WindowSetTitle(t) {
 export async function ConnectControl() {
   return call('ConnectControl');
 }
-export async function OpenSession(id, cols, rows) {
+export async function OpenSession(id: string, cols: number, rows: number) {
   return call('OpenSession', { id, cols: cols || 0, rows: rows || 0 });
 }
-export async function CloseAttach(id) {
+export async function CloseAttach(id: string) {
   return call('CloseAttach', { id });
 }
 
-const stdinLog = [];
-export async function WriteStdin(id, b64) {
+const stdinLog: { id: string; b64: string; text: string }[] = [];
+export async function WriteStdin(id: string, b64: string) {
   let text = '';
   try {
     const bin = atob(b64);
@@ -117,20 +135,20 @@ export async function WriteStdin(id, b64) {
   stdinLog.push({ id, b64, text });
   return call('WriteStdin', { id, b64 });
 }
-export async function ResizeSession(id, cols, rows) {
+export async function ResizeSession(id: string, cols: number, rows: number) {
   return call('ResizeSession', { id, cols, rows });
 }
-export async function RequestScrollbackReplay(id) {
+export async function RequestScrollbackReplay(id: string) {
   return call('RequestScrollbackReplay', { id });
 }
 export async function CreateSession(
-  agentID,
-  projectID,
-  name,
-  color,
-  cols,
-  rows,
-  useWorktree,
+  agentID: string,
+  projectID: string,
+  name: string,
+  color: string,
+  cols: number,
+  rows: number,
+  useWorktree: boolean,
 ) {
   // The Wails signature uses positional args; map to the bridge's
   // CreateSpec shape.
@@ -147,13 +165,18 @@ export async function CreateSession(
 export async function DuplicateSession() {
   return CreateSession('', '', 'dup', '', 80, 24, false);
 }
-export async function KillSession(id, force) {
+export async function KillSession(id: string, force: boolean) {
   return call('KillSession', { session_id: id, force: !!force });
 }
-export async function RestartSession(_id) {
+export async function RestartSession(_id: string) {
   return '';
 }
-export async function UpdateSession(_id, _name, _color, _order) {
+export async function UpdateSession(
+  _id: string,
+  _name: string,
+  _color: string,
+  _order: number,
+) {
   return '';
 }
 export async function ListAgents() {
@@ -222,7 +245,7 @@ let clipboard = '';
 export async function ClipboardGetText() {
   return clipboard;
 }
-export async function SetClipboardText(text) {
+export async function SetClipboardText(text: unknown) {
   clipboard = String(text ?? '');
 }
 
@@ -231,7 +254,7 @@ export async function SetClipboardText(text) {
 if (typeof window !== 'undefined') {
   window.__hive = {
     stdinLog,
-    stdinText(id) {
+    stdinText(id?: string) {
       return stdinLog
         .filter((e) => id == null || e.id === id)
         .map((e) => e.text)
@@ -241,7 +264,7 @@ if (typeof window !== 'undefined') {
       stdinLog.length = 0;
     },
     listeners,
-    emit(name, ...args) {
+    emit(name: string, ...args: unknown[]) {
       const arr = listeners.get(name) || [];
       for (const fn of arr) {
         try {

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
@@ -94,12 +94,15 @@ async function call(method: string, params?: Record<string, unknown>) {
 // --- runtime surface (matches wails-mock.ts / wailsjs/runtime) ---
 
 export function EventsOn(name: string, handler: Handler) {
-  const arr = listeners.get(name) ?? [];
-  if (!listeners.has(name)) listeners.set(name, arr);
-  arr.push(handler);
+  const arr = listeners.get(name);
+  if (arr) arr.push(handler);
+  else listeners.set(name, [handler]);
+  // Re-look-up rather than closing over `arr` — EventsOff replaces the
+  // array, and the JS original unsubscribed against whatever is current.
   return () => {
-    const i = arr.indexOf(handler);
-    if (i >= 0) arr.splice(i, 1);
+    const cur = listeners.get(name) || [];
+    const i = cur.indexOf(handler);
+    if (i >= 0) cur.splice(i, 1);
   };
 }
 export function EventsOff(name: string) {

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -38,12 +38,15 @@ function emit(name: string, ...args: unknown[]) {
 // --- runtime ---
 
 export function EventsOn(name: string, handler: Handler) {
-  const arr = listeners.get(name) ?? [];
-  if (!listeners.has(name)) listeners.set(name, arr);
-  arr.push(handler);
+  const arr = listeners.get(name);
+  if (arr) arr.push(handler);
+  else listeners.set(name, [handler]);
+  // Re-look-up rather than closing over `arr` — EventsOff replaces the
+  // array, and the JS original unsubscribed against whatever is current.
   return () => {
-    const i = arr.indexOf(handler);
-    if (i >= 0) arr.splice(i, 1);
+    const cur = listeners.get(name) || [];
+    const i = cur.indexOf(handler);
+    if (i >= 0) cur.splice(i, 1);
   };
 }
 

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -4,9 +4,27 @@
 // native Wails runtime. Drives the UI through a tiny scripted
 // daemon-state machine that Playwright can poke via window.__hive.
 
-const listeners = new Map(); // event name -> [handler, ...]
+import type { ProjectInfo, SessionInfo } from '../../src/app/state.js';
+// Type-only, so it is erased before Vite ever sees it — the whole point of
+// this module is to stand in for wailsjs at runtime. Using the generated
+// shapes (invariant 3) is what makes the mock drift-detectable.
+import type { main } from '../../wailsjs/go/models';
 
-function emit(name, ...args) {
+type AgentInfo = main.AgentInfo;
+type CustomAgent = main.CustomAgent;
+
+// The wire shapes the daemon really sends carry a `created` stamp that no
+// app module reads, so it is not on SessionInfo/ProjectInfo. Intersect
+// rather than widen the source interfaces — the mock is the one that has
+// to match the app, not the other way round.
+type MockSession = SessionInfo & { created: string };
+type MockProject = ProjectInfo & { created: string };
+
+type Handler = (...args: unknown[]) => void;
+
+const listeners = new Map<string, Handler[]>(); // event name -> [handler, ...]
+
+function emit(name: string, ...args: unknown[]) {
   const arr = listeners.get(name) || [];
   for (const fn of arr) {
     try {
@@ -19,20 +37,20 @@ function emit(name, ...args) {
 
 // --- runtime ---
 
-export function EventsOn(name, handler) {
-  if (!listeners.has(name)) listeners.set(name, []);
-  listeners.get(name).push(handler);
+export function EventsOn(name: string, handler: Handler) {
+  const arr = listeners.get(name) ?? [];
+  if (!listeners.has(name)) listeners.set(name, arr);
+  arr.push(handler);
   return () => {
-    const arr = listeners.get(name) || [];
     const i = arr.indexOf(handler);
     if (i >= 0) arr.splice(i, 1);
   };
 }
 
-export function EventsOff(name) {
+export function EventsOff(name: string) {
   listeners.delete(name);
 }
-export function WindowSetTitle(t) {
+export function WindowSetTitle(t: string) {
   document.title = t;
 }
 
@@ -44,7 +62,7 @@ export async function ClipboardGetText() {
   maybeFail('ClipboardGetText');
   return clipboard;
 }
-export async function SetClipboardText(text) {
+export async function SetClipboardText(text: unknown) {
   maybeFail('SetClipboardText');
   clipboard = String(text ?? '');
 }
@@ -54,10 +72,10 @@ export async function SetClipboardText(text) {
 // window.__hive.failNext(method, message) arms a one-shot rejection for
 // the named binding, so E2E can assert that a failed daemon call
 // surfaces user-visible feedback instead of being silently swallowed.
-const failures = new Map(); // method name -> error message
-function maybeFail(method) {
-  if (failures.has(method)) {
-    const msg = failures.get(method);
+const failures = new Map<string, string>(); // method name -> error message
+function maybeFail(method: string) {
+  const msg = failures.get(method);
+  if (msg !== undefined) {
     failures.delete(method);
     throw new Error(msg);
   }
@@ -66,10 +84,10 @@ function maybeFail(method) {
 // window.__hive.delayNext(method, ms) arms a one-shot delay for the
 // named binding, so E2E can observe in-flight UI (loading rows,
 // spinners) that a microtask-fast mock would otherwise skip past.
-const delays = new Map(); // method name -> ms
-async function maybeDelay(method) {
-  if (delays.has(method)) {
-    const ms = delays.get(method);
+const delays = new Map<string, number>(); // method name -> ms
+async function maybeDelay(method: string) {
+  const ms = delays.get(method);
+  if (ms !== undefined) {
     delays.delete(method);
     await new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -77,7 +95,7 @@ async function maybeDelay(method) {
 
 // --- App bindings ---
 
-const state = {
+const state: { projects: MockProject[]; sessions: MockSession[] } = {
   projects: [
     {
       id: 'p1',
@@ -116,53 +134,56 @@ export async function ConnectControl() {
   setTimeout(broadcast, 0);
   return '';
 }
-export async function OpenSession(id) {
+export async function OpenSession(id: string) {
   return id;
 }
-export async function CloseAttach(_id) {
+export async function CloseAttach(_id: string) {
   return '';
 }
-const stdinLog = []; // [{ id, b64, text }] — populated by WriteStdin so E2E can assert input routing.
-export async function WriteStdin(id, b64) {
+// Populated by WriteStdin so E2E can assert input routing.
+const stdinLog: { id: string; b64: string; text: string }[] = [];
+export async function WriteStdin(id: string, b64: string) {
   let text = '';
   try {
-    if (typeof atob === 'function' && typeof TextDecoder !== 'undefined') {
-      // atob() returns a Latin-1 "binary string" — feed each char's
-      // code unit into a Uint8Array, then decode as UTF-8 so non-ASCII
-      // input round-trips correctly in E2E assertions.
-      const bin = atob(b64);
-      const bytes = new Uint8Array(bin.length);
-      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-      text = new TextDecoder('utf-8').decode(bytes);
-    } else {
-      text = Buffer.from(b64, 'base64').toString('utf-8');
-    }
-  } catch {}
+    // atob() returns a Latin-1 "binary string" — feed each char's
+    // code unit into a Uint8Array, then decode as UTF-8 so non-ASCII
+    // input round-trips correctly in E2E assertions. This module only
+    // ever loads in a browser (Vite substitution), so atob/TextDecoder
+    // are always there; the old Buffer fallback was dead.
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    text = new TextDecoder('utf-8').decode(bytes);
+  } catch {
+    /* ignore decode errors — test hook only */
+  }
   stdinLog.push({ id, b64, text });
   return '';
 }
-export async function ResizeSession(_id, _cols, _rows) {
+export async function ResizeSession(_id: string, _cols: number, _rows: number) {
   return '';
 }
-const replayLog = []; // [{ id, t }] — populated by RequestScrollbackReplay so E2E can detect spurious replays after layout reflows.
-export async function RequestScrollbackReplay(id) {
+// Populated by RequestScrollbackReplay so E2E can detect spurious replays
+// after layout reflows.
+const replayLog: { id: string; t: number }[] = [];
+export async function RequestScrollbackReplay(id: string) {
   replayLog.push({ id, t: Date.now() });
   return '';
 }
 // Positional args matching the real Wails binding:
 // CreateSession(agentID, projectID, name, color, cols, rows, useWorktree).
 export async function CreateSession(
-  agentID,
-  projectID,
-  name,
-  color,
-  _cols,
-  _rows,
-  _useWorktree,
+  agentID: string,
+  projectID: string,
+  name: string,
+  color: string,
+  _cols: number,
+  _rows: number,
+  _useWorktree: boolean,
 ) {
   maybeFail('CreateSession');
   const id = `mock-${state.sessions.length + 1}`;
-  const s = {
+  const s: MockSession = {
     id,
     name: name || `s${state.sessions.length + 1}`,
     color: color || '#0af',
@@ -180,11 +201,15 @@ export async function CreateSession(
   return id;
 }
 // Positional: DuplicateSession(agentID, projectID, cwd).
-export async function DuplicateSession(agentID, projectID, _cwd) {
+export async function DuplicateSession(
+  agentID: string,
+  projectID: string,
+  _cwd: string,
+) {
   maybeFail('DuplicateSession');
   return CreateSession(agentID, projectID, 'dup', '', 0, 0, false);
 }
-export async function KillSession(id) {
+export async function KillSession(id: string) {
   maybeFail('KillSession');
   const i = state.sessions.findIndex((s) => s.id === id);
   if (i < 0) return '';
@@ -192,7 +217,7 @@ export async function KillSession(id) {
   emit('session:event', JSON.stringify({ kind: 'removed', session: removed }));
   return '';
 }
-export async function RestartSession(_id) {
+export async function RestartSession(_id: string) {
   maybeFail('RestartSession');
   return '';
 }
@@ -200,7 +225,12 @@ export async function RestartSession(_id) {
 // bridge): UpdateSession(id, name, color, order). Empty string / -1
 // mean "no change". The old object-shaped signature silently no-op'd
 // every rename driven through the UI.
-export async function UpdateSession(id, name, color, _order) {
+export async function UpdateSession(
+  id: string,
+  name: string,
+  color: string,
+  _order: number,
+) {
   maybeFail('UpdateSession');
   const s = state.sessions.find((x) => x.id === id);
   if (!s) return '';
@@ -211,10 +241,10 @@ export async function UpdateSession(id, name, color, _order) {
 }
 // Custom agents start empty; the settings modal writes into this
 // module-level array so a save → reopen round-trip works in E2E.
-let customAgents = [];
+let customAgents: CustomAgent[] = [];
 // One real-shaped agent so launcher E2E can exercise the full
 // open → select → create flow (matches internal/agent's wire shape).
-export async function ListAgents() {
+export async function ListAgents(): Promise<AgentInfo[]> {
   await maybeDelay('ListAgents');
   maybeFail('ListAgents');
   // Mirrors Go's agent.All(): built-ins first, then custom agents.
@@ -242,7 +272,7 @@ export async function ListCustomAgents() {
   maybeFail('ListCustomAgents');
   return customAgents;
 }
-export async function SaveCustomAgents(list) {
+export async function SaveCustomAgents(list: CustomAgent[] | null) {
   await maybeDelay('SaveCustomAgents');
   maybeFail('SaveCustomAgents');
   // Mirror Go's id assignment so the mock round-trips like the real
@@ -264,10 +294,10 @@ export async function SaveCustomAgents(list) {
 // order). The old object-shaped/no-op forms silently no-op'd every
 // project create/save/delete driven through the UI — the same defect
 // UpdateSession had.
-export async function CreateProject(name, color, cwd) {
+export async function CreateProject(name: string, color: string, cwd: string) {
   maybeFail('CreateProject');
   const id = `p-${state.projects.length + 1}`;
-  const p = {
+  const p: MockProject = {
     id,
     name: name || 'new',
     color: color || '#0af',
@@ -279,7 +309,7 @@ export async function CreateProject(name, color, cwd) {
   emit('project:event', JSON.stringify({ kind: 'added', project: p }));
   return id;
 }
-export async function KillProject(id, killSessions) {
+export async function KillProject(id: string, killSessions: boolean) {
   maybeFail('KillProject');
   const i = state.projects.findIndex((p) => p.id === id);
   if (i < 0) return '';
@@ -297,7 +327,13 @@ export async function KillProject(id, killSessions) {
 }
 // Empty string / -1 mean "no change", mirroring UpdateSession (order is
 // accepted but not modelled, same as UpdateSession's _order).
-export async function UpdateProject(id, name, color, cwd, _order) {
+export async function UpdateProject(
+  id: string,
+  name: string,
+  color: string,
+  cwd: string,
+  _order: number,
+) {
   maybeFail('UpdateProject');
   const p = state.projects.find((x) => x.id === id);
   if (!p) return '';
@@ -321,27 +357,27 @@ export async function CloseWindow() {
   maybeFail('CloseWindow');
   return '';
 }
-export async function IsGitRepo(_dir) {
+export async function IsGitRepo(_dir: string) {
   return false;
 }
-export async function OpenURL(_url) {
+export async function OpenURL(_url: string) {
   maybeFail('OpenURL');
   return '';
 }
-export async function OpenTerminalAt(_dir) {
+export async function OpenTerminalAt(_dir: string) {
   maybeFail('OpenTerminalAt');
   return '';
 }
-export async function Notify(_title, _body) {
+export async function Notify(_title: string, _body: string) {
   return '';
 }
-export async function LogFrontend(_msg) {
+export async function LogFrontend(_msg: string) {
   return '';
 }
-export async function SetDebugTrace(_on) {
+export async function SetDebugTrace(_on: boolean) {
   return '';
 }
-export async function Confirm(_title, _body) {
+export async function Confirm(_title: string, _body: string) {
   return true;
 }
 export async function RestartDaemon() {
@@ -356,15 +392,15 @@ if (typeof window !== 'undefined') {
   window.__hive = {
     state,
     emit,
-    addSession(name) {
+    addSession(name: string) {
       return CreateSession('', 'p1', name, '', 0, 0, false);
     },
-    killSession(id) {
+    killSession(id: string) {
       return KillSession(id);
     },
     listeners,
     stdinLog,
-    stdinText(id) {
+    stdinText(id?: string) {
       return stdinLog
         .filter((e) => id == null || e.id === id)
         .map((e) => e.text)
@@ -374,16 +410,16 @@ if (typeof window !== 'undefined') {
       stdinLog.length = 0;
     },
     replayLog,
-    replayCount(id) {
+    replayCount(id?: string) {
       return replayLog.filter((e) => id == null || e.id === id).length;
     },
     resetReplay() {
       replayLog.length = 0;
     },
-    failNext(method, message = 'injected failure') {
+    failNext(method: string, message = 'injected failure') {
       failures.set(method, message);
     },
-    delayNext(method, ms = 250) {
+    delayNext(method: string, ms = 250) {
       delays.set(method, ms);
     },
   };

--- a/cmd/hivegui/frontend/tsconfig.json
+++ b/cmd/hivegui/frontend/tsconfig.json
@@ -36,11 +36,18 @@
   // test/unit is safe to include wholesale from wave 1: the un-converted
   // *.test.js files land in the program but `checkJs: false` skips them, so
   // each test starts being checked exactly when it's renamed to .ts.
+  // The two harnesses are listed file-by-file, not as test/e2e{,-real}/**:
+  // nothing imports them (the Vite substitution is invisible to tsc), so they
+  // only get checked by being named here, and the *.spec.js siblings around
+  // them are wave 7's job.
   "include": [
     "src/lib/**/*",
     "src/app/**/*",
+    "src/bridge.ts",
     "src/globals.d.ts",
-    "test/unit/**/*"
+    "test/unit/**/*",
+    "test/e2e/wails-mock.ts",
+    "test/e2e-real/wails-bridge.ts"
   ],
   "exclude": ["node_modules", "dist", "wailsjs"]
 }

--- a/cmd/hivegui/frontend/vite.config.js
+++ b/cmd/hivegui/frontend/vite.config.js
@@ -2,9 +2,9 @@ import { defineConfig } from 'vite';
 import path from 'node:path';
 
 // Wails bridge substitution for tests:
-//   VITE_WAILS_MOCK=1  → resolve App/runtime to test/e2e/wails-mock.js
+//   VITE_WAILS_MOCK=1  → resolve App/runtime to test/e2e/wails-mock.ts
 //                        (in-browser scripted state machine; fast).
-//   VITE_WAILS_REAL=1  → resolve to test/e2e-real/wails-bridge.js,
+//   VITE_WAILS_REAL=1  → resolve to test/e2e-real/wails-bridge.ts,
 //                        which round-trips every call through
 //                        hived-ws-bridge to a real hived daemon
 //                        (Layer B end-to-end coverage).
@@ -14,9 +14,9 @@ import path from 'node:path';
 const useMock = process.env.VITE_WAILS_MOCK === '1';
 const useReal = process.env.VITE_WAILS_REAL === '1';
 const substitute = useReal
-  ? path.resolve(__dirname, 'test/e2e-real/wails-bridge.js')
+  ? path.resolve(__dirname, 'test/e2e-real/wails-bridge.ts')
   : useMock
-    ? path.resolve(__dirname, 'test/e2e/wails-mock.js')
+    ? path.resolve(__dirname, 'test/e2e/wails-mock.ts')
     : null;
 
 export default defineConfig({

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -2,7 +2,7 @@
 
 - **Spec:** [docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md](../../analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md) §2c
 - **Issue:** TBD
-- **Stage:** IMPLEMENT (waves 1–3 merged; wave 4 next)
+- **Stage:** IMPLEMENT (waves 1–4 done, 1–3 merged; wave 5 next)
 - **Status:** active
 
 ## Summary
@@ -147,8 +147,8 @@ each split across waves.
 1. **`vite.config.js` holds string literals at BOTH ends of the Wails substitution.** The
    specifiers (`:30-31`) must never change — renaming `bridge.js` → `bridge.ts` is safe,
    editing those two strings silently breaks both Playwright harnesses with no build error.
-   The substitution *targets* (`:17,19`) are hardcoded `.js` paths and must be updated in
-   wave 4. `bridge` must stay a sibling of `main` (its header documents why).
+   The substitution *targets* (`:17,19`) are hardcoded paths — updated to `.ts` in wave 4.
+   `bridge` must stay a sibling of `main` (its header documents why).
 2. **No explicit `any`** — `suspicious/noExplicitAny` fails `npm run ci`. Use `unknown` plus
    a narrow, or a per-file `biome-ignore` with a reason. Run `biome check --write` per wave
    to absorb autofixable TS rules (e.g. `style/useImportType`).
@@ -345,6 +345,46 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
   — `main` at `1e82220` fails 6 of the same specs unstashed, so it's the known
   local flake, not the diff. Non-vacuity re-proved with a planted
   `const _probe: string = state.fontSize` in `selectors.ts` (TS2322).
+
+- **2026-08-08** — Wave 4 complete: `src/bridge.ts`, both Playwright
+  harnesses, and the two `path.resolve` targets in `vite.config.js`.
+  114 errors after the bulk `git mv`, all mechanical (implicit-any params,
+  untyped `Map`/array literals) — none in `bridge.ts`, which needed zero
+  annotations because it is pure re-export.
+  - **`include` gained three explicit file paths**, not `test/e2e/**`:
+    nothing imports either harness (the Vite substitution is invisible to
+    `tsc`), so they only get checked by being named — invariant 6 again.
+    Naming the files rather than the directories keeps the `*.spec.js`
+    siblings out until wave 7.
+  - **No structural conformance check between the harnesses and
+    `bridge.ts`.** The plan floated `Partial<typeof import('../../src/bridge')>`;
+    it was tried and dropped. The two harnesses deliberately diverge in
+    return type from the real bindings (`CreateSession` returns the new id in
+    the mock so `window.__hive.addSession` can use it; the real one is
+    `Promise<void>`), so any assertion strong enough to catch arity drift
+    would have to be defeated for the returns. Deferred, not free — a mock
+    whose parameter list drifts from `app.go` still silently no-ops, which is
+    the exact bug class `UpdateSession`/`UpdateProject` already hit twice.
+  - **Generated types used where they exist.** The mock's `ListAgents` /
+    custom-agent surface is typed off `main.AgentInfo` / `main.CustomAgent`
+    via a **type-only** import of `wailsjs/go/models` — erased before Vite
+    sees it, so the module still stands in for wailsjs at runtime.
+    Sessions/projects reuse `SessionInfo`/`ProjectInfo` from `state.ts`,
+    intersected with `{ created: string }` rather than widening the source
+    interfaces for the mock's benefit.
+  - `wails-mock.ts`'s `Buffer.from(b64, 'base64')` fallback was deleted, not
+    typed: the module only ever loads in a browser, so the `typeof atob`
+    guard could never take the other branch. Same for the now-unused
+    module-level `ws` in `wails-bridge.ts` (`call` awaits the socket).
+  - `globals.d.ts` gained `__WS_BRIDGE_URL`.
+
+  Gates: typecheck/build/biome green, vitest 322 in 32 files (unchanged),
+  Playwright mock 79 passed + 1 skipped (unchanged) — which is itself the
+  proof the substitution still fires on the renamed target, since every one
+  of those specs needs `window.__hive`. e2e-real 7 passed / 5 failed, and
+  `origin/main` at `87b70e3` fails **the same 5** with the diff stashed.
+  Non-vacuity proved on all three converted files with planted errors
+  (TS2322 in both harnesses, TS2304 in `bridge.ts`).
 
 ## Open questions
 


### PR DESCRIPTION
Wave 4 of the [TypeScript migration plan](docs/exec-plans/active/typescript-migration.md): `src/bridge.ts`, `test/e2e/wails-mock.ts`, `test/e2e-real/wails-bridge.ts`, and the two `path.resolve` substitution targets in `vite.config.js`.

`bridge.ts` needed zero annotations — it is pure re-export, and the generated `App.d.ts` already types the 33 bindings. The 114 errors the bulk `git mv` produced were all in the two harnesses and all mechanical: implicit-any params, untyped `Map`/array literals.

### Notes

- **`include` gains three explicit file paths, not `test/e2e/**`.** Nothing imports either harness — the Vite substitution is invisible to `tsc` — so they only enter the program by being named. Same silent-miss trap as wave 3. Naming files rather than directories keeps the `*.spec.js` siblings out until wave 7.
- **Generated types where they exist.** `main.AgentInfo` / `main.CustomAgent` via a **type-only** import of `wailsjs/go/models`, erased before Vite sees it, so the mock still stands in for wailsjs at runtime. Sessions/projects reuse `SessionInfo`/`ProjectInfo` from `state.ts`, intersected with `{ created: string }` rather than widening the source interfaces to suit the mock.
- **Two deletions instead of annotations.** The mock's `Buffer.from(b64, 'base64')` fallback is unreachable (the module only ever loads in a browser, so the `typeof atob` guard can't take the other branch), and `wails-bridge`'s module-level `ws` is unused now that `call` awaits the socket out of `ensureWS`.
- **No structural conformance assertion between the harnesses and `bridge.ts`.** The plan floated `Partial<typeof import('../../src/bridge')>`; it was tried and dropped, because the harnesses deliberately diverge in return type from the real bindings (`CreateSession` returns the new id in the mock so `window.__hive.addSession` can use it). Any check strong enough to catch arity drift would have to be defeated for the returns. Recorded in the plan as deferred, not free — a mock whose parameter list drifts from `app.go` still silently no-ops, the exact bug class `UpdateSession`/`UpdateProject` already hit twice.
- `globals.d.ts` gains `__WS_BRIDGE_URL`.

### Gates

| gate | result |
|---|---|
| `npm run typecheck` | green |
| `npm run build` | green |
| `npm run ci` (biome) | green |
| `npx vitest run` | 322 in 32 files — unchanged |
| `npx playwright test` | 79 passed + 1 skipped — unchanged |
| `npx playwright test --config=playwright.real.config.js` | 7 passed / 5 failed; `origin/main` at 87b70e3 fails **the same 5** with this diff stashed |

The unchanged Playwright mock count *is* the substitution check the plan asks for after wave 4 — every one of those specs needs `window.__hive`, which only exists if the resolver found the renamed target.

Non-vacuity proved on all three converted files with planted errors: TS2322 in both harnesses, TS2304 in `bridge.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Converted browser mock and real bridge harnesses to TypeScript with stronger typing.
  * Improved end-to-end test validation by including bridge files in TypeScript checks.
  * Preserved existing session, event, clipboard, and WebSocket test behavior.

* **Documentation**
  * Updated testing and migration guidance to reflect the TypeScript bridge files.

* **Refactor**
  * Updated development tooling to use the TypeScript test bridges without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->