### PR TITLE
frontend: TypeScript migration wave 6c — session-term

### DIFF
--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -20,8 +20,9 @@ import {
   OpenURL,
   UpdateSession,
 } from '../bridge.js';
-import { state } from './state.js';
+import { state, type SessionInfo } from './state.js';
 import { flashStatus, reportFailure } from './dom.js';
+import { mustEl } from './el.js';
 import { anyModalOpen } from './modals/registry.js';
 import { isMac } from '../lib/platform.js';
 import { isShiftEnter, NEWLINE_SEQ } from '../lib/keymap.js';
@@ -35,6 +36,7 @@ import {
   acquireWebglSlot,
   releaseWebglSlot,
   recordWebglLoss,
+  type WebglLossState,
 } from '../lib/webgl-budget.js';
 import { LogFrontend } from '../bridge.js';
 
@@ -47,7 +49,7 @@ const WEBGL_LOSS_STORM_WINDOW_MS = 10000;
 
 // Best-effort disk log — the webview console is /dev/null under
 // LaunchServices, so renderer/freeze evidence has nowhere else to land.
-function feLog(msg) {
+function feLog(msg: string) {
   try {
     LogFrontend(msg);
   } catch {
@@ -66,6 +68,7 @@ import { classifyViewportMove } from '../lib/scroll-debug.js';
 import {
   wheelToScrollLines,
   shouldScrollViewport,
+  type WheelEventLike,
 } from '../lib/wheel-scroll.js';
 import { onSessionBell, clearAttention } from './events.js';
 import {
@@ -94,7 +97,7 @@ function nowMs() {
 // radius, used by both the link-activation and click-to-position
 // hit-tests below.
 const CLICK_RADIUS_SQ = 25;
-function isClick(dx, dy) {
+function isClick(dx: number, dy: number) {
   return dx * dx + dy * dy < CLICK_RADIUS_SQ;
 }
 
@@ -106,8 +109,91 @@ const STICKY_BOTTOM_LINES = 2;
 // count as user-driven (vs parse-driven cap-trim drift).
 const USER_SCROLL_GRACE_MS = 250;
 
+// The link the Linkifier currently has under the cursor, reached through
+// xterm's private `_core`: the public API exposes no way to ask "is a
+// link here?", and the mouse-protocol workaround below needs exactly that.
+interface TermLink {
+  text: string;
+  activate(event: MouseEvent, text: string): void;
+}
+type LinkifierPeek = {
+  _core?: { linkifier?: { currentLink?: { link?: TermLink } | null } | null };
+};
+
 export class SessionTerm {
-  constructor(info) {
+  info: SessionInfo;
+  decoder: TextDecoder;
+  host: HTMLDivElement;
+  header: HTMLDivElement;
+  body: HTMLDivElement;
+  tileColor: HTMLSpanElement;
+  tileName: HTMLSpanElement;
+  tileWorktree: HTMLSpanElement;
+  tileProject: HTMLSpanElement;
+  tileTermTitle: HTMLSpanElement;
+  tileMinimize: HTMLButtonElement;
+  term: Terminal;
+  fit: FitAddon;
+  ro: ResizeObserver;
+  attached: boolean;
+  needsReattach: boolean;
+  termTitle: string;
+  // Assigned in the constructor body (it closes over `this.info`), so no
+  // initializer — unlike the fields below, which are written by helpers
+  // the constructor calls and would otherwise trip strictPropertyInitialization.
+  _writePty: (data: string) => void;
+
+  // Dead-session overlay.
+  deadOverlay: HTMLDivElement;
+  deadCloseBtn: HTMLButtonElement;
+  deadDismissBtn: HTMLButtonElement;
+  deadOverlayShown: boolean;
+
+  // Renderer.
+  webgl: WebglAddon | null = null;
+  _hasWebglSlot = false;
+  _webglGaveUp = false;
+  _webglLoss?: WebglLossState;
+  _dprWatcher: { teardown(): void } | null = null;
+  _onVisibility: (() => void) | null = null;
+
+  // Attach / geometry.
+  _pendingAttach = false;
+  _revealRaf = 0;
+  // Optional (not `= 0`) because the code branches on `=== undefined` to
+  // mean "no baseline measured yet".
+  _replayBaselineCols?: number;
+  _replayTimer = 0;
+  // Deleted, not zeroed, at every cancel site — so it must be optional.
+  _replayWantsBottom?: boolean;
+  _replaysInFlight = 0;
+
+  // Scroll follow-intent.
+  _followBottom = true;
+  _lastUserScrollTs = -Infinity;
+  _lastReplayTs = -Infinity;
+  _lastViewportY = 0;
+  _repinning = false;
+  _pointerDown = false;
+  _onWindowMouseUp: (() => void) | null = null;
+
+  // Link / click-to-position hit-testing.
+  _pendingLink: TermLink | null = null;
+  _pendingLinkX = 0;
+  _pendingLinkY = 0;
+  _pendingClick = false;
+  _pendingClickX = 0;
+  _pendingClickY = 0;
+
+  _renameInput: HTMLInputElement | null = null;
+
+  // writeData burst probe.
+  _wroteBytes = 0;
+  _wroteCount = 0;
+  _writeWindowStart?: number;
+  _writeBurstLogged = false;
+
+  constructor(info: SessionInfo) {
     this.info = info;
     // Per-session UTF-8 decoder. Streaming mode buffers partial multi-byte
     // sequences at chunk boundaries; sharing one decoder across sessions
@@ -128,7 +214,7 @@ export class SessionTerm {
     this.tileColor.className = 'tile-color';
     this.tileName = document.createElement('span');
     this.tileName.className = 'tile-name';
-    this.tileName.textContent = info.name;
+    this.tileName.textContent = info.name ?? '';
     this.tileWorktree = document.createElement('span');
     this.tileWorktree.className = 'worktree-glyph';
     this.tileWorktree.textContent = '⎇';
@@ -175,7 +261,7 @@ export class SessionTerm {
     this.body.className = 'term-body';
 
     this.host.append(this.header, this.body);
-    document.getElementById('terms').appendChild(this.host);
+    mustEl('terms').appendChild(this.host);
 
     this.term = new Terminal({
       fontFamily: 'Menlo, "DejaVu Sans Mono", monospace',
@@ -246,12 +332,13 @@ export class SessionTerm {
     // is under the cursor, suppress the event so it doesn't reach the
     // mouse protocol handler, letting the Linkifier's own handlers
     // process it and call activate.
-    const screen = this.body.querySelector('.xterm-screen');
+    const screen = this.body.querySelector<HTMLElement>('.xterm-screen');
     if (screen) {
       screen.addEventListener(
         'mousedown',
         (e) => {
-          const link = this.term._core?.linkifier?.currentLink;
+          const link = (this.term as Terminal & LinkifierPeek)._core?.linkifier
+            ?.currentLink;
           if (link?.link) {
             this._pendingLink = link.link;
             this._pendingLinkX = e.clientX;
@@ -571,7 +658,7 @@ export class SessionTerm {
             id: this.info.id,
             deltaY: e.deltaY,
             deltaMode: e.deltaMode,
-            wheelDeltaY: e.wheelDeltaY,
+            wheelDeltaY: (e as WheelEventLike).wheelDeltaY,
             lines,
           });
         }
@@ -843,21 +930,26 @@ export class SessionTerm {
       scrollTrace.rec('webgl-recover', { id: this.info.id, reattached });
   }
 
-  _installRendererRecoveryListeners() {
-    // Clear the glyph atlas and force a full repaint. Cheap; safe to
-    // call when no WebGL addon is loaded (DOM renderer ignores the
-    // atlas hint and still benefits from the refresh).
-    this._refreshRenderer = () => {
-      if (scrollTrace.rec.enabled)
-        scrollTrace.rec('renderer-refresh', { id: this.info.id });
-      try {
-        this.webgl?.clearTextureAtlas();
-      } catch {}
-      try {
-        this.term.refresh(0, this.term.rows - 1);
-      } catch {}
-    };
+  // Clear the glyph atlas and force a full repaint. Cheap; safe to
+  // call when no WebGL addon is loaded (DOM renderer ignores the
+  // atlas hint and still benefits from the refresh).
+  //
+  // A method rather than the constructor-assigned closure it used to be:
+  // it is only ever reached through `this`, so the field bought nothing
+  // and would have needed a throwaway initializer to satisfy
+  // strictPropertyInitialization.
+  _refreshRenderer() {
+    if (scrollTrace.rec.enabled)
+      scrollTrace.rec('renderer-refresh', { id: this.info.id });
+    try {
+      this.webgl?.clearTextureAtlas();
+    } catch {}
+    try {
+      this.term.refresh(0, this.term.rows - 1);
+    } catch {}
+  }
 
+  _installRendererRecoveryListeners() {
     // DPR change: move-to-different-display or OS zoom. A
     // `(resolution: Xdppx)` MQL only fires `change` on the single
     // transition away from X, so the helper rebinds against the new
@@ -878,10 +970,10 @@ export class SessionTerm {
     document.addEventListener('visibilitychange', this._onVisibility);
   }
 
-  setInfo(info) {
+  setInfo(info: SessionInfo) {
     this.info = info;
     this.host.style.setProperty('--session-color', info.color || '#888');
-    this.tileName.textContent = info.name;
+    this.tileName.textContent = info.name ?? '';
     this.header.setAttribute('aria-label', `Session ${info.name}`);
     const wtBranch = info.worktreeBranch ?? info.worktree_branch;
     if (wtBranch) {
@@ -916,13 +1008,16 @@ export class SessionTerm {
     if (this._renameInput) return; // already editing
     beginInlineRename({
       className: 'tile-name-input',
-      value: this.info.name,
+      value: this.info.name ?? '',
       mount: (input) => {
         // Set the reentrancy guard here (mount runs before focus/select)
         // to match the original's ordering: guard set, then focus stolen.
         this._renameInput = input;
         this.tileName.style.display = 'none';
-        this.tileName.parentNode.insertBefore(input, this.tileName);
+        // `this.header` rather than `tileName.parentNode`: the span is
+        // appended to the header in the constructor and never reparented,
+        // so this is the same node with no nullable indirection.
+        this.header.insertBefore(input, this.tileName);
       },
       // Drop the visual focus border before stealing keyboard focus —
       // setFocusedTile is the only writer of .term-focused, so without
@@ -941,7 +1036,7 @@ export class SessionTerm {
     });
   }
 
-  setProject(name, color) {
+  setProject(name?: string, color?: string) {
     this.tileProject.textContent = name || '';
     this.host.style.setProperty('--project-color', color || '#888');
   }
@@ -1145,7 +1240,7 @@ export class SessionTerm {
   // re-fitted, so triggering shouldRequestReplay would be spurious and
   // visibly drops or duplicates content. Pure window resize is handled
   // by the threshold path in _onBodyResize and must not call this.
-  rebaselineReplayCols(_reason) {
+  rebaselineReplayCols(_reason: string) {
     applyRebaseline(this);
   }
 
@@ -1209,7 +1304,7 @@ export class SessionTerm {
     }
   }
 
-  writeData(b64) {
+  writeData(b64: string) {
     const bin = atob(b64);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
@@ -1262,7 +1357,7 @@ export class SessionTerm {
     this.host.remove();
   }
 
-  setDead(isDead, reason) {
+  setDead(isDead: boolean, reason?: string) {
     this.deadOverlayShown = isDead;
     this.deadOverlay.hidden = !isDead;
     this.host.classList.toggle('dead', isDead);
@@ -1300,7 +1395,11 @@ export class SessionTerm {
 
 export function applyFontSize() {
   for (const st of state.terms.values()) {
-    st.term.options.fontSize = state.fontSize;
+    // Guarded rather than `st.term.options.fontSize = …`: TermTile's `term`
+    // is optional because the DOM-test stubs omit it. Every real tile has
+    // one, so this is the same write on every path that matters.
+    const opts = st.term?.options;
+    if (opts) opts.fontSize = state.fontSize;
     // Body box doesn't change on font-size change, so ResizeObserver
     // won't fire — call the resize handler explicitly so fit.fit()
     // recomputes (cols, rows) from new char metrics.
@@ -1309,7 +1408,7 @@ export function applyFontSize() {
   localStorage.setItem('hive.fontSize', String(state.fontSize));
 }
 
-export function bumpFontSize(delta) {
+export function bumpFontSize(delta: number) {
   const next = clampFont(state.fontSize + delta);
   if (next === state.fontSize) return;
   state.fontSize = next;
@@ -1326,7 +1425,7 @@ export function resetFontSize() {
   flashStatus(`font ${state.fontSize}px`);
 }
 
-export function ensureTerm(info) {
+export function ensureTerm(info: SessionInfo) {
   let st = state.terms.get(info.id);
   if (!st) {
     st = new SessionTerm(info);

--- a/cmd/hivegui/frontend/src/app/state.ts
+++ b/cmd/hivegui/frontend/src/app/state.ts
@@ -32,8 +32,8 @@ export interface SessionInfo {
   worktreePath?: string;
   worktree_branch?: string;
   worktreeBranch?: string;
-  // Why the dead-session overlay reads: events.js:131 and
-  // session-term.js:1173 both fall back off it.
+  // Why the dead-session overlay reads: events.ts:174 and
+  // session-term.ts:1269 both fall back off it.
   last_error?: string;
   lastError?: string;
 }
@@ -46,14 +46,18 @@ export interface ProjectInfo {
   order?: number;
 }
 
-// A structural view of SessionTerm (app/session-term.js), which is still
-// JS until wave 6. Wave 3 typed the registry `unknown` so its files
-// couldn't pretend to know the class; wave 5b reverses that, because
-// view.ts and focus.ts touch these members at ~30 sites and the
-// alternative is 12 unchecked `as` casts at the `state.terms.get()`
-// calls. This lists only what app modules actually reach for — wave 6
-// replaces it with SessionTerm's own type, which must then satisfy this
-// shape or widen it deliberately.
+// A structural view of SessionTerm (app/session-term.ts). Wave 3 typed
+// the registry `unknown` so its files couldn't pretend to know the class;
+// wave 5b reversed that, because view.ts and focus.ts touch these members
+// at ~30 sites and the alternative is 12 unchecked `as` casts at the
+// `state.terms.get()` calls.
+//
+// Wave 6 was expected to replace this with SessionTerm's own type once
+// that file converted. It deliberately did NOT: `Map<string, SessionTerm>`
+// would force every DOM-test stub to spell out 53 fields instead of 16.
+// The interface stays, listing only what app modules actually reach for,
+// and SessionTerm satisfies it structurally — which is the check
+// `state.terms.set()` already performs at every insertion site.
 //
 // `term` stays optional and structural rather than `import { Terminal }`
 // so a TermTile is still assignable to SnapTarget (lib/view-scroll.ts) —
@@ -68,13 +72,13 @@ export interface ProjectInfo {
 export interface TermTile extends ReplayFlags {
   host: HTMLElement;
   termTitle?: string;
-  // Required, not optional: session-term.js:426,432 always initializes
+  // Required, not optional: session-term.ts:514,520 always initializes
   // both and every reader branches on the value, never on absence
   // (scrollback.ts:28 states the rule).
   attached: boolean;
   needsReattach: boolean;
   // Timestamp of the last replay event, used by the scroll-jump
-  // detector to label a following up-move (session-term.js:594,728).
+  // detector to label a following up-move (session-term.ts:682,816).
   _lastReplayTs?: number;
   // `options` is here for applyFontSize (session-term.ts), the one app-side
   // writer of xterm's live config. Optional like the rest of the
@@ -86,7 +90,7 @@ export interface TermTile extends ReplayFlags {
       })
     | null;
   // Dead-session overlay. Required for the same reason as `attached`:
-  // session-term.js:525 initializes it and setDead writes it on every
+  // session-term.ts:613 initializes it and setDead writes it on every
   // transition, so readers branch on the value, never on absence.
   // keyboard.ts routes Enter/Escape to the two handlers when it's shown.
   deadOverlayShown: boolean;

--- a/cmd/hivegui/frontend/src/app/state.ts
+++ b/cmd/hivegui/frontend/src/app/state.ts
@@ -76,7 +76,15 @@ export interface TermTile extends ReplayFlags {
   // Timestamp of the last replay event, used by the scroll-jump
   // detector to label a following up-move (session-term.js:594,728).
   _lastReplayTs?: number;
-  term?: (ReplayXterm & { focus?: () => void }) | null;
+  // `options` is here for applyFontSize (session-term.ts), the one app-side
+  // writer of xterm's live config. Optional like the rest of the
+  // intersection: the DOM-test stubs omit `term` entirely.
+  term?:
+    | (ReplayXterm & {
+        focus?: () => void;
+        options?: { fontSize?: number };
+      })
+    | null;
   // Dead-session overlay. Required for the same reason as `attached`:
   // session-term.js:525 initializes it and setDead writes it on every
   // transition, so readers branch on the value, never on absence.
@@ -88,6 +96,10 @@ export interface TermTile extends ReplayFlags {
   hide(): void;
   ensureAttached(): void;
   rebaselineReplayCols(reason: string): void;
+  // The single resize entry point. applyFontSize (session-term.ts) calls it
+  // explicitly because a font-size change doesn't resize the body box, so
+  // the ResizeObserver never fires on its own.
+  _onBodyResize(): void;
   setInfo(info: SessionInfo): void;
   // Both params are optional because the implementation defaults them
   // (`name || ''`, `color || '#888'`) and ProjectInfo's fields are optional.

--- a/cmd/hivegui/frontend/test/dom/attention-jump-integration.test.ts
+++ b/cmd/hivegui/frontend/test/dom/attention-jump-integration.test.ts
@@ -73,6 +73,7 @@ function fakeTerm(): TermTile {
     show() {},
     hide() {},
     rebaselineReplayCols() {},
+    _onBodyResize() {},
     setInfo() {},
     setProject() {},
     setDead() {},

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -2,7 +2,7 @@
 
 - **Spec:** [docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md](../../analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md) §2c
 - **Issue:** TBD
-- **Stage:** IMPLEMENT (waves 1–4 merged, wave 5 done; wave 6 next)
+- **Stage:** IMPLEMENT (waves 1–5 merged, wave 6 done; wave 7 next — the last)
 - **Status:** active
 
 ## Summary
@@ -142,8 +142,10 @@ Wave notes:
 - **6** — split into 3 PRs, not 2; no cycle exists. **6a** (landed, #265): `events`,
   `test/dom/{events-focus,restart-hive}.test` — 67 errors, all mechanical. **6b** (landed,
   #266): `keyboard` + all three of the remaining DOM tests, which import `keyboard.js` and
-  nothing from `session-term.js`, so they belong with it. **6c**: `session-term.js`
-  (1,333 LOC) alone — the hardest file; expect the bulk of the errors.
+  nothing from `session-term.js`, so they belong with it. **6c** (landed):
+  `session-term.js` (1,333 LOC) alone — the hardest file, and it did carry the
+  bulk of the errors (388), though 352 were one missing-field-declaration
+  error repeated across 53 fields.
 - **7** — last wave. No strictness ramp follows. Also carries the **cross-language
   stale-path sweep**: a rename here leaves dead paths in files no wave touches — Go
   comments (`cmd/hivegui/menu_darwin{,_test}.go`), `AGENTS.md`'s Keybindings Policy,
@@ -566,6 +568,84 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
   Playwright mock 79 passed + 1 skipped (unchanged). The **`dev-iso.sh`
   GUI smoke was run** and passed, clearing half of wave 6's debt —
   `session-term` still owes its own in 6c.
+
+- **2026-08-08** — Wave 6c complete: `session-term.ts` (1,333 LOC), the last
+  file in wave 6. 388 errors after the `git mv`, but **352 of them were one
+  error repeated**: `TS2339 Property 'x' does not exist on type 'SessionTerm'`
+  across 53 distinct fields. A class body is not a type — every field a JS
+  class assigns through `this` has to be declared. One declaration block took
+  the count 388 → 42, and the remaining 42 were the usual implicit-anys.
+  **This is the shape of every remaining class conversion**: count the
+  distinct field names, not the errors.
+  - **`strictPropertyInitialization` decides where a field may be written.**
+    Fields assigned in the constructor body need no initializer; fields
+    written by a helper the constructor calls (`_attachWebgl`,
+    `_installRendererRecoveryListeners`) are invisible to the check and need
+    one. Rather than sprinkle throwaway defaults, `_refreshRenderer` became a
+    real **method** — it was a constructor-assigned closure only ever reached
+    through `this`, so the field bought nothing. `_dprWatcher` /
+    `_onVisibility` / `_onWindowMouseUp` stay fields (`removeEventListener`
+    needs the stable reference) and take `| null = null`, which is what
+    `destroy()`'s guards already assumed.
+  - **Optional vs. initialized is dictated by `delete`.** `_replayWantsBottom`
+    must be `?:` because the class deletes it; `_replayBaselineCols` because
+    the code reads `=== undefined` as "never measured". `_replayTimer` is
+    `= 0` — it is zeroed, never deleted, and 0 is the falsy the `if` already
+    relied on. Same rule as wave 2's: optional means the code branches on
+    absence.
+  - **`TermTile` survived, and gained exactly two members.** The plan floated
+    replacing it with `SessionTerm`'s own type; that was tried in thought and
+    dropped — `state.terms: Map<string, SessionTerm>` would force every DOM
+    test stub to spell out 53 fields instead of 16. Instead `_onBodyResize()`
+    and `term.options` were added, both genuinely present on every tile in the
+    map, and `SessionTerm` structurally satisfies the interface with no cast —
+    which is the assignability check `state.terms.set()` performs for free.
+    The wave-6b `fakeTerm()` did exactly what its comment promised: adding
+    `_onBodyResize` surfaced as one compile error there.
+  - **Three edits that are not annotation-only**, all where `tsc` saw a
+    nullable the runtime cannot produce. `getElementById('terms')` →
+    `mustEl('terms')` (function body, 6b's precedent). `tileName.parentNode
+    .insertBefore` → `this.header.insertBefore` — same node, the span is
+    appended in the constructor and never reparented, and the nullable
+    disappears rather than being asserted away. `applyFontSize` guards
+    `st.term?.options` because `TermTile.term` is optional *for the stubs'
+    sake*; every real tile has one, so it is the same write on every path
+    that matters.
+  - **Two casts, both narrow and commented.** `this.term._core?.linkifier
+    ?.currentLink` goes through a local `LinkifierPeek` type — the public
+    xterm API has no "is a link under the cursor?" query and the
+    mouse-reporting workaround needs one. `e.wheelDeltaY` in the wheel trace
+    reuses `WheelEventLike` from `lib/wheel-scroll.ts`, which already exists
+    for exactly this non-standard field. `querySelector<HTMLElement>` fixes
+    the `.xterm-screen` handlers: `Element.addEventListener` has no
+    `HTMLElementEventMap` overload, so every `e` was `Event` and every
+    `clientX` an error.
+
+  Gates: typecheck/build/biome green, vitest 344 in 33 files (unchanged),
+  Playwright mock 84 passed + 1 skipped — re-measured on the stashed baseline
+  in this same run, not copied from an earlier wave. e2e-real 7 passed /
+  5 failed, the same 5 waves 4/5a/5b recorded against `main`. Non-vacuity
+  proved with a planted `const _probe: string = DEFAULT_FONT_SIZE` (TS2322).
+
+  The **`dev-iso.sh` GUI smoke was run** and passed, clearing wave 6's
+  remaining debt. Two halves, verified separately.
+
+  The automated half, from the frontend disk log: the whole boot path on a real
+  WKWebView — construction, `ensureAttached` (fit + OpenSession), the initial
+  `writeData` burst, `_onBodyResize` firing a `replay-skip` with
+  `following:true` when a second tile reflowed the grid, and
+  `replay-restore` — with no error, panic, or renderer fallback logged.
+  That covers the constructor, the attach path and the resize/replay state
+  machine, which is where the field-declaration work could plausibly have
+  broken something.
+
+  The input surface — wheel scrolling in a full buffer, click-to-position,
+  link activation, ⌘Backspace / Shift+Enter / Ctrl+Shift+C-V-A, dblclick
+  rename on a tile name, the dead-session overlay — is not reachable from a
+  log and was **checked by hand by the user** in the same isolated app.
+  Recorded because a WKWebView window can't be driven from the agent side:
+  every later wave's input-path smoke needs a human at the keyboard, or it
+  isn't a smoke.
 
 ## Open questions
 


### PR DESCRIPTION
The last file in wave 6, and the hardest: `session-term.js` → `.ts`, 1,333 LOC
whose 53 `this.` fields TypeScript cannot infer from a JS class body. **388
errors after the `git mv`, 352 of them the same TS2339 repeated**; one
declaration block took it to 42, all mechanical implicit-anys.

Wave 6 is now complete (6a #265, 6b #266, 6c here). Only wave 7 — `main.js`,
the e2e specs, and the cross-language stale-path sweep — remains.

## Beyond the annotations

- **`_refreshRenderer` becomes a method.** It was a constructor-assigned
  closure only ever called through `this`, so as a field it would have needed
  a throwaway initializer to satisfy `strictPropertyInitialization` for no
  gain. The three that must stay fields — `_dprWatcher`, `_onVisibility`,
  `_onWindowMouseUp`, where `removeEventListener` needs the stable reference —
  take `| null = null`, which `destroy()`'s guards already assumed.
- **Two nullables removed rather than asserted away.**
  `getElementById('terms')` → `mustEl('terms')` (function body, wave 6b's
  precedent), and `tileName.parentNode.insertBefore` →
  `this.header.insertBefore` — the same node, since the span is appended to
  the header in the constructor and never reparented.
- **`TermTile` gains `_onBodyResize()` and `term.options`.** Both are present
  on every tile the map actually holds, and `SessionTerm` then satisfies the
  interface structurally with no cast — the check `state.terms.set()` performs
  for free. The plan floated replacing `TermTile` with `SessionTerm`'s own
  type; that would force every DOM stub to spell out 53 fields instead of 16,
  so it stays. Wave 6b's fully-spelled-out `fakeTerm()` surfaced the addition
  as one compile error, exactly as its comment promised.
- **`applyFontSize` guards `st.term?.options`** because `TermTile.term` is
  optional for the stubs' sake. Every real tile has one, so it is the same
  write on every path that matters.
- **Two narrow casts, both commented.** xterm's private `_core` (the public
  API has no "is a link under the cursor?" query, which the mouse-reporting
  workaround needs), and `wheelDeltaY` via the `WheelEventLike` that
  `lib/wheel-scroll.ts` already carries for exactly that non-standard field.
  Separately, `querySelector<HTMLElement>` fixes the `.xterm-screen` handlers:
  `Element.addEventListener` has no `HTMLElementEventMap` overload, so every
  `e` was `Event` and every `clientX` an error.

## Gates

- `npm run typecheck` / `npm run build` / `biome ci .` — green.
- vitest **344 in 33 files**, Playwright mock **84 passed + 1 skipped** — both
  re-measured against the stashed baseline in the same run, not copied from an
  earlier wave.
- e2e-real **7 passed / 5 failed** — the same 5 that fail on `main`.
- Non-vacuity proved with a planted `const _probe: string = DEFAULT_FONT_SIZE`
  (TS2322), so the file really is in the program.
- `dev-iso.sh` GUI smoke passed. The lifecycle half is in the frontend disk
  log on a real WKWebView — construction, `ensureAttached` (fit +
  OpenSession), the initial `writeData` burst, `_onBodyResize` firing a
  `replay-skip` with `following:true`, `replay-restore` — with no error,
  panic, or renderer fallback. The input surface a log can't reach was checked
  by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session stability when session details, terminal settings, or DOM elements are unavailable.
  * Improved handling of terminal resizing, font-size changes, renaming, link interactions, and replay refreshes.
  * Added safeguards for terminal lifecycle and WebGL rendering edge cases.

* **Quality Improvements**
  * Completed another stage of the frontend modernization effort, with validation across builds, tests, linting, and GUI smoke checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->