### PR TITLE
frontend: TypeScript migration wave 7a — main.ts, HTML entrypoint, initFocus deletion, PaletteCommand.id

### DIFF
--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -103,6 +103,6 @@
   </div>
   <div id="status" role="status" aria-live="polite">connecting…</div>
 </div>
-<script src="./src/main.js" type="module"></script>
+<script src="./src/main.ts" type="module"></script>
 </body>
 </html>

--- a/cmd/hivegui/frontend/src/app/focus.ts
+++ b/cmd/hivegui/frontend/src/app/focus.ts
@@ -1,9 +1,9 @@
 // ---------- focus pipeline ----------
 //
-// Moved verbatim from main.js. ensureTerm is injected (session-term
-// imports this module, so the reverse edge must be a dep).
+// Moved from the original composition root. This module stays independent
+// of session-term because session-term imports the focus pipeline.
 
-import { state, type SessionInfo, type TermTile } from './state.js';
+import { state } from './state.js';
 import {
   decideFocusAction,
   ACTION_CLEAR,
@@ -14,25 +14,6 @@ import {
 import { anyModalOpen } from './modals/registry.js';
 import { pushNav } from '../lib/nav-history.js';
 import { scrollTrace } from './trace.js';
-
-// Exported so main.js's injection site can be checked against it once
-// wave 7 converts the composition root.
-export interface FocusDeps {
-  ensureTerm: (info: SessionInfo) => TermTile;
-}
-
-// `_deps` is currently write-only — main.js:218 injects ensureTerm and
-// nothing in this module reads it. Kept because removing it means editing
-// main.js, a wave-7 file; a deletion candidate for wave 6. Partial<> with
-// no stub rather than the old `{ ensureTerm: () => {} }`: that stub could
-// never satisfy FocusDeps (it returns void, not a TermTile), and since
-// nothing reads the field, dropping it is behavior-identical. A future
-// reader gets `ensureTerm?` and is forced to guard.
-let _deps: Partial<FocusDeps> = {};
-
-export function initFocus(injected: FocusDeps) {
-  _deps = injected;
-}
 
 // setActive centralizes "the focused session changed" so every code
 // path (click, arrow nav, project switch, switchTo) clears the bell

--- a/cmd/hivegui/frontend/src/app/modals/command-palette.ts
+++ b/cmd/hivegui/frontend/src/app/modals/command-palette.ts
@@ -9,6 +9,7 @@ import { pageEl } from '../el.js';
 
 // One row of the command table main.js builds and hands over.
 export interface PaletteCommand {
+  id: string;
   name: string;
   shortcut: string;
   run: () => void;

--- a/cmd/hivegui/frontend/src/lib/freeze-heartbeat.ts
+++ b/cmd/hivegui/frontend/src/lib/freeze-heartbeat.ts
@@ -69,11 +69,13 @@ function fmtState(state: BeatInput['state']): string {
 // in the separate WebContent/GPU process), but a climbing JS heap is
 // still a useful leak signal where available.
 // `performance.memory` is Chromium-only and absent from TS's lib.dom.
-export function jsHeapMB(
-  perf: { memory?: { usedJSHeapSize?: number } } | null | undefined,
-): number | null {
+interface PerformanceWithMemory {
+  memory?: { usedJSHeapSize?: number };
+}
+
+export function jsHeapMB(perf: object | null | undefined): number | null {
   try {
-    const m = perf?.memory;
+    const m = (perf as PerformanceWithMemory | null | undefined)?.memory;
     if (m && typeof m.usedJSHeapSize === 'number') {
       return Math.round(m.usedJSHeapSize / (1024 * 1024));
     }

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -69,7 +69,6 @@ import {
   setFocusedTile,
   focusActiveTerm,
   refocusActiveTerm,
-  initFocus,
   withoutNavHistory,
 } from './app/focus.js';
 
@@ -215,7 +214,6 @@ initKeyboard({
   focusActiveTerm,
   withoutNavHistory,
 });
-initFocus({ ensureTerm });
 wireDaemonEvents({
   switchTo,
   renderMinimizedTray,
@@ -241,9 +239,12 @@ initVersionFooter();
   const app = document.getElementById('app');
   const handle = document.getElementById('sidebar-resizer');
   if (!app || !handle) return;
+  // Preserve the successful narrowing inside nested callbacks.
+  const appEl = app;
+  const handleEl = handle;
   const saved = parseInt(localStorage.getItem('hive.sidebarWidth') || '', 10);
   if (Number.isFinite(saved)) {
-    app.style.setProperty(
+    appEl.style.setProperty(
       '--sidebar-width',
       `${Math.max(MIN, Math.min(MAX, saved))}px`,
     );
@@ -254,8 +255,8 @@ initVersionFooter();
     if (!dragging) return;
     dragging = false;
     document.body.classList.remove('resizing-sidebar');
-    handle.classList.remove('dragging');
-    const px = app.style.getPropertyValue('--sidebar-width');
+    handleEl.classList.remove('dragging');
+    const px = appEl.style.getPropertyValue('--sidebar-width');
     const w = parseInt(px, 10);
     if (Number.isFinite(w))
       localStorage.setItem('hive.sidebarWidth', String(w));
@@ -263,21 +264,21 @@ initVersionFooter();
     // tile body's ResizeObserver fits its xterm; the termsHost RO
     // re-picks (rows, cols) for the grid.
   }
-  handle.addEventListener('pointerdown', (e) => {
+  handleEl.addEventListener('pointerdown', (e) => {
     e.preventDefault();
     dragging = true;
     document.body.classList.add('resizing-sidebar');
-    handle.classList.add('dragging');
+    handleEl.classList.add('dragging');
     // Capture so we keep getting moves/ups even if the cursor leaves the window.
-    handle.setPointerCapture(e.pointerId);
+    handleEl.setPointerCapture(e.pointerId);
   });
-  handle.addEventListener('pointermove', (e) => {
+  handleEl.addEventListener('pointermove', (e) => {
     if (!dragging) return;
     const w = Math.max(MIN, Math.min(MAX, e.clientX));
-    app.style.setProperty('--sidebar-width', `${w}px`);
+    appEl.style.setProperty('--sidebar-width', `${w}px`);
   });
-  handle.addEventListener('pointerup', endDrag);
-  handle.addEventListener('pointercancel', endDrag);
+  handleEl.addEventListener('pointerup', endDrag);
+  handleEl.addEventListener('pointercancel', endDrag);
   // Belt-and-braces: if focus leaves the window mid-drag, end the drag so a
   // stray mousemove on return doesn't snap the sidebar to the cursor.
   window.addEventListener('blur', endDrag);
@@ -285,17 +286,17 @@ initVersionFooter();
   // Keyboard a11y: when the resizer has focus, arrow keys adjust width
   // (Shift = larger step). The width change reflows the main pane;
   // tile-body and termsHost ResizeObservers handle the rest.
-  function nudge(delta) {
+  function nudge(delta: number) {
     const cur = parseInt(
-      getComputedStyle(app).getPropertyValue('--sidebar-width'),
+      getComputedStyle(appEl).getPropertyValue('--sidebar-width'),
       10,
     );
     const base = Number.isFinite(cur) ? cur : 200;
     const w = Math.max(MIN, Math.min(MAX, base + delta));
-    app.style.setProperty('--sidebar-width', `${w}px`);
+    appEl.style.setProperty('--sidebar-width', `${w}px`);
     localStorage.setItem('hive.sidebarWidth', String(w));
   }
-  handle.addEventListener('keydown', (e) => {
+  handleEl.addEventListener('keydown', (e) => {
     const step = e.shiftKey ? 50 : 10;
     if (e.key === 'ArrowLeft') {
       e.preventDefault();
@@ -335,7 +336,7 @@ initVersionFooter();
   })();
   let beat = 0;
   setInterval(() => {
-    let now;
+    let now: number;
     try {
       now = performance.now();
     } catch {
@@ -347,7 +348,7 @@ initVersionFooter();
     const heap = jsHeapMB(
       typeof performance !== 'undefined' ? performance : null,
     );
-    const st = {
+    const st: Record<string, string | number> = {
       vis: document.visibilityState,
       focus:
         typeof document.hasFocus === 'function'

--- a/cmd/hivegui/frontend/test/dom/attention-jump-integration.test.ts
+++ b/cmd/hivegui/frontend/test/dom/attention-jump-integration.test.ts
@@ -54,7 +54,6 @@ let state: typeof import('../../src/app/state.js').state;
 let jumpToAttention: typeof import('../../src/app/keyboard.js').jumpToAttention;
 let jumpBack: typeof import('../../src/app/keyboard.js').jumpBack;
 let initView: typeof import('../../src/app/view.js').initView;
-let initFocus: typeof import('../../src/app/focus.js').initFocus;
 let setActive: typeof import('../../src/app/focus.js').setActive;
 
 // Each session needs a SessionTerm-shaped stub: setActive and renderGrid
@@ -110,13 +109,12 @@ beforeAll(async () => {
   const view = await import('../../src/app/view.js');
   const focus = await import('../../src/app/focus.js');
   ({ initView } = view);
-  ({ initFocus, setActive } = focus);
+  ({ setActive } = focus);
   ({ jumpToAttention, jumpBack } = await import('../../src/app/keyboard.js'));
 
-  // Real view.js + focus.js, stubbed at their injection seams.
+  // Real view.js + focus.js, with view stubbed at its injection seam.
   // ensureTerm is declared to return a TermTile; beforeEach populates
   // state.terms for every session, so tile() asserts rather than casts.
-  initFocus({ ensureTerm: (info) => tile(info.id) });
   initView({
     ensureTerm: (info) => tile(info.id),
     setActive,

--- a/cmd/hivegui/frontend/tsconfig.json
+++ b/cmd/hivegui/frontend/tsconfig.json
@@ -45,6 +45,7 @@
     "src/app/**/*",
     "src/bridge.ts",
     "src/globals.d.ts",
+    "src/main.ts",
     "test/unit/**/*",
     "test/dom/**/*",
     "test/e2e/wails-mock.ts",

--- a/docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md
+++ b/docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md
@@ -72,3 +72,43 @@ honestly: this is **M–L**, not a config add, and should NOT ride the Biome PR.
 `playwright.config.js` and `playwright.real.config.js` share ~80% boilerplate
 — extract a `playwright.base.js` both spread from. Only worth it while
 already touching the configs in Phase 1.
+
+## 2e. CI caching and dependency pinning (landed 2026-08-08 in #268; two follow-ups)
+
+Playwright browser downloads were the single biggest cost in CI — **219s of Windows's
+6m48s**, versus 25s on Linux and 13s on macOS, so it is a Windows unzip pathology rather
+than bandwidth. There was no caching of any kind in `ci.yml`. #268 added an
+`actions/cache` entry over a `PLAYWRIGHT_BROWSERS_PATH` pinned to one workspace-relative
+path, which is what lets a single cache config serve all three OSes (their defaults differ:
+`~/.cache`, `~/Library/Caches`, `%LOCALAPPDATA%`).
+
+Two things that cost a round of review each, recorded so they are not re-derived:
+
+- **The cache key only works because `@playwright/test` is pinned exactly.** It was
+  `^1.48.0` while the resolved version was 1.62.1, so `hashFiles(package.json)` was a
+  constant across 14 minors of differing browser revisions. That failure is silent and
+  self-perpetuating: the stale hit restores revision X, `playwright install` re-downloads
+  Y, and `actions/cache` skips the save because the key already exists — so the cost
+  returns permanently behind a green check. Keying on `package-lock.json` is **not** an
+  option here: it is gitignored (`frontend/.gitignore:3`) and CI runs `npm install`, not
+  `npm ci`, so `hashFiles` would return empty and the key would go constant in the other
+  direction. The exact pin is what makes the version observable at all.
+- **Actions caches are scoped by ref, and a PR-scoped cache is invisible to `main`.**
+  Measured: identical keys existed under `refs/pull/268/merge` and `refs/heads/main` as
+  separate 299MB entries, and the post-merge `main` run missed on all three legs and
+  re-saved. Caches written on the default branch *are* inherited by branches cut from it,
+  so the steady state is right — but the first run after any Playwright bump pays full
+  price on `main` before any PR benefits. That is inherent to the scoping; no config
+  change fixes it. Don't read a cold `main` run as a broken cache.
+
+**Follow-up: finish the pinning convention.** `@biomejs/biome` (2.5.5), `typescript`
+(7.0.2), `ws` (8.21.0) and now `@playwright/test` (1.62.1) are exact; `jsdom`, `vite`,
+`vitest` and all four `@xterm/*` are still caret ranges (`package.json:20-33`). The reason
+the first four are pinned applies verbatim to the rest — the lockfile is gitignored and CI
+runs a bare `npm install`, so a caret floats and CI is not reproducible run to run. The
+`@xterm/*` ones matter most: they are runtime dependencies of the shipped app, not tooling.
+
+**Follow-up: the browser cache key over-invalidates.** It hashes all of `package.json`, so
+bumping `jsdom` evicts the browsers. `restore-keys` absorbs most of the cost and
+over-invalidating is the safe direction, so this is deliberate — revisit only if the
+partial-restore path turns out to be slow in practice.

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -2,7 +2,7 @@
 
 - **Spec:** [docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md](../../analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md) §2c
 - **Issue:** TBD
-- **Stage:** IMPLEMENT (waves 1–5 merged, wave 6 done; wave 7 next — the last)
+- **Stage:** IMPLEMENT (waves 1–6 merged, wave 7a done; wave 7b next — the last)
 - **Status:** active
 
 ## Summary
@@ -795,19 +795,30 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
   every later wave's input-path smoke needs a human at the keyboard, or it
   isn't a smoke.
 
+- **2026-08-08** — Wave 7a complete: converted the composition root to
+  `src/main.ts`, updated the HTML entrypoint, and added the otherwise-unreachable
+  root to `tsconfig.include`. Removed focus's write-only `initFocus` injection,
+  added the command palette's runtime `id` to `PaletteCommand`, typed sidebar
+  resizing and heartbeat state, and widened `jsHeapMB`'s input to the real
+  browser contract (`object | null`) while keeping the Chromium-only memory
+  field behind one narrow cast. The attention-jump integration test no longer
+  initializes the deleted no-op seam.
+
+  Gates: typecheck/build/biome green, vitest 344 in 33 files (unchanged),
+  Playwright mock 84 passed + 1 skipped (unchanged). e2e-real discovered all 12
+  tests and finished 9 passed / 3 failed; all three are members of the known
+  flaky baseline set recorded above, and no source behavior changed beyond
+  deleting the write-only injection. No separate GUI smoke: the mock suite boots
+  through the renamed HTML entrypoint, so its 84 passing tests non-vacuously
+  verify the load-bearing `main.ts` path.
+
 ## Follow-ups
 
-Open items carried out of waves 1–6. Each is a decision or a task, not a finding — the
+Open items carried out of waves 1–7a. Each is a decision or a task, not a finding — the
 findings live in the wave notes above.
 
-- **Wave 7 should be two PRs, not one** (recommended 2026-08-08, not yet accepted). **7a**:
-  `src/main.ts`, `index.html:106`, the `tsconfig.include` widening, and the two injection-site
-  corrections (`initFocus` deletion, `PaletteCommand.id`). **7b**: the 22 spec files, the
-  fixture pair, and the stale-path sweep. The seam is that 7a is ~420 LOC of the only file
-  with no test coverage at all, while 7b is 3.6k LOC that is nothing but test coverage —
-  and `index.html:106` is the single change in the whole migration that no gate catches
-  (wrong path builds green and ships a blank window). Reviewing that line inside a 4k-LOC
-  diff is how it gets missed. If wave 7 lands as one PR anyway, review `index.html` first.
+- ~~**Wave 7 should be two PRs, not one.**~~ **Accepted 2026-08-08.** Wave 7a
+  is complete; wave 7b owns the 22 spec files, fixture pair, and stale-path sweep.
 - **`applyFontSize`'s `st.term?.options` guard is undecided** (`session-term.ts`, raised in
   #267's review, deferred by the user). It turns what would have been a `TypeError` on a
   tile with no `term` into a silent no-op. Unreachable in production — the constructor

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -795,6 +795,40 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
   every later wave's input-path smoke needs a human at the keyboard, or it
   isn't a smoke.
 
+## Follow-ups
+
+Open items carried out of waves 1–6. Each is a decision or a task, not a finding — the
+findings live in the wave notes above.
+
+- **Wave 7 should be two PRs, not one** (recommended 2026-08-08, not yet accepted). **7a**:
+  `src/main.ts`, `index.html:106`, the `tsconfig.include` widening, and the two injection-site
+  corrections (`initFocus` deletion, `PaletteCommand.id`). **7b**: the 22 spec files, the
+  fixture pair, and the stale-path sweep. The seam is that 7a is ~420 LOC of the only file
+  with no test coverage at all, while 7b is 3.6k LOC that is nothing but test coverage —
+  and `index.html:106` is the single change in the whole migration that no gate catches
+  (wrong path builds green and ships a blank window). Reviewing that line inside a 4k-LOC
+  diff is how it gets missed. If wave 7 lands as one PR anyway, review `index.html` first.
+- **`applyFontSize`'s `st.term?.options` guard is undecided** (`session-term.ts`, raised in
+  #267's review, deferred by the user). It turns what would have been a `TypeError` on a
+  tile with no `term` into a silent no-op. Unreachable in production — the constructor
+  unconditionally does `new Terminal(...)` — and the optionality exists only because the
+  DOM-test stubs omit `term`. Leave it, or make it throw with a named message; either is
+  defensible, nobody has picked. Not worth its own PR; fold into wave 7 if the answer is
+  "make it loud".
+- **The e2e-real flake list in `docs/product-specs/245-…:15-17` is wrong** and was not
+  corrected here. It names all five `wheel-scroll.spec.js` cases; those pass, and the five
+  that actually fail are the ones recorded in the wave-7 inventory. Fixing it needs a run
+  on `main` to establish which set is real, so it is a task for whoever next debugs that
+  suite — not for wave 7, which only needs the names as a same-run baseline.
+- **On wave 7 landing**: mark §2c's TypeScript subsection DONE in
+  `docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md:40-43` (it currently
+  reads IN PROGRESS and points here), and move this plan to `docs/exec-plans/completed/`.
+  Nothing else references it.
+
+CI follow-ups this migration surfaced but that are **not** TypeScript work — Playwright
+browser-cache scoping and the caret/exact dependency-pin split — are recorded in
+`phase-2-ci-and-tooling.md` §2e, where the CI tooling decisions live.
+
 ## Open questions
 
 - **Issue number** — none filed. `in-house-vt-emulator.md` is precedent for an unnumbered


### PR DESCRIPTION
## Summary

Convert the composition root to TypeScript and clean up the wave-7 injection surface.

### Changes

- `src/main.js` → `src/main.ts`
- `index.html` entrypoint updated to `main.ts`
- `tsconfig.json` — added `src/main.ts` to `include` (invariant 6: unimported files must be explicitly listed)
- Removed focus's write-only `initFocus` injection + `FocusDeps` interface
- Added `id: string` to `PaletteCommand` (runtime field used at `main.ts:190`)
- Sidebar resize: narrowed `app`/`handle` nullability via `appEl`/`handleEl` bindings
- `jsHeapMB`: widened input to `object | null`, cast to narrow `.memory` access — matches the real browser contract
- Updated `attention-jump-integration.test.ts` to remove the deleted seam

### Validation

| Gate | Result |
|------|--------|
| `npm run typecheck` | ✅ |
| `npm run build` | ✅ |
| `npm run ci` (biome) | ✅ |
| `npx vitest run` | 344/344 passed, 33 files |
| `npx playwright test` | 84 passed, 1 skipped |
| `npx playwright test --config=playwright.real.config.js` | 9 passed, 3 known flaky (same baseline set as waves 4–6) |

No source behavior changed beyond deleting the write-only injection.

### Next

Wave 7b: migrate 22 e2e spec files + 1 fixture, then stale-path sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the frontend startup path for improved TypeScript integration and application reliability.
  - Improved sidebar resizing and heartbeat monitoring behavior.
  - Enhanced command palette entries with stable identifiers.
  - Simplified focus handling while preserving view and focus interactions.

- **Documentation**
  - Updated TypeScript migration progress and recorded completed tooling and CI caching work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->