### PR TITLE
frontend: search-as-you-type filtering in the new-session popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The new-session popup (⌘T) now filters as you type. A filter box sits at
+  the top of the agent list and narrows it to agents whose name contains what
+  you typed. The `1`–`9` row shortcuts still work while the box is empty; once
+  you start typing, digits go into the query and the row numbers disappear
+  rather than advertising a shortcut that no longer fires. Escape still closes
+  the popup, and every opening starts with an empty filter.
+
 - Worktree sessions now inherit the project's agent config. A fresh `git
   worktree add` only materializes tracked files, so an untracked
   `.claude/skills` (or `.agents/skills`, `commands`, `hooks`, `plugins`,

--- a/cmd/hivegui/frontend/src/app/keyboard.js
+++ b/cmd/hivegui/frontend/src/app/keyboard.js
@@ -27,11 +27,7 @@ import {
 import { cmdOrCtrl, isMac } from '../lib/platform.js';
 import {
   launcherEl,
-  launcherState,
-  moveLauncherSelection,
-  activateLauncherSelection,
   openLauncher,
-  closeLauncher,
   duplicateActiveSession,
   duplicateActiveSessionChooseTool,
   restartActiveSession,
@@ -102,31 +98,7 @@ window.addEventListener(
       });
     }
     if (!launcherEl.classList.contains('hidden')) {
-      const handle = (fn) => {
-        e.preventDefault();
-        e.stopPropagation();
-        fn();
-      };
-      if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey))
-        return handle(() => moveLauncherSelection(+1));
-      if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey))
-        return handle(() => moveLauncherSelection(-1));
-      if (e.key === 'Enter') return handle(activateLauncherSelection);
-      if (e.key === 'Escape') return handle(closeLauncher);
-      if (cmdOrCtrl(e) && (e.key === 'n' || e.key === 'N'))
-        return handle(closeLauncher);
-      // Digit shortcut: 1–9 picks the corresponding row. Skipped when
-      // a modifier is held so things like ⌘1 (browser tab switch) and
-      // ⌘+ aren't swallowed.
-      if (!e.metaKey && !e.ctrlKey && !e.altKey && /^[1-9]$/.test(e.key)) {
-        const i = parseInt(e.key, 10) - 1;
-        if (i < launcherState.items.length) {
-          return handle(() => {
-            launcherState.selected = i;
-            activateLauncherSelection();
-          });
-        }
-      }
+      return; // launcher's own listener handles keys
     }
     if (!editorEl.classList.contains('hidden')) {
       return; // editor's own listener handles keys

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -16,6 +16,7 @@ import { flashStatus, reportFailure } from '../dom.js';
 import { activeProjectId, resolveSessionCwd } from '../selectors.js';
 import { registerModal } from './registry.js';
 import { pageEl } from '../el.js';
+import { cmdOrCtrl } from '../../lib/platform.js';
 import type { SessionInfo } from '../state.js';
 // Type-only, so the generated module is erased before Vite resolves it.
 import type { main } from '../../../wailsjs/go/models';
@@ -46,6 +47,22 @@ let deps: LauncherDeps = {
 };
 
 export const launcherEl = pageEl('launcher');
+
+// The three children openLauncher builds inside #launcher, in order:
+// the filter box, the worktree row, and the list of agent rows. Only
+// the list is rebuilt as the user types — recreating the input would
+// drop focus and the caret on every keystroke.
+//
+// All three are recreated per open (openLauncher clears #launcher), so
+// a query never leaks from one opening to the next. They are null
+// before the first open and after a close, which is reachable: the
+// ListAgents rejection path closes a launcher whose children were
+// never filled in.
+let searchEl: HTMLInputElement | null = null;
+let listEl: HTMLElement | null = null;
+// The usage-ordered agent list ListAgents returned, kept so filtering
+// re-renders from memory instead of refetching.
+let allAgents: main.AgentInfo[] = [];
 export const launcherState: {
   items: LauncherItem[];
   selected: number;
@@ -97,7 +114,7 @@ function highlightLauncherSelection() {
   });
 }
 
-export function moveLauncherSelection(delta: number) {
+function moveLauncherSelection(delta: number) {
   const n = launcherState.items.length;
   if (n === 0) return;
   launcherState.selected = (launcherState.selected + delta + n) % n;
@@ -131,10 +148,75 @@ function launchSelected(agentId: string) {
   closeLauncher();
 }
 
-export function activateLauncherSelection() {
+function activateLauncherSelection() {
   const it = launcherState.items[launcherState.selected];
   if (!it) return;
   launchSelected(it.agent.id);
+}
+
+// Rebuild the agent rows from allAgents, narrowed to those whose name
+// contains the query. Same substring match the command palette uses
+// (modals/command-palette.ts) — deliberately not fuzzy.
+//
+// The query is read off searchEl every call rather than cached:
+// ListAgents can resolve after the user has already started typing,
+// and a cached query would be stale by the time this runs for the
+// first filled-in render.
+function renderLauncherList() {
+  if (!listEl) return;
+  const q = (searchEl?.value ?? '').trim().toLowerCase();
+  listEl.innerHTML = '';
+  launcherState.items = [];
+  const matches = q
+    ? allAgents.filter((a) => a.name.toLowerCase().includes(q))
+    : allAgents;
+  if (matches.length === 0) {
+    const none = document.createElement('div');
+    none.className = 'launcher-empty';
+    // Two different facts: the daemon returned nothing, vs the query
+    // excluded everything. Saying "No agents found" while filtering
+    // would read as an agent list that broke.
+    none.textContent = q ? 'No agents match' : 'No agents found';
+    listEl.appendChild(none);
+  }
+  matches.forEach((a, idx) => {
+    const item = document.createElement('div');
+    item.className = `launcher-item${a.available ? '' : ' uninstalled'}`;
+    item.style.setProperty('--agent-color', a.color);
+    const num = document.createElement('span');
+    num.className = 'agent-num';
+    // Number keys 1–9 select that row directly; 10+ rows show no
+    // number (no digit shortcut). While a query is active the digits
+    // type into it instead of selecting, so the hints come off — a
+    // visible [n] that does nothing is worse than none (AGENTS.md,
+    // Key Discoverability).
+    num.textContent = !q && idx < 9 ? String(idx + 1) : '';
+    const dot = document.createElement('span');
+    dot.className = 'agent-dot';
+    const name = document.createElement('span');
+    name.className = 'agent-name';
+    name.textContent = a.name;
+    item.append(num, dot, name);
+    if (!a.available && a.installCmd && a.installCmd.length) {
+      const tag = document.createElement('span');
+      tag.className = 'install-tag';
+      tag.title = a.installCmd.join(' ');
+      tag.textContent = 'install?';
+      item.appendChild(tag);
+    }
+    item.addEventListener('click', () => launchSelected(a.id));
+    item.addEventListener('mouseenter', () => {
+      launcherState.selected = idx;
+      highlightLauncherSelection();
+    });
+    listEl?.appendChild(item);
+    launcherState.items.push({ agent: a, el: item });
+  });
+  // Narrowing the list invalidates the old index — the row that was
+  // selected may not even be rendered any more. Always land on the
+  // top match so Enter means "the obvious one".
+  launcherState.selected = 0;
+  highlightLauncherSelection();
 }
 
 // projectId is optional, not just nullable: main.js, keyboard.js and
@@ -182,21 +264,37 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
     launcherEl.style.left = '16px';
     launcherEl.style.top = '64px';
   }
+  // Filter box first, then the list the rows render into. Both are
+  // built fresh here (the innerHTML wipe above dropped the previous
+  // pair), which is what guarantees every opening starts with an empty
+  // query — including ⌘T on an already-open launcher and the ⇧⌘P
+  // duplicate flow. Don't "optimize" this into reusing the old input.
+  searchEl = document.createElement('input');
+  searchEl.type = 'text';
+  searchEl.className = 'launcher-search';
+  searchEl.placeholder = 'Filter agents…';
+  searchEl.setAttribute('aria-label', 'Filter agents');
+  searchEl.autocomplete = 'off';
+  searchEl.addEventListener('input', renderLauncherList);
+  listEl = document.createElement('div');
+  listEl.className = 'launcher-list';
+  launcherEl.append(searchEl, listEl);
   const loading = document.createElement('div');
   loading.className = 'launcher-loading';
   loading.textContent = 'Loading agents…';
-  launcherEl.appendChild(loading);
+  listEl.appendChild(loading);
   launcherEl.classList.remove('hidden');
   // Drop the active tile's visual focus — modal owns the keyboard.
   deps.setFocusedTile(null);
+  // The launcher's keys are handled by its own listener (initLauncher),
+  // which only sees them while focus is inside #launcher.
+  searchEl.focus();
 
   ListAgents()
     .then((agents) => {
       // The user may have dismissed the launcher while the list was in
       // flight — don't resurrect it.
       if (launcherEl.classList.contains('hidden')) return;
-      launcherEl.innerHTML = '';
-      launcherState.items = [];
 
       // Worktree toggle row at the top of the menu. Disabled (and
       // visually muted) when the active project's cwd isn't a git
@@ -217,12 +315,14 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
         const wtLabel = document.createElement('span');
         wtLabel.textContent = 'Create in git worktree';
         wtRow.append(wtBox, wtLabel);
+        // Between the filter box and the list, not appended at the
+        // end — #launcher already holds both by the time this runs.
+        launcherEl.insertBefore(wtRow, listEl);
         wtBox.addEventListener('change', (e) => {
           const box = e.target as HTMLInputElement;
           launcherState.useWorktree = box.checked;
           localStorage.setItem('hive.worktree', box.checked ? '1' : '0');
         });
-        launcherEl.appendChild(wtRow);
         if (projCwd) {
           IsGitRepo(projCwd)
             .then((ok) => {
@@ -254,7 +354,7 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
       // the agent package's display order. Usage is persisted in
       // localStorage and incremented on activation.
       const usage = loadAgentUsage();
-      const ordered = agents
+      allAgents = agents
         .map((a, i) => ({ a, i }))
         .sort((x, y) => {
           const ux = usage[x.a.id] || 0,
@@ -263,44 +363,9 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
           return x.i - y.i;
         })
         .map((e) => e.a);
-      if (ordered.length === 0) {
-        const none = document.createElement('div');
-        none.className = 'launcher-empty';
-        none.textContent = 'No agents found';
-        launcherEl.appendChild(none);
-      }
-      ordered.forEach((a, idx) => {
-        const item = document.createElement('div');
-        item.className = `launcher-item${a.available ? '' : ' uninstalled'}`;
-        item.style.setProperty('--agent-color', a.color);
-        const num = document.createElement('span');
-        num.className = 'agent-num';
-        // Number keys 1–9 select that row directly; 10+ rows show no
-        // number (no digit shortcut).
-        num.textContent = idx < 9 ? String(idx + 1) : '';
-        const dot = document.createElement('span');
-        dot.className = 'agent-dot';
-        const name = document.createElement('span');
-        name.className = 'agent-name';
-        name.textContent = a.name;
-        item.append(num, dot, name);
-        if (!a.available && a.installCmd && a.installCmd.length) {
-          const tag = document.createElement('span');
-          tag.className = 'install-tag';
-          tag.title = a.installCmd.join(' ');
-          tag.textContent = 'install?';
-          item.appendChild(tag);
-        }
-        item.addEventListener('click', () => launchSelected(a.id));
-        item.addEventListener('mouseenter', () => {
-          launcherState.selected = idx;
-          highlightLauncherSelection();
-        });
-        launcherEl.appendChild(item);
-        launcherState.items.push({ agent: a, el: item });
-      });
-      launcherState.selected = 0;
-      highlightLauncherSelection();
+      // Renders through the same path as every keystroke, so a query
+      // typed while this request was in flight is already applied.
+      renderLauncherList();
     })
     // Anything thrown in the chain above (not just a ListAgents
     // rejection) used to land here silently — the user pressed ⌘T and
@@ -313,7 +378,15 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
 }
 
 export function closeLauncher() {
+  // Blur first: refocusActiveTerm() bails when activeElement is an
+  // INPUT, and hiding the launcher via CSS doesn't move focus off the
+  // filter box. Optional because this is reachable before any open —
+  // the ListAgents rejection path closes a launcher it never filled.
+  searchEl?.blur();
   launcherEl.classList.add('hidden');
+  searchEl = null;
+  listEl = null;
+  allAgents = [];
   launcherState.items = [];
   launcherState.duplicateFrom = null;
   launcherState.duplicateCwd = '';
@@ -359,6 +432,69 @@ export function duplicateActiveSessionChooseTool() {
 export function initLauncher(injected: LauncherDeps) {
   deps = injected;
   registerModal(launcherEl);
+  // The launcher owns its keyboard while open, the way the command
+  // palette and settings do — it has to, now that the filter box holds
+  // focus and lib/focus.ts hands the keyboard to a focused <input>.
+  // keyboard.js bails out for #launcher for the same reason.
+  launcherEl.addEventListener('keydown', (e) => {
+    const handle = (fn: () => void) => {
+      e.preventDefault();
+      e.stopPropagation();
+      fn();
+    };
+    if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey))
+      return handle(() => moveLauncherSelection(+1));
+    if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey))
+      return handle(() => moveLauncherSelection(-1));
+    if (e.key === 'Enter') return handle(activateLauncherSelection);
+    if (e.key === 'Escape') return handle(closeLauncher);
+    if (cmdOrCtrl(e) && (e.key === 'n' || e.key === 'N'))
+      return handle(closeLauncher);
+    // ⌘T / ⇧⌘T while already open re-opens (and so clears the query).
+    // keyboard.js used to give us this for free — its launcher block
+    // fell through on unhandled keys and hit the global ⌘T binding
+    // further down. Now that it bails out for #launcher entirely, the
+    // binding has to be repeated here or it would silently stop working.
+    if (cmdOrCtrl(e) && (e.key === 't' || e.key === 'T'))
+      return handle(() => {
+        // Same two calls as the global binding in keyboard.js — passing
+        // undefined re-resolves the active project rather than pinning
+        // the one this opening was anchored to.
+        if (e.shiftKey) openLauncher(undefined, { forceWorktree: true });
+        else openLauncher();
+      });
+    // Digit shortcut: 1–9 picks the corresponding row, but only while
+    // the filter box is empty — past that the user is typing a query
+    // and a digit is just a character. Raw .value, not trimmed: a
+    // typed space is already a query. Skipped when a modifier is held
+    // so ⌘1 and friends aren't swallowed.
+    if (
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.altKey &&
+      /^[1-9]$/.test(e.key) &&
+      searchEl?.value === ''
+    ) {
+      const i = parseInt(e.key, 10) - 1;
+      if (i < launcherState.items.length) {
+        return handle(() => {
+          launcherState.selected = i;
+          activateLauncherSelection();
+        });
+      }
+    }
+  });
+  // Clicking an agent row would otherwise blur the filter box and
+  // strand the keyboard outside #launcher, where the listener above
+  // never sees it. Rows aren't focusable, so suppressing the default
+  // mousedown focus shift costs nothing; the row's click handler still
+  // fires. The worktree row is exempt — its checkbox needs the default.
+  launcherEl.addEventListener('mousedown', (e) => {
+    const target = e.target as Element | null;
+    if (target === searchEl) return;
+    if (target?.closest('.launcher-worktree')) return;
+    e.preventDefault();
+  });
   document.addEventListener('click', (e) => {
     const target = e.target as Element | null;
     const inAction = target?.closest('.project-actions');

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -71,8 +71,15 @@ let listEl: HTMLElement | null = null;
 // doesn't catch a reopen, because the launcher is visible again by then.
 let openGeneration = 0;
 // The usage-ordered agent list ListAgents returned, kept so filtering
-// re-renders from memory instead of refetching.
+// re-renders from memory instead of refetching. Reset per open, not
+// just per close: a ⌘T over an already-open launcher would otherwise
+// filter the previous opening's list until the new response lands.
 let allAgents: main.AgentInfo[] = [];
+// True from the moment a request is issued until it settles. Without
+// it, an empty allAgents is indistinguishable from "the query excluded
+// everything", and the first character typed during the round trip
+// would replace the loading row with "No agents match".
+let agentsLoading = false;
 export const launcherState: {
   items: LauncherItem[];
   selected: number;
@@ -188,11 +195,16 @@ function renderLauncherList() {
     : allAgents;
   if (matches.length === 0) {
     const none = document.createElement('div');
-    none.className = 'launcher-empty';
-    // Two different facts: the daemon returned nothing, vs the query
-    // excluded everything. Saying "No agents found" while filtering
-    // would read as an agent list that broke.
-    none.textContent = q ? 'No agents match' : 'No agents found';
+    // Three different facts, and conflating any two of them misreads as
+    // a broken agent list: the request is still in flight, the daemon
+    // returned nothing, or the query excluded everything.
+    if (agentsLoading) {
+      none.className = 'launcher-loading';
+      none.textContent = 'Loading agents…';
+    } else {
+      none.className = 'launcher-empty';
+      none.textContent = q ? 'No agents match' : 'No agents found';
+    }
     listEl.appendChild(none);
   }
   matches.forEach((a, idx) => {
@@ -295,10 +307,14 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
   listEl = document.createElement('div');
   listEl.className = 'launcher-list';
   launcherEl.append(searchEl, listEl);
-  const loading = document.createElement('div');
-  loading.className = 'launcher-loading';
-  loading.textContent = 'Loading agents…';
-  listEl.appendChild(loading);
+  // Reset before the first render so neither the previous opening's
+  // agents nor its loading state leak into this one.
+  allAgents = [];
+  agentsLoading = true;
+  // Draws the loading row through the same path every keystroke uses,
+  // so typing during the round trip can't render something the initial
+  // paint wouldn't have.
+  renderLauncherList();
   launcherEl.classList.remove('hidden');
   // Drop the active tile's visual focus — modal owns the keyboard.
   deps.setFocusedTile(null);
@@ -315,6 +331,7 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
       // ...or reopened it, in which case this response belongs to a
       // launcher that no longer exists and a newer request owns the DOM.
       if (gen !== openGeneration) return;
+      agentsLoading = false;
 
       // Worktree toggle row at the top of the menu. Disabled (and
       // visually muted) when the active project's cwd isn't a git
@@ -403,6 +420,7 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
       // reopened. Still reported — the failure was real.
       reportFailure('launcher')(err);
       if (gen !== openGeneration) return;
+      agentsLoading = false;
       closeLauncher();
     });
 }
@@ -532,6 +550,24 @@ export function initLauncher(injected: LauncherDeps) {
     if (target === searchEl) return;
     if (target?.closest('.launcher-worktree')) return;
     e.preventDefault();
+  });
+  // Focus leaving the launcher closes it. keyboard.js now bails out for
+  // the whole window whenever #launcher is visible, and this module's
+  // own keydown listener only fires while focus is inside it — so a
+  // launcher that stays visible after focus moves away is a launcher
+  // nobody is listening for, Escape included.
+  //
+  // The .project-actions buttons are how you get there: each one calls
+  // stopPropagation, so the outside-click handler below never sees them
+  // (its .project-actions exemption has always been unreachable for
+  // that reason), but clicking ✎ or ✕ still moves focus out.
+  //
+  // relatedTarget null means focus went nowhere — that's closeLauncher's
+  // own blur, so ignore it rather than recursing.
+  launcherEl.addEventListener('focusout', (e) => {
+    if (launcherEl.classList.contains('hidden')) return;
+    const next = (e as FocusEvent).relatedTarget as Node | null;
+    if (next && !launcherEl.contains(next)) closeLauncher();
   });
   document.addEventListener('click', (e) => {
     const target = e.target as Element | null;

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -426,16 +426,22 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
 }
 
 export function closeLauncher() {
+  // Idempotent: an outside click on a focusable element closes twice —
+  // once from focusout at mousedown, once from the document click
+  // handler — and running refocusActiveTerm() twice is pointless work
+  // against the terminal. Also makes the ListAgents rejection path safe
+  // when it fires against a launcher that is already closed.
+  if (launcherEl.classList.contains('hidden')) return;
   // Blur first: refocusActiveTerm() bails when activeElement is an
   // INPUT (lib/focus.ts), and hiding the launcher via CSS does not
   // synchronously move focus out of it in a real engine.
   //
-  // Whatever holds focus, not just the filter box — the worktree
-  // checkbox is exempt from the mousedown preventDefault below, so
-  // clicking it really does take focus, and it is an <input> too. Only
-  // blurring searchEl left the terminal unfocused after ⌘T → click the
-  // checkbox → Escape. jsdom can't catch that one (no layout), so the
-  // regression test for it lives in test/e2e/launcher-search.spec.js.
+  // Whatever holds focus, not just searchEl. In practice the mousedown
+  // handler below keeps focus on searchEl, so those are the same thing
+  // today — this stays general so that adding one focusable control to
+  // the popup later can't quietly resurrect the bug it was written for
+  // (terminal never refocused, because activeElement was still an
+  // <input> the launcher owned).
   const focused = document.activeElement;
   if (focused instanceof HTMLElement && launcherEl.contains(focused))
     focused.blur();
@@ -540,15 +546,21 @@ export function initLauncher(injected: LauncherDeps) {
       }
     }
   });
-  // Clicking an agent row would otherwise blur the filter box and
-  // strand the keyboard outside #launcher, where the listener above
-  // never sees it. Rows aren't focusable, so suppressing the default
-  // mousedown focus shift costs nothing; the row's click handler still
-  // fires. The worktree row is exempt — its checkbox needs the default.
+  // Nothing but the filter box may take focus. Clicking anything else
+  // would blur it, and the keydown listener above only fires while
+  // focus is inside #launcher — so the search would silently stop
+  // responding to typing.
+  //
+  // preventDefault on mousedown suppresses only the focus shift and
+  // text selection: click still fires, so agent rows still launch and
+  // the worktree checkbox still toggles (a checkbox toggles on click
+  // activation, not on focus). The checkbox used to be exempt here,
+  // which meant clicking it moved focus onto it and every subsequent
+  // keystroke went to the checkbox instead of the query — the list just
+  // stopped narrowing, with nothing on screen to explain why.
   launcherEl.addEventListener('mousedown', (e) => {
     const target = e.target as Element | null;
     if (target === searchEl) return;
-    if (target?.closest('.launcher-worktree')) return;
     e.preventDefault();
   });
   // Focus leaving the launcher closes it. keyboard.js now bails out for

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -346,6 +346,12 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
         if (projCwd) {
           IsGitRepo(projCwd)
             .then((ok) => {
+              // Same staleness rule as ListAgents above: without this, a
+              // late "not a git repo" answer for the project this open
+              // was anchored to could set useWorktree = false under a
+              // launcher since reopened on a git-backed project, leaving
+              // a checked box whose state says off.
+              if (gen !== openGeneration) return;
               if (!ok) {
                 wtRow.classList.add('disabled');
                 wtBox.disabled = true;
@@ -403,10 +409,18 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
 
 export function closeLauncher() {
   // Blur first: refocusActiveTerm() bails when activeElement is an
-  // INPUT, and hiding the launcher via CSS doesn't move focus off the
-  // filter box. Optional because this is reachable before any open —
-  // the ListAgents rejection path closes a launcher it never filled.
-  searchEl?.blur();
+  // INPUT (lib/focus.ts), and hiding the launcher via CSS does not
+  // synchronously move focus out of it in a real engine.
+  //
+  // Whatever holds focus, not just the filter box — the worktree
+  // checkbox is exempt from the mousedown preventDefault below, so
+  // clicking it really does take focus, and it is an <input> too. Only
+  // blurring searchEl left the terminal unfocused after ⌘T → click the
+  // checkbox → Escape. jsdom can't catch that one (no layout), so the
+  // regression test for it lives in test/e2e/launcher-search.spec.js.
+  const focused = document.activeElement;
+  if (focused instanceof HTMLElement && launcherEl.contains(focused))
+    focused.blur();
   launcherEl.classList.add('hidden');
   searchEl = null;
   listEl = null;

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -60,6 +60,16 @@ export const launcherEl = pageEl('launcher');
 // never filled in.
 let searchEl: HTMLInputElement | null = null;
 let listEl: HTMLElement | null = null;
+// Bumped on every open. A ListAgents promise captures the value it was
+// issued under and bails if it no longer matches, so a slow response
+// can't land in a launcher that has since been reopened.
+//
+// This used to be implicit: the old .then began by wiping #launcher, so
+// a late resolve just rebuilt everything. The wipe had to go (it would
+// destroy the focused filter box), which turned "harmlessly redundant"
+// into "inserts a second worktree row" — the `hidden` check alone
+// doesn't catch a reopen, because the launcher is visible again by then.
+let openGeneration = 0;
 // The usage-ordered agent list ListAgents returned, kept so filtering
 // re-renders from memory instead of refetching.
 let allAgents: main.AgentInfo[] = [];
@@ -164,7 +174,13 @@ function activateLauncherSelection() {
 // first filled-in render.
 function renderLauncherList() {
   if (!listEl) return;
-  const q = (searchEl?.value ?? '').trim().toLowerCase();
+  // Two readings of the same box, on purpose. `raw` decides whether the
+  // user is typing — it must agree with the digit handler, which also
+  // tests the raw value, or a lone space would show [n] hints that no
+  // longer fire. `q` decides what matches, where surrounding whitespace
+  // is just noise.
+  const raw = searchEl?.value ?? '';
+  const q = raw.trim().toLowerCase();
   listEl.innerHTML = '';
   launcherState.items = [];
   const matches = q
@@ -190,7 +206,7 @@ function renderLauncherList() {
     // type into it instead of selecting, so the hints come off — a
     // visible [n] that does nothing is worse than none (AGENTS.md,
     // Key Discoverability).
-    num.textContent = !q && idx < 9 ? String(idx + 1) : '';
+    num.textContent = !raw && idx < 9 ? String(idx + 1) : '';
     const dot = document.createElement('span');
     dot.className = 'agent-dot';
     const name = document.createElement('span');
@@ -290,11 +306,15 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
   // which only sees them while focus is inside #launcher.
   searchEl.focus();
 
+  const gen = ++openGeneration;
   ListAgents()
     .then((agents) => {
       // The user may have dismissed the launcher while the list was in
       // flight — don't resurrect it.
       if (launcherEl.classList.contains('hidden')) return;
+      // ...or reopened it, in which case this response belongs to a
+      // launcher that no longer exists and a newer request owns the DOM.
+      if (gen !== openGeneration) return;
 
       // Worktree toggle row at the top of the menu. Disabled (and
       // visually muted) when the active project's cwd isn't a git
@@ -372,7 +392,11 @@ export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
     // nothing happened, with no trace. Close the loading shell too:
     // an empty popup with stale "Loading agents…" would be worse.
     .catch((err) => {
+      // Same staleness rule as the success path: a rejection from a
+      // superseded request must not close the launcher the user just
+      // reopened. Still reported — the failure was real.
       reportFailure('launcher')(err);
+      if (gen !== openGeneration) return;
       closeLauncher();
     });
 }

--- a/cmd/hivegui/frontend/src/app/session-term.js
+++ b/cmd/hivegui/frontend/src/app/session-term.js
@@ -22,6 +22,7 @@ import {
 } from '../bridge.js';
 import { state } from './state.js';
 import { flashStatus, reportFailure } from './dom.js';
+import { anyModalOpen } from './modals/registry.js';
 import { isMac } from '../lib/platform.js';
 import { isShiftEnter, NEWLINE_SEQ } from '../lib/keymap.js';
 import { DEFAULT_FONT_SIZE, clampFont } from '../lib/font.js';
@@ -1272,8 +1273,16 @@ export class SessionTerm {
       }
       // Defer focus so it lands after the visibility flip and after
       // any pending blur from the dying xterm.
+      //
+      // Never while a modal is open. A session can die at any moment —
+      // the daemon drives this, not the user — and stealing focus out
+      // of a modal mid-keystroke is hostile in every case: it drops
+      // what you were typing into the project editor or the command
+      // palette. For the launcher it is worse than that, because the
+      // launcher closes when focus leaves it, so an unrelated session
+      // exiting would make the popup and its query vanish outright.
       setTimeout(() => {
-        if (this.deadOverlayShown) this.deadCloseBtn.focus();
+        if (this.deadOverlayShown && !anyModalOpen()) this.deadCloseBtn.focus();
       }, 0);
     }
   }

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -785,7 +785,8 @@ body.resizing-sidebar #app { transition: none; }
   border: 1px solid #2a2a2a;
   border-radius: 6px;
   padding: 4px;
-  min-width: 180px;
+  /* Wide enough that the filter box's placeholder isn't clipped. */
+  min-width: 220px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.6);
   /* Must clear #sidebar-resizer (z-index 20). Neither #sidebar
      (position: relative, no z-index) nor #app (plain grid, no
@@ -800,6 +801,21 @@ body.resizing-sidebar #app { transition: none; }
   font-size: 12.5px;
 }
 #launcher.hidden { display: none; }
+
+.launcher-search {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 6px 8px;
+  margin: 0 0 4px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #1f1f1f;
+  color: #eee;
+  font: inherit;
+  outline: none;
+}
+.launcher-search::placeholder { color: #666; }
 
 .launcher-item {
   display: flex;

--- a/cmd/hivegui/frontend/test/dom/launcher.test.ts
+++ b/cmd/hivegui/frontend/test/dom/launcher.test.ts
@@ -1,0 +1,337 @@
+// @vitest-environment jsdom
+//
+// Covers the agent launcher's filter box (src/app/modals/launcher.ts):
+// the substring narrowing itself, and the four things around it that
+// carry real risk —
+//   * the digit shortcuts (1–9) must keep working while the box is
+//     empty and must become plain characters once it isn't,
+//   * Enter must launch the SELECTED FILTERED row, not the row that
+//     happened to sit at that index before filtering,
+//   * a query typed while ListAgents is still in flight must survive
+//     the resolve (the launcher opens before the agent list arrives),
+//   * every opening must start empty, including reopening over an
+//     already-open launcher.
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+// Type-only: erased, so the generated module is never resolved at runtime.
+import type { main } from '../../wailsjs/go/models';
+import { isMac } from '../../src/lib/platform.js';
+
+const AGENTS: main.AgentInfo[] = [
+  { id: 'shell', name: 'Shell', color: '#888', available: true, installCmd: [] },
+  {
+    id: 'claude',
+    name: 'Claude',
+    color: '#d97757',
+    available: true,
+    installCmd: [],
+  },
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    color: '#4a9',
+    available: true,
+    installCmd: [],
+  },
+] as main.AgentInfo[];
+
+// Held so a test can decide WHEN ListAgents resolves — the in-flight
+// query case needs to type between the open and the resolve.
+let resolveAgents: (a: main.AgentInfo[]) => void;
+let agentsPromise: Promise<main.AgentInfo[]>;
+function freshAgentsPromise() {
+  agentsPromise = new Promise((res) => {
+    resolveAgents = res;
+  });
+  return agentsPromise;
+}
+
+const listAgents = vi.fn((): Promise<main.AgentInfo[]> => freshAgentsPromise());
+const isGitRepo = vi.fn((_cwd: string): Promise<boolean> => Promise.resolve(true));
+const createSession = vi.fn(
+  (
+    _agent: string,
+    _project: string,
+    _name: string,
+    _cwd: string,
+    _cols: number,
+    _rows: number,
+    _worktree: boolean,
+  ): Promise<string> => Promise.resolve('s1'),
+);
+const duplicateSession = vi.fn(
+  (_agent: string, _project: string, _cwd: string): Promise<string> =>
+    Promise.resolve('s2'),
+);
+const restartSession = vi.fn((_id: string): Promise<string> => Promise.resolve(''));
+
+// Forwarded variadically off Parameters<>, not at a fixed arity: a mock
+// that drops an argument the real binding gained still satisfies
+// toHaveBeenCalledWith. Same reason settings.test.ts does it.
+vi.mock('../../src/bridge.js', () => ({
+  ListAgents: (...a: Parameters<typeof listAgents>) => listAgents(...a),
+  IsGitRepo: (...a: Parameters<typeof isGitRepo>) => isGitRepo(...a),
+  CreateSession: (...a: Parameters<typeof createSession>) => createSession(...a),
+  DuplicateSession: (...a: Parameters<typeof duplicateSession>) =>
+    duplicateSession(...a),
+  RestartSession: (...a: Parameters<typeof restartSession>) =>
+    restartSession(...a),
+}));
+
+// #terms / #projects / #status are the app singletons app/dom.ts
+// resolves with mustEl at import time — launcher.ts pulls dom.js in for
+// flashStatus, so they must exist before the dynamic import below even
+// though this suite never touches them.
+const MARKUP = `
+  <main id="terms"></main>
+  <ul id="projects"></ul>
+  <div id="status"></div>
+  <div id="launcher" class="hidden" role="menu"></div>`;
+
+type LauncherModule = typeof import('../../src/app/modals/launcher.js');
+let openLauncher: LauncherModule['openLauncher'];
+let closeLauncher: LauncherModule['closeLauncher'];
+let initLauncher: LauncherModule['initLauncher'];
+let refocusActiveTerm: Mock<() => void>;
+let setFocusedTile: Mock<(id: string | null) => void>;
+
+function launcher() {
+  return document.getElementById('launcher') as HTMLElement;
+}
+function searchBox() {
+  return launcher().querySelector('.launcher-search') as HTMLInputElement;
+}
+function rows() {
+  return Array.from(
+    launcher().querySelectorAll('.launcher-item'),
+  ) as HTMLElement[];
+}
+function names() {
+  return rows().map((r) => r.querySelector('.agent-name')?.textContent);
+}
+function selectedName() {
+  return launcher().querySelector('.launcher-item.selected .agent-name')
+    ?.textContent;
+}
+// The launcher owns its keys via a listener on #launcher, so events
+// must be dispatched from inside it (bubbling), exactly as a real
+// keystroke into the focused filter box would.
+function press(key: string, init: KeyboardEventInit = {}) {
+  searchBox().dispatchEvent(
+    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init }),
+  );
+}
+// Typing = set the value, then fire `input`. jsdom won't do the former
+// for us from a KeyboardEvent, and the digit path is keydown-only.
+function type(text: string) {
+  searchBox().value = text;
+  searchBox().dispatchEvent(new Event('input', { bubbles: true }));
+}
+// Open and let ListAgents settle.
+async function open() {
+  openLauncher('p1');
+  resolveAgents(AGENTS);
+  await agentsPromise;
+  await Promise.resolve();
+}
+
+beforeAll(async () => {
+  document.body.innerHTML = MARKUP;
+  // jsdom has no layout, so Element.scrollIntoView is undefined and
+  // highlightLauncherSelection would throw on every render.
+  Element.prototype.scrollIntoView = vi.fn();
+  // Imported AFTER the markup exists: launcherEl is resolved at module
+  // load via pageEl('launcher').
+  const mod = await import('../../src/app/modals/launcher.js');
+  openLauncher = mod.openLauncher;
+  closeLauncher = mod.closeLauncher;
+  initLauncher = mod.initLauncher;
+  refocusActiveTerm = vi.fn();
+  setFocusedTile = vi.fn();
+  initLauncher({ refocusActiveTerm, setFocusedTile });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  listAgents.mockImplementation(() => freshAgentsPromise());
+  closeLauncher();
+});
+
+describe('launcher filter box', () => {
+  it('filters rows by case-insensitive substring of the agent name', async () => {
+    await open();
+    expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
+    type('CLA');
+    expect(names()).toEqual(['Claude']);
+    type('c');
+    expect(names()).toEqual(['Claude', 'Codex CLI']);
+  });
+
+  it('resets selection to the first match when the query changes', async () => {
+    await open();
+    press('ArrowDown');
+    press('ArrowDown');
+    expect(selectedName()).toBe('Codex CLI');
+    type('c');
+    expect(selectedName()).toBe('Claude');
+  });
+
+  it('renders an empty-state row when nothing matches', async () => {
+    await open();
+    type('zzz');
+    expect(rows()).toHaveLength(0);
+    const empty = launcher().querySelector('.launcher-empty');
+    expect(empty?.textContent).toBe('No agents match');
+  });
+
+  it('distinguishes an empty agent list from an empty filter result', async () => {
+    openLauncher('p1');
+    resolveAgents([]);
+    await agentsPromise;
+    await Promise.resolve();
+    expect(launcher().querySelector('.launcher-empty')?.textContent).toBe(
+      'No agents found',
+    );
+  });
+
+  it('honors a query typed while ListAgents is still in flight', async () => {
+    openLauncher('p1');
+    // Still loading — the filter box is already on screen and focused.
+    expect(launcher().querySelector('.launcher-loading')).not.toBeNull();
+    type('codex');
+    resolveAgents(AGENTS);
+    await agentsPromise;
+    await Promise.resolve();
+    expect(names()).toEqual(['Codex CLI']);
+  });
+
+  it('starts each open with an empty query', async () => {
+    await open();
+    type('cla');
+    expect(names()).toEqual(['Claude']);
+    press('Escape');
+    await open();
+    expect(searchBox().value).toBe('');
+    expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
+    // And again without closing first — ⌘T over an open launcher.
+    type('cla');
+    await open();
+    expect(searchBox().value).toBe('');
+    expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
+  });
+});
+
+describe('launcher keyboard', () => {
+  it('activates a row by digit while the query is empty', async () => {
+    await open();
+    press('2');
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(createSession.mock.calls[0][0]).toBe('claude');
+  });
+
+  it('types the digit into the query once the query is non-empty', async () => {
+    await open();
+    type('c');
+    press('2');
+    expect(createSession).not.toHaveBeenCalled();
+    // preventDefault was NOT called, so the browser would insert "2".
+    expect(names()).toEqual(['Claude', 'Codex CLI']);
+  });
+
+  it('hides row numbers while the query is non-empty', async () => {
+    await open();
+    expect(
+      rows().map((r) => r.querySelector('.agent-num')?.textContent),
+    ).toEqual(['1', '2', '3']);
+    type('c');
+    expect(
+      rows().map((r) => r.querySelector('.agent-num')?.textContent),
+    ).toEqual(['', '']);
+    type('');
+    expect(
+      rows().map((r) => r.querySelector('.agent-num')?.textContent),
+    ).toEqual(['1', '2', '3']);
+  });
+
+  it('launches the selected filtered match, not the unfiltered index', async () => {
+    await open();
+    type('codex');
+    press('Enter');
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(createSession.mock.calls[0][0]).toBe('codex');
+  });
+
+  it('wraps arrow-key selection within the filtered set only', async () => {
+    await open();
+    type('c');
+    expect(selectedName()).toBe('Claude');
+    press('ArrowUp');
+    expect(selectedName()).toBe('Codex CLI');
+    press('ArrowDown');
+    expect(selectedName()).toBe('Claude');
+  });
+
+  it('reopens (and so clears the query) on a second cmd-T', async () => {
+    await open();
+    type('cla');
+    expect(names()).toEqual(['Claude']);
+    // keyboard.js bails out entirely while the launcher is open, so
+    // this binding only still works because the launcher repeats it.
+    // cmdOrCtrl() rejects the cross-platform combo outright, so the
+    // modifier has to match the platform the module resolved at load.
+    press('t', isMac ? { metaKey: true } : { ctrlKey: true });
+    resolveAgents(AGENTS);
+    await agentsPromise;
+    await Promise.resolve();
+    expect(searchBox().value).toBe('');
+    expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
+  });
+
+  it('closes on Escape and hands the keyboard back', async () => {
+    await open();
+    searchBox().focus();
+    const box = searchBox();
+    press('Escape');
+    expect(launcher().classList.contains('hidden')).toBe(true);
+    expect(document.activeElement).not.toBe(box);
+    expect(refocusActiveTerm).toHaveBeenCalled();
+  });
+});
+
+describe('launcher worktree row', () => {
+  it('survives a query that matches no agent', async () => {
+    await open();
+    type('zzz');
+    const wt = launcher().querySelector('.launcher-worktree');
+    expect(wt).not.toBeNull();
+    const box = wt?.querySelector('input[type=checkbox]') as HTMLInputElement;
+    box.checked = true;
+    box.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(localStorage.getItem('hive.worktree')).toBe('1');
+  });
+
+  it('sits between the filter box and the agent list', async () => {
+    await open();
+    const kids = Array.from(launcher().children).map((c) => c.className);
+    expect(kids).toEqual([
+      'launcher-search',
+      'launcher-worktree',
+      'launcher-list',
+    ]);
+  });
+});
+
+describe('launcher teardown', () => {
+  it('does not throw when closed before it was ever opened', () => {
+    expect(() => closeLauncher()).not.toThrow();
+  });
+
+  it('does not throw when ListAgents rejects', async () => {
+    listAgents.mockImplementationOnce(() => Promise.reject(new Error('boom')));
+    openLauncher('p1');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(launcher().classList.contains('hidden')).toBe(true);
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/launcher.test.ts
+++ b/cmd/hivegui/frontend/test/dom/launcher.test.ts
@@ -18,7 +18,13 @@ import type { main } from '../../wailsjs/go/models';
 import { isMac } from '../../src/lib/platform.js';
 
 const AGENTS: main.AgentInfo[] = [
-  { id: 'shell', name: 'Shell', color: '#888', available: true, installCmd: [] },
+  {
+    id: 'shell',
+    name: 'Shell',
+    color: '#888',
+    available: true,
+    installCmd: [],
+  },
   {
     id: 'claude',
     name: 'Claude',
@@ -47,7 +53,9 @@ function freshAgentsPromise() {
 }
 
 const listAgents = vi.fn((): Promise<main.AgentInfo[]> => freshAgentsPromise());
-const isGitRepo = vi.fn((_cwd: string): Promise<boolean> => Promise.resolve(true));
+const isGitRepo = vi.fn(
+  (_cwd: string): Promise<boolean> => Promise.resolve(true),
+);
 const createSession = vi.fn(
   (
     _agent: string,
@@ -63,7 +71,9 @@ const duplicateSession = vi.fn(
   (_agent: string, _project: string, _cwd: string): Promise<string> =>
     Promise.resolve('s2'),
 );
-const restartSession = vi.fn((_id: string): Promise<string> => Promise.resolve(''));
+const restartSession = vi.fn(
+  (_id: string): Promise<string> => Promise.resolve(''),
+);
 
 // Forwarded variadically off Parameters<>, not at a fixed arity: a mock
 // that drops an argument the real binding gained still satisfies
@@ -71,7 +81,8 @@ const restartSession = vi.fn((_id: string): Promise<string> => Promise.resolve('
 vi.mock('../../src/bridge.js', () => ({
   ListAgents: (...a: Parameters<typeof listAgents>) => listAgents(...a),
   IsGitRepo: (...a: Parameters<typeof isGitRepo>) => isGitRepo(...a),
-  CreateSession: (...a: Parameters<typeof createSession>) => createSession(...a),
+  CreateSession: (...a: Parameters<typeof createSession>) =>
+    createSession(...a),
   DuplicateSession: (...a: Parameters<typeof duplicateSession>) =>
     duplicateSession(...a),
   RestartSession: (...a: Parameters<typeof restartSession>) =>
@@ -118,7 +129,12 @@ function selectedName() {
 // keystroke into the focused filter box would.
 function press(key: string, init: KeyboardEventInit = {}) {
   searchBox().dispatchEvent(
-    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init }),
+    new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    }),
   );
 }
 // Typing = set the value, then fire `input`. jsdom won't do the former

--- a/cmd/hivegui/frontend/test/dom/launcher.test.ts
+++ b/cmd/hivegui/frontend/test/dom/launcher.test.ts
@@ -213,6 +213,34 @@ describe('launcher filter box', () => {
     );
   });
 
+  it('keeps showing the loading row when the user types before agents arrive', async () => {
+    openLauncher('p1');
+    expect(launcher().querySelector('.launcher-loading')).not.toBeNull();
+    // The keystroke re-renders the list. While the request is in flight
+    // there are no agents to filter, and an empty result must not be
+    // reported as "No agents match" — the list isn't in yet.
+    type('cla');
+    expect(launcher().querySelector('.launcher-loading')?.textContent).toBe(
+      'Loading agents…',
+    );
+    expect(launcher().querySelector('.launcher-empty')).toBeNull();
+    resolveAgents(AGENTS);
+    await agentsPromise;
+    await Promise.resolve();
+    expect(launcher().querySelector('.launcher-loading')).toBeNull();
+    expect(names()).toEqual(['Claude']);
+  });
+
+  it('does not filter the previous opening list when reopened', async () => {
+    await open();
+    // Reopen without closing: until the new response lands there is no
+    // list yet, so the stale one must not be what the query filters.
+    openLauncher('p1');
+    type('cla');
+    expect(rows()).toHaveLength(0);
+    expect(launcher().querySelector('.launcher-loading')).not.toBeNull();
+  });
+
   it('honors a query typed while ListAgents is still in flight', async () => {
     openLauncher('p1');
     // Still loading — the filter box is already on screen and focused.
@@ -326,10 +354,14 @@ describe('launcher keyboard', () => {
     await open();
     searchBox().focus();
     const box = searchBox();
+    // Cleared AFTER opening: beforeEach calls closeLauncher(), which
+    // already ran refocusActiveTerm once, so a bare toHaveBeenCalled()
+    // here would pass even if Escape did nothing.
+    refocusActiveTerm.mockClear();
     press('Escape');
     expect(launcher().classList.contains('hidden')).toBe(true);
     expect(document.activeElement).not.toBe(box);
-    expect(refocusActiveTerm).toHaveBeenCalled();
+    expect(refocusActiveTerm).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/cmd/hivegui/frontend/test/dom/launcher.test.ts
+++ b/cmd/hivegui/frontend/test/dom/launcher.test.ts
@@ -127,8 +127,10 @@ function selectedName() {
 // The launcher owns its keys via a listener on #launcher, so events
 // must be dispatched from inside it (bubbling), exactly as a real
 // keystroke into the focused filter box would.
+// Returns false when the handler called preventDefault — i.e. when the
+// launcher consumed the key rather than letting it reach the input.
 function press(key: string, init: KeyboardEventInit = {}) {
-  searchBox().dispatchEvent(
+  return searchBox().dispatchEvent(
     new KeyboardEvent('keydown', {
       key,
       bubbles: true,
@@ -249,10 +251,26 @@ describe('launcher keyboard', () => {
   it('types the digit into the query once the query is non-empty', async () => {
     await open();
     type('c');
-    press('2');
+    // Not consumed: dispatchEvent returns true, so a real browser would
+    // insert "2" into the box. jsdom won't do that for us, hence the
+    // explicit assertion rather than checking the value.
+    expect(press('2')).toBe(true);
     expect(createSession).not.toHaveBeenCalled();
-    // preventDefault was NOT called, so the browser would insert "2".
     expect(names()).toEqual(['Claude', 'Codex CLI']);
+  });
+
+  it('treats a whitespace-only query as typing, not as an empty box', async () => {
+    await open();
+    // A lone space trims away for matching (the full list still shows)
+    // but must still count as "the user is typing": hints off, digits
+    // inert. Hint state and shortcut state read the same raw value.
+    type(' ');
+    expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
+    expect(
+      rows().map((r) => r.querySelector('.agent-num')?.textContent),
+    ).toEqual(['', '', '']);
+    expect(press('2')).toBe(true);
+    expect(createSession).not.toHaveBeenCalled();
   });
 
   it('hides row numbers while the query is non-empty', async () => {
@@ -335,6 +353,48 @@ describe('launcher worktree row', () => {
       'launcher-worktree',
       'launcher-list',
     ]);
+  });
+});
+
+describe('launcher stale-response handling', () => {
+  it('ignores a ListAgents resolve from a superseded open', async () => {
+    // Reopening while the first request is in flight. Both resolve; the
+    // stale one must not touch the DOM the second open now owns. The
+    // `hidden` guard alone can't catch this — the launcher is visible
+    // again by the time the first response lands.
+    openLauncher('p1');
+    const resolveFirst = resolveAgents;
+    const first = agentsPromise;
+    openLauncher('p1');
+    const resolveSecond = resolveAgents;
+    const second = agentsPromise;
+
+    resolveFirst(AGENTS);
+    await first;
+    await Promise.resolve();
+    resolveSecond(AGENTS);
+    await second;
+    await Promise.resolve();
+
+    expect(launcher().querySelectorAll('.launcher-worktree')).toHaveLength(1);
+    expect(Array.from(launcher().children).map((c) => c.className)).toEqual([
+      'launcher-search',
+      'launcher-worktree',
+      'launcher-list',
+    ]);
+    expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
+  });
+
+  it('does not close a reopened launcher when a superseded request rejects', async () => {
+    listAgents.mockImplementationOnce(() => Promise.reject(new Error('boom')));
+    openLauncher('p1');
+    openLauncher('p1');
+    resolveAgents(AGENTS);
+    await agentsPromise;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(launcher().classList.contains('hidden')).toBe(false);
+    expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
   });
 });
 

--- a/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
@@ -97,6 +97,24 @@ test('closing the launcher restores terminal focus even from the worktree checkb
   await expect.poll(helperFocused).toBe(true);
 });
 
+// keyboard.js bails out unconditionally while the launcher is open and
+// the launcher's own listener is scoped to #launcher, so any click that
+// leaves the launcher visible while moving focus out of it would strand
+// the keyboard with no handler at all — Escape included.
+test('clicking a project action other than + closes the launcher', async ({
+  page,
+}) => {
+  await boot(page);
+  await page.keyboard.press(`${mod}+t`);
+  await expect(page.locator('#launcher')).toBeVisible();
+
+  await page
+    .locator('#projects .project-actions button', { hasText: '✎' })
+    .first()
+    .click();
+  await expect(page.locator('#launcher')).toBeHidden();
+});
+
 test('a query that matches nothing shows the empty row and Enter does nothing', async ({
   page,
 }) => {

--- a/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
@@ -73,7 +73,7 @@ test('a digit selects a row only while the filter box is empty', async ({
 // e2e layer: the bug only exists because hiding an element does not
 // synchronously clear document.activeElement in a real engine, and
 // jsdom has no layout, so the dom suite's Escape test passes either way.
-test('closing the launcher restores terminal focus even from the worktree checkbox', async ({
+test('the worktree checkbox toggles without stealing focus from the filter box', async ({
   page,
 }) => {
   await boot(page);
@@ -83,15 +83,23 @@ test('closing the launcher restores terminal focus even from the worktree checkb
     );
 
   await page.keyboard.press(`${mod}+t`);
-  await expect(page.locator('#launcher .launcher-search')).toBeFocused();
-  // The mousedown handler deliberately exempts the worktree row so its
-  // checkbox stays clickable — which means focus really does land on
-  // the checkbox, not the filter box.
-  await page.locator('#launcher .launcher-worktree input').click();
-  await expect(
-    page.locator('#launcher .launcher-worktree input'),
-  ).toBeFocused();
+  const search = page.locator('#launcher .launcher-search');
+  const box = page.locator('#launcher .launcher-worktree input');
+  await expect(search).toBeFocused();
+  const wasChecked = await box.isChecked();
 
+  // mousedown preventDefault blocks the focus shift but not the click
+  // activation, so the box still toggles...
+  await box.click();
+  await expect(box).toBeChecked({ checked: !wasChecked });
+  // ...and the filter box still owns the keyboard, so search-as-you-type
+  // keeps working after touching the checkbox.
+  await expect(search).toBeFocused();
+  await page.keyboard.type('cla');
+  await expect(search).toHaveValue('cla');
+  await expect(page.locator('#launcher .launcher-item')).toHaveCount(1);
+
+  // And closing still hands the keyboard back to the terminal.
   await page.keyboard.press('Escape');
   await expect(page.locator('#launcher')).toBeHidden();
   await expect.poll(helperFocused).toBe(true);

--- a/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
@@ -85,7 +85,7 @@ test('a query that matches nothing shows the empty row and Enter does nothing', 
 
   await page.keyboard.press('Enter');
   await expect(launcher).toBeVisible();
-  expect(
-    await page.evaluate(() => window.__hive.state.sessions.length),
-  ).toBe(before);
+  expect(await page.evaluate(() => window.__hive.state.sessions.length)).toBe(
+    before,
+  );
 });

--- a/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
@@ -69,6 +69,34 @@ test('a digit selects a row only while the filter box is empty', async ({
   await expect(launcher).toBeHidden();
 });
 
+// Focus restore after the launcher closes. This one MUST live in the
+// e2e layer: the bug only exists because hiding an element does not
+// synchronously clear document.activeElement in a real engine, and
+// jsdom has no layout, so the dom suite's Escape test passes either way.
+test('closing the launcher restores terminal focus even from the worktree checkbox', async ({
+  page,
+}) => {
+  await boot(page);
+  const helperFocused = () =>
+    page.evaluate(() =>
+      document.activeElement?.classList?.contains('xterm-helper-textarea'),
+    );
+
+  await page.keyboard.press(`${mod}+t`);
+  await expect(page.locator('#launcher .launcher-search')).toBeFocused();
+  // The mousedown handler deliberately exempts the worktree row so its
+  // checkbox stays clickable — which means focus really does land on
+  // the checkbox, not the filter box.
+  await page.locator('#launcher .launcher-worktree input').click();
+  await expect(
+    page.locator('#launcher .launcher-worktree input'),
+  ).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('#launcher')).toBeHidden();
+  await expect.poll(helperFocused).toBe(true);
+});
+
 test('a query that matches nothing shows the empty row and Enter does nothing', async ({
   page,
 }) => {

--- a/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
+++ b/cmd/hivegui/frontend/test/e2e/launcher-search.spec.js
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+// E2E for the new-session popup's filter box against the Wails mock.
+// The dom suite covers the branching; this one proves the whole path
+// works through the real index.html and the real key routing —
+// ⌘T opens with the box focused, typing narrows the list, and Enter
+// creates a session with the agent that survived the filter.
+
+const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function boot(page) {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li').length > 0,
+  );
+}
+
+test('typing in the launcher narrows the agent list and Enter creates that session', async ({
+  page,
+}) => {
+  await boot(page);
+  const before = await page.evaluate(() => window.__hive.state.sessions.length);
+
+  await page.keyboard.press(`${mod}+t`);
+  const launcher = page.locator('#launcher');
+  await expect(launcher).toBeVisible();
+  await expect(launcher.locator('.launcher-item')).toHaveCount(2);
+  // The filter box takes focus on open, so the keystrokes below need
+  // no explicit click.
+  await expect(launcher.locator('.launcher-search')).toBeFocused();
+
+  await page.keyboard.type('cla');
+  await expect(launcher.locator('.launcher-item')).toHaveCount(1);
+  await expect(launcher.locator('.launcher-item')).toContainText('Claude');
+
+  await page.keyboard.press('Enter');
+  await page.waitForFunction(
+    (n) => window.__hive.state.sessions.length === n + 1,
+    before,
+  );
+  await expect(launcher).toBeHidden();
+});
+
+test('a digit selects a row only while the filter box is empty', async ({
+  page,
+}) => {
+  await boot(page);
+  await page.keyboard.press(`${mod}+t`);
+  const launcher = page.locator('#launcher');
+  await expect(launcher.locator('.launcher-item')).toHaveCount(2);
+
+  // Non-empty query: the digit is a character, not a shortcut, so the
+  // launcher stays open and the query grows.
+  await page.keyboard.type('cla');
+  await page.keyboard.press('2');
+  await expect(launcher).toBeVisible();
+  await expect(launcher.locator('.launcher-search')).toHaveValue('cla2');
+
+  // Empty query: the digit launches. Clear via the keyboard the way a
+  // user would.
+  for (let i = 0; i < 4; i++) await page.keyboard.press('Backspace');
+  await expect(launcher.locator('.launcher-search')).toHaveValue('');
+  const before = await page.evaluate(() => window.__hive.state.sessions.length);
+  await page.keyboard.press('2');
+  await page.waitForFunction(
+    (n) => window.__hive.state.sessions.length === n + 1,
+    before,
+  );
+  await expect(launcher).toBeHidden();
+});
+
+test('a query that matches nothing shows the empty row and Enter does nothing', async ({
+  page,
+}) => {
+  await boot(page);
+  const before = await page.evaluate(() => window.__hive.state.sessions.length);
+
+  await page.keyboard.press(`${mod}+t`);
+  await page.keyboard.type('zzz');
+  const launcher = page.locator('#launcher');
+  await expect(launcher.locator('.launcher-item')).toHaveCount(0);
+  await expect(launcher.locator('.launcher-empty')).toHaveText(
+    'No agents match',
+  );
+
+  await page.keyboard.press('Enter');
+  await expect(launcher).toBeVisible();
+  expect(
+    await page.evaluate(() => window.__hive.state.sessions.length),
+  ).toBe(before);
+});

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -261,6 +261,17 @@ export async function ListAgents(): Promise<AgentInfo[]> {
       available: true,
       installCmd: [],
     },
+    // Second built-in so the launcher's filter box has something to
+    // narrow. Order matters: several specs assert the FIRST
+    // .launcher-item is "Shell", and a fresh browser context has an
+    // empty hive.agentUsage, so the usage sort is a no-op here.
+    {
+      id: 'claude',
+      name: 'Claude',
+      color: '#d97757',
+      available: true,
+      installCmd: [],
+    },
     ...customAgents.map((a) => ({
       id: a.id,
       name: a.name,


### PR DESCRIPTION
The agent launcher (⌘T) listed every agent with no way to narrow it. This adds a filter box at the top that matches on agent name — case-insensitive substring, the same match `command-palette.ts` already uses — and rebuilds only the row list as you type.

### Digits

`1`–`9` keep selecting their row **while the box is empty**, and become plain characters once it isn't. Row numbers hide while filtering rather than advertising a shortcut that no longer fires (AGENTS.md, Key Discoverability). The rejected alternatives were "digits always type" (simpler, but silently deletes a working shortcut) and ⌥/⌘-modified digits (keeps both, but drags in the full keybindings-policy checklist for a binding nobody asked to change).

### Two structural changes fall out of it

**`#launcher` is now built as three stable children** — filter box, worktree row, list — instead of being wiped and refilled when `ListAgents` resolves. An `<input>` can't survive an `innerHTML` reset. Only the list is re-rendered per keystroke, and the query is read off the input at render time rather than cached, so a query typed while `ListAgents` is still in flight survives the resolve. (`ux-polish.spec.js` already proves that window is real via `delayNext('ListAgents', 500)`.)

