### PR TITLE
frontend: TypeScript migration wave 7c — the 5 e2e-real specs

### DIFF
--- a/cmd/hivegui/frontend/test/e2e-real/glyph-utf8.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/glyph-utf8.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect } from '@playwright/test';
+// `state.terms` is a Map<string, TermTile> — the deliberately narrow structural
+// view app modules use (app/state.ts). These specs poke the concrete tile the
+// map actually holds, which is what carries the real xterm Terminal, so they
+// assert SessionTerm rather than widening TermTile for every app caller and
+// DOM-test stub (wave 5b's rule).
+import type { SessionTerm } from '../../src/app/session-term.js';
 
 // Layer B regression cover for the multi-byte-glyph class (#195).
 // The daemon emits raw PTY bytes; the frontend's per-session
@@ -41,8 +47,15 @@ test('multi-byte UTF-8 round-trips through the real wire path without corruption
 
   await page.evaluate(() => {
     const helper =
-      document.querySelector('.term-host.active .xterm-helper-textarea') ||
-      document.querySelector('.term-host .xterm-helper-textarea');
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host.active .xterm-helper-textarea',
+      ) ||
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host .xterm-helper-textarea',
+      );
+    // The waitForFunction above already proved it exists; throwing here says
+    // so rather than turning a broken wait into a silently unfocused term.
+    if (!helper) throw new Error('no xterm helper textarea to focus');
     helper.focus();
   });
   await page.keyboard.type('stty -echo\n');
@@ -62,7 +75,7 @@ test('multi-byte UTF-8 round-trips through the real wire path without corruption
           if (!terms) return null;
           const out = [];
           for (const st of terms.values()) {
-            const buf = st.term?.buffer?.active;
+            const buf = (st as SessionTerm).term.buffer.active;
             if (!buf) continue;
             for (let i = 0; i < buf.length; i++) {
               out.push(buf.getLine(i)?.translateToString(true) || '');

--- a/cmd/hivegui/frontend/test/e2e-real/lifecycle.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/lifecycle.spec.ts
@@ -1,4 +1,10 @@
 import { test, expect } from '@playwright/test';
+// `state.terms` is a Map<string, TermTile> — the deliberately narrow structural
+// view app modules use (app/state.ts). These specs poke the concrete tile the
+// map actually holds, which is what carries the real xterm Terminal, so they
+// assert SessionTerm rather than widening TermTile for every app caller and
+// DOM-test stub (wave 5b's rule).
+import type { SessionTerm } from '../../src/app/session-term.js';
 
 // Layer B smoke: real-daemon end-to-end. Boots the frontend against a
 // real hived daemon (via hived-ws-bridge), waits for the bootstrap
@@ -52,8 +58,15 @@ test('boots, sees bootstrap session, echoes typed input through real hived', asy
   // alongside the output — keeps the assertion robust.
   await page.evaluate(async () => {
     const helper =
-      document.querySelector('.term-host.active .xterm-helper-textarea') ||
-      document.querySelector('.term-host .xterm-helper-textarea');
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host.active .xterm-helper-textarea',
+      ) ||
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host .xterm-helper-textarea',
+      );
+    // The waitForFunction above already proved it exists; throwing here says
+    // so rather than turning a broken wait into a silently unfocused term.
+    if (!helper) throw new Error('no xterm helper textarea to focus');
     helper.focus();
   });
   await page.keyboard.type('stty -echo\n');
@@ -74,7 +87,7 @@ test('boots, sees bootstrap session, echoes typed input through real hived', asy
           if (!terms) return null;
           const out = [];
           for (const st of terms.values()) {
-            const buf = st.term?.buffer?.active;
+            const buf = (st as SessionTerm).term.buffer.active;
             if (!buf) continue;
             for (let i = 0; i < buf.length; i++) {
               out.push(buf.getLine(i)?.translateToString(true) || '');

--- a/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.ts
@@ -275,8 +275,12 @@ test('viewport converges to the bottom after a mode switch under continuous outp
   // lags (the parse-ordered re-snap lands when the queue drains). The
   // bug class this guards against -- a stale restore pinning the
   // viewport in history forever -- still fails convergence.
+  // Deliberately the nullable scrollState, not mustScrollState: this is an
+  // expect.poll() callback, and Playwright calls the value function outside
+  // its retry try/catch — a throw here would abort the poll on the first tick
+  // instead of letting a momentarily unreadable term recover within the 20s.
   const atBottom = async () => {
-    const s = await mustScrollState(page);
+    const s = await scrollState(page);
     return s ? s.baseY - s.viewportY : NaN;
   };
 

--- a/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+// `state.terms` is a Map<string, TermTile> — the deliberately narrow structural
+// view app modules use (app/state.ts). These specs poke the concrete tile the
+// map actually holds, which is what carries the real xterm Terminal, so they
+// assert SessionTerm rather than widening TermTile for every app caller and
+// DOM-test stub (wave 5b's rule).
+import type { SessionTerm } from '../../src/app/session-term.js';
 
 // Repro harness for the "scrolling jumps around with Codex when
 // switching to grid mode or back" report. The mock-Wails e2e layer
@@ -58,7 +64,7 @@ test.afterEach(async ({ page }, testInfo) => {
 
 const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
 
-async function bootWithTerm(page) {
+async function bootWithTerm(page: Page) {
   test.skip(!WS_URL, 'WS_BRIDGE_URL not set — globalSetup did not run');
   await page.goto('/');
   await page.waitForFunction(
@@ -76,11 +82,18 @@ async function bootWithTerm(page) {
   await page.waitForTimeout(200);
 }
 
-async function focusFirstTerm(page) {
+async function focusFirstTerm(page: Page) {
   await page.evaluate(() => {
     const helper =
-      document.querySelector('.term-host.active .xterm-helper-textarea') ||
-      document.querySelector('.term-host .xterm-helper-textarea');
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host.active .xterm-helper-textarea',
+      ) ||
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host .xterm-helper-textarea',
+      );
+    // The waitForFunction above already proved it exists; throwing here says
+    // so rather than turning a broken wait into a silently unfocused term.
+    if (!helper) throw new Error('no xterm helper textarea to focus');
     helper.focus();
   });
 }
@@ -92,18 +105,21 @@ async function focusFirstTerm(page) {
 // broadcasts session:event(added) to every control conn, so the
 // page's sidebar updates on its own. With two tiles, grid mode splits
 // the width and the col delta always crosses REPLAY_COL_THRESHOLD.
-async function addSecondSession(page) {
-  // Node < 22 has no global WebSocket; fall back to the ws package.
+async function addSecondSession(page: Page) {
+  if (!WS_URL)
+    throw new Error('WS_BRIDGE_URL not set — globalSetup did not run');
+  // Node < 22 has no global WebSocket; fall back to the ws package, typed by
+  // the hand-written ws-shim.d.ts (see there for why not @types/ws).
   const WS = globalThis.WebSocket ?? (await import('ws')).WebSocket;
   const ws = new WS(WS_URL);
   await new Promise((res, rej) => {
     ws.onopen = res;
     ws.onerror = rej;
   });
-  const send = (id, method, params = {}) =>
+  const send = (id: number, method: string, params: object = {}) =>
     ws.send(JSON.stringify({ id, method, params }));
-  const waitFor = (id) =>
-    new Promise((res) => {
+  const waitFor = (id: number) =>
+    new Promise<{ id: number; error?: string }>((res) => {
       ws.addEventListener('message', function h(ev) {
         const m = JSON.parse(ev.data);
         if (m.id === id) {
@@ -135,14 +151,14 @@ async function addSecondSession(page) {
 
 // Reads the FIRST session's buffer as text lines via xterm's buffer
 // API (WebGL paints to canvas; the DOM holds nothing readable).
-function bufferLines(page) {
+function bufferLines(page: Page) {
   return page.evaluate(() => {
     const terms = window.__hive_state?.terms;
     if (!terms) return [];
-    const st = [...terms.values()][0];
+    const st = [...terms.values()][0] as SessionTerm | undefined;
     const buf = st?.term?.buffer?.active;
     if (!buf) return [];
-    const out = [];
+    const out: string[] = [];
     for (let i = 0; i < buf.length; i++) {
       out.push(buf.getLine(i)?.translateToString(true) || '');
     }
@@ -150,17 +166,27 @@ function bufferLines(page) {
   });
 }
 
-function scrollState(page) {
+function scrollState(page: Page) {
   return page.evaluate(() => {
     const terms = window.__hive_state?.terms;
-    const st = terms ? [...terms.values()][0] : null;
+    const st = terms ? ([...terms.values()][0] as SessionTerm) : null;
     const buf = st?.term?.buffer?.active;
     if (!buf) return null;
     return { viewportY: buf.viewportY, baseY: buf.baseY, type: buf.type };
   });
 }
 
-function traceTags(page, tag) {
+// Every direct-assertion site below has already waited for the term to attach,
+// so a null there is a broken wait rather than a state worth asserting on.
+// expect.poll() keeps using scrollState(), which must tolerate the
+// not-yet-attached window.
+async function mustScrollState(page: Page) {
+  const s = await scrollState(page);
+  if (!s) throw new Error('no term buffer — the boot wait did not hold');
+  return s;
+}
+
+function traceTags(page: Page, tag: string) {
   return page.evaluate(
     (t) => (window.__hive_scrolltrace || []).filter((e) => e.tag === t).length,
     tag,
@@ -171,14 +197,14 @@ function traceTags(page, tag) {
 // Bursty: awk floods `burst` lines flat-out, then sleeps — keeps
 // xterm's async write queue loaded the way codex output does, without
 // an unbounded loop that could leak past teardown.
-async function startMarkerPump(page, count, burst = 40) {
+async function startMarkerPump(page: Page, count: number, burst = 40) {
   await page.keyboard.type(
     `i=0; while [ $i -lt ${count} ]; do awk -v s=$i -v n=${burst} 'BEGIN{for(j=s;j<s+n;j++) printf "HIVE_SCROLL_%06d ................................................\\n", j}'; i=$((i+${burst})); sleep 0.05; done; echo HIVE_PUMP_DONE\n`,
   );
 }
 
-function extractMarkers(lines) {
-  const out = [];
+function extractMarkers(lines: string[]) {
+  const out: number[] = [];
   for (const l of lines) {
     const m = l.match(/HIVE_SCROLL_(\d{6})/);
     if (m) out.push(parseInt(m[1], 10));
@@ -250,7 +276,7 @@ test('viewport converges to the bottom after a mode switch under continuous outp
   // bug class this guards against -- a stale restore pinning the
   // viewport in history forever -- still fails convergence.
   const atBottom = async () => {
-    const s = await scrollState(page);
+    const s = await mustScrollState(page);
     return s ? s.baseY - s.viewportY : NaN;
   };
 
@@ -324,7 +350,7 @@ test('full scrollback: an unscrolled user is not stranded in history by a resize
 
   await page.waitForTimeout(1500); // let the last replay land
 
-  const s = await scrollState(page);
+  const s = await mustScrollState(page);
   const restores = await page.evaluate(() =>
     (window.__hive_scrolltrace || []).filter((e) => e.tag === 'replay-restore'),
   );
@@ -372,7 +398,7 @@ test('a reader scrolled into history is not yanked to the bottom by a resize rep
     await page.mouse.wheel(0, -300);
     await page.waitForTimeout(50);
   }
-  const before = await scrollState(page);
+  const before = await mustScrollState(page);
   expect(before.viewportY).toBeLessThan(before.baseY);
 
   // A viewport resize big enough to cross REPLAY_COL_THRESHOLD fires a
@@ -381,7 +407,7 @@ test('a reader scrolled into history is not yanked to the bottom by a resize rep
   await page.waitForTimeout(1500);
 
   expect(await traceTags(page, 'replay-request')).toBeGreaterThan(0);
-  const after = await scrollState(page);
+  const after = await mustScrollState(page);
   expect(
     after.viewportY,
     'replay-done yanked the reader to the bottom',

--- a/cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+// `state.terms` is a Map<string, TermTile> — the deliberately narrow structural
+// view app modules use (app/state.ts). These specs poke the concrete tile the
+// map actually holds, which is what carries the real xterm Terminal, so they
+// assert SessionTerm rather than widening TermTile for every app caller and
+// DOM-test stub (wave 5b's rule).
+import type { SessionTerm } from '../../src/app/session-term.js';
 
 // Regression guard for the restream strand: a FOLLOWING viewport must stay
 // pinned to the bottom for the WHOLE resize-replay restream, not just end
@@ -37,7 +43,7 @@ test.afterEach(async ({ page }, testInfo) => {
   }
 });
 
-async function bootWithTerm(page) {
+async function bootWithTerm(page: Page) {
   // Quarantined on CI: flaky setup under CI CPU contention (spec 245). Runs
   // locally via `npm run test:e2e:real`. Re-gate per spec 245 (10 green runs).
   test.skip(!!process.env.CI, 'quarantined on CI — flaky setup, spec 245');
@@ -55,24 +61,33 @@ async function bootWithTerm(page) {
   );
   await page.evaluate(() => {
     const h =
-      document.querySelector('.term-host.active .xterm-helper-textarea') ||
-      document.querySelector('.term-host .xterm-helper-textarea');
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host.active .xterm-helper-textarea',
+      ) ||
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host .xterm-helper-textarea',
+      );
+    // The waitForFunction above already proved it exists; throwing here says
+    // so rather than turning a broken wait into a silently unfocused term.
+    if (!h) throw new Error('no xterm helper textarea to focus');
     h.focus();
   });
   await page.keyboard.type('stty -echo\n');
   await page.waitForTimeout(200);
 }
 
-function scrollState(page) {
+function scrollState(page: Page) {
   return page.evaluate(() => {
-    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+      | SessionTerm
+      | undefined;
     const buf = st?.term?.buffer?.active;
     if (!buf) return null;
     return { viewportY: buf.viewportY, baseY: buf.baseY, type: buf.type };
   });
 }
 
-function traceTags(page, tag) {
+function traceTags(page: Page, tag: string) {
   return page.evaluate(
     (t) => (window.__hive_scrolltrace || []).filter((e) => e.tag === t).length,
     tag,
@@ -110,7 +125,9 @@ test('single full-buffer session: no transient viewport-jump on threshold-crossi
     for (let i = 0; i < 4; i++) {
       await page.waitForTimeout(90);
       const s = await page.evaluate(() => {
-        const st = [...(window.__hive_state?.terms?.values() || [])][0];
+        const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+          | SessionTerm
+          | undefined;
         const buf = st?.term?.buffer?.active;
         if (!buf) return null;
         return {
@@ -144,7 +161,9 @@ test('single full-buffer session: no transient viewport-jump on threshold-crossi
     .poll(
       async () =>
         page.evaluate(() => {
-          const st = [...(window.__hive_state?.terms?.values() || [])][0];
+          const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+            | SessionTerm
+            | undefined;
           const buf = st?.term?.buffer?.active;
           return buf ? buf.baseY - buf.viewportY : null;
         }),

--- a/cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.ts
@@ -1,4 +1,24 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+// `state.terms` is a Map<string, TermTile> — the deliberately narrow structural
+// view app modules use (app/state.ts). These specs poke the concrete tile the
+// map actually holds, which is what carries the real xterm Terminal, so they
+// assert SessionTerm rather than widening TermTile for every app caller and
+// DOM-test stub (wave 5b's rule).
+import type { SessionTerm } from '../../src/app/session-term.js';
+
+// `wheelDeltaY` is a legacy read-only getter, not a WheelEventInit member, so
+// it rides along here and is installed on the instance (see dispatchWheel).
+// `view` is omitted because comparing the app's augmented Window back to lib
+// DOM's Window trips a structural check in the clipboard types; no spec passes
+// it, and the event's default view is the page's own.
+type WheelInit = Omit<WheelEventInit, 'view'> & { wheelDeltaY?: number };
+
+// The scrollLines spy below lives only for the duration of one spec. Local
+// types rather than a `declare global`: these are not part of the app's
+// runtime surface, and a global declaration would advertise them to src/ too
+// (see test/e2e/hive-global.d.ts on why that file's globals are program-wide).
+type SpyWindow = Window & { __takeoverCalls?: number };
+type SpyTerm = SessionTerm & { __wheelWrapped?: boolean };
 
 // Repro for "the terminal won't scroll by mouse wheel or trackpad on one of my
 // Macs" (selection-drag still scrolls). PR #229 theorized a WKWebView quirk
@@ -55,7 +75,7 @@ test.afterEach(async ({ page }, testInfo) => {
   }
 });
 
-async function bootWithTerm(page) {
+async function bootWithTerm(page: Page) {
   test.skip(!WS_URL, 'WS_BRIDGE_URL not set — globalSetup did not run');
   await page.goto('/');
   await page.waitForFunction(
@@ -70,8 +90,15 @@ async function bootWithTerm(page) {
   );
   await page.evaluate(() => {
     const helper =
-      document.querySelector('.term-host.active .xterm-helper-textarea') ||
-      document.querySelector('.term-host .xterm-helper-textarea');
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host.active .xterm-helper-textarea',
+      ) ||
+      document.querySelector<HTMLTextAreaElement>(
+        '.term-host .xterm-helper-textarea',
+      );
+    // The waitForFunction above already proved it exists; throwing here says
+    // so rather than turning a broken wait into a silently unfocused term.
+    if (!helper) throw new Error('no xterm helper textarea to focus');
     helper.focus();
   });
   await page.keyboard.type('stty -echo\n');
@@ -81,15 +108,17 @@ async function bootWithTerm(page) {
 // Bounded high-rate marker pump (bursty: flood, sleep) — fills scrollback so
 // there is history above the viewport to scroll INTO, then stops so the read
 // position is stable.
-async function startMarkerPump(page, count, burst = 40) {
+async function startMarkerPump(page: Page, count: number, burst = 40) {
   await page.keyboard.type(
     `i=0; while [ $i -lt ${count} ]; do awk -v s=$i -v n=${burst} 'BEGIN{for(j=s;j<s+n;j++) printf "HIVE_SCROLL_%06d ................................................\\n", j}'; i=$((i+${burst})); sleep 0.05; done; echo HIVE_PUMP_DONE\n`,
   );
 }
 
-function bufferLines(page) {
+function bufferLines(page: Page) {
   return page.evaluate(() => {
-    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+      | SessionTerm
+      | undefined;
     const buf = st?.term?.buffer?.active;
     if (!buf) return [];
     const out = [];
@@ -100,13 +129,25 @@ function bufferLines(page) {
   });
 }
 
-function scrollState(page) {
+function scrollState(page: Page) {
   return page.evaluate(() => {
-    const st = [...(window.__hive_state?.terms?.values() || [])][0];
+    const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+      | SessionTerm
+      | undefined;
     const buf = st?.term?.buffer?.active;
     if (!buf) return null;
     return { viewportY: buf.viewportY, baseY: buf.baseY, type: buf.type };
   });
+}
+
+// Every direct-assertion site below has already waited for the term to attach,
+// so a null there is a broken wait rather than a state worth asserting on.
+// expect.poll() keeps using scrollState(), which must tolerate the
+// not-yet-attached window.
+async function mustScrollState(page: Page) {
+  const s = await scrollState(page);
+  if (!s) throw new Error('no term buffer — the boot wait did not hold');
+  return s;
 }
 
 // Dispatch a real WheelEvent at the element actually under the terminal's
@@ -114,12 +155,13 @@ function scrollState(page) {
 // event must propagate up through the capture phase to SessionTerm's listener
 // on .term-host. This is faithful to a webview-delivered gesture: it exercises
 // not just the handler math but that the event PATH reaches the handler at all.
-async function dispatchWheel(page, init, times = 6) {
+async function dispatchWheel(page: Page, init: WheelInit, times = 6) {
   await page.evaluate(
     ({ init, times }) => {
       const host =
-        document.querySelector('.term-host.active') ||
-        document.querySelector('.term-host');
+        document.querySelector<HTMLElement>('.term-host.active') ||
+        document.querySelector<HTMLElement>('.term-host');
+      if (!host) throw new Error('no .term-host to dispatch the wheel at');
       const r = host.getBoundingClientRect();
       const target =
         document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2) ||
@@ -152,30 +194,35 @@ async function dispatchWheel(page, init, times = 6) {
 // dispatched gesture. Distinguishes "handler bailed, event went to the app"
 // (count 0 — correct under mouse tracking / alt buffer) from "handler ran"
 // (count > 0). Wraps scrollLines once per session and resets the counter per call.
-async function countTakeover(page, init) {
+async function countTakeover(page: Page, init: WheelInit) {
   await page.evaluate(() => {
-    const st = [...(window.__hive_state?.terms?.values() || [])][0];
-    window.__takeoverCalls = 0;
+    const w = window as SpyWindow;
+    const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+      | SpyTerm
+      | undefined;
+    w.__takeoverCalls = 0;
     if (st && !st.__wheelWrapped) {
       const orig = st.term.scrollLines.bind(st.term);
-      st.term.scrollLines = (n) => {
-        window.__takeoverCalls++;
+      st.term.scrollLines = (n: number) => {
+        w.__takeoverCalls = (w.__takeoverCalls ?? 0) + 1;
         return orig(n);
       };
       st.__wheelWrapped = true;
     }
   });
   await dispatchWheel(page, init);
-  return page.evaluate(() => window.__takeoverCalls);
+  return page.evaluate(() => (window as SpyWindow).__takeoverCalls ?? 0);
 }
 
 // Make the running program enable mouse tracking (DECSET 1000), as Claude/vim
 // do. The bytes flow shell → pty → xterm, which sets term.modes.mouseTrackingMode.
-async function enableMouseTracking(page) {
+async function enableMouseTracking(page: Page) {
   await page.keyboard.type("printf '\\033[?1000h'\n");
   await page.waitForFunction(
     () => {
-      const st = [...(window.__hive_state?.terms?.values() || [])][0];
+      const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+        | SessionTerm
+        | undefined;
       return (
         st?.term?.modes?.mouseTrackingMode &&
         st.term.modes.mouseTrackingMode !== 'none'
@@ -188,11 +235,13 @@ async function enableMouseTracking(page) {
 
 // Switch the session into the alternate screen buffer (DECSET 1049), as a
 // full-screen TUI does — there is no scrollback there, so scrollLines is a no-op.
-async function enterAltBuffer(page) {
+async function enterAltBuffer(page: Page) {
   await page.keyboard.type("printf '\\033[?1049h'\n");
   await page.waitForFunction(
     () => {
-      const st = [...(window.__hive_state?.terms?.values() || [])][0];
+      const st = [...(window.__hive_state?.terms?.values() || [])][0] as
+        | SessionTerm
+        | undefined;
       return st?.term?.buffer?.active?.type === 'alternate';
     },
     null,
@@ -202,7 +251,7 @@ async function enterAltBuffer(page) {
 
 // Fill scrollback and confirm the viewport is following the bottom, so any
 // subsequent upward move is unambiguously the wheel gesture's doing.
-async function primeScrollback(page) {
+async function primeScrollback(page: Page) {
   await bootWithTerm(page);
   await startMarkerPump(page, 200);
   await expect
@@ -211,7 +260,7 @@ async function primeScrollback(page) {
       intervals: [250, 500],
     })
     .toContain('HIVE_PUMP_DONE');
-  const at = await scrollState(page);
+  const at = await mustScrollState(page);
   expect(at.baseY, 'scrollback should be populated').toBeGreaterThan(0);
   expect(at.viewportY, 'viewport should start at the bottom').toBe(at.baseY);
 }
@@ -225,7 +274,7 @@ test('pixel-mode wheel scrolls into history (control — the working path)', asy
 }) => {
   await primeScrollback(page);
   await dispatchWheel(page, { deltaMode: 0, deltaY: -300 });
-  const after = await scrollState(page);
+  const after = await mustScrollState(page);
   expect(after.viewportY, 'pixel wheel did not scroll up').toBeLessThan(
     after.baseY,
   );
@@ -236,7 +285,7 @@ test('pixel-mode wheel scrolls into history (control — the working path)', asy
 test('line-mode wheel scrolls into history (deltaMode 1)', async ({ page }) => {
   await primeScrollback(page);
   await dispatchWheel(page, { deltaMode: 1, deltaY: -3 });
-  const after = await scrollState(page);
+  const after = await mustScrollState(page);
   expect(after.viewportY, 'line-mode wheel did not scroll up').toBeLessThan(
     after.baseY,
   );
@@ -249,7 +298,7 @@ test('legacy wheelDeltaY-only wheel scrolls into history (deltaY 0)', async ({
 }) => {
   await primeScrollback(page);
   await dispatchWheel(page, { deltaMode: 0, deltaY: 0, wheelDeltaY: 120 });
-  const after = await scrollState(page);
+  const after = await mustScrollState(page);
   expect(
     after.viewportY,
     'wheelDeltaY-only wheel did not scroll up',

--- a/cmd/hivegui/frontend/test/e2e-real/ws-shim.d.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/ws-shim.d.ts
@@ -7,7 +7,11 @@
 // test/e2e/hive-global.d.ts hand-writes `process` instead.
 //
 // The spec only ever calls the constructor, and only through the DOM
-// WebSocket surface, so that is all this declares.
+// WebSocket surface, so that is all this declares. The lie runs one way:
+// `ws`-only APIs (ws.on('message')) correctly fail to compile, while
+// DOM-only ones `ws` never implemented (dispatchEvent, binaryType 'blob')
+// would typecheck and throw on the Node < 22 path. Keep the call site to
+// the members below and that stays theoretical.
 declare module 'ws' {
   export const WebSocket: typeof globalThis.WebSocket;
 }

--- a/cmd/hivegui/frontend/test/e2e-real/ws-shim.d.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/ws-shim.d.ts
@@ -1,0 +1,13 @@
+// Minimal typing for the `ws` package, used by scroll-codex.spec's Node-side
+// JSON-RPC client on Node < 22 (no global WebSocket).
+//
+// Deliberately NOT `@types/ws`: that package pulls in @types/node, whose
+// globals are program-wide — setTimeout starts returning NodeJS.Timeout and
+// src/app/{session-term,view}.ts stop compiling. Same reason
+// test/e2e/hive-global.d.ts hand-writes `process` instead.
+//
+// The spec only ever calls the constructor, and only through the DOM
+// WebSocket surface, so that is all this declares.
+declare module 'ws' {
+  export const WebSocket: typeof globalThis.WebSocket;
+}

--- a/cmd/hivegui/frontend/tsconfig.json
+++ b/cmd/hivegui/frontend/tsconfig.json
@@ -41,10 +41,8 @@
   // substitution is invisible to tsc), so they are checked only by being named
   // here — the trap the comment above describes, and the reason the glob
   // widened in the same commit as the rename.
-  //
-  // test/e2e-real is still file-by-file: its 5 *.spec.js are wave 7c's job,
-  // and widening ahead of the wave that converts them would cost the
-  // belt-and-braces for nothing.
+  // test/e2e-real joined them in wave 7c, the last of the migration. Its
+  // globalSetup/globalTeardown stay .mjs and are skipped by `checkJs: false`.
   "include": [
     "src/lib/**/*",
     "src/app/**/*",
@@ -54,7 +52,7 @@
     "test/unit/**/*",
     "test/dom/**/*",
     "test/e2e/**/*",
-    "test/e2e-real/wails-bridge.ts"
+    "test/e2e-real/**/*"
   ],
   "exclude": ["node_modules", "dist", "wailsjs"]
 }

--- a/docs/exec-plans/active/typescript-migration.md
+++ b/docs/exec-plans/active/typescript-migration.md
@@ -2,7 +2,8 @@
 
 - **Spec:** [docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md](../../analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md) §2c
 - **Issue:** TBD
-- **Stage:** IMPLEMENT (waves 1–6 merged, wave 7a done; wave 7b next — the last)
+- **Stage:** IMPLEMENT (waves 1–7c done — every file converted; wave 7d, the
+  stale-path sweep + closeout, is the last)
 - **Status:** active
 
 ## Summary
@@ -812,13 +813,65 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
   through the renamed HTML entrypoint, so its 84 passing tests non-vacuously
   verify the load-bearing `main.ts` path.
 
+- **2026-08-09** — Wave 7c complete: the 5 `test/e2e-real/*.spec.ts`, and
+  `tsconfig.include` swapped `test/e2e-real/wails-bridge.ts` for
+  `test/e2e-real/**/*` (invariant 6 — nothing imports a spec). 78 errors after
+  the `git mv`, all but four families mechanical implicit-anys and
+  `possibly null` DOM lookups.
+  - **`@types/ws` was installed and then reverted — do not reach for it.**
+    `scroll-codex.spec` falls back to the `ws` package on Node < 22 (no global
+    `WebSocket`), which is `TS7016` untyped. `@types/ws` depends on
+    `@types/node`, whose globals are program-wide: `setTimeout` starts
+    returning `NodeJS.Timeout` and `src/app/{session-term,view}.ts` — files this
+    wave never touched — stop compiling. Replaced with a 2-line
+    `test/e2e-real/ws-shim.d.ts` declaring only the constructor, the same call
+    `test/e2e/hive-global.d.ts` made for `process`.
+  - **The specs assert `SessionTerm`, following 7b's precedent.** `state.terms`
+    is `Map<string, TermTile>`, whose `term` is the narrow structural stub; every
+    e2e-real buffer probe (`buffer.active.getLine`, `scrollLines`, `modes`) needs
+    the real xterm `Terminal`, which only the concrete tile carries. One cast per
+    probe site, never a widened `TermTile`.
+  - **Test-only spies stay local types, not `declare global`.**
+    `wheel-scroll.spec`'s `__takeoverCalls` / `__wheelWrapped` are
+    `Window & {…}` / `SessionTerm & {…}` aliases used at the cast site.
+    A `declare global` in an included file is visible to `src/**` too —
+    `hive-global.d.ts` says so about its own contents, and a spy that exists for
+    the length of one spec has no business in the app's surface.
+  - `WheelInit` is `Omit<WheelEventInit, 'view'> & { wheelDeltaY?: number }`.
+    `wheelDeltaY` is a legacy getter, not a ctor member (it is installed on the
+    instance); `view` is omitted because structurally comparing the augmented
+    `Window` back to lib DOM's `Window` fails deep inside the clipboard types.
+  - `mustScrollState()` wraps the nullable `scrollState()` for the direct
+    assertion sites, which have all already waited for the term; `expect.poll()`
+    keeps the nullable form, since tolerating the not-yet-attached window is the
+    whole point of polling. Same for the four `helper.focus()` sites, which now
+    throw a named error instead of silently focusing nothing.
+
+  Gates: typecheck/build/biome green, vitest 344 in 33 files (unchanged),
+  Playwright mock 84 passed + 1 skipped (unchanged), `check-spec-discovery`
+  collects all 17 + all 5. e2e-real 12 discovered, 9 passed / 3 failed — the
+  same three specs, and the same result as the baseline measured on this branch
+  before the `git mv`. Non-vacuity proved in all five converted files with a
+  planted `const _probe: string = 1`.
+
+  **The stale-path sweep is NOT in this wave** — see the follow-up below.
+
 ## Follow-ups
 
 Open items carried out of waves 1–7a. Each is a decision or a task, not a finding — the
 findings live in the wave notes above.
 
-- ~~**Wave 7 should be two PRs, not one.**~~ **Accepted 2026-08-08.** Wave 7a
-  is complete; wave 7b owns the 22 spec files, fixture pair, and stale-path sweep.
+- ~~**Wave 7 should be two PRs, not one.**~~ **Accepted 2026-08-08**, and it
+  became three: 7a (composition root), 7b (17 mock specs + fixture pair), 7c
+  (5 e2e-real specs). Every `.js`/`.mjs` that was ever going to convert has.
+- **The stale-path sweep is all that is left of the migration**, and it is now a
+  wave of its own (7d) — it touches no `.ts` and cannot break a build, so
+  bundling it with a spec conversion only made both harder to review. Populations
+  1–3 in the wave-7 inventory still stand as written; spot-checked 2026-08-09,
+  `AGENTS.md:138`, `cmd/hivegui/{app.go:135,221, menu_darwin.go:18,
+  menu_other.go:18}`, `index.html:29`, `playwright.real.config.js:12` and the
+  in-frontend comment population are all still stale. Land it with the two
+  closeout items below.
 - **`applyFontSize`'s `st.term?.options` guard is undecided** (`session-term.ts`, raised in
   #267's review, deferred by the user). It turns what would have been a `TypeError` on a
   tile with no `term` into a silent no-op. Unreachable in production — the constructor


### PR DESCRIPTION
Last wave that converts a file. `test/e2e-real/{glyph-utf8,lifecycle,scroll-codex,scroll-restream-strand,wheel-scroll}.spec.js` → `.ts`, and `tsconfig.include` swaps the single named harness path for `test/e2e-real/**/*` (invariant 6 — nothing imports a spec, so being named is the only thing that puts it in the program).

After this, no `.js`/`.mjs` under `frontend/` is left to convert except the 7 the plan always excluded: the four configs, `globalSetup/Teardown.mjs`, and `check-spec-discovery.mjs`.

## Three calls worth reviewing

**`ws-shim.d.ts`, not `@types/ws`.** `scroll-codex.spec` falls back to the `ws` package when Node has no global `WebSocket` (< 22; CI runs 20), which is `TS7016`. `@types/ws` depends on `@types/node`, and those globals are program-wide: `setTimeout` starts returning `NodeJS.Timeout` and `src/app/session-term.ts` + `src/app/view.ts` — files this wave never touches — stop compiling. I installed it, saw that, and reverted; `package.json` is unchanged. The shim declares only the constructor, the same call `test/e2e/hive-global.d.ts` already made for `process`.

**Buffer probes assert `SessionTerm`** (7b's precedent, `grid-scroll-regressions.spec.ts:180-185`). `state.terms` is `Map<string, TermTile>`, whose `term` is the deliberately narrow structural stub; `buffer.active.getLine`, `scrollLines` and `modes` exist only on the real xterm `Terminal` that the concrete tile carries. One cast per probe site rather than widening `TermTile` for every app caller and DOM-test stub.

**Test-only spies stay local type aliases.** `wheel-scroll`'s `__takeoverCalls` / `__wheelWrapped` are `Window & {…}` / `SessionTerm & {…}` at the cast site, not a `declare global` — an included `.d.ts` advertises its globals to `src/` too, which `hive-global.d.ts` says about its own contents.

Smaller ones: `mustScrollState()` wraps the nullable `scrollState()` at the direct-assertion sites (all of which already waited for the term) while `expect.poll()` keeps the nullable form, since tolerating a not-yet-attached window is what polling is for; the four `helper.focus()` lookups now throw a named error instead of silently focusing nothing; `WheelInit` omits `view` because structurally comparing the augmented `Window` back to lib DOM's trips a check deep in the clipboard types.

## Gates

All re-measured on this branch, not copied.

- `tsc --noEmit` 0 errors. Non-vacuity proved per file with a planted `const _probe: string = 1` in each of the five.
- `npm run build`, `biome ci .` green.
- `scripts/check-spec-discovery.mjs`: 17/17 and 5/5 collected.
- vitest 344 tests / 33 files — unchanged.
- Playwright mock 84 passed + 1 skipped — unchanged.
- e2e-real 12 discovered, 9 passed / 3 failed: `scroll-codex.spec:215`, `scroll-codex.spec:262`, `scroll-restream-strand.spec:97` — identical to the baseline run on this branch before the `git mv`, and members of the known flaky set (that suite is `test.skip`ped on CI).

No GUI smoke: this wave changes no source behavior, only test-side annotations.

## Not in this PR

The stale-path sweep, which the plan had bundled into wave 7. It touches no `.ts` and cannot break a build, so it lands as 7d with the two closeout items (mark phase-2 §2c DONE, move the plan to `docs/exec-plans/completed/`). Recorded in the plan's follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated browser test coverage and reliability for terminal focus, scrolling, replay integrity, resizing, and mouse-wheel interactions.
  * Added clearer failure handling when terminal controls or state are unavailable.

* **Documentation**
  * Updated the TypeScript migration plan to reflect completed work and remaining closeout tasks.

* **Chores**
  * Expanded type checking across the real-browser test suite and strengthened supporting tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->