### PR TITLE
frontend: TypeScript migration wave 6a — events + its two DOM tests

### DIFF
--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -13,22 +13,65 @@ import {
   LogFrontend,
 } from '../bridge.js';
 import { state, saveCollapsed } from './state.js';
+import type { SessionInfo, ProjectInfo } from './state.js';
 import { setStatus, flashStatus, reportFailure } from './dom.js';
 import { orderedSessions } from './selectors.js';
 import { renderSidebar, updateSidebarSelection } from './sidebar.js';
 import { pruneCollapsed } from '../lib/collapsed.js';
 import { pruneNav } from '../lib/nav-history.js';
 import { handleScrollbackEvent, abandonReplays } from '../lib/scrollback.js';
+import { createScrollTrace } from '../lib/scroll-debug.js';
+import type { ScrollTrace } from '../lib/scroll-debug.js';
 
-let deps = {
+export interface EventsDeps {
+  switchTo: (id: string) => void;
+  renderMinimizedTray: () => void;
+  updateAppTitle: () => void;
+  focusActiveTerm: () => void;
+  refocusActiveTerm: () => void;
+  isDaemonRestarting: () => boolean;
+  // Unlike view.ts's Pick<…, 'rec' | 'count'>, the pty:data probe also
+  // reads `counters` directly.
+  scrollTrace: Pick<ScrollTrace, 'rec' | 'count' | 'counters'>;
+}
+
+// Pre-wireDaemonEvents stub. A real disabled tracer rather than a
+// hand-rolled `{ rec }` literal, same as view.ts: enabled:false
+// short-circuits inside rec/count, so the no-op behavior is identical
+// and the stub can't drift out of the interface.
+let deps: EventsDeps = {
   switchTo: () => {},
   renderMinimizedTray: () => {},
   updateAppTitle: () => {},
   focusActiveTerm: () => {},
   refocusActiveTerm: () => {},
   isDaemonRestarting: () => false,
-  scrollTrace: { rec: Object.assign(() => {}, { enabled: false }) },
+  scrollTrace: createScrollTrace({ enabled: false }),
 };
+
+// Wire payloads the daemon pushes over EventsOn. Hand-written for the
+// same reason SessionInfo is (state.ts): these cross as raw JSON, never
+// as a bound method's return, so they are absent from wailsjs/go/models.
+interface ProjectEvent {
+  kind: 'added' | 'removed' | 'updated';
+  project: ProjectInfo;
+}
+
+interface SessionEvent {
+  kind: 'added' | 'removed' | 'updated';
+  session: SessionInfo;
+}
+
+interface ControlError {
+  code?: string;
+  message?: string;
+  session_id?: string;
+}
+
+interface PtyError {
+  code?: string;
+  message?: string;
+}
 
 // Control-connection reconnect loop. Guarded so overlapping disconnect
 // events don't spawn parallel loops. Backoff climbs 500ms → 5s cap so a
@@ -73,7 +116,7 @@ async function reconnectControl() {
 // only on the transition from no-attention → attention, so a session
 // emitting bells in a tight loop doesn't spam the OS notification
 // center.
-export function onSessionBell(info) {
+export function onSessionBell(info: SessionInfo) {
   const isActive = info.id === state.activeId;
   const windowFocused = document.hasFocus();
   if (isActive && windowFocused) return;
@@ -89,7 +132,7 @@ export function onSessionBell(info) {
   if (!alreadyAttention) fireBellNotification(info);
 }
 
-export function clearAttention(sessionId) {
+export function clearAttention(sessionId: string) {
   if (state.attention.delete(sessionId)) {
     state.terms.get(sessionId)?.host.classList.remove('attention');
     updateSidebarSelection();
@@ -102,7 +145,7 @@ export function clearAttention(sessionId) {
 // toast). The session id is passed as the tag so the OS can dedupe
 // repeated bells from the same session and the click handler knows
 // which session to switch to.
-function fireBellNotification(info) {
+function fireBellNotification(info: SessionInfo) {
   const proj = state.projects.find(
     (p) => p.id === (info.projectId ?? info.project_id),
   );
@@ -119,7 +162,7 @@ function fireBellNotification(info) {
 // onSessionDeath fires once when a session transitions Alive→dead.
 // Shows the in-tile overlay, marks attention, and posts a desktop
 // notification distinct from a normal bell.
-function onSessionDeath(info) {
+function onSessionDeath(info: SessionInfo) {
   state.dismissedDead.delete(info.id);
   const t = state.terms.get(info.id);
   if (t) {
@@ -148,7 +191,7 @@ function onSessionDeath(info) {
   ).catch(() => {});
 }
 
-export function wireDaemonEvents(injected) {
+export function wireDaemonEvents(injected: EventsDeps) {
   deps = injected;
 
   // Whenever the window regains focus, clear the active session's
@@ -161,8 +204,8 @@ export function wireDaemonEvents(injected) {
     deps.refocusActiveTerm();
   });
 
-  EventsOn('project:list', (jsonStr) => {
-    const { projects } = JSON.parse(jsonStr);
+  EventsOn('project:list', (jsonStr: string) => {
+    const { projects } = JSON.parse(jsonStr) as { projects?: ProjectInfo[] };
     state.projects = projects || [];
     if (!state.currentProjectId && state.projects[0]) {
       state.currentProjectId = state.projects[0].id;
@@ -180,8 +223,8 @@ export function wireDaemonEvents(injected) {
     renderSidebar();
   });
 
-  EventsOn('project:event', (jsonStr) => {
-    const ev = JSON.parse(jsonStr);
+  EventsOn('project:event', (jsonStr: string) => {
+    const ev = JSON.parse(jsonStr) as ProjectEvent;
     const i = state.projects.findIndex((p) => p.id === ev.project.id);
     if (ev.kind === 'added') {
       if (i < 0) state.projects.push(ev.project);
@@ -213,7 +256,7 @@ export function wireDaemonEvents(injected) {
   // known value for this session and fires the death/revive side
   // effects on the boundary. First sight of a session (no prior entry)
   // just records the value without firing anything.
-  function processAliveTransition(info) {
+  function processAliveTransition(info: SessionInfo) {
     const prev = state.aliveById.get(info.id);
     state.aliveById.set(info.id, !!info.alive);
     if (prev === true && info.alive === false) {
@@ -229,7 +272,7 @@ export function wireDaemonEvents(injected) {
         // session's prompt lands on a clean screen instead of stacking on
         // the old cursor position.
         try {
-          t.term.reset();
+          t.term?.reset();
         } catch {}
         abandonReplays(t); // the wipe abandons any in-flight restream
         t.attached = false;
@@ -238,8 +281,8 @@ export function wireDaemonEvents(injected) {
     }
   }
 
-  EventsOn('session:list', (jsonStr) => {
-    const { sessions } = JSON.parse(jsonStr);
+  EventsOn('session:list', (jsonStr: string) => {
+    const { sessions } = JSON.parse(jsonStr) as { sessions?: SessionInfo[] };
     state.sessions = sessions || [];
     for (const s of state.sessions) processAliveTransition(s);
     // Drop any minimized ids whose sessions no longer exist (e.g. after
@@ -256,8 +299,8 @@ export function wireDaemonEvents(injected) {
     }
   });
 
-  EventsOn('session:event', (jsonStr) => {
-    const ev = JSON.parse(jsonStr);
+  EventsOn('session:event', (jsonStr: string) => {
+    const ev = JSON.parse(jsonStr) as SessionEvent;
     const i = state.sessions.findIndex((s) => s.id === ev.session.id);
     if (ev.kind === 'added' || ev.kind === 'updated') {
       processAliveTransition(ev.session);
@@ -313,7 +356,7 @@ export function wireDaemonEvents(injected) {
         if (st.needsReattach && ev.session.alive) {
           st.needsReattach = false;
           try {
-            st.term.reset();
+            st.term?.reset();
           } catch {}
           abandonReplays(st); // the wipe abandons any in-flight restream
           const visible =
@@ -332,7 +375,7 @@ export function wireDaemonEvents(injected) {
       deps.renderMinimizedTray();
   });
 
-  EventsOn('pty:data', (id, b64) => {
+  EventsOn('pty:data', (id: string, b64: string) => {
     // Daemon-traffic probe: is the freeze the daemon flooding us? Count
     // every inbound frame + (base64) byte volume, and drop a timestamped
     // checkpoint every 200 frames so a flood shows as a steep bytes/sec
@@ -352,9 +395,9 @@ export function wireDaemonEvents(injected) {
     state.terms.get(id)?.writeData(b64);
   });
 
-  EventsOn('pty:event', (id, jsonStr) => {
+  EventsOn('pty:event', (id: string, jsonStr: string) => {
     try {
-      const ev = JSON.parse(jsonStr);
+      const ev = JSON.parse(jsonStr) as { kind: string };
       const st = state.terms.get(id);
       if (!st) return;
       // Begin: wipe xterm so replay paints onto a clean slate (otherwise
@@ -395,7 +438,7 @@ export function wireDaemonEvents(injected) {
     }
   });
 
-  EventsOn('pty:disconnect', (id) => {
+  EventsOn('pty:disconnect', (id: string) => {
     const st = state.terms.get(id);
     if (st) {
       st.attached = false;
@@ -410,12 +453,12 @@ export function wireDaemonEvents(injected) {
     }
   });
 
-  EventsOn('pty:error', (id, jsonStr) => {
+  EventsOn('pty:error', (id: string, jsonStr: string) => {
     const st = state.terms.get(id);
     if (st) {
       try {
-        const e = JSON.parse(jsonStr);
-        st.term.write(
+        const e = JSON.parse(jsonStr) as PtyError;
+        st.term?.write?.(
           `\r\n\x1b[31m[hived: ${e.code}: ${e.message}]\x1b[0m\r\n`,
         );
       } catch {}
@@ -441,7 +484,7 @@ export function wireDaemonEvents(injected) {
   // User clicked a notification toast. Route to that session in the
   // current view (single keeps single, grid keeps grid) without toggling
   // modes. switchTo handles the view-aware repaint.
-  EventsOn('bell-click', (sessionId) => {
+  EventsOn('bell-click', (sessionId: string) => {
     if (!sessionId) return;
     const info = state.sessions.find((s) => s.id === sessionId);
     if (!info) return;
@@ -449,10 +492,10 @@ export function wireDaemonEvents(injected) {
     clearAttention(sessionId);
   });
 
-  EventsOn('control:error', async (jsonStr) => {
-    let e;
+  EventsOn('control:error', async (jsonStr: string) => {
+    let e: ControlError;
     try {
-      e = JSON.parse(jsonStr);
+      e = JSON.parse(jsonStr) as ControlError;
     } catch {
       flashStatus('hived error', true);
       return;

--- a/cmd/hivegui/frontend/src/app/state.ts
+++ b/cmd/hivegui/frontend/src/app/state.ts
@@ -68,8 +68,11 @@ export interface ProjectInfo {
 export interface TermTile extends ReplayFlags {
   host: HTMLElement;
   termTitle?: string;
-  attached?: boolean;
-  needsReattach?: boolean;
+  // Required, not optional: session-term.js:426,432 always initializes
+  // both and every reader branches on the value, never on absence
+  // (scrollback.ts:28 states the rule).
+  attached: boolean;
+  needsReattach: boolean;
   // Timestamp of the last replay event, used by the scroll-jump
   // detector to label a following up-move (session-term.js:594,728).
   _lastReplayTs?: number;

--- a/cmd/hivegui/frontend/src/app/state.ts
+++ b/cmd/hivegui/frontend/src/app/state.ts
@@ -12,6 +12,7 @@ import {
 } from '../lib/collapsed.js';
 import { createNavHistory, type NavHistory } from '../lib/nav-history.js';
 import type { ViewMode } from '../lib/view.js';
+import type { ReplayFlags, ReplayXterm } from '../lib/scrollback.js';
 
 // Wire payloads from the daemon (internal/wire/control.go) are
 // snake_case; some paths also carry camelCase, so both spellings are
@@ -59,18 +60,31 @@ export interface ProjectInfo {
 // which view.ts relies on at snapVisibleTermsToBottom(). The shared
 // `term` key is also what keeps that assignment out of TS's weak-type
 // check, since every SnapTarget member is optional.
-export interface TermTile {
+//
+// Extends ReplayFlags and types `term` as ReplayXterm so a TermTile is
+// accepted where lib/scrollback.ts wants a ReplayTerm — events.ts hands
+// tiles straight to handleScrollbackEvent/abandonReplays, and the
+// alternative was a cast at each of those five call sites.
+export interface TermTile extends ReplayFlags {
   host: HTMLElement;
   termTitle?: string;
-  term?: {
-    focus?: () => void;
-    scrollToBottom?: () => void;
-    write?: (data: string, callback?: () => void) => void;
-  } | null;
+  attached?: boolean;
+  needsReattach?: boolean;
+  // Timestamp of the last replay event, used by the scroll-jump
+  // detector to label a following up-move (session-term.js:594,728).
+  _lastReplayTs?: number;
+  term?: (ReplayXterm & { focus?: () => void }) | null;
   show(): void;
   hide(): void;
   ensureAttached(): void;
   rebaselineReplayCols(reason: string): void;
+  setInfo(info: SessionInfo): void;
+  // Both params are optional because the implementation defaults them
+  // (`name || ''`, `color || '#888'`) and ProjectInfo's fields are optional.
+  setProject(name?: string, color?: string): void;
+  setDead(isDead: boolean, reason?: string): void;
+  writeData(b64: string): void;
+  destroy(): void;
 }
 
 export interface AppState {

--- a/cmd/hivegui/frontend/test/dom/events-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/events-focus.test.ts
@@ -8,6 +8,7 @@
 // This test drives the real handler through a real DOM 'focus' event
 // so any missed deps.* substitution in that path throws here.
 import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { createScrollTrace } from '../../src/lib/scroll-debug.js';
 
 // The bridge re-exports the Wails runtime, which doesn't exist under
 // vitest (the vite-plugin substitution only applies to the Playwright
@@ -51,7 +52,8 @@ vi.mock('../../src/bridge.js', () => {
   };
 });
 
-let state, wireDaemonEvents;
+let state: typeof import('../../src/app/state.js').state;
+let wireDaemonEvents: typeof import('../../src/app/events.js').wireDaemonEvents;
 
 beforeAll(async () => {
   // dom.js dereferences #terms at import time; give it the singletons.
@@ -71,7 +73,10 @@ describe('wireDaemonEvents window-focus handler', () => {
       focusActiveTerm: vi.fn(),
       refocusActiveTerm,
       isDaemonRestarting: () => false,
-      scrollTrace: { rec: Object.assign(() => {}, { enabled: false }) },
+      // A real disabled tracer, not a hand-rolled `{ rec }` literal: the
+      // pty:data path also reads .count()/.counters, which the literal
+      // never had (wave 5b's view.ts lesson).
+      scrollTrace: createScrollTrace({ enabled: false }),
     });
 
     state.activeId = 'sess-1';

--- a/cmd/hivegui/frontend/test/dom/restart-hive.test.ts
+++ b/cmd/hivegui/frontend/test/dom/restart-hive.test.ts
@@ -19,7 +19,20 @@ const bridge = vi.hoisted(() => ({
 
 vi.mock('../../src/bridge.js', () => bridge);
 
-let restartHive, isDaemonRestarting, bannerEl, bannerText;
+let restartHive: typeof import('../../src/app/banners.js').restartHive;
+let isDaemonRestarting: typeof import('../../src/app/banners.js').isDaemonRestarting;
+let bannerEl: HTMLElement;
+let bannerText: HTMLElement;
+
+// Throwing lookup rather than `!`: biome's recommended preset bans
+// non-null assertions, and a missing scaffold element should name
+// itself instead of surfacing as a null-property TypeError three
+// assertions later.
+function mustEl(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`missing #${id} in test scaffold`);
+  return el;
+}
 
 beforeAll(async () => {
   // dom.js runs side effects on import (it decorates #terms), and
@@ -41,8 +54,8 @@ beforeAll(async () => {
   ({ restartHive, isDaemonRestarting } = await import(
     '../../src/app/banners.js'
   ));
-  bannerEl = document.getElementById('daemon-banner');
-  bannerText = document.getElementById('daemon-banner-text');
+  bannerEl = mustEl('daemon-banner');
+  bannerText = mustEl('daemon-banner-text');
 });
 
 beforeEach(() => {
@@ -89,7 +102,7 @@ describe('restartHive', () => {
 // spawn the replacement GUI twice).
 describe('restartHive re-entrancy', () => {
   it('ignores a second invocation while one is in flight', async () => {
-    let releaseConfirm;
+    let releaseConfirm: (() => void) | undefined;
     bridge.Confirm.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -99,6 +112,9 @@ describe('restartHive re-entrancy', () => {
 
     const first = restartHive();
     const second = restartHive(); // must be a no-op, not a second run
+    // Not `releaseConfirm?.()` — an unset releaser means Confirm was
+    // never reached, which is the bug this test exists to catch.
+    if (!releaseConfirm) throw new Error('Confirm was never called');
     releaseConfirm();
     await Promise.all([first, second]);
 


### PR DESCRIPTION
Wave 6a of the [TypeScript migration](docs/exec-plans/active/typescript-migration.md). Wave 6 splits at the one clean seam: `events.js` (this PR) and `keyboard.js` + `session-term.js` (6b).

## What moved

- `src/app/events.js` → `.ts`
- `test/dom/events-focus.test.js` → `.ts` (imports `events`)
- `test/dom/restart-hive.test.js` → `.ts` (imports `banners`, already TS)

67 errors after the bulk `git mv`, all mechanical. No `tsconfig` change — `include` already covers `src/app/**/*` and `test/dom/**/*`.

## Notes

- **`TermTile` grew.** It now carries what `events.ts` touches (`attached`, `needsReattach`, `setInfo`/`setProject`/`setDead`/`writeData`/`destroy`, `_lastReplayTs`) and `extends ReplayFlags` with `term` typed as `ReplayXterm`, so a tile is assignable to `lib/scrollback.ts`'s `ReplayTerm` — the alternative was an unchecked cast at each of the five `handleScrollbackEvent`/`abandonReplays` handoffs. Wave 6b replaces `TermTile` with `SessionTerm`'s own type, which must satisfy this shape.
- **`setProject(name?, color?)`.** The implementation defaults both (`name || ''`, `color || '#888'`) and `ProjectInfo`'s fields are optional — typing the real contract rather than forcing `?? ''` at the caller.
- **Three optional-chain swaps**, all already inside `try { } catch {}`: two `t.term.reset()` → `t.term?.reset()`, plus `st.term.write(…)` → `st.term?.write?.(…)` in the `pty:error` handler (a double chain — `write` is optional on `ReplayXterm`). Absent-term went from "TypeError, caught, no-op" to "no-op" — same outcome, unlike wave 2's `reset?.()` regression where the `catch` wasn't there.
- **`EventsDeps.scrollTrace` is `Pick<ScrollTrace, 'rec' | 'count' | 'counters'>`** — one member wider than `view.ts`'s Pick, because the `pty:data` probe reads `counters` directly. The pre-init stub is `createScrollTrace({ enabled: false })`, not the hand-rolled `{ rec }` literal it replaced, which had already drifted past `.count()`.
- **`attached` / `needsReattach` are required, not optional** (follow-up commit): `session-term.js:426,432` always initializes both and every reader branches on the value, not on absence — the rule `scrollback.ts:28` states.
- `restart-hive.test.ts` gained a local throwing `mustEl()` and a `if (!releaseConfirm) throw` — a `?.()` there would have silently passed the re-entrancy test when `Confirm` was never reached.

## Gates

`typecheck` / `build` / `biome ci` green. vitest 322 in 32 files, Playwright mock 79 passed + 1 skipped — both unchanged from the `main` baseline. Non-vacuity proved with a planted error in all three converted files.

GUI smoke is not owed here (this wave lands no rendering or input code); wave 6b owes one for `keyboard` + `session-term`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