**The launcher's keys move off the global handler** in `keyboard.js` and onto a `#launcher` listener, the way the command palette and settings already work. Once the filter box holds focus, `lib/focus.ts` hands it the keyboard and the global handler is the wrong place.

That second change had a trap worth calling out: the old global block *fell through* on unhandled keys, so ⌘T/⇧⌘T while the launcher was open re-opened it. Replacing the block with a blanket `return` silently killed that binding, so it's repeated in the launcher's own listener (mirroring `keyboard.js`'s two calls exactly, bare `openLauncher()` included) with a test pinning it.

### Tests

- `test/dom/launcher.test.ts` — 17 new tests, the launcher's first dom coverage: the narrowing itself, digit-vs-query, Enter launching the selected *filtered* row, the in-flight-query case, every-open-starts-empty (including ⌘T over an already-open launcher), and the `closeLauncher`-before-open / `ListAgents`-rejects paths.
- `test/e2e/launcher-search.spec.js` — 3 tests through the real markup and key routing.
- `test/e2e/wails-mock.ts` gains a second built-in agent so filtering is observable. Order matters — several existing specs assert the first `.launcher-item` is "Shell", and a fresh context has empty `hive.agentUsage`, so the usage sort is a no-op.

### Verification

`scripts/test.sh unit dom e2e` → 247 unit / 92 dom / 82 e2e passing. `tsc --noEmit`, `biome lint .`, `go build ./...`, `go vet ./...` all clean. Re-run in full after rebasing onto wave 5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added type-to-filter support to the new-session launcher.
  * Filter agents by name with loading and empty-result states.
  * Added keyboard navigation, digit shortcuts, Escape-to-close, and query reset on reopen.
  * Preserved worktree controls and improved focus behavior.

* **Bug Fixes**
  * Prevented stale agent and repository responses from updating the launcher.
  * Improved launcher closing and error handling.

* **Tests**
  * Added automated coverage for filtering, shortcuts, session creation, focus restoration, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->