### PR TITLE
ci: cache Playwright browsers, guard against silently-dropped specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
             # platform-specific frontend bug reports (#177, #183).
             e2e_mock: true
 
+    # Pin the browser download location to one path that is the same on all
+    # three OSes (the default differs: ~/.cache, ~/Library/Caches,
+    # %LOCALAPPDATA%), so a single actions/cache entry covers every leg.
+    # Job-level so the install step and both test steps resolve the same dir.
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+
     steps:
       - uses: actions/checkout@v4
 
@@ -116,6 +123,22 @@ jobs:
         working-directory: cmd/hivegui/frontend
         run: ./node_modules/.bin/vitest run
 
+      - name: Cache Playwright browsers
+        if: matrix.e2e_mock
+        # The single biggest cost in CI: this download was 219s of Windows's
+        # 6m48s (vs 25s Linux, 13s macOS — Windows unzip is the outlier).
+        # Keyed on package.json because that is where the @playwright/test
+        # pin lives; it over-invalidates on any dependency bump, which is the
+        # safe direction. The install step below still runs on a hit — it is
+        # a fast no-op when the browsers are already present, and skipping it
+        # on cache-hit would leave a leg with no browser if the cache were
+        # ever partial. On Linux it also installs the apt deps, which are not
+        # cacheable.
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.playwright-browsers
+          key: playwright-${{ runner.os }}-${{ hashFiles('cmd/hivegui/frontend/package.json') }}
+
       - name: Install Playwright browsers
         if: matrix.e2e_mock
         # Install BOTH the full chromium and the headless-shell variant.
@@ -124,6 +147,15 @@ jobs:
         # the shell, leading to "Executable doesn't exist" at launch.
         working-directory: cmd/hivegui/frontend
         run: ./node_modules/.bin/playwright install --with-deps chromium chromium-headless-shell
+
+      - name: Assert every spec file is collected
+        if: matrix.biome
+        # Playwright reports a spec that matches no testMatch glob as ABSENT,
+        # not as a failure, so a stale glob makes tests silently stop running
+        # while this job stays green. Platform-independent, so it rides the
+        # same single-leg flag as Biome and the typecheck.
+        working-directory: cmd/hivegui/frontend
+        run: node scripts/check-spec-discovery.mjs
 
       - name: Test (frontend E2E — mock Wails)
         if: matrix.e2e_mock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,17 +127,28 @@ jobs:
         if: matrix.e2e_mock
         # The single biggest cost in CI: this download was 219s of Windows's
         # 6m48s (vs 25s Linux, 13s macOS — Windows unzip is the outlier).
-        # Keyed on package.json because that is where the @playwright/test
-        # pin lives; it over-invalidates on any dependency bump, which is the
-        # safe direction. The install step below still runs on a hit — it is
-        # a fast no-op when the browsers are already present, and skipping it
-        # on cache-hit would leave a leg with no browser if the cache were
-        # ever partial. On Linux it also installs the apt deps, which are not
-        # cacheable.
+        #
+        # Keyed on package.json, which works ONLY because @playwright/test is
+        # pinned exactly there. A caret range would make this key constant
+        # across every version bump, and the failure is silent and total: the
+        # stale hit restores browser revision X, `playwright install`
+        # re-downloads Y, and actions/cache skips the save because the key
+        # already exists — so the 219s comes back forever behind a green
+        # check. package-lock.json is gitignored here, so it cannot be the
+        # key; the exact pin is what makes the version observable at all.
+        # restore-keys warms a partial dir on the bump itself, where the
+        # primary key correctly misses and a fresh entry does get saved.
+        #
+        # The install step below still runs on a hit — it is a fast no-op
+        # when the browsers are present, and skipping it on cache-hit would
+        # leave a leg with no browser if a cache were ever partial. On Linux
+        # it also installs the apt deps, which are not cacheable.
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.playwright-browsers
           key: playwright-${{ runner.os }}-${{ hashFiles('cmd/hivegui/frontend/package.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install Playwright browsers
         if: matrix.e2e_mock

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ Thumbs.db
 # Playwright e2e artifacts
 /cmd/hivegui/frontend/test-results/
 
+# Playwright browser downloads. CI pins PLAYWRIGHT_BROWSERS_PATH here so one
+# actions/cache entry covers all three OSes; a local run with the same env
+# var set would otherwise leave a few hundred MB untracked in the worktree.
+/.playwright-browsers/
+
 # hivesmith local tooling config
 .hivesmith/
 

--- a/cmd/hivegui/frontend/package.json
+++ b/cmd/hivegui/frontend/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.5",
-    "@playwright/test": "^1.48.0",
+    "@playwright/test": "1.62.1",
     "jsdom": "^25.0.0",
     "typescript": "7.0.2",
     "vite": "^8.0.10",

--- a/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
+++ b/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
@@ -53,8 +53,11 @@ for (const [config, dir] of SUITES) {
     .filter((f) => IS_SPEC.test(f))
     .sort();
 
+  // The local bin, not `npx`, matching every Playwright step in ci.yml —
+  // `npx` can reach the network on a resolution miss, which a check that
+  // exists to be deterministic should never do.
   const out = execSync(
-    `npx playwright test --config=${config} --list --reporter=json`,
+    `./node_modules/.bin/playwright test --config=${config} --list --reporter=json`,
     {
       encoding: 'utf8',
       maxBuffer: 64 * 1024 * 1024,

--- a/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
+++ b/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Fail if a *.spec.* file on disk is not discovered by its Playwright config.
+//
+// The failure this exists for is SILENT. Playwright treats a spec file that
+// matches no `testMatch` glob as absent, not as an error — so a rename that
+// falls out of the glob makes those tests stop running while CI stays green
+// and the coverage claim reads as true. That is failure mode (2) in
+// docs/exec-plans/active/typescript-migration.md's "Silent breakage is the
+// real risk", and wave 7 renames all 22 spec files at once.
+//
+// Compares SETS, not counts, so there is no expected number to maintain: a
+// new spec passes on the day it is added, and only a spec that exists but
+// isn't collected fails. Runs with --list, which does not execute the
+// suites (and so does not fire playwright.real.config.js's globalSetup, which
+// would spawn a real hived — verified, not assumed).
+//
+// Blind spot, stated so nobody trusts it further than it goes: a rename that
+// stops the file LOOKING like a spec at all (`x.spec.js` → `x.speec.js`)
+// drops off both sides of the comparison and passes. Guarding that needs a
+// baseline of what used to be a spec, which is what `git status` and the
+// per-wave count comparison already are. What this catches is the case those
+// two miss because it is invisible in both: the file is renamed correctly and
+// the CONFIG is what's stale.
+
+import { execSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+
+const SUITES = [
+  ['playwright.config.js', 'test/e2e'],
+  ['playwright.real.config.js', 'test/e2e-real'],
+];
+const IS_SPEC = /\.spec\.[cm]?[jt]s$/;
+
+// Playwright nests suites per file and per describe block; the `file` key
+// appears at every level, so collect it recursively rather than assuming a
+// depth that a reporter change could invalidate.
+function collectFiles(node, into) {
+  if (Array.isArray(node)) {
+    for (const n of node) collectFiles(n, into);
+    return into;
+  }
+  if (!node || typeof node !== 'object') return into;
+  if (typeof node.file === 'string' && IS_SPEC.test(node.file))
+    into.add(node.file.replaceAll('\\', '/'));
+  for (const v of Object.values(node)) collectFiles(v, into);
+  return into;
+}
+
+let failed = false;
+for (const [config, dir] of SUITES) {
+  const onDisk = readdirSync(dir, { recursive: true })
+    .map((f) => String(f).replaceAll('\\', '/'))
+    .filter((f) => IS_SPEC.test(f))
+    .sort();
+
+  const out = execSync(
+    `npx playwright test --config=${config} --list --reporter=json`,
+    {
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    },
+  );
+  // Report paths are already relative to testDir, which is the same shape
+  // readdirSync gives — so the two sets compare directly.
+  const discovered = collectFiles(JSON.parse(out), new Set());
+
+  const missing = onDisk.filter((f) => !discovered.has(f));
+  if (missing.length) {
+    failed = true;
+    console.error(
+      `${config}: ${missing.length} spec file(s) on disk that ${config} does NOT collect:`,
+    );
+    for (const f of missing) console.error(`  ${dir}/${f}`);
+  } else {
+    console.log(`${config}: all ${onDisk.length} spec files collected`);
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
+++ b/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
@@ -24,6 +24,13 @@
 
 import { execSync } from 'node:child_process';
 import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Every path below is relative to the frontend root, so anchor there rather
+// than inheriting the caller's cwd — run from the repo root this would
+// otherwise die on a bare `ENOENT: test/e2e` that reads like a missing
+// directory rather than a wrong working directory.
+process.chdir(join(import.meta.dirname, '..'));
 
 const SUITES = [
   ['playwright.config.js', 'test/e2e'],

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -167,11 +167,11 @@ each split across waves.
 
 Taken 2026-08-08 on `ts-wave-6c`, so wave 7 executes without re-discovery.
 
-**23 files convert.** `src/main.js` (419), `test/e2e/fixtures/xterm-reflow.js`, the 16
+**24 files convert.** `src/main.js` (419), `test/e2e/fixtures/xterm-reflow.js`, the 17
 `test/e2e/*.spec.js`, and the 5 `test/e2e-real/*.spec.js`.
 
 **7 files stay JS, and the list in "Files to change" is complete** — `find frontend -name
-'*.js' -o -name '*.mjs'` returns exactly the 23 above plus `vite.config.js`,
+'*.js' -o -name '*.mjs'` returns exactly the 24 above plus `vite.config.js`,
 `vitest.config.js`, `playwright.config.js`, `playwright.real.config.js`,
 `globalSetup.mjs`, `globalTeardown.mjs`, and `scripts/check-spec-discovery.mjs` (and
 gitignored `dist/`, `wailsjs/`). Nothing sits in neither bucket. The fixture is *not* config despite living beside tests: it is a real
@@ -356,7 +356,8 @@ Config files (`vite.config.js`, `vitest.config.js`, `playwright*.config.js`,
 so converting it is a coin flip on Playwright's CJS transform for zero gain.
 `scripts/check-spec-discovery.mjs` joins them on the same rule: it drives the Playwright
 CLI and is not in `tsconfig.include`. **List re-confirmed complete at wave 7** — those
-seven plus the 23 wave-7 files are every remaining `.js`/`.mjs` under `frontend/`.
+seven plus the 24 wave-7 files are every remaining `.js`/`.mjs` under `frontend/` — 31
+in total, verified by `find` against the tree rather than by adding up this list.
 
 ### New files
 

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -87,6 +87,13 @@ below.
   specs silently *stop running* — Playwright reports zero-match files as absent, not as
   failures; (3) `npm run build` succeeding proves nothing about types. So the per-wave
   check compares **spec counts before vs. after**, not just exit codes.
+  **(2) is now enforced in CI**, ahead of wave 7 renaming all 22 spec files at once:
+  `frontend/scripts/check-spec-discovery.mjs` asserts that the set of `*.spec.*` files on
+  disk equals the set each Playwright config actually collects via `--list`. Sets, not
+  counts, so no expected number needs maintaining. It does not replace the before/after
+  comparison — a rename that stops the file looking like a spec at all drops off both sides
+  — but it catches the case neither `git status` nor a count can see: the file renamed
+  correctly and the *config* left stale.
 - A wave that turns out bigger than expected gets **split, never merged half-done**.
 
 ### Strictness: `strict: true` from PR 1
@@ -146,18 +153,152 @@ Wave notes:
   `session-term.js` (1,333 LOC) alone — the hardest file, and it did carry the
   bulk of the errors (388), though 352 were one missing-field-declaration
   error repeated across 53 fields.
-- **7** — last wave. No strictness ramp follows. Also carries the **cross-language
-  stale-path sweep**: a rename here leaves dead paths in files no wave touches — Go
-  comments (`cmd/hivegui/menu_darwin{,_test}.go`), `AGENTS.md`'s Keybindings Policy,
-  `docs/`. 6b fixed the four it caused, but three waves in a row have produced some, so
-  the last wave ends with one `grep -rn` for `\.js` across `AGENTS.md`, `cmd/hivegui/*.go`
-  and `docs/` (excluding `docs/exec-plans/`, whose mentions are dated records and stay).
-  Deferred to 7 rather than swept per-wave because until `main.js` converts, a `.js` path
-  in a comment can still be correct — the sweep only becomes a clean yes/no once every
-  file has moved.
+- **7** — last wave. No strictness ramp follows. `main.js` + 21 `*.spec.js` + one fixture,
+  plus the **cross-language stale-path sweep** deferred here because until `main.js`
+  converts, a `.js` path in a comment can still be correct — the sweep only becomes a clean
+  yes/no once every file has moved. Fully inventoried below; the one-line version is that
+  the sweep is four times wider than this bullet assumed (104 of the stale refs are inside
+  the frontend's own `.ts` comments, which the planned `grep` scope excluded).
 
 Tests are assigned **by what they import, not by directory** — `test/unit/` and `test/dom/`
 each split across waves.
+
+### Wave 7 inventory
+
+Taken 2026-08-08 on `ts-wave-6c`, so wave 7 executes without re-discovery.
+
+**23 files convert.** `src/main.js` (419), `test/e2e/fixtures/xterm-reflow.js`, the 16
+`test/e2e/*.spec.js`, and the 5 `test/e2e-real/*.spec.js`.
+
+**6 files stay JS, and the list in "Files to change" is complete** — `find frontend -name
+'*.js' -o -name '*.mjs'` returns exactly the 23 above plus `vite.config.js`,
+`vitest.config.js`, `playwright.config.js`, `playwright.real.config.js`,
+`globalSetup.mjs`, `globalTeardown.mjs` (and gitignored `dist/`, `wailsjs/`). Nothing sits
+in neither bucket. The fixture is *not* config despite living beside tests: it is a real
+xterm harness (`fixtures/xterm-reflow.js:6` `import { Terminal }`) and converts.
+
+**`tsconfig.include` gains three entries, and the first is the trap.** `src/main.js` is not
+in `include` today (`tsconfig.json:43-52` names `src/lib/**`, `src/app/**`, `src/bridge.ts`,
+`src/globals.d.ts`) and nothing imports it — so `src/main.ts` would sit outside the program,
+unchecked, with `tsc` green. Invariant 6, third occurrence after waves 3 and 4. Add
+`src/main.ts`, and replace the two file-by-file harness paths at `:50-51` with
+`test/e2e/**/*` + `test/e2e-real/**/*`, which the `*.spec.ts` siblings now need.
+
+**Load-bearing `.js` strings** — changing them wrong (or not at all) breaks something no
+type or lint gate sees:
+
+- `index.html:106` `./src/main.js` — Vite's HTML entry. Wrong path builds fine and ships a
+  blank window; the only detector is that every Playwright spec dies.
+- `test/e2e/fixtures/xterm-reflow.html:15` `./xterm-reflow.js` — served by `vite dev`
+  (`xterm-reflow.spec.js:8` navigates `/test/e2e/fixtures/xterm-reflow.html`). The mock
+  suite never runs `vite build`, so a `.ts` src is transformed on the fly. Fails loudly:
+  3 specs.
+- `vite.config.js:17,19` — **already `.ts`, verified**; wave 4 did it. Nothing to do in 7.
+- `vitest.config.js:29,37`, `playwright.config.js:9`, `playwright.real.config.js:16` —
+  `{js,ts}` braces since wave 1, verified. Nothing to change, but the spec-count comparison
+  is still the only thing that would catch a regression here.
+- `playwright.real.config.js:24-25` (`globalSetup.mjs` / `globalTeardown.mjs`) and
+  `package.json:13` (`--config=playwright.real.config.js`) point at files that stay JS.
+- `cmd/hivegui/main.go:17` `//go:embed all:frontend/dist` is directory-level and
+  extension-agnostic.
+
+Searched and found nothing else: no dynamic `import()` of a `.js` path in `src/` (the only
+`import()`s are vitest mocks under `test/**`, which resolve by the rule the pilot proved),
+no string-built module paths, no `.js` glob in `biome.json:8` (`**`), `ci.yml`, or
+`scripts/*.sh`.
+
+**Injection sites in `main.js`** — every one is checked against its interface for the first
+time in this wave.
+
+| main.js | interface | verdict |
+|---|---|---|
+| `:198` `initLauncher` | `LauncherDeps` (`launcher.ts:26`) | ok |
+| `:199` `initProjectEditor` | `ProjectEditorDeps` (`project-editor.ts:18`) | ok |
+| `:200` `initCommandPalette` | `CommandPaletteDeps & { commands: PaletteCommand[] }` (`command-palette.ts:17,11,91-94`) | **watch** |
+| `:201` `initSettings` | `SettingsDeps` (`settings.ts:21`) | ok |
+| `:202` `initHelpOverlay` | `HelpOverlayDeps` (`help-overlay.ts:12`) | ok — `focusActiveTerm`, not `refocus`; 5a's split holds |
+| `:203-209` `initSidebar` | `SidebarDeps` (`sidebar.ts:24`) | ok |
+| `:210` `initBanners` | — | no deps |
+| `:211` `initView` | `ViewDeps` (`view.ts:29`) | ok |
+| `:212-217` `initKeyboard` | `KeyboardDeps` (`keyboard.ts:60`) | ok |
+| `:218` `initFocus` | `FocusDeps` (`focus.ts:20`) | **dead — delete** |
+| `:219-227` `wireDaemonEvents` | `EventsDeps` (`events.ts:26`) | ok |
+| `:231` `initVersionFooter` | — | no deps |
+
+The two non-ok rows. `initFocus({ ensureTerm })` at `main.js:218` — **line number
+confirmed** — feeds `focus.ts`'s write-only `_deps` (`focus.ts:24-31`); delete the call,
+`initFocus`, `FocusDeps` and `_deps` together, in one edit. The palette is the one to expect
+trouble from: `PaletteCommand` (`command-palette.ts:11-15`) has `name`/`shortcut`/`run` and
+no `id`, while `main.js:82-190` builds a 30+-element heterogeneous array literal carrying
+`id`, then `.map`s it. The extra field survives only because the argument is a `.map` result
+rather than a fresh literal (no excess-property check); if the inferred element union
+doesn't collapse to one object type, it is `TS2322`. Widen `PaletteCommand` with `id: string`
+— `main.js:190` reads `c.id` — rather than casting the array.
+
+Two errors are already readable off the source, before the `git mv`: `main.js:361`
+`st.heapMB = heap` is `TS2339` (`st` at `:350` is a literal without the field), and
+`main.js:347-349` passes `performance` to `jsHeapMB`, whose parameter
+(`lib/freeze-heartbeat.ts:72-74`) is the all-optional weak type `{ memory?: … } | null`,
+which DOM's `Performance` has no property in common with — `TS2559`. Fix at the callee
+(the Chromium-only `memory` field *is* the real contract) rather than casting the call site.
+Plus the usual implicit-anys, e.g. `nudge(delta)` at `:288`.
+
+Note also 5b's generalization applied to this wave: `switchTo` is `(id: string | null)`
+(`view.ts:73`) against `SidebarDeps`/`EventsDeps`'s `(id: string)`, and
+`confirmAndDeleteProject` is `(proj: ProjectInfo | undefined | null)` (`keyboard.ts:607`)
+against `SidebarDeps`'s `(p: ProjectInfo)`. Both are wider-param functions assigned to
+narrower types, which is legal and correct — do not "fix" either.
+
+**Stale-path sweep.** Three populations, each verified against the current tree:
+
+1. *Already stale* — the target was renamed in waves 1–6. `AGENTS.md:138`
+   `src/lib/platform.js` (a line the Keybindings Policy missed while `:131-132,:137` were
+   updated to `keymap.ts`/`keyboard.ts`); `cmd/hivegui/app.go:135` and
+   `internal/activity/activity.go:5` (`session-term.js`); `cmd/hived-ws-bridge/main.go:10`
+   (`wails-bridge.js`, wave 4); `index.html:29` (`app/version-footer.js`, 5a);
+   `docs/analysis/2026-07-19-improvement-plan/00-overview.md:32,61` and
+   `phase-3-go-consolidation.md:104,112`.
+2. *Goes stale when wave 7 renames.* `cmd/hivegui/menu_darwin.go:18` and
+   `menu_other.go:18` (`frontend/src/main.js`) — `menu_darwin_test.go:29-33` is **already
+   correct** (`app/keyboard.ts`, `attention-jump.test.ts`), so only the two non-test files;
+   `cmd/hivegui/app.go:221`; `scripts/ci-bootstrap.sh:8`;
+   `docs/analysis/2026-07-19-improvement-plan/phase-1-unblock-ci.md:9,10,11,24`
+   (`*.spec.js`); plus the two load-bearing HTML srcs above.
+3. *Inside the frontend's own `.ts` comments* — **104 references across 30 files**, the
+   population the original bullet's `grep` scope missed entirely. 60 already point at
+   renamed files (`keyboard.js`, `view.js`, `session-term.js`, `keymap.js`, `platform.js`,
+   `state.js`, `events.js`, `focus.js`, `banners.js`, `trace.js`, `scrollback.js`,
+   `dom.js`, `settings.js`, `launcher.js`, `status.js`, `empty-state.js`,
+   `wheel-scroll.js`, `renderer-recovery.js`, `nav-history.js`, `keymap.test.js`), 43 name
+   `main.js`, 1 names a spec. `src/lib/shortcuts.ts:9-15` is the sharpest: it is the
+   canonical five-file drift checklist for a keybinding change and three of its five
+   entries are wrong. `playwright.real.config.js:12` and `src/bridge.ts:3` are in this set
+   too. Judgment applies to the `main.js` ones — "Moved verbatim from main.js" is
+   provenance, not a path, and stays as-is once retargeted or dropped.
+
+So the sweep command in the wave-7 bullet is wrong in scope. Use, from the repo root:
+`grep -rn '\.js\b' AGENTS.md README.md cmd/ internal/ scripts/ .github/ docs/analysis/
+cmd/hivegui/frontend/src cmd/hivegui/frontend/test cmd/hivegui/frontend/index.html`,
+filtering `xterm.js` (the library), `*.json`, and import specifiers (which stay `.js` — the
+pilot's result).
+
+**`docs/product-specs/`, `docs/native-rewrite/` and `CHANGELOG.md` are excluded, on the same
+rule as `docs/exec-plans/`: dated records.** Evidence that they are records and not
+pointers: `docs/product-specs/217-…:13,34` cites `main.js:2768` and `main.js:243`, and
+`main.js` is 419 lines — those were dead before this migration started, and "fixing" the
+extension would make a wrong reference look current.
+
+**Baselines for the before/after comparison**, measured on this branch, not copied:
+
+- `npx vitest run` — **344 tests / 33 files**.
+- `npx playwright test` — **85 tests / 17 files** (84 passed + 1 skipped).
+- `npx playwright test --config=playwright.real.config.js` — **12 tests / 5 files**,
+  7 passed / 5 failed. The 5, by name: `glyph-utf8.spec.js:25`, `lifecycle.spec.js:24`,
+  `scroll-codex.spec.js:189`, `scroll-codex.spec.js:236`,
+  `scroll-restream-strand.spec.js:82`. **This set is not stable and must be re-measured on
+  the stashed tree in the same run** — `docs/product-specs/245-…:15-17` fingers all five
+  `wheel-scroll.spec.js` cases as the flakes, and all five of those passed here. The count
+  (5) has held since wave 4; the membership has not.
 
 ### Invariants
 
@@ -198,6 +339,9 @@ each split across waves.
 - `cmd/hivegui/frontend/vite.config.js` — the two `path.resolve` targets at `:17,19` (wave 4)
 - `cmd/hivegui/frontend/index.html:106`, `test/e2e/fixtures/xterm-reflow.html:15` — script
   `src` (wave 7)
+- `cmd/hivegui/frontend/tsconfig.json:43-52` — `include` gains `src/main.ts` (nothing
+  imports it, so it is otherwise outside the program) and swaps the two named harness paths
+  for `test/e2e/**/*` + `test/e2e-real/**/*` (wave 7)
 - `.github/workflows/ci.yml` — `npm run typecheck` step immediately after "Build frontend"
   (`:66`), guarded by `if: matrix.biome` (copy the pattern at `:94` rather than adding a
   matrix key; same "platform-independent, Linux leg only" rationale). Placed there it fails
@@ -209,7 +353,9 @@ each split across waves.
 Config files (`vite.config.js`, `vitest.config.js`, `playwright*.config.js`,
 `globalSetup.mjs`, `globalTeardown.mjs`) stay JS: no type surface worth checking, and
 `globalSetup.mjs:16` uses `import.meta.url` with no `"type": "module"` in `package.json`,
-so converting it is a coin flip on Playwright's CJS transform for zero gain.
+so converting it is a coin flip on Playwright's CJS transform for zero gain. **List
+re-confirmed complete at wave 7** — those six plus the 23 wave-7 files are every remaining
+`.js`/`.mjs` under `frontend/`.
 
 ### New files
 

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -170,11 +170,11 @@ Taken 2026-08-08 on `ts-wave-6c`, so wave 7 executes without re-discovery.
 **23 files convert.** `src/main.js` (419), `test/e2e/fixtures/xterm-reflow.js`, the 16
 `test/e2e/*.spec.js`, and the 5 `test/e2e-real/*.spec.js`.
 
-**6 files stay JS, and the list in "Files to change" is complete** — `find frontend -name
+**7 files stay JS, and the list in "Files to change" is complete** — `find frontend -name
 '*.js' -o -name '*.mjs'` returns exactly the 23 above plus `vite.config.js`,
 `vitest.config.js`, `playwright.config.js`, `playwright.real.config.js`,
-`globalSetup.mjs`, `globalTeardown.mjs` (and gitignored `dist/`, `wailsjs/`). Nothing sits
-in neither bucket. The fixture is *not* config despite living beside tests: it is a real
+`globalSetup.mjs`, `globalTeardown.mjs`, and `scripts/check-spec-discovery.mjs` (and
+gitignored `dist/`, `wailsjs/`). Nothing sits in neither bucket. The fixture is *not* config despite living beside tests: it is a real
 xterm harness (`fixtures/xterm-reflow.js:6` `import { Terminal }`) and converts.
 
 **`tsconfig.include` gains three entries, and the first is the trap.** `src/main.js` is not
@@ -353,9 +353,10 @@ extension would make a wrong reference look current.
 Config files (`vite.config.js`, `vitest.config.js`, `playwright*.config.js`,
 `globalSetup.mjs`, `globalTeardown.mjs`) stay JS: no type surface worth checking, and
 `globalSetup.mjs:16` uses `import.meta.url` with no `"type": "module"` in `package.json`,
-so converting it is a coin flip on Playwright's CJS transform for zero gain. **List
-re-confirmed complete at wave 7** — those six plus the 23 wave-7 files are every remaining
-`.js`/`.mjs` under `frontend/`.
+so converting it is a coin flip on Playwright's CJS transform for zero gain.
+`scripts/check-spec-discovery.mjs` joins them on the same rule: it drives the Playwright
+CLI and is not in `tsconfig.include`. **List re-confirmed complete at wave 7** — those
+seven plus the 23 wave-7 files are every remaining `.js`/`.mjs` under `frontend/`.
 
 ### New files
 


### PR DESCRIPTION
Three changes, all aimed at wave 7 of the TypeScript migration — the last wave, which
renames all 22 Playwright spec files at once.

## 1. Cache the Playwright browsers

There was **no caching of any kind in `ci.yml`**. Measured on run 31288540668:

| Leg | Total | `Install Playwright browsers` |
|---|---|---|
| Windows | 6m48s | **219s** |
| macOS | 3m35s | 13s |
| Linux | 2m44s | 25s |

So it's a Windows unzip pathology, not bandwidth — and it was over half that leg's
wall-clock. `PLAYWRIGHT_BROWSERS_PATH` is pinned to one workspace-relative path so a single
`actions/cache` entry serves all three OSes, whose defaults otherwise differ (`~/.cache`,
`~/Library/Caches`, `%LOCALAPPDATA%`).

The install step still runs on a cache hit, deliberately: it's a fast no-op when the
browsers are already present, and gating it on `cache-hit` would leave a leg with no
browser if a cache were ever partial. On Linux it also installs the apt deps, which aren't
cacheable.

**npm is deliberately not cached.** `package-lock.json` is gitignored
(`frontend/.gitignore:3`), so `setup-node`'s cache has no lockfile to hash, and
`npm install` is folded into an 11–19s step anyway. Not worth a bespoke key.

## 2. Assert every spec file is collected

Playwright reports a spec that matches no `testMatch` glob as **absent, not as a failure**.
A stale glob therefore makes tests silently stop running while CI stays green and the
coverage claim reads as true — failure mode (2) in the migration plan's "Silent breakage is
the real risk" section, and the one wave 7 is most exposed to.

`frontend/scripts/check-spec-discovery.mjs` compares the **set** of `*.spec.*` files on disk
against the set each config actually collects via `--list`. Sets rather than counts, so
there's no expected number to maintain — a new spec passes the day it's added.

Verified non-vacuously: narrowing the glob back to `'**/*.spec.js'` and renaming one spec to
`.ts` fails it with that file named. `--list` does not run `globalSetup`, so pointing it at
the real-daemon config doesn't spawn a `hived` — checked against the process table rather
than assumed.

Its blind spot is documented in the file header: a rename that stops the file looking like a
spec at all (`x.spec.js` → `x.speec.js`) drops off both sides and passes. `git status` and
the per-wave count comparison already cover that; this covers the case they can't see, where
the file is renamed correctly and the *config* is what's stale.

## 3. Record the wave-7 inventory in the plan

The stale-path sweep deferred to wave 7 turned out **four times wider than the plan's bullet
assumed**. The plan now carries a full `### Wave 7 inventory`. The findings that change the
work:

- **104 stale `.js` refs live in the frontend's own `.ts` comments**, across 30 files — a
  scope the planned `grep` (`AGENTS.md`, `cmd/hivegui/*.go`, `docs/`) excluded entirely. 60
  already point at renamed files. `src/lib/shortcuts.ts:9-15` is the sharpest: it's the
  canonical five-file drift checklist for a keybinding change and **three of five entries
  are wrong**.
- **`src/main.ts` would land outside `tsconfig.include` and go silently unchecked** —
  nothing imports `main.js`, so it never enters the program. Invariant 6's third occurrence
  after waves 3 and 4.
- **Two `main.js` injection sites won't typecheck as-is**: `initFocus({ ensureTerm })` at
  `:218` is fully dead (confirmed), and `initCommandPalette` is an `openLauncher`-class
  hazard — `PaletteCommand` has no `id` but the 30+-element array carries one, surviving
  today only because a `.map` result skips the excess-property check.
- **The 5 known e2e-real failures are not a stable set.** The count has held at 5 since wave
  4; the membership has not — `docs/product-specs/245-…:15-17` names all five
  `wheel-scroll.spec.js` cases, and all five of those pass now. Recorded as a run-local
  baseline to re-measure, not an allowlist.

## Gates

`typecheck` / `build` / `biome ci` green; vitest 344 in 33 files; Playwright mock 84 passed
+ 1 skipped; the new guard passes (17 + 5 files) and fails correctly when sabotaged. No
source file changed — this is CI config, one new script, and the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)