### PR TITLE
frontend: TypeScript migration wave 5a — banners, version-footer, modals

### DIFF
--- a/cmd/hivegui/frontend/src/app/banners.ts
+++ b/cmd/hivegui/frontend/src/app/banners.ts
@@ -15,6 +15,10 @@ import {
   OpenURL,
 } from '../bridge.js';
 import { flashStatus, reportFailure } from './dom.js';
+import { pageEl } from './el.js';
+// Type-only, so the generated module is erased before Vite resolves it.
+import type { main } from '../../wailsjs/go/models';
+import type { DaemonStaleEvent } from './version-footer.js';
 
 export function isDaemonRestarting() {
   return daemonRestarting;
@@ -30,14 +34,14 @@ export function isDaemonRestarting() {
 // Dismissal is keyed on the specific daemonBuild that was dismissed,
 // so a *different* mismatched build later will still surface. A "match"
 // reconnect clears the dismissal flag too.
-const daemonBannerEl = document.getElementById('daemon-banner');
-const daemonBannerText = document.getElementById('daemon-banner-text');
-const daemonBannerRestart = document.getElementById('daemon-banner-restart');
-const daemonBannerDismiss = document.getElementById('daemon-banner-dismiss');
-let daemonBannerDismissedFor = null;
+const daemonBannerEl = pageEl('daemon-banner');
+const daemonBannerText = pageEl('daemon-banner-text');
+const daemonBannerRestart = pageEl<HTMLButtonElement>('daemon-banner-restart');
+const daemonBannerDismiss = pageEl('daemon-banner-dismiss');
+let daemonBannerDismissedFor: string | null = null;
 let daemonRestarting = false;
 
-function showDaemonBanner(text) {
+function showDaemonBanner(text: string) {
   daemonBannerText.textContent = text;
   daemonBannerEl.classList.remove('hidden');
 }
@@ -97,7 +101,7 @@ function wireDaemonBanner() {
   });
   daemonBannerRestart.addEventListener('click', restartHive);
 
-  EventsOn('daemon:stale', (ev) => {
+  EventsOn('daemon:stale', (ev: DaemonStaleEvent | null) => {
     if (!ev) return;
     daemonBannerEl.dataset.daemonBuild = ev.daemonBuild || '';
     if (ev.severity === 'match') {
@@ -130,15 +134,15 @@ function wireDaemonBanner() {
 // responsive. Dismissals are remembered per-version in localStorage
 // so the 6h tick doesn't re-nag for a release the user has already
 // seen.
-const updateBannerEl = document.getElementById('update-banner');
-const updateBannerText = document.getElementById('update-banner-text');
-const updateBannerDownload = document.getElementById('update-banner-download');
-const updateBannerDismiss = document.getElementById('update-banner-dismiss');
+const updateBannerEl = pageEl('update-banner');
+const updateBannerText = pageEl('update-banner-text');
+const updateBannerDownload = pageEl('update-banner-download');
+const updateBannerDismiss = pageEl('update-banner-dismiss');
 const UPDATE_DISMISS_KEY = 'hive.updateDismissedFor';
-let updateBannerAutoHideTimer = null;
+let updateBannerAutoHideTimer: ReturnType<typeof setTimeout> | null = null;
 
 function showUpdateBanner(
-  text,
+  text: string,
   { downloadUrl = '', showDownload = true, autoHideMs = 0 } = {},
 ) {
   updateBannerText.textContent = text;
@@ -171,7 +175,10 @@ function hideUpdateBanner() {
 // stays sticky — it has a Download button the user actually needs.
 const UPDATE_TRANSIENT_MS = 4000;
 
-function applyUpdateInfo(info, { manual = false } = {}) {
+function applyUpdateInfo(
+  info: main.UpdateInfo | null,
+  { manual = false }: { manual?: boolean } = {},
+) {
   if (!info) return;
   if (info.skipped) {
     if (manual) {
@@ -224,7 +231,9 @@ function wireUpdateBanner() {
     hideUpdateBanner();
   });
 
-  EventsOn('update:available', (info) => applyUpdateInfo(info));
+  EventsOn('update:available', (info: main.UpdateInfo | null) =>
+    applyUpdateInfo(info),
+  );
 
   // Pull once on load. The Go side's periodic loop only fires every
   // 6h, so without this the user wouldn't see an "available" banner

--- a/cmd/hivegui/frontend/src/app/dom.ts
+++ b/cmd/hivegui/frontend/src/app/dom.ts
@@ -3,16 +3,12 @@
 // rather than re-querying the document.
 
 import { createStatus } from '../lib/status.js';
+import { mustEl } from './el.js';
 
 // index.html owns these three ids; a missing one means the document and
 // this module have drifted, which is a load-time bug, not a runtime
-// condition to branch on. Throwing here beats `!` — it names the id.
-function mustEl(id: string): HTMLElement {
-  const el = document.getElementById(id);
-  if (!el) throw new Error(`missing #${id} in index.html`);
-  return el;
-}
-
+// condition to branch on. mustEl throws rather than using `!` — it names
+// the id. See el.ts for why the modals use the non-throwing pageEl().
 export const termsHost = mustEl('terms');
 termsHost.classList.add('single');
 

--- a/cmd/hivegui/frontend/src/app/el.ts
+++ b/cmd/hivegui/frontend/src/app/el.ts
@@ -1,0 +1,29 @@
+// getElementById wrappers for the ids index.html owns. Neither treats
+// the null half of the return as a runtime condition — a missing id is
+// document/module drift, a load-time bug. They differ only in WHEN that
+// bug surfaces, and the choice is forced by who imports the module.
+//
+// This file must stay side-effect free: the modal modules import it and
+// are themselves pulled in transitively by view.ts and keyboard.ts.
+
+// Throws, naming the id — preferred, and what dom.ts's app singletons
+// use. Only safe in a module every importer is guaranteed to load with
+// the markup present.
+export function mustEl(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`missing #${id} in index.html`);
+  return el;
+}
+
+// Casts instead of throwing, preserving today's behavior exactly: a
+// missing id surfaces as a TypeError at first use, not at import. Used
+// by the modals and by banners.ts, which view.ts / keyboard.ts drag into
+// jsdom tests that mount only the markup they exercise — those tests
+// never open a modal or a banner, and a load-time throw would break them
+// for elements they legitimately don't have.
+//
+// The type parameter names the element kind index.html declares (an
+// <input>, a <select>) so call sites reach .value without a second cast.
+export function pageEl<T extends HTMLElement = HTMLElement>(id: string): T {
+  return document.getElementById(id) as T;
+}

--- a/cmd/hivegui/frontend/src/app/modals/command-palette.ts
+++ b/cmd/hivegui/frontend/src/app/modals/command-palette.ts
@@ -5,16 +5,31 @@
 // initCommandPalette — this module owns only the palette UI.
 
 import { registerModal } from './registry.js';
+import { pageEl } from '../el.js';
 
-let deps = {
+// One row of the command table main.js builds and hands over.
+export interface PaletteCommand {
+  name: string;
+  shortcut: string;
+  run: () => void;
+}
+
+export interface CommandPaletteDeps {
+  focusActiveTerm: () => void;
+}
+
+let deps: CommandPaletteDeps = {
   focusActiveTerm: () => {},
 };
-let paletteCommands = [];
+let paletteCommands: PaletteCommand[] = [];
 
-export const paletteEl = document.getElementById('command-palette');
-const paletteInput = document.getElementById('command-palette-input');
-const paletteList = document.getElementById('command-palette-list');
-const paletteState = { items: [], selected: 0 };
+export const paletteEl = pageEl('command-palette');
+const paletteInput = pageEl<HTMLInputElement>('command-palette-input');
+const paletteList = pageEl('command-palette-list');
+const paletteState: { items: PaletteCommand[]; selected: number } = {
+  items: [],
+  selected: 0,
+};
 
 function renderPalette() {
   const q = paletteInput.value.trim().toLowerCase();
@@ -64,7 +79,7 @@ export function closeCommandPalette() {
   deps.focusActiveTerm();
 }
 
-function activatePalette(i) {
+function activatePalette(i: number) {
   const c = paletteState.items[i];
   if (!c) return;
   closeCommandPalette();
@@ -73,7 +88,10 @@ function activatePalette(i) {
   setTimeout(() => c.run(), 0);
 }
 
-export function initCommandPalette({ commands, ...injected }) {
+export function initCommandPalette({
+  commands,
+  ...injected
+}: CommandPaletteDeps & { commands: PaletteCommand[] }) {
   deps = injected;
   paletteCommands = commands;
   registerModal(paletteEl);
@@ -106,6 +124,6 @@ export function initCommandPalette({ commands, ...injected }) {
   });
   document.addEventListener('mousedown', (e) => {
     if (paletteEl.classList.contains('hidden')) return;
-    if (!paletteEl.contains(e.target)) closeCommandPalette();
+    if (!paletteEl.contains(e.target as Node)) closeCommandPalette();
   });
 }

--- a/cmd/hivegui/frontend/src/app/modals/help-overlay.ts
+++ b/cmd/hivegui/frontend/src/app/modals/help-overlay.ts
@@ -5,15 +5,23 @@
 import { isMac } from '../../lib/platform.js';
 import { shortcutGroups } from '../../lib/shortcuts.js';
 import { registerModal } from './registry.js';
+import { pageEl } from '../el.js';
 
-let deps = {
+// Narrow on purpose: this overlay needs exactly two callbacks off the
+// focus pipeline, so it names those two rather than the whole module.
+export interface HelpOverlayDeps {
+  setFocusedTile: (id: string | null) => void;
+  focusActiveTerm: () => void;
+}
+
+let deps: HelpOverlayDeps = {
   setFocusedTile: () => {},
   focusActiveTerm: () => {},
 };
 
-export const helpEl = document.getElementById('help-overlay');
-const helpGroupsEl = document.getElementById('help-overlay-groups');
-const helpCloseBtn = document.getElementById('help-overlay-close');
+export const helpEl = pageEl('help-overlay');
+const helpGroupsEl = pageEl('help-overlay-groups');
+const helpCloseBtn = pageEl('help-overlay-close');
 let helpRendered = false;
 
 function renderHelpOverlay() {
@@ -63,7 +71,7 @@ export function toggleHelpOverlay() {
   else closeHelpOverlay();
 }
 
-export function initHelpOverlay(injected) {
+export function initHelpOverlay(injected: HelpOverlayDeps) {
   deps = injected;
   registerModal(helpEl);
   helpCloseBtn.addEventListener('click', closeHelpOverlay);

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -15,14 +15,45 @@ import { state } from '../state.js';
 import { flashStatus, reportFailure } from '../dom.js';
 import { activeProjectId, resolveSessionCwd } from '../selectors.js';
 import { registerModal } from './registry.js';
+import { pageEl } from '../el.js';
+import type { SessionInfo } from '../state.js';
+// Type-only, so the generated module is erased before Vite resolves it.
+import type { main } from '../../../wailsjs/go/models';
 
-let deps = {
+// Narrow on purpose: this modal needs exactly two callbacks off the
+// focus pipeline, so it names those two rather than the whole module.
+export interface LauncherDeps {
+  setFocusedTile: (id: string | null) => void;
+  refocusActiveTerm: () => void;
+}
+
+// One rendered agent row, paired with the element that draws it so
+// highlightLauncherSelection can toggle .selected without re-querying.
+interface LauncherItem {
+  agent: main.AgentInfo;
+  el: HTMLElement;
+}
+
+export interface LauncherOpts {
+  forceWorktree?: boolean;
+  duplicateFrom?: SessionInfo | null;
+  duplicateCwd?: string;
+}
+
+let deps: LauncherDeps = {
   setFocusedTile: () => {},
   refocusActiveTerm: () => {},
 };
 
-export const launcherEl = document.getElementById('launcher');
-export const launcherState = {
+export const launcherEl = pageEl('launcher');
+export const launcherState: {
+  items: LauncherItem[];
+  selected: number;
+  projectId: string | null;
+  useWorktree: boolean;
+  duplicateFrom: SessionInfo | null;
+  duplicateCwd: string;
+} = {
   items: [],
   selected: 0,
   projectId: null,
@@ -38,14 +69,18 @@ export const launcherState = {
   duplicateCwd: '',
 };
 
-function loadAgentUsage() {
+// Agent id → launch count, persisted in localStorage. Read back as
+// unknown JSON, so every lookup is `|| 0`.
+type AgentUsage = Record<string, number>;
+
+function loadAgentUsage(): AgentUsage {
   try {
     return JSON.parse(localStorage.getItem('hive.agentUsage') || '{}') || {};
   } catch {
     return {};
   }
 }
-export function bumpAgentUsage(id) {
+export function bumpAgentUsage(id: string | undefined) {
   if (!id) return;
   const u = loadAgentUsage();
   u[id] = (u[id] || 0) + 1;
@@ -62,7 +97,7 @@ function highlightLauncherSelection() {
   });
 }
 
-export function moveLauncherSelection(delta) {
+export function moveLauncherSelection(delta: number) {
   const n = launcherState.items.length;
   if (n === 0) return;
   launcherState.selected = (launcherState.selected + delta + n) % n;
@@ -73,7 +108,7 @@ export function moveLauncherSelection(delta) {
 // the keyboard-select path (activateLauncherSelection) and the
 // per-item click handler in openLauncher: bump usage, flash status,
 // call the daemon, close the launcher.
-function launchSelected(agentId) {
+function launchSelected(agentId: string) {
   bumpAgentUsage(agentId);
   flashStatus('creating session…');
   if (launcherState.duplicateFrom) {
@@ -102,7 +137,7 @@ export function activateLauncherSelection() {
   launchSelected(it.agent.id);
 }
 
-export function openLauncher(projectId, opts) {
+export function openLauncher(projectId: string | null, opts?: LauncherOpts) {
   launcherState.projectId = projectId || activeProjectId();
   // Re-read the sticky pref each open so a one-shot forceWorktree from a
   // previous opening doesn't leak into the next regular open. forceWorktree
@@ -179,8 +214,9 @@ export function openLauncher(projectId, opts) {
         wtLabel.textContent = 'Create in git worktree';
         wtRow.append(wtBox, wtLabel);
         wtBox.addEventListener('change', (e) => {
-          launcherState.useWorktree = e.target.checked;
-          localStorage.setItem('hive.worktree', e.target.checked ? '1' : '0');
+          const box = e.target as HTMLInputElement;
+          launcherState.useWorktree = box.checked;
+          localStorage.setItem('hive.worktree', box.checked ? '1' : '0');
         });
         launcherEl.appendChild(wtRow);
         if (projCwd) {
@@ -316,11 +352,12 @@ export function duplicateActiveSessionChooseTool() {
   openLauncher(pid, { duplicateFrom: s, duplicateCwd: cwd });
 }
 
-export function initLauncher(injected) {
+export function initLauncher(injected: LauncherDeps) {
   deps = injected;
   registerModal(launcherEl);
   document.addEventListener('click', (e) => {
-    const inAction = e.target.closest('.project-actions');
-    if (!launcherEl.contains(e.target) && !inAction) closeLauncher();
+    const target = e.target as Element | null;
+    const inAction = target?.closest('.project-actions');
+    if (!launcherEl.contains(target) && !inAction) closeLauncher();
   });
 }

--- a/cmd/hivegui/frontend/src/app/modals/project-editor.ts
+++ b/cmd/hivegui/frontend/src/app/modals/project-editor.ts
@@ -10,20 +10,30 @@ import {
 } from '../../bridge.js';
 import { reportFailure } from '../dom.js';
 import { registerModal } from './registry.js';
+import { pageEl } from '../el.js';
+import type { ProjectInfo } from '../state.js';
 
-let deps = {
+// Narrow on purpose: this modal needs exactly two callbacks off the
+// focus pipeline, so it names those two rather than the whole module.
+export interface ProjectEditorDeps {
+  setFocusedTile: (id: string | null) => void;
+  refocusActiveTerm: () => void;
+}
+
+let deps: ProjectEditorDeps = {
   setFocusedTile: () => {},
   refocusActiveTerm: () => {},
 };
 
-export const editorEl = document.getElementById('project-editor');
-const editorTitle = document.getElementById('project-editor-title');
-const editorName = document.getElementById('project-editor-name');
-const editorCwd = document.getElementById('project-editor-cwd');
-const editorColor = document.getElementById('project-editor-color');
-const editorState = { editing: null }; // null = create; else project object
+export const editorEl = pageEl('project-editor');
+const editorTitle = pageEl('project-editor-title');
+const editorName = pageEl<HTMLInputElement>('project-editor-name');
+const editorCwd = pageEl<HTMLInputElement>('project-editor-cwd');
+const editorColor = pageEl<HTMLInputElement>('project-editor-color');
+// null = create; else the project being edited
+const editorState: { editing: ProjectInfo | null } = { editing: null };
 
-export function openProjectEditor(project) {
+export function openProjectEditor(project: ProjectInfo | null) {
   editorState.editing = project || null;
   editorTitle.textContent = project ? 'Edit project' : 'New project';
   editorName.value = project?.name ?? '';
@@ -67,25 +77,19 @@ function saveProjectEditor() {
   closeProjectEditor();
 }
 
-export function initProjectEditor(injected) {
+export function initProjectEditor(injected: ProjectEditorDeps) {
   deps = injected;
   registerModal(editorEl);
-  document
-    .getElementById('project-editor-cancel')
-    .addEventListener('click', closeProjectEditor);
-  document
-    .getElementById('project-editor-save')
-    .addEventListener('click', saveProjectEditor);
-  document
-    .getElementById('project-editor-browse')
-    .addEventListener('click', async () => {
-      try {
-        const picked = await PickDirectory(editorCwd.value || '');
-        if (picked) editorCwd.value = picked;
-      } catch (_err) {
-        // Silently ignore (user cancelled, or platform refused).
-      }
-    });
+  pageEl('project-editor-cancel').addEventListener('click', closeProjectEditor);
+  pageEl('project-editor-save').addEventListener('click', saveProjectEditor);
+  pageEl('project-editor-browse').addEventListener('click', async () => {
+    try {
+      const picked = await PickDirectory(editorCwd.value || '');
+      if (picked) editorCwd.value = picked;
+    } catch (_err) {
+      // Silently ignore (user cancelled, or platform refused).
+    }
+  });
   editorEl.addEventListener('keydown', (e) => {
     if (
       e.key === 'Enter' &&
@@ -97,7 +101,7 @@ export function initProjectEditor(injected) {
       closeProjectEditor();
     }
   });
-  document
-    .getElementById('new-project-btn')
-    .addEventListener('click', () => openProjectEditor(null));
+  pageEl('new-project-btn').addEventListener('click', () =>
+    openProjectEditor(null),
+  );
 }

--- a/cmd/hivegui/frontend/src/app/modals/settings.ts
+++ b/cmd/hivegui/frontend/src/app/modals/settings.ts
@@ -12,20 +12,32 @@
 
 import { ListCustomAgents, SaveCustomAgents } from '../../bridge.js';
 import { registerModal } from './registry.js';
+import { pageEl } from '../el.js';
+// Type-only, so the generated module is erased before Vite resolves it.
+import type { main } from '../../../wailsjs/go/models';
 
-let deps = {
+// Narrow on purpose: this modal needs exactly two callbacks off the
+// focus pipeline, so it names those two rather than the whole module.
+export interface SettingsDeps {
+  setFocusedTile: (id: string | null) => void;
+  refocusActiveTerm: () => void;
+}
+
+let deps: SettingsDeps = {
   setFocusedTile: () => {},
   refocusActiveTerm: () => {},
 };
 
-export const settingsEl = document.getElementById('settings');
-const listEl = document.getElementById('settings-agents-list');
-const errorEl = document.getElementById('settings-error');
+export const settingsEl = pageEl('settings');
+const listEl = pageEl('settings-agents-list');
+const errorEl = pageEl('settings-error');
 
 const DEFAULT_COLOR = '#64748b';
 
-// draft is the in-progress edit; discarded on cancel.
-let draft = [];
+// draft is the in-progress edit; discarded on cancel. Rows are plain
+// objects, not main.CustomAgent instances — the generated class is a
+// data shape and Go re-slugs the ids on save.
+let draft: main.CustomAgent[] = [];
 
 // loading distinguishes "still fetching" from "genuinely empty" so the
 // empty state never renders over a list that is about to arrive.
@@ -49,15 +61,19 @@ let openToken = 0;
  * shape people actually type. agents.json stores a real array, so an
  * argument containing spaces stays hand-editable in the file. Upgrade
  * path if this bites: a real tokenizer here and in Go's validator.
+ *
+ * Takes `string | null` because a test asserts splitCommand(null) is [];
+ * the String(line || '') guard is part of the contract, not defensive
+ * padding around a narrower one.
  */
-export function splitCommand(line) {
+export function splitCommand(line: string | null): string[] {
   return String(line || '')
     .trim()
     .split(/\s+/)
     .filter(Boolean);
 }
 
-function showError(msg) {
+function showError(msg: string) {
   errorEl.textContent = msg;
   errorEl.classList.toggle('hidden', !msg);
 }
@@ -127,9 +143,13 @@ function render() {
       // <body> — from there the Tab trap has no boundary to wrap and
       // the next Tab walks behind the backdrop. Put focus back on the
       // row that took this one's place, or on "+ Add agent".
-      const dels = listEl.querySelectorAll('.settings-agent-delete');
-      const next = dels[Math.min(i, dels.length - 1)];
-      (next || document.getElementById('settings-agent-add'))?.focus();
+      const dels = listEl.querySelectorAll<HTMLElement>(
+        '.settings-agent-delete',
+      );
+      const next =
+        dels[Math.min(i, dels.length - 1)] ??
+        document.getElementById('settings-agent-add');
+      next?.focus();
     });
 
     row.append(color, name, cmd, del);
@@ -199,9 +219,9 @@ export function closeSettings() {
 
 // setEditingEnabled gates the controls that can mutate agents.json.
 // They stay disabled while a load is in flight or after one failed.
-function setEditingEnabled(on) {
-  const save = document.getElementById('settings-save');
-  const add = document.getElementById('settings-agent-add');
+function setEditingEnabled(on: boolean) {
+  const save = pageEl<HTMLButtonElement>('settings-save');
+  const add = pageEl<HTMLButtonElement>('settings-agent-add');
   if (save) save.disabled = !on;
   if (add) add.disabled = !on;
 }
@@ -220,28 +240,22 @@ function saveSettings() {
     .catch((err) => showError(String(err?.message || err)));
 }
 
-export function initSettings(injected) {
+export function initSettings(injected: SettingsDeps) {
   deps = injected;
   registerModal(settingsEl);
-  document
-    .getElementById('settings-close')
-    .addEventListener('click', closeSettings);
-  document
-    .getElementById('settings-cancel')
-    .addEventListener('click', closeSettings);
-  document
-    .getElementById('settings-save')
-    .addEventListener('click', saveSettings);
-  document
-    .getElementById('settings-agent-add')
-    .addEventListener('click', () => {
-      draft.push({ id: '', name: '', cmd: [], color: DEFAULT_COLOR });
-      showError('');
-      render();
-      listEl
-        .querySelector('.settings-agent-row:last-child .settings-agent-name')
-        ?.focus();
-    });
+  pageEl('settings-close').addEventListener('click', closeSettings);
+  pageEl('settings-cancel').addEventListener('click', closeSettings);
+  pageEl('settings-save').addEventListener('click', saveSettings);
+  pageEl('settings-agent-add').addEventListener('click', () => {
+    draft.push({ id: '', name: '', cmd: [], color: DEFAULT_COLOR });
+    showError('');
+    render();
+    listEl
+      .querySelector<HTMLElement>(
+        '.settings-agent-row:last-child .settings-agent-name',
+      )
+      ?.focus();
+  });
   settingsEl.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
       // Consume it. This listener fires before the window handler in
@@ -253,7 +267,7 @@ export function initSettings(injected) {
       closeSettings();
     } else if (
       e.key === 'Enter' &&
-      e.target.tagName === 'INPUT' &&
+      e.target instanceof HTMLInputElement &&
       e.target.type === 'text'
     ) {
       e.preventDefault();
@@ -265,10 +279,14 @@ export function initSettings(injected) {
       // two boundaries wrap. Without this, Tab past Save lands on a
       // terminal behind the backdrop and keystrokes leak into it.
       const focusable = [
-        ...settingsEl.querySelectorAll(
-          'button, input, [tabindex]:not([tabindex="-1"])',
-        ),
-      ].filter((el) => !el.disabled && el.offsetParent !== null);
+        ...settingsEl.querySelectorAll<
+          HTMLButtonElement | HTMLInputElement | HTMLElement
+        >('button, input, [tabindex]:not([tabindex="-1"])'),
+      ].filter(
+        (el) =>
+          !('disabled' in el && el.disabled) &&
+          (el as HTMLElement).offsetParent !== null,
+      );
       if (focusable.length === 0) return;
       const first = focusable[0];
       const last = focusable[focusable.length - 1];

--- a/cmd/hivegui/frontend/src/app/version-footer.ts
+++ b/cmd/hivegui/frontend/src/app/version-footer.ts
@@ -26,7 +26,10 @@ import { EventsOn } from '../bridge.js';
 // field is a required string; daemonVersionEvent() fills all five and the
 // struct carries no omitempty.
 export interface DaemonStaleEvent {
-  severity: string;
+  // Closed set — daemonVersionEvent() in app.go emits exactly these
+  // three. A literal union catches a typo'd comparison at the three
+  // call sites in banners.ts / version-footer.ts.
+  severity: 'match' | 'mismatch' | 'unknown';
   guiBuild: string;
   daemonBuild: string;
   guiRelease: string;

--- a/cmd/hivegui/frontend/src/app/version-footer.ts
+++ b/cmd/hivegui/frontend/src/app/version-footer.ts
@@ -19,13 +19,44 @@
 
 import { EventsOn } from '../bridge.js';
 
+// Payload of the "daemon:stale" Wails event — cmd/hivegui/app.go's
+// DaemonStaleEvent. Hand-written like state.ts's SessionInfo: the struct
+// only ever crosses the boundary via EventsEmit, never as a bound method's
+// return, so it is absent from the generated wailsjs/go/models.ts. Every
+// field is a required string; daemonVersionEvent() fills all five and the
+// struct carries no omitempty.
+export interface DaemonStaleEvent {
+  severity: string;
+  guiBuild: string;
+  daemonBuild: string;
+  guiRelease: string;
+  daemonRelease: string;
+}
+
+// Structural rather than HTMLElement on purpose: the unit test injects
+// fakes carrying exactly these members, and that is the contract this
+// function actually has. Nullable because initVersionFooter() feeds it
+// getElementById results and renderVersionFooter branches on their absence.
+export interface VersionFooterEls {
+  root: { classList: { toggle(name: string, force: boolean): unknown } } | null;
+  gui: { textContent: string | null } | null;
+  // `hidden` is `string | boolean` to match lib.dom's HTMLElement, which
+  // widened it for the `until-found` value. This code only ever writes
+  // booleans.
+  daemon: { textContent: string | null; hidden: string | boolean } | null;
+}
+
 // Renders one binary as "<name> <release> (<build>)", degrading as
 // fields go missing. An older daemon — one built before wire.Welcome
 // gained the Release field — sends no release, so it must not render
 // as "hived  (a3f9c1)" with a hole in it. buildinfo.Version() never
 // returns "" on a current build, so an empty release is a reliable
 // signal of exactly that older-daemon case.
-export function formatBinary(name, release, build) {
+export function formatBinary(
+  name: string,
+  release: string,
+  build: string,
+): string {
   const parts = [name];
   if (release) parts.push(release);
   if (build) parts.push(`(${build})`);
@@ -37,7 +68,10 @@ export function formatBinary(name, release, build) {
 
 // Pure render step, exported for unit tests. `els` is injected so the
 // tests can pass fakes instead of reaching into a live document.
-export function renderVersionFooter(ev, els) {
+export function renderVersionFooter(
+  ev: DaemonStaleEvent | null,
+  els: VersionFooterEls,
+) {
   const { root, gui, daemon } = els;
   if (!root || !gui || !daemon) return;
   if (!ev) return;
@@ -62,7 +96,7 @@ export function renderVersionFooter(ev, els) {
 }
 
 export function initVersionFooter() {
-  const els = {
+  const els: VersionFooterEls = {
     root: document.getElementById('sidebar-hints'),
     gui: document.getElementById('ver-gui'),
     daemon: document.getElementById('ver-daemon'),
@@ -70,5 +104,7 @@ export function initVersionFooter() {
   // Left empty until the first connect. The daemon's version is
   // unknowable before the handshake, and a placeholder would only
   // duplicate the daemon-down messaging the banner already owns.
-  EventsOn('daemon:stale', (ev) => renderVersionFooter(ev, els));
+  EventsOn('daemon:stale', (ev: DaemonStaleEvent | null) =>
+    renderVersionFooter(ev, els),
+  );
 }

--- a/cmd/hivegui/frontend/test/dom/settings.test.ts
+++ b/cmd/hivegui/frontend/test/dom/settings.test.ts
@@ -18,9 +18,15 @@ const saveCustomAgents = vi.fn(
   (_agents: main.CustomAgent[]): Promise<void> => Promise.resolve(),
 );
 
+// Forwarded variadically off Parameters<>, not at a fixed arity: a mock
+// that drops an argument the real binding gained still satisfies
+// toHaveBeenCalledWith, which is how UpdateSession/UpdateProject drifted
+// twice before.
 vi.mock('../../src/bridge.js', () => ({
-  ListCustomAgents: () => listCustomAgents(),
-  SaveCustomAgents: (agents: main.CustomAgent[]) => saveCustomAgents(agents),
+  ListCustomAgents: (...a: Parameters<typeof listCustomAgents>) =>
+    listCustomAgents(...a),
+  SaveCustomAgents: (...a: Parameters<typeof saveCustomAgents>) =>
+    saveCustomAgents(...a),
 }));
 
 const MARKUP = `

--- a/cmd/hivegui/frontend/test/dom/settings.test.ts
+++ b/cmd/hivegui/frontend/test/dom/settings.test.ts
@@ -7,13 +7,20 @@
 // the agent id, so a changed id breaks revive), and a save rejected by
 // Go must surface its error instead of closing the modal.
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+// Type-only: erased, so the generated module is never resolved at runtime.
+import type { main } from '../../wailsjs/go/models';
 
-const listCustomAgents = vi.fn(() => Promise.resolve([]));
-const saveCustomAgents = vi.fn(() => Promise.resolve());
+const listCustomAgents = vi.fn(
+  (): Promise<main.CustomAgent[]> => Promise.resolve([]),
+);
+const saveCustomAgents = vi.fn(
+  (_agents: main.CustomAgent[]): Promise<void> => Promise.resolve(),
+);
 
 vi.mock('../../src/bridge.js', () => ({
-  ListCustomAgents: (...a) => listCustomAgents(...a),
-  SaveCustomAgents: (...a) => saveCustomAgents(...a),
+  ListCustomAgents: () => listCustomAgents(),
+  SaveCustomAgents: (agents: main.CustomAgent[]) => saveCustomAgents(agents),
 }));
 
 const MARKUP = `
@@ -32,8 +39,18 @@ const MARKUP = `
     </div>
   </div>`;
 
-let openSettings, closeSettings, initSettings, splitCommand;
-let refocusActiveTerm, setFocusedTile;
+// Typed off the module itself rather than restated, so a changed export
+// signature fails here instead of silently widening to any.
+type SettingsModule = typeof import('../../src/app/modals/settings.js');
+let openSettings: SettingsModule['openSettings'];
+let closeSettings: SettingsModule['closeSettings'];
+let initSettings: SettingsModule['initSettings'];
+let splitCommand: SettingsModule['splitCommand'];
+// Declared with their exact signatures, not ReturnType<typeof vi.fn>:
+// vitest's Mock<T> is invariant enough that the bare form won't satisfy
+// the SettingsDeps fields initSettings expects.
+let refocusActiveTerm: Mock<() => void>;
+let setFocusedTile: Mock<(id: string | null) => void>;
 
 beforeAll(async () => {
   document.body.innerHTML = MARKUP;
@@ -50,15 +67,27 @@ beforeEach(() => {
   saveCustomAgents.mockReset().mockResolvedValue(undefined);
   refocusActiveTerm.mockReset();
   setFocusedTile.mockReset();
-  document.getElementById('settings').classList.add('hidden');
+  el('settings').classList.add('hidden');
 });
 
-const el = (id) => document.getElementById(id);
-const rows = () => [...document.querySelectorAll('.settings-agent-row')];
+// MARKUP above is this file's contract, so a missing id is a bug in the
+// fixture, not a case to branch on — cast rather than null-check at 40
+// call sites. The type parameter names the element kind the markup
+// declares (a <button>, an <input>) so .disabled / .value resolve.
+const el = <T extends HTMLElement = HTMLElement>(id: string): T =>
+  document.getElementById(id) as T;
+const rows = () => [
+  ...document.querySelectorAll<HTMLElement>('.settings-agent-row'),
+];
+// Same contract, one level down: render() always builds all four cells.
+const cell = <T extends HTMLElement = HTMLInputElement>(
+  row: Element,
+  sel: string,
+): T => row.querySelector(sel) as T;
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 // Drives an <input> the way a user does: set the value, fire 'input'.
-function type(input, value) {
+function type(input: HTMLInputElement, value: string) {
   input.value = value;
   input.dispatchEvent(new window.Event('input', { bubbles: true }));
 }
@@ -100,10 +129,8 @@ describe('settings modal', () => {
     await flush();
 
     expect(rows()).toHaveLength(1);
-    expect(rows()[0].querySelector('.settings-agent-name').value).toBe(
-      'Claude Lite',
-    );
-    expect(rows()[0].querySelector('.settings-agent-cmd').value).toBe(
+    expect(cell(rows()[0], '.settings-agent-name').value).toBe('Claude Lite');
+    expect(cell(rows()[0], '.settings-agent-cmd').value).toBe(
       'claude --model haiku',
     );
 
@@ -118,11 +145,8 @@ describe('settings modal', () => {
 
     el('settings-agent-add').click();
     expect(rows()).toHaveLength(1);
-    type(rows()[0].querySelector('.settings-agent-name'), 'Claude Lite');
-    type(
-      rows()[0].querySelector('.settings-agent-cmd'),
-      'claude --model haiku',
-    );
+    type(cell(rows()[0], '.settings-agent-name'), 'Claude Lite');
+    type(cell(rows()[0], '.settings-agent-cmd'), 'claude --model haiku');
 
     el('settings-save').click();
     await flush();
@@ -153,7 +177,7 @@ describe('settings modal', () => {
     openSettings();
     await flush();
 
-    type(rows()[0].querySelector('.settings-agent-name'), 'Claude Litest');
+    type(cell(rows()[0], '.settings-agent-name'), 'Claude Litest');
     el('settings-save').click();
     await flush();
 
@@ -172,7 +196,7 @@ describe('settings modal', () => {
     await flush();
     expect(rows()).toHaveLength(3);
 
-    rows()[1].querySelector('.settings-agent-delete').click();
+    cell(rows()[1], '.settings-agent-delete').click();
     expect(rows()).toHaveLength(2);
 
     el('settings-save').click();
@@ -187,8 +211,8 @@ describe('settings modal', () => {
     await flush();
 
     el('settings-agent-add').click();
-    type(rows()[0].querySelector('.settings-agent-name'), 'Real');
-    type(rows()[0].querySelector('.settings-agent-cmd'), 'realtool');
+    type(cell(rows()[0], '.settings-agent-name'), 'Real');
+    type(cell(rows()[0], '.settings-agent-cmd'), 'realtool');
     el('settings-agent-add').click(); // left entirely blank
 
     el('settings-save').click();
@@ -207,8 +231,8 @@ describe('settings modal', () => {
     await flush();
 
     el('settings-agent-add').click();
-    type(rows()[0].querySelector('.settings-agent-name'), 'Claude');
-    type(rows()[0].querySelector('.settings-agent-cmd'), 'claude');
+    type(cell(rows()[0], '.settings-agent-name'), 'Claude');
+    type(cell(rows()[0], '.settings-agent-cmd'), 'claude');
     el('settings-save').click();
     await flush();
 
@@ -232,7 +256,7 @@ describe('settings modal', () => {
     ]);
     openSettings();
     await flush();
-    type(rows()[0].querySelector('.settings-agent-name'), 'Scribbled');
+    type(cell(rows()[0], '.settings-agent-name'), 'Scribbled');
 
     el('settings-cancel').click();
     expect(el('settings').classList.contains('hidden')).toBe(true);
@@ -241,7 +265,7 @@ describe('settings modal', () => {
     // Reopening re-reads from disk rather than showing the discarded draft.
     openSettings();
     await flush();
-    expect(rows()[0].querySelector('.settings-agent-name').value).toBe('Keep');
+    expect(cell(rows()[0], '.settings-agent-name').value).toBe('Keep');
   });
 
   it('closes on Escape', async () => {
@@ -268,8 +292,8 @@ describe('failed load', () => {
 
     expect(el('settings-error').classList.contains('hidden')).toBe(false);
     expect(el('settings-error').textContent).toMatch(/agents\.json/);
-    expect(el('settings-save').disabled).toBe(true);
-    expect(el('settings-agent-add').disabled).toBe(true);
+    expect(el<HTMLButtonElement>('settings-save').disabled).toBe(true);
+    expect(el<HTMLButtonElement>('settings-agent-add').disabled).toBe(true);
 
     el('settings-save').click();
     await flush();
@@ -288,15 +312,15 @@ describe('failed load', () => {
     listCustomAgents.mockResolvedValue([]);
     openSettings();
     await flush();
-    expect(el('settings-save').disabled).toBe(false);
-    expect(el('settings-agent-add').disabled).toBe(false);
+    expect(el<HTMLButtonElement>('settings-save').disabled).toBe(false);
+    expect(el<HTMLButtonElement>('settings-agent-add').disabled).toBe(false);
     closeSettings();
   });
 });
 
 describe('load race', () => {
   it('does not clobber a draft with a stale response from a previous open', async () => {
-    let resolveFirst;
+    let resolveFirst: (v: main.CustomAgent[]) => void = () => {};
     listCustomAgents.mockReturnValue(
       new Promise((r) => {
         resolveFirst = r;
@@ -317,7 +341,7 @@ describe('load race', () => {
     await flush();
 
     expect(rows()).toHaveLength(1);
-    expect(rows()[0].querySelector('.settings-agent-name').value).toBe('Kept');
+    expect(cell(rows()[0], '.settings-agent-name').value).toBe('Kept');
     closeSettings();
   });
 });
@@ -331,7 +355,7 @@ describe('focus containment', () => {
     openSettings();
     await flush();
 
-    const del = rows()[0].querySelector('.settings-agent-delete');
+    const del = cell(rows()[0], '.settings-agent-delete');
     del.focus();
     del.click();
 
@@ -342,7 +366,7 @@ describe('focus containment', () => {
     expect(el('settings').contains(document.activeElement)).toBe(true);
 
     // Deleting the last remaining row falls back to "+ Add agent".
-    rows()[0].querySelector('.settings-agent-delete').click();
+    cell(rows()[0], '.settings-agent-delete').click();
     expect(rows()).toHaveLength(0);
     expect(document.activeElement).toBe(el('settings-agent-add'));
     closeSettings();

--- a/cmd/hivegui/frontend/test/unit/version-footer.test.ts
+++ b/cmd/hivegui/frontend/test/unit/version-footer.test.ts
@@ -14,11 +14,11 @@ const { formatBinary, renderVersionFooter } = await import(
 // Minimal stand-ins for the footer elements. renderVersionFooter takes
 // them injected precisely so this file needs no live document.
 function makeRoot() {
-  const classes = new Set();
+  const classes = new Set<string>();
   return {
     classes,
     classList: {
-      toggle(name, on) {
+      toggle(name: string, on: boolean) {
         if (on) classes.add(name);
         else classes.delete(name);
       },
@@ -26,8 +26,16 @@ function makeRoot() {
   };
 }
 
-let els;
-let root;
+// Annotated with the *fake* shapes, not VersionFooterEls: the assertions
+// read `root.classes` and dereference `els.gui`, neither of which survives
+// the nullable public interface. Assignability into renderVersionFooter is
+// what proves the fakes still satisfy the real contract.
+let els: {
+  root: ReturnType<typeof makeRoot>;
+  gui: { textContent: string };
+  daemon: { textContent: string; hidden: boolean };
+};
+let root: ReturnType<typeof makeRoot>;
 beforeEach(() => {
   root = makeRoot();
   els = {

--- a/cmd/hivegui/frontend/tsconfig.json
+++ b/cmd/hivegui/frontend/tsconfig.json
@@ -46,6 +46,7 @@
     "src/bridge.ts",
     "src/globals.d.ts",
     "test/unit/**/*",
+    "test/dom/**/*",
     "test/e2e/wails-mock.ts",
     "test/e2e-real/wails-bridge.ts"
   ],

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -2,7 +2,7 @@
 
 - **Spec:** [docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md](../../analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md) §2c
 - **Issue:** TBD
-- **Stage:** IMPLEMENT (waves 1–4 done, 1–3 merged; wave 5 next)
+- **Stage:** IMPLEMENT (waves 1–4 merged, wave 5a done; wave 5b next)
 - **Status:** active
 
 ## Summary
@@ -134,7 +134,11 @@ Wave notes:
   is not required for correctness. Leave `globalSetup.mjs`/`globalTeardown.mjs` as `.mjs`.
 - **5** — intra-wave edges only (`view`→`sidebar`→`modals/*`). Real `@xterm/*` types land
   **here**, not in wave 6: `test/dom/xterm-reflow.test.js:11` imports `@xterm/xterm`
-  directly. Splittable.
+  directly. **Split, as anticipated** — the whole wave produced 460 errors after the bulk
+  `git mv`. **5a** (landed): `banners`, `version-footer`, `modals/*` (5),
+  `test/unit/version-footer.test`, `test/dom/settings.test` — nothing in that set imports
+  anything else in the wave. **5b**: `sidebar`, `focus`, `view`,
+  `test/dom/{environment,selectors,xterm-reflow}.test`.
 - **6** — splittable into 2 PRs; no cycle exists. `session-term.js` (1,259 LOC) is the
   hardest file; expect the bulk of the errors.
 - **7** — last wave. No strictness ramp follows.
@@ -385,6 +389,50 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
   `origin/main` at `87b70e3` fails **the same 5** with the diff stashed.
   Non-vacuity proved on all three converted files with planted errors
   (TS2322 in both harnesses, TS2304 in `bridge.ts`).
+
+- **2026-08-08** — Wave 5a complete: `banners`, `version-footer`, all five
+  `modals/*`, `test/unit/version-footer.test`, `test/dom/settings.test`.
+  `include` gained `test/dom/**/*` (invariant 6). The full wave was 460
+  errors, so it split along the one clean seam — nothing in 5a imports
+  anything else in wave 5.
+  - **`src/app/el.ts` is new, and the two wrappers in it are not
+    interchangeable.** dom.ts's private throwing `mustEl` moved there
+    unchanged; `pageEl<T>()` casts instead. Which one a module may use is
+    forced by its importers, not by taste: `keyboard.js` imports
+    `banners.js` and `view.js` imports `launcher.js`/`project-editor.js`,
+    so `attention-jump{,-integration}`, `nav-history` and `restart-hive`
+    pull those modules into jsdom mounting only the markup each test
+    exercises. A load-time throw would break tests for elements they
+    legitimately don't have. **Wave 5b and 6 inherit this constraint** —
+    check who imports a module before reaching for `mustEl`.
+  - **`DaemonStaleEvent` is hand-written** in `version-footer.ts`;
+    `banners.ts` imports it type-only. Same call as `SessionInfo`: the Go
+    struct crosses only via `EventsEmit`, never as a bound method's
+    return, so it is absent from the generated `models.ts` and invariant 3
+    doesn't apply. `UpdateInfo` / `CustomAgent`, which *are* generated,
+    come from `wailsjs/go/models` (type-only, erased before Vite).
+  - **Per-modal deps interfaces, not one shared type.** `help-overlay`
+    takes `focusActiveTerm`; the other three take `refocusActiveTerm`. A
+    union would loosen all four — the wave-2 lesson about narrower
+    parameter types, applied to injection.
+  - `splitCommand` is `(line: string | null)`: a test asserts
+    `splitCommand(null)` is `[]`, so `String(line || '')` is the contract.
+  - **Watch for `?.` erasure when converting.** Two optional-chained call
+    sites in `settings.ts` were rewritten to throwing lookups mid-pass and
+    put back. `?.` means the code tolerates absence; replacing it turns a
+    no-op focus into a TypeError. Same class as wave 2's `reset?.()`
+    regression, in the opposite direction.
+
+  Gates: typecheck/build/biome green, vitest 322 in 32 files (unchanged),
+  Playwright mock 79 passed + 1 skipped (unchanged) — itself the proof the
+  substitution still fires, since every one of those specs needs
+  `window.__hive`. e2e-real 7 passed / 5 failed, the same 5 wave 4
+  recorded against `main`. Non-vacuity proved with planted errors in
+  `banners.ts`, `launcher.ts` and `settings.test.ts`. The `dev-iso.sh` GUI
+  smoke was **not** run: 5a's whole surface (help overlay open/close + Tab
+  trap, version footer, launcher agent-select → create session, palette)
+  is already driven in a real browser by the mock e2e suite. It is still
+  owed for 5b and 6, which land `view`/`focus`/`keyboard`.
 
 ## Open questions
 


### PR DESCRIPTION
Converts the leaf half of wave 5: `banners.js`, `version-footer.js` and all five `modals/*`, plus `test/unit/version-footer.test.js` and `test/dom/settings.test.js`.

`sidebar`/`focus`/`view` and the three remaining `test/dom` files follow in 5b. The full wave produced **460 errors** after the bulk `git mv` — too large for one reviewable diff, and [the plan](docs/exec-plans/active/typescript-migration.md) already marked wave 5 splittable. The seam is clean: nothing in 5a imports anything else in the wave.

`tsconfig.json` `include` gains `test/dom/**/*` (invariant 6 — nothing imports a test file, so a converted spec left outside `include` is silently unchecked while `tsc` stays green).

## Worth a reviewer's attention

- **New `src/app/el.ts`, and its two wrappers are not interchangeable.** `dom.ts`'s private throwing `mustEl` moves there unchanged; `pageEl<T>()` is the non-throwing sibling the modals and `banners.ts` use. The distinction is forced, not stylistic: `keyboard.js` imports `banners.js` and `view.js` imports `launcher.js`/`project-editor.js`, so `attention-jump{,-integration}`, `nav-history` and `restart-hive` drag those modules into jsdom with only the markup each test exercises. A load-time throw would break tests for elements they legitimately don't mount. `pageEl` preserves today's behavior exactly — a missing id is a TypeError at first use.
- **`DaemonStaleEvent` is hand-written** in `version-footer.ts` (`banners.ts` imports it type-only). Same call as `state.ts`'s `SessionInfo`: the Go struct crosses only via `EventsEmit`, never as a bound method's return, so it's absent from the generated `models.ts` and invariant 3 doesn't apply. `UpdateInfo` and `CustomAgent`, which *are* generated, come from `wailsjs/go/models` — type-only, so the module is erased before Vite resolves it.
- **Per-modal deps interfaces, not one shared type.** `help-overlay` takes `focusActiveTerm`; the other three take `refocusActiveTerm`. A shared union would loosen all four.
- **`splitCommand` is `(line: string | null)`.** A test asserts `splitCommand(null)` is `[]`, so the `String(line || '')` guard is the contract, not padding around a narrower signature.
- **Two `?.` call sites in `settings.ts` were rewritten to throwing lookups mid-pass and put back.** `?.` means the code tolerates the element's absence; dropping it turns a no-op focus into a TypeError. Same class as wave 2's `reset?.()` regression, opposite direction.

## Gates

| gate | result |
|---|---|
| `tsc --noEmit` | green |
| `npm run build` | green |
| `npm run ci` (biome) | green |
| vitest | 322 tests / 32 files — **unchanged** |
| Playwright mock | 79 passed + 1 skipped — **unchanged** |
| Playwright e2e-real | 7 passed / 5 failed — the same 5 wave 4 recorded against `main` (known local flake) |

The unchanged Playwright mock count is itself the proof the harness substitution still fires: every one of those specs needs `window.__hive`.

Non-vacuity proved with planted type errors in `banners.ts`, `launcher.ts` and `settings.test.ts` (TS2322 in each).

`scripts/dev-iso.sh` GUI smoke was **not** run — 5a's whole surface (help overlay open/close + Tab trap, version footer, launcher agent-select → create session, palette) is already driven in a real browser by the mock e2e suite. Still owed for 5b and 6, which land `view`/`focus`/`keyboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)