### PR TITLE
frontend: TypeScript migration wave 7d — stale-path sweep + closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ omitting one creates drift that confuses users and other contributors.
 ### Required updates for any new or changed keybinding
 
 1. **Keymap** — add or update the binding in `src/lib/keymap.ts`. Use the
-   platform helpers in `src/lib/platform.js` (⌘ on macOS, Ctrl elsewhere)
+   platform helpers in `src/lib/platform.ts` (⌘ on macOS, Ctrl elsewhere)
    rather than hard-coding a modifier.
 2. **Help overlay + command palette** — make sure the action appears with its
    binding in the `⌘/` keyboard-shortcuts overlay and the command palette.

--- a/cmd/hived-ws-bridge/main.go
+++ b/cmd/hived-ws-bridge/main.go
@@ -7,7 +7,7 @@
 // It exists to make the Wails-fronted GUI testable end-to-end against
 // the real daemon without spawning the native Wails process — the
 // Vite-dev frontend imports a thin JS bridge (test/e2e-real/
-// wails-bridge.js) that talks to this shim over WS, in place of the
+// wails-bridge.ts) that talks to this shim over WS, in place of the
 // generated Wails runtime + App bindings.
 //
 // Isolation contract: this binary refuses to start unless HIVE_SOCKET

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -132,7 +132,7 @@ func (a *App) startup(ctx context.Context) {
 	// Opt out of macOS App Nap / activity-based timer throttling. Defensive
 	// hygiene so a backgrounded webview keeps streaming PTY output and
 	// repainting — NOT the fix for the reported freeze (that was a synchronous
-	// full-ring scrollback replay; see session-term.js). See internal/activity.
+	// full-ring scrollback replay; see session-term.ts). See internal/activity.
 	activity.DisableThrottling()
 	if a.haveInitialPos {
 		wruntime.WindowSetPosition(ctx, a.initialX, a.initialY)
@@ -218,7 +218,7 @@ func (a *App) dialHandshake(hello wire.Hello) (*wire.Client, error) {
 // as "session:list" and "session:event" events.
 //
 // It REPLACES rather than reuses, and that is the whole point. Every caller
-// is a frontend with no session state that needs the snapshot: main.js runs
+// is a frontend with no session state that needs the snapshot: main.ts runs
 // this once per page load, and the reconnect loop runs it after a drop. The
 // snapshot only ever arrives on handshake, so reusing a live connection
 // returned success while leaving a freshly-loaded page with a permanently

--- a/cmd/hivegui/build/darwin/Info.plist
+++ b/cmd/hivegui/build/darwin/Info.plist
@@ -24,7 +24,7 @@
         <!-- Disable macOS App Nap. This is DEFENSIVE hygiene, not the fix for
              the "GUI frozen" reports — that turned out to be a synchronous
              full-ring scrollback replay (see internal/session/vt.go ringCap
-             and the alt-screen replay skip in session-term.js). App Nap can
+             and the alt-screen replay skip in session-term.ts). App Nap can
              still clamp a backgrounded webview's timers to ~1 Hz, and a
              terminal multiplexer must keep streaming PTY output and repainting
              even when it isn't the foreground app, so we opt out regardless. -->

--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -26,7 +26,7 @@
     <ul id="projects"></ul>
     <!-- Version/build readout for hive (GUI) and hived (daemon).
          Both spans start empty: the daemon's version is only known
-         once the control handshake lands, so app/version-footer.js
+         once the control handshake lands, so app/version-footer.ts
          fills these from the "daemon:stale" event. #ver-daemon stays
          hidden while the builds match (the common case) and is
          revealed only on mismatch. -->

--- a/cmd/hivegui/frontend/playwright.real.config.js
+++ b/cmd/hivegui/frontend/playwright.real.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 // Layer B: Playwright suite running against a REAL hived daemon via
-// hived-ws-bridge. globalSetup.js spawns the daemon + bridge with
+// hived-ws-bridge. globalSetup.mjs spawns the daemon + bridge with
 // fully isolated temp paths (HOME / HIVE_STATE_DIR / HIVE_SOCKET) and
 // writes the bridge URL to process.env.WS_BRIDGE_URL. The Vite dev
 // server boots with VITE_WAILS_REAL=1, which makes vite resolve the
@@ -9,7 +9,7 @@ import { defineConfig } from '@playwright/test';
 // instead of the in-browser mock.
 //
 // Specs read process.env.WS_BRIDGE_URL inside a Playwright addInitScript
-// to install window.__WS_BRIDGE_URL before main.js loads.
+// to install window.__WS_BRIDGE_URL before main.ts loads.
 
 export default defineConfig({
   testDir: './test/e2e-real',

--- a/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
+++ b/cmd/hivegui/frontend/scripts/check-spec-discovery.mjs
@@ -15,7 +15,7 @@
 // would spawn a real hived — verified, not assumed).
 //
 // Blind spot, stated so nobody trusts it further than it goes: a rename that
-// stops the file LOOKING like a spec at all (`x.spec.js` → `x.speec.js`)
+// stops the file LOOKING like a spec at all (`x.spec.ts` → `x.speec.ts`)
 // drops off both sides of the comparison and passes. Guarding that needs a
 // baseline of what used to be a spec, which is what `git status` and the
 // per-wave count comparison already are. What this catches is the case those

--- a/cmd/hivegui/frontend/src/app/banners.ts
+++ b/cmd/hivegui/frontend/src/app/banners.ts
@@ -2,10 +2,10 @@
 //
 // Moved verbatim from main.js. initBanners() performs the listener
 // and EventsOn registrations plus the boot-time update poll — the
-// module has no side effects on import, matching events.js's
+// module has no side effects on import, matching events.ts's
 // wireDaemonEvents pattern.
 // isDaemonRestarting() is read by the control:disconnect handler in
-// events.js so a user-initiated restart doesn't flash a red status.
+// events.ts so a user-initiated restart doesn't flash a red status.
 
 import {
   EventsOn,

--- a/cmd/hivegui/frontend/src/app/dom.ts
+++ b/cmd/hivegui/frontend/src/app/dom.ts
@@ -31,7 +31,7 @@ export function setStatus(text: string, isError = false): void {
 }
 
 // flashStatus owns transient per-action feedback; it auto-reverts to
-// the persistent slot (errors linger 6s, info 2.5s — see lib/status.js).
+// the persistent slot (errors linger 6s, info 2.5s — see lib/status.ts).
 export function flashStatus(text: string, isError = false): void {
   statusCtl.flash(text, isError);
 }

--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -2,7 +2,7 @@
 //
 // Moved verbatim from main.js. wireDaemonEvents(deps) registers every
 // EventsOn handler; view/focus callbacks and the scroll tracer are
-// injected because they live in main.js until later stages.
+// injected because they live in main.ts until later stages.
 
 import {
   EventsOn,

--- a/cmd/hivegui/frontend/src/app/focus.ts
+++ b/cmd/hivegui/frontend/src/app/focus.ts
@@ -39,8 +39,8 @@ export function setActive(id: string | null) {
   // Record the DEPARTURE before activeId is overwritten. This lives in
   // setActive rather than switchTo because four selection paths reach
   // setActive directly and would otherwise go unrecorded: tile mousedown
-  // (session-term.js), gridSpatialMove / shiftActiveProject /
-  // minimizeSession (view.js). "No matter how you switched" is the
+  // (session-term.ts), gridSpatialMove / shiftActiveProject /
+  // minimizeSession (view.ts). "No matter how you switched" is the
   // feature, so the hook has to sit on the choke point.
   if (!_navSuppress && id && id !== state.activeId)
     pushNav(state.nav, state.activeId);

--- a/cmd/hivegui/frontend/src/app/keyboard.ts
+++ b/cmd/hivegui/frontend/src/app/keyboard.ts
@@ -68,9 +68,9 @@ let deps: KeyboardDeps = {
   bumpFontSize: () => {},
   resetFontSize: () => {},
   focusActiveTerm: () => {},
-  // Injected from main.js like focusActiveTerm above: keyboard.ts must
+  // Injected from main.ts like focusActiveTerm above: keyboard.ts must
   // not import the focus pipeline directly (see the acyclic-modules
-  // note at the wiring block in main.js). The default still RUNS fn —
+  // note at the wiring block in main.ts). The default still RUNS fn —
   // an un-wired harness gets working navigation without suppression,
   // not a silently swallowed switch.
   withoutNavHistory: (fn) => fn(),
@@ -509,7 +509,7 @@ export function switchToNthSession(n: number) {
   if (n - 1 < ord.length) switchTo(ord[n - 1].id);
 }
 
-// Debug: arm/disarm the scroll tracer. trace.js latches hive.debug at
+// Debug: arm/disarm the scroll tracer. trace.ts latches hive.debug at
 // module load, so the new state only takes effect after a reload — do it
 // here so the user never needs the devtools console to flip the gate.
 function toggleScrollDebug() {
@@ -524,7 +524,7 @@ function toggleScrollDebug() {
   } catch {
     /* storage off */
   }
-  // The reload is intentional and unavoidable: trace.js reads hive.debug
+  // The reload is intentional and unavoidable: trace.ts reads hive.debug
   // once at module load, so the new state only takes effect on a fresh load.
   // The menu label says "(Reloads)" so this isn't a surprise.
   location.reload();
@@ -532,7 +532,7 @@ function toggleScrollDebug() {
 
 // Debug: copy the captured scroll trace to the clipboard via the Go side
 // (works without devtools and without a clipboard user-gesture). Reuses
-// window.__hive_dumpscroll (trace.js) so the dump shape matches what the
+// window.__hive_dumpscroll (trace.ts) so the dump shape matches what the
 // e2e harness and bug reports expect.
 function copyScrollTrace() {
   const dump =

--- a/cmd/hivegui/frontend/src/app/modals/command-palette.ts
+++ b/cmd/hivegui/frontend/src/app/modals/command-palette.ts
@@ -1,13 +1,13 @@
 // ---------- command palette ----------
 //
-// Moved verbatim from main.js. The command table is BUILT by main.js
+// Moved verbatim from main.js. The command table is BUILT by main.ts
 // (the actions live there until later stages) and handed to
 // initCommandPalette — this module owns only the palette UI.
 
 import { registerModal } from './registry.js';
 import { pageEl } from '../el.js';
 
-// One row of the command table main.js builds and hands over.
+// One row of the command table main.ts builds and hands over.
 export interface PaletteCommand {
   id: string;
   name: string;

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -2,7 +2,7 @@
 //
 // Moved verbatim from main.js. Focus-pipeline callbacks are injected
 // via initLauncher(deps) — the launcher must never import the focus
-// pipeline directly (main.js owns that wiring).
+// pipeline directly (main.ts owns that wiring).
 
 import {
   CreateSession,
@@ -247,7 +247,7 @@ function renderLauncherList() {
   highlightLauncherSelection();
 }
 
-// projectId is optional, not just nullable: main.js, keyboard.js and
+// projectId is optional, not just nullable: main.ts, keyboard.ts and
 // view.ts all call openLauncher() bare and let the `|| activeProjectId()`
 // fallback below pick the project. Wave 5a typed it as required because
 // every one of those callers was still unchecked JS.
@@ -497,7 +497,7 @@ export function initLauncher(injected: LauncherDeps) {
   // The launcher owns its keyboard while open, the way the command
   // palette and settings do — it has to, now that the filter box holds
   // focus and lib/focus.ts hands the keyboard to a focused <input>.
-  // keyboard.js bails out for #launcher for the same reason.
+  // keyboard.ts bails out for #launcher for the same reason.
   launcherEl.addEventListener('keydown', (e) => {
     const handle = (fn: () => void) => {
       e.preventDefault();
@@ -513,13 +513,13 @@ export function initLauncher(injected: LauncherDeps) {
     if (cmdOrCtrl(e) && (e.key === 'n' || e.key === 'N'))
       return handle(closeLauncher);
     // ⌘T / ⇧⌘T while already open re-opens (and so clears the query).
-    // keyboard.js used to give us this for free — its launcher block
+    // keyboard.ts used to give us this for free — its launcher block
     // fell through on unhandled keys and hit the global ⌘T binding
     // further down. Now that it bails out for #launcher entirely, the
     // binding has to be repeated here or it would silently stop working.
     if (cmdOrCtrl(e) && (e.key === 't' || e.key === 'T'))
       return handle(() => {
-        // Same two calls as the global binding in keyboard.js — passing
+        // Same two calls as the global binding in keyboard.ts — passing
         // undefined re-resolves the active project rather than pinning
         // the one this opening was anchored to.
         if (e.shiftKey) openLauncher(undefined, { forceWorktree: true });
@@ -563,7 +563,7 @@ export function initLauncher(injected: LauncherDeps) {
     if (target === searchEl) return;
     e.preventDefault();
   });
-  // Focus leaving the launcher closes it. keyboard.js now bails out for
+  // Focus leaving the launcher closes it. keyboard.ts now bails out for
   // the whole window whenever #launcher is visible, and this module's
   // own keydown listener only fires while focus is inside it — so a
   // launcher that stays visible after focus moves away is a launcher

--- a/cmd/hivegui/frontend/src/app/modals/registry.ts
+++ b/cmd/hivegui/frontend/src/app/modals/registry.ts
@@ -1,5 +1,5 @@
 // Modal registry — the seam that lets the focus pipeline ask "does a
-// modal own the keyboard?" without main.js hard-coding every modal
+// modal own the keyboard?" without main.ts hard-coding every modal
 // element. Each modal module registers its root element at init;
 // anyModalOpen() is consumed by focusSnapshot (and is the ONLY
 // intentional behavior-adjacent edit of the modularization — it

--- a/cmd/hivegui/frontend/src/app/modals/settings.ts
+++ b/cmd/hivegui/frontend/src/app/modals/settings.ts
@@ -161,7 +161,7 @@ export function openSettings() {
   // Re-entry must not discard an in-progress draft. This is reachable
   // on macOS: the native File ▸ Settings… accelerator consumes ⌘,
   // before the webview's keydown listener sees it (same precedence
-  // that makes the '?' branch in keyboard.js dead on darwin, per
+  // that makes the '?' branch in keyboard.ts dead on darwin, per
   // menu_darwin.go), so pressing ⌘, with the modal already open
   // arrives here as menu:settings rather than as the toggle-to-close
   // in the keydown gate. Without this guard the `draft = []` below
@@ -259,7 +259,7 @@ export function initSettings(injected: SettingsDeps) {
   settingsEl.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
       // Consume it. This listener fires before the window handler in
-      // keyboard.js, which would otherwise see an already-hidden
+      // keyboard.ts, which would otherwise see an already-hidden
       // dialog, fall past its settings gate, and spend the same
       // Escape on whatever is behind the modal.
       e.preventDefault();

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -621,7 +621,7 @@ export class SessionTerm {
     // from firing. wheelToScrollLines normalizes deltaMode / legacy
     // wheelDeltaY so the cap math doesn't collapse to zero (and the
     // terminal become unscrollable) on WKWebView builds that report
-    // wheel events in line/page mode — see lib/wheel-scroll.js.
+    // wheel events in line/page mode — see lib/wheel-scroll.ts.
     const linesPerPixel = 1 / 14; // ~one line per ~14 px of delta
     const maxLinesPerEvent = 8; // about half a screen on a small tile
     this.host.addEventListener(
@@ -872,7 +872,7 @@ export class SessionTerm {
   _onWebglContextLoss() {
     // The current addon's context died (commonly: too many WebGL
     // contexts process-wide). Recovery logic — dispose, reattach, fall
-    // back to refresh — lives in lib/renderer-recovery.js so it can be
+    // back to refresh — lives in lib/renderer-recovery.ts so it can be
     // unit-tested without xterm or a real WebGL context.
     const dead = this.webgl;
     this.webgl = null;

--- a/cmd/hivegui/frontend/src/app/sidebar.ts
+++ b/cmd/hivegui/frontend/src/app/sidebar.ts
@@ -3,7 +3,7 @@
 // Moved verbatim from main.js. View/focus callbacks (switchTo,
 // switchToProject, confirmAndDeleteProject, renderEmptyState,
 // refocusActiveTerm) are injected via initSidebar(deps) — they still
-// live in main.js until later stages.
+// live in main.ts until later stages.
 
 import { UpdateSession, UpdateProject } from '../bridge.js';
 import {
@@ -20,7 +20,7 @@ import { beginInlineRename } from './inline-rename.js';
 
 // Per-module, not a shared deps union: sidebar wants refocusActiveTerm
 // where view wants focusActiveTerm, and one union type would loosen both.
-// Exported so wave 7 can check main.js's injection site against it.
+// Exported so wave 7 can check main.ts's injection site against it.
 export interface SidebarDeps {
   switchTo: (id: string) => void;
   switchToProject: (pid: string) => void;

--- a/cmd/hivegui/frontend/src/app/state.ts
+++ b/cmd/hivegui/frontend/src/app/state.ts
@@ -1,7 +1,7 @@
 // ---------- app state ----------
 //
 // The single shared mutable state object. Every app module imports it
-// from here; main.js stays the composition root that wires behavior.
+// from here; main.ts stays the composition root that wires behavior.
 
 import { DEFAULT_FONT_SIZE, clampFont } from '../lib/font.js';
 import { normalizeView, VIEW_STORAGE_KEY } from '../lib/view.js';
@@ -148,7 +148,7 @@ export const state: AppState = {
   //   (Ctrl+- / Ctrl+Shift+-). Deliberately NOT
   //   persisted, unlike `collapsed`: the terminals
   //   are gone after a restart anyway. Written from
-  //   setActive (app/focus.js), the sole writer of
+  //   setActive (app/focus.ts), the sole writer of
   //   activeId, so every switch path is recorded.
   minimized: new Set(), // session ids hidden from grid views; restored via tray
   aliveById: new Map(), // session id -> last-seen Alive bool (for transition detection)

--- a/cmd/hivegui/frontend/src/app/trace.ts
+++ b/cmd/hivegui/frontend/src/app/trace.ts
@@ -5,7 +5,7 @@ import { LogFrontend, SetDebugTrace } from '../bridge.js';
 // focus consistency checker's switch). The gate is latched here at
 // module init: users hitting scroll-jump bugs set the key, RELOAD,
 // reproduce, then dump window.__hive_scrolltrace. The e2e-real scroll
-// specs arm it via addInitScript (before main.js runs) and read the
+// specs arm it via addInitScript (before main.ts runs) and read the
 // ring to prove a scenario actually fired replays.
 // The debug switch — gates EVERYTHING the tracer does: the in-memory ring,
 // the heartbeat watchdog, the scroll-jump detector, and the log tee below.

--- a/cmd/hivegui/frontend/src/app/version-footer.ts
+++ b/cmd/hivegui/frontend/src/app/version-footer.ts
@@ -12,7 +12,7 @@
 // and no extra Wails-bound method to call.
 //
 // This module takes its OWN EventsOn subscription rather than extending
-// the handler in banners.js: that one early-returns on severity ===
+// the handler in banners.ts: that one early-returns on severity ===
 // 'match', which is exactly the case this footer must render (and the
 // overwhelmingly common one). Wails supports multiple listeners per
 // event, so the banner's control flow is left untouched.

--- a/cmd/hivegui/frontend/src/app/view.ts
+++ b/cmd/hivegui/frontend/src/app/view.ts
@@ -3,7 +3,7 @@
 // Moved verbatim from main.js. ensureTerm / setActive /
 // focusActiveTerm and the scroll tracer are injected via
 // initView(deps) — they live in session-term/focus modules (stage 6)
-// and main.js.
+// and main.ts.
 
 import { WindowSetTitle, LogFrontend } from '../bridge.js';
 import { state, type SessionInfo, type TermTile } from './state.js';
@@ -25,7 +25,7 @@ import { isMac } from '../lib/platform.js';
 import { createScrollTrace, type ScrollTrace } from '../lib/scroll-debug.js';
 
 // Per-module deps (view wants focusActiveTerm where sidebar wants
-// refocusActiveTerm). Exported so wave 7 can check main.js's injection.
+// refocusActiveTerm). Exported so wave 7 can check main.ts's injection.
 export interface ViewDeps {
   ensureTerm: (info: SessionInfo) => TermTile;
   setActive: (id: string | null) => void;
@@ -505,13 +505,13 @@ export function renderMinimizedTray() {
 
 // renderEmptyState shows an actionable hint pane when the current
 // scope has nothing to display (first run, empty project, everything
-// minimized). Pure model in lib/empty-state.js; this just projects it
+// minimized). Pure model in lib/empty-state.ts; this just projects it
 // onto the #empty-state element. Cheap enough to call from every
 // repaint path — DOM is rebuilt only when the model changes.
 export function renderEmptyState() {
   // getElementById + a guard, deliberately not el.ts's mustEl/pageEl:
   // this runs on every repaint, not at load, so absence is a tolerated
-  // branch (keyboard.js imports this module into DOM tests that mount
+  // branch (keyboard.ts imports this module into DOM tests that mount
   // only the markup they exercise) rather than a contract to assert.
   const el = document.getElementById('empty-state');
   if (!el) return;

--- a/cmd/hivegui/frontend/src/bridge.ts
+++ b/cmd/hivegui/frontend/src/bridge.ts
@@ -1,6 +1,6 @@
 // Single re-export point for the Wails bridge surface.
 //
-// MUST stay a sibling of main.js: the vite plugin in vite.config.js
+// MUST stay a sibling of main.ts: the vite plugin in vite.config.js
 // substitutes the test harnesses (wails-mock.ts / wails-bridge.ts) by
 // matching the EXACT literal specifiers '../wailsjs/go/main/App' and
 // '../wailsjs/runtime/runtime' — moving this file changes the relative

--- a/cmd/hivegui/frontend/src/lib/empty-state.ts
+++ b/cmd/hivegui/frontend/src/lib/empty-state.ts
@@ -1,4 +1,4 @@
-// Empty-state model for the terminals pane. Pure — main.js renders
+// Empty-state model for the terminals pane. Pure — main.ts renders
 // whatever this returns, tests assert on the model.
 //
 // Returns null when at least one session is visible in the current

--- a/cmd/hivegui/frontend/src/lib/font.ts
+++ b/cmd/hivegui/frontend/src/lib/font.ts
@@ -5,7 +5,7 @@ export const MIN_FONT_SIZE = 8;
 export const MAX_FONT_SIZE = 32;
 
 // `n` is `unknown`, not `number`: callers feed it parsed localStorage
-// (`state.js:43`) and arithmetic on possibly-absent state, so garbage is part
+// (`state.ts:43`) and arithmetic on possibly-absent state, so garbage is part
 // of the contract, not a caller bug. `typeof` does the narrowing —
 // `Number.isFinite` is typed `(n: unknown) => boolean` and narrows nothing.
 export function clampFont(n: unknown): number {

--- a/cmd/hivegui/frontend/src/lib/keymap.ts
+++ b/cmd/hivegui/frontend/src/lib/keymap.ts
@@ -1,8 +1,8 @@
 // Pure key-decision helpers for the terminal's custom key handler.
 //
 // Extracted from main.js so the decision logic can be unit-tested with
-// fake event objects (see test/unit/keymap.test.js), mirroring the
-// platform.js idiom. main.js keeps only the imperative wiring.
+// fake event objects (see test/unit/keymap.test.ts), mirroring the
+// platform.ts idiom. main.ts keeps only the imperative wiring.
 
 // Byte written to the PTY to insert a newline in the agent's input
 // without submitting. This is Ctrl+J (LF, 0x0a) — the one newline
@@ -42,7 +42,7 @@ export function isShiftEnter(e: KeyEventLike): boolean {
 // keyboard-shortcuts panel. Both ⌘/ and ⌘? are accepted: "?" is Shift+/
 // on a US layout, so e.key is already "?" when shift is held and no
 // separate shiftKey check is needed — the same shape as the '=' / '+'
-// zoom pair in app/keyboard.js.
+// zoom pair in app/keyboard.ts.
 //
 // The '?' branch only ever fires on Windows/Linux. On macOS the Help
 // menu item's ⌘/ accelerator already matches both chords (AppKit matches
@@ -65,13 +65,13 @@ export function isHelpOverlayKey(e: KeyEventLike): boolean {
 //   Win / Linux   Ctrl+Alt+-    / Ctrl+Alt+Shift+-
 //
 // The split mirrors VS Code, and for the same reason: on Windows and
-// Linux the app's primary modifier is Ctrl (see lib/platform.js
+// Linux the app's primary modifier is Ctrl (see lib/platform.ts
 // cmdOrCtrl), so Ctrl+- and Ctrl+= are ALREADY zoom out / in in
-// app/keyboard.js. Requiring Alt there keeps zoom intact; the
+// app/keyboard.ts. Requiring Alt there keeps zoom intact; the
 // !e.altKey branch on mac keeps ⌥⌃- free for the terminal.
 //
 // Callers must dispatch this BEFORE the cmdOrCtrl() gate in
-// app/keyboard.js — on macOS that gate rejects plain Ctrl outright.
+// app/keyboard.ts — on macOS that gate rejects plain Ctrl outright.
 //
 // Key matching accepts '-' and '_' (shifted '-' on a US layout, the
 // same shape as the '=' / '+' zoom pair) and falls back to the

--- a/cmd/hivegui/frontend/src/lib/nav-history.ts
+++ b/cmd/hivegui/frontend/src/lib/nav-history.ts
@@ -1,13 +1,13 @@
 // Back / forward navigation history over visited sessions.
 //
 // Pure module: no DOM, no imports, unit-testable — same idiom as
-// lib/collapsed.js and lib/minimized.js. Operates on a plain history
+// lib/collapsed.ts and lib/minimized.ts. Operates on a plain history
 // object `{ back: [], fwd: [] }` passed in by the caller (it lives on
-// app/state.js as state.nav).
+// app/state.ts as state.nav).
 //
 // Semantics are VS Code's, not alt-tab's: `back` is a stack of
 // DEPARTED session ids, and navigating somewhere new discards the
-// forward branch. app/focus.js records a departure from setActive —
+// forward branch. app/focus.ts records a departure from setActive —
 // the sole writer of state.activeId — so every way of changing the
 // active session is captured, including the paths that never go
 // through switchTo (tile mousedown, gridSpatialMove).

--- a/cmd/hivegui/frontend/src/lib/scroll-debug.ts
+++ b/cmd/hivegui/frontend/src/lib/scroll-debug.ts
@@ -18,7 +18,7 @@ export const SCROLL_TRACE_CAP = 2000;
 //
 // The whitelist is per-EVENT, not per-frame. `resize` is deliberately absent:
 // _onBodyResize fires continuously for every tile during a window or sidebar
-// drag (see its own comment in session-term.js), so teeing it writes hundreds
+// drag (see its own comment in session-term.ts), so teeing it writes hundreds
 // of lines per second and drowns the records that matter. Its diagnostic
 // payload is redundant anyway — the debounced outcome it leads to is captured
 // by `replay-request` / `replay-skip`, which fire at most once per drag.

--- a/cmd/hivegui/frontend/src/lib/scrollback.ts
+++ b/cmd/hivegui/frontend/src/lib/scrollback.ts
@@ -1,5 +1,5 @@
 // Scrollback-replay decision helpers. Pure functions so the resize-
-// driven replay logic in main.js can be unit-tested without dragging
+// driven replay logic in main.ts can be unit-tested without dragging
 // xterm.js or the Wails bridge into jsdom.
 
 // A viewport within this many lines of the bottom counts as "at the

--- a/cmd/hivegui/frontend/src/lib/shortcuts.ts
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.ts
@@ -2,16 +2,16 @@
 // (⌘/) renders shortcutGroups(); the command palette pulls its
 // shortcut column from paletteShortcuts() — both consume this module,
 // so the two surfaces cannot drift from each other. (They can still
-// drift from the actual handlers in main.js/menu.go, which is why
+// drift from the actual handlers in main.ts/menu.go, which is why
 // every binding change must touch this file too — see AGENTS.md.)
 //
 // The full drift surface for a GUI binding change is five files:
-//   1. the handler — app/keyboard.js (+ lib/keymap.js for a predicate)
+//   1. the handler — app/keyboard.ts (+ lib/keymap.ts for a predicate)
 //   2. this file — shortcutGroups() AND paletteShortcuts()
-//   3. the palette command table — main.js
+//   3. the palette command table — main.ts
 //   4. the native macOS menu — cmd/hivegui/menu_darwin.go (⌘ chords only;
 //      Ctrl-only chords are deliberately JS-side, see the Ctrl+` comment
-//      in app/keyboard.js)
+//      in app/keyboard.ts)
 //   5. the user-facing shortcut table in README.md
 //
 // Pure module: no DOM, unit-testable.
@@ -59,7 +59,7 @@ function mod(
 }
 
 // Ctrl on every platform (Ctrl+`, Ctrl+Shift+C/V/A — deliberately not
-// ⌘ on mac, see main.js comments).
+// ⌘ on mac, see main.ts comments).
 function ctrl(
   isMac: boolean,
   key: string,
@@ -73,7 +73,7 @@ function ctrl(
 // Session back/forward is the one binding that is not simply
 // "cmd on mac, ctrl elsewhere" or "ctrl everywhere": it is Ctrl on
 // macOS but Ctrl+Alt on Windows/Linux, because plain Ctrl+- is
-// already zoom-out there. See lib/keymap.js navHistoryKey.
+// already zoom-out there. See lib/keymap.ts navHistoryKey.
 function ctrlAlt(
   isMac: boolean,
   key: string,

--- a/cmd/hivegui/frontend/src/lib/view-scroll.ts
+++ b/cmd/hivegui/frontend/src/lib/view-scroll.ts
@@ -19,7 +19,7 @@
 //     keeps baseY pinned at the scrollback cap while the viewport
 //     drifts off-bottom). The empty-write callback re-asserts bottom
 //     only after the write queue drains, mirroring the parse-ordered
-//     discipline in scrollback.js.
+//     discipline in scrollback.ts.
 //
 // Pure helper — no xterm.js import — so it can be unit-tested in
 // jsdom against plain mocks. Accepts any iterable (array, Map.values()).
@@ -68,7 +68,7 @@ export function snapVisibleTermsToBottom(
     // `term`. This does change one thing from the original
     // `st.term.scrollToBottom()`: the terminal OBJECT is now captured
     // at snap time rather than re-read when the callback fires. Safe —
-    // `SessionTerm.term` is assigned once (app/session-term.js) and
+    // `SessionTerm.term` is assigned once (app/session-term.ts) and
     // never reassigned or nulled. The `?.` still re-reads the method
     // off that object at call time.
     const term = st.term;

--- a/cmd/hivegui/frontend/src/lib/wire.ts
+++ b/cmd/hivegui/frontend/src/lib/wire.ts
@@ -3,7 +3,7 @@
 // camelCase.
 
 // readProjectId tolerates both snake_case and camelCase on session
-// objects already in flight — many code paths in main.js do this
+// objects already in flight — many code paths in main.ts do this
 // inline; this is the canonical helper.
 export function readProjectId(
   session: { projectId?: string; project_id?: string } | null | undefined,

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -74,7 +74,7 @@ import {
 
 // ---------- command palette table ----------
 
-// Shortcut strings come from lib/shortcuts.js so the palette and the
+// Shortcut strings come from lib/shortcuts.ts so the palette and the
 // ⌘/ help overlay can't drift from each other.
 const PALETTE_KEYS = paletteShortcuts({ isMac });
 

--- a/cmd/hivegui/frontend/test/dom/attention-jump-integration.test.ts
+++ b/cmd/hivegui/frontend/test/dom/attention-jump-integration.test.ts
@@ -2,7 +2,7 @@
 //
 // ⌘B / ⇧⌘B against the REAL switchTo → setActive chain.
 //
-// The sibling attention-jump.test.ts mocks view.js to isolate the
+// The sibling attention-jump.test.ts mocks view.ts to isolate the
 // return-slot logic, which means the thing ⌘B's correctness actually
 // rests on — setActive clearing the target's attention flag — is
 // simulated there, not executed. If setActive stopped deleting from
@@ -93,7 +93,7 @@ function tile(id: string): TermTile {
 }
 
 beforeAll(async () => {
-  // view.js installs a container ResizeObserver at module load; jsdom
+  // view.ts installs a container ResizeObserver at module load; jsdom
   // has no implementation. The grid-reflow path it drives is not what
   // this file tests, so a no-op stub is enough.
   globalThis.ResizeObserver = class {
@@ -112,7 +112,7 @@ beforeAll(async () => {
   ({ setActive } = focus);
   ({ jumpToAttention, jumpBack } = await import('../../src/app/keyboard.js'));
 
-  // Real view.js + focus.js, with view stubbed at its injection seam.
+  // Real view.ts + focus.ts, with view stubbed at its injection seam.
   // ensureTerm is declared to return a TermTile; beforeEach populates
   // state.terms for every session, so tile() asserts rather than casts.
   initView({

--- a/cmd/hivegui/frontend/test/dom/events-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/events-focus.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 //
 // Regression test for the window-focus handler registered by
-// wireDaemonEvents (src/app/events.js). The stage-3/4 modularization
+// wireDaemonEvents (src/app/events.ts). The stage-3/4 modularization
 // once mangled `refocusActiveTerm()` into `redeps.focusActiveTerm()`
 // during the verbatim move — a ReferenceError on every window focus
 // that silently killed both attention-clearing and xterm refocus.
@@ -56,7 +56,7 @@ let state: typeof import('../../src/app/state.js').state;
 let wireDaemonEvents: typeof import('../../src/app/events.js').wireDaemonEvents;
 
 beforeAll(async () => {
-  // dom.js dereferences #terms at import time; give it the singletons.
+  // dom.ts dereferences #terms at import time; give it the singletons.
   document.body.innerHTML =
     '<div id="terms"></div><ul id="projects"></ul><div id="status"></div>';
   ({ state } = await import('../../src/app/state.js'));

--- a/cmd/hivegui/frontend/test/dom/launcher.test.ts
+++ b/cmd/hivegui/frontend/test/dom/launcher.test.ts
@@ -90,7 +90,7 @@ vi.mock('../../src/bridge.js', () => ({
 }));
 
 // #terms / #projects / #status are the app singletons app/dom.ts
-// resolves with mustEl at import time — launcher.ts pulls dom.js in for
+// resolves with mustEl at import time — launcher.ts pulls dom.ts in for
 // flashStatus, so they must exist before the dynamic import below even
 // though this suite never touches them.
 const MARKUP = `
@@ -338,7 +338,7 @@ describe('launcher keyboard', () => {
     await open();
     type('cla');
     expect(names()).toEqual(['Claude']);
-    // keyboard.js bails out entirely while the launcher is open, so
+    // keyboard.ts bails out entirely while the launcher is open, so
     // this binding only still works because the launcher repeats it.
     // cmdOrCtrl() rejects the cross-platform combo outright, so the
     // modifier has to match the platform the module resolved at load.

--- a/cmd/hivegui/frontend/test/dom/nav-history.test.ts
+++ b/cmd/hivegui/frontend/test/dom/nav-history.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 //
 // Session back/forward (Ctrl+- / Ctrl+Shift+-) end-to-end through the
-// real recording hook: app/focus.js setActive → lib/nav-history.
+// real recording hook: app/focus.ts setActive → lib/nav-history.
 //
 // The hook lives in setActive rather than switchTo precisely because
 // four selection paths (tile mousedown, gridSpatialMove,
@@ -59,7 +59,7 @@ vi.mock('../../src/bridge.js', () => {
 
 // The real switchTo owns xterm/DOM work we don't need here, but it
 // MUST still funnel through setActive — that is the contract this
-// feature depends on (view.js:51). The stub preserves exactly that
+// feature depends on (view.ts:51). The stub preserves exactly that
 // edge and nothing else.
 vi.mock('../../src/app/view.js', async () => {
   const { setActive } = await import('../../src/app/focus.js');
@@ -69,7 +69,7 @@ vi.mock('../../src/app/view.js', async () => {
     setView: vi.fn(),
     gridSpatialMove: vi.fn(),
     shiftActiveProject: vi.fn(),
-    // Mirrors the real restoreSession (view.js): un-minimize, then switchTo.
+    // Mirrors the real restoreSession (view.ts): un-minimize, then switchTo.
     restoreSession: vi.fn((id: string | null) => {
       if (id) state.minimized.delete(id);
       setActive(id);
@@ -87,7 +87,7 @@ let setActive: Focus['setActive'];
 let withoutNavHistory: Focus['withoutNavHistory'];
 let navBack: Keyboard['navBack'];
 let navForward: Keyboard['navForward'];
-// vi.mocked over a hand-written signature: view.js is vi.mock'd above, so
+// vi.mocked over a hand-written signature: view.ts is vi.mock'd above, so
 // the mock types stay pinned to the real exports.
 let switchTo: MockedFunction<View['switchTo']>;
 let restoreSession: MockedFunction<View['restoreSession']>;
@@ -116,7 +116,7 @@ beforeAll(async () => {
   restoreSession = vi.mocked(view.restoreSession);
   const kb = await import('../../src/app/keyboard.js');
   ({ navBack, navForward } = kb);
-  // main.js injects the focus pipeline into keyboard.ts so the modules
+  // main.ts injects the focus pipeline into keyboard.ts so the modules
   // stay acyclic; this harness has to do the same or the suppression
   // that stops back/forward ping-ponging is never wired.
   kb.initKeyboard({
@@ -158,7 +158,7 @@ describe('recording', () => {
   });
 
   it('records a bare setActive — the tile-mousedown / grid-arrow path', () => {
-    // session-term.js:386 and view.js:262 call setActive directly and
+    // session-term.ts:386 and view.ts:262 call setActive directly and
     // never touch switchTo. Losing these is the failure mode this
     // design exists to prevent, so assert on setActive itself.
     setActive('a');

--- a/cmd/hivegui/frontend/test/dom/restart-hive.test.ts
+++ b/cmd/hivegui/frontend/test/dom/restart-hive.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 //
-// restartHive (src/app/banners.js) used to be an anonymous click
+// restartHive (src/app/banners.ts) used to be an anonymous click
 // handler on the daemon-stale banner's button — the only trigger in
 // the whole app. With matching GUI/daemon builds the banner never
 // renders, so there was no way to restart Hive at all. It is now an
@@ -35,8 +35,8 @@ function mustEl(id: string): HTMLElement {
 }
 
 beforeAll(async () => {
-  // dom.js runs side effects on import (it decorates #terms), and
-  // banners.js pulls it in for flashStatus — so the scaffold needs
+  // dom.ts runs side effects on import (it decorates #terms), and
+  // banners.ts pulls it in for flashStatus — so the scaffold needs
   // those elements even though this file never touches them.
   document.body.innerHTML = `
     <div id="terms"></div><ul id="projects"></ul>
@@ -88,7 +88,7 @@ describe('restartHive', () => {
     );
   });
 
-  // events.js reads this to suppress the red "control disconnected"
+  // events.ts reads this to suppress the red "control disconnected"
   // status while a restart is deliberately tearing the conn down.
   it('clears the restarting flag when the call settles', async () => {
     await restartHive();

--- a/cmd/hivegui/frontend/test/dom/settings.test.ts
+++ b/cmd/hivegui/frontend/test/dom/settings.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 //
-// Covers the settings modal (src/app/modals/settings.js): the
+// Covers the settings modal (src/app/modals/settings.ts): the
 // add/edit/delete round-trip, the exact payload handed to
 // SaveCustomAgents, and the two behaviors that carry real risk —
 // existing ids must survive a rename (registry entries persist only

--- a/cmd/hivegui/frontend/test/e2e-real/globalSetup.mjs
+++ b/cmd/hivegui/frontend/test/e2e-real/globalSetup.mjs
@@ -1,7 +1,7 @@
 // Layer B globalSetup: build hived + hived-ws-bridge, spawn both
 // against fully-isolated temp dirs, write the bridge URL to a temp
 // file so individual specs (and the Vite server) can pick it up.
-// Teardown runs in globalTeardown.js.
+// Teardown runs in globalTeardown.mjs.
 //
 // Isolation invariants (mirroring the Layer A Go side):
 //   HOME, HIVE_STATE_DIR, HIVE_SOCKET → fresh mktemp paths each run.
@@ -114,7 +114,7 @@ export default async function globalSetup() {
 
   // Pass state to the spec process(es) and to the Vite dev server. The
   // tests use process.env.WS_BRIDGE_URL inside addInitScript to install
-  // window.__WS_BRIDGE_URL before main.js loads.
+  // window.__WS_BRIDGE_URL before main.ts loads.
   process.env.WS_BRIDGE_URL = wsUrl.trim();
   process.env.HIVE_E2E_REAL_TMP = tmp;
   process.env.HIVE_E2E_REAL_PIDS = JSON.stringify({

--- a/cmd/hivegui/frontend/test/e2e-real/lifecycle.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/lifecycle.spec.ts
@@ -20,7 +20,7 @@ import type { SessionTerm } from '../../src/app/session-term.js';
 const WS_URL = process.env.WS_BRIDGE_URL;
 
 test.beforeEach(async ({ page }) => {
-  // Inject the bridge URL BEFORE main.js loads so the bridge module's
+  // Inject the bridge URL BEFORE main.ts loads so the bridge module's
   // ensureWS() can resolve it.
   await page.addInitScript((url) => {
     window.__WS_BRIDGE_URL = url;

--- a/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.ts
@@ -35,7 +35,7 @@ test.beforeEach(async ({ page }) => {
   test.skip(!!process.env.CI, 'quarantined on CI — flaky setup, spec 245');
   await page.addInitScript((url) => {
     window.__WS_BRIDGE_URL = url;
-    // Arm the scroll tracer (window.__hive_scrolltrace) before main.js loads.
+    // Arm the scroll tracer (window.__hive_scrolltrace) before main.ts loads.
     try {
       localStorage.setItem('hive.debug', '1');
     } catch {}

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
@@ -240,7 +240,7 @@ export async function CheckForUpdate() {
   return null;
 }
 
-// Clipboard bindings. main.js imports ClipboardGetText (runtime) and
+// Clipboard bindings. main.ts imports ClipboardGetText (runtime) and
 // SetClipboardText (App), both aliased to this bridge under
 // VITE_WAILS_REAL=1; without these exports the ESM import throws at
 // module load and the app never boots. In-memory is sufficient here.

--- a/cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.ts
@@ -23,7 +23,7 @@ type SpyTerm = SessionTerm & { __wheelWrapped?: boolean };
 // Repro for "the terminal won't scroll by mouse wheel or trackpad on one of my
 // Macs" (selection-drag still scrolls). PR #229 theorized a WKWebView quirk
 // (deltaMode LINE/PAGE or deltaY=0 with the value only in legacy wheelDeltaY)
-// and normalized the math in lib/wheel-scroll.js — yet the Mac still doesn't
+// and normalized the math in lib/wheel-scroll.ts — yet the Mac still doesn't
 // scroll, which means the root cause is OUTSIDE that pure function.
 //
 // The existing scroll-codex.spec drives scrolling via page.mouse.wheel, which
@@ -50,7 +50,7 @@ test.beforeEach(async ({ page }) => {
   test.skip(!!process.env.CI, 'quarantined on CI — flaky setup, spec 245');
   await page.addInitScript((url) => {
     window.__WS_BRIDGE_URL = url;
-    // Arm the scroll tracer (window.__hive_scrolltrace) before main.js loads,
+    // Arm the scroll tracer (window.__hive_scrolltrace) before main.ts loads,
     // so a failure attaches the derived `lines` per wheel event below.
     try {
       localStorage.setItem('hive.debug', '1');

--- a/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.ts
@@ -164,7 +164,7 @@ test.describe('#208 grid-mode scroll regressions', () => {
   // routes a viewport change through renderGrid → ensureAttached, which
   // re-latches _followBottom to true for every tile (see attachDeferred) —
   // so a grid tile cannot be held scrolled-up across a resize by design.
-  // The single-view observer early-returns (view.js), so the scrolled-up
+  // The single-view observer early-returns (view.ts), so the scrolled-up
   // state survives and the real wiring is exercised end to end.
   test('R-reader: a real window resize DOES replay a tile scrolled up into history', async ({
     page,

--- a/cmd/hivegui/frontend/test/e2e/launcher-search.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/launcher-search.spec.ts
@@ -109,7 +109,7 @@ test('the worktree checkbox toggles without stealing focus from the filter box',
   await expect.poll(helperFocused).toBe(true);
 });
 
-// keyboard.js bails out unconditionally while the launcher is open and
+// keyboard.ts bails out unconditionally while the launcher is open and
 // the launcher's own listener is scoped to #launcher, so any click that
 // leaves the launcher visible while moving focus out of it would strand
 // the keyboard with no handler at all — Escape included.

--- a/cmd/hivegui/frontend/test/e2e/nav-history.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/nav-history.spec.ts
@@ -4,12 +4,12 @@ import { test, expect, type Page } from '@playwright/test';
 //
 // This exists because the jsdom test can't cover the chord that
 // actually ships on macOS. jsdom reports a non-mac navigator, so
-// lib/platform.js isMac is false there and only the Ctrl+Alt+- branch
+// lib/platform.ts isMac is false there and only the Ctrl+Alt+- branch
 // is exercised. Chromium on darwin reports "MacIntel", so this spec
 // drives the real mac chord — plain Ctrl+-, no Alt — through the real
 // capture-phase keydown listener.
 //
-// The load-bearing detail: app/keyboard.js gates most bindings behind
+// The load-bearing detail: app/keyboard.ts gates most bindings behind
 // cmdOrCtrl(), which rejects plain Ctrl on macOS. The nav dispatch is
 // placed AHEAD of that gate for exactly this reason. A regression that
 // moves it below the gate passes every unit test and silently kills

--- a/cmd/hivegui/frontend/test/e2e/payload-shapes.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/payload-shapes.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, type Page } from '@playwright/test';
 // Layer C: payload-shape parity. The real hived daemon emits JSON
 // with snake_case keys (SessionInfo.project_id, .worktree_branch,
 // .worktree_path); some Wails / consumer paths historically emitted
-// camelCase. main.js reads both via `snake_case ?? camelCase` (or
+// camelCase. main.ts reads both via `snake_case ?? camelCase` (or
 // vice versa). These tests pin BOTH shapes so a future refactor
 // that drops one branch surfaces here, not in production where a
 // daemon update silently breaks the sidebar.
@@ -73,7 +73,7 @@ for (const { kind, shape } of SHAPES) {
     await expect(row).toBeVisible({ timeout: 2000 });
     // Name renders.
     await expect(row).toContainText(`shape-${id}`);
-    // Worktree glyph (main.js:1119, className 'worktree-glyph') is
+    // Worktree glyph (app/sidebar.ts, className 'worktree-glyph') is
     // rendered iff `s.worktreeBranch ?? s.worktree_branch` resolves —
     // this is the read-both pattern under test.
     await expect(row.locator('.worktree-glyph')).toBeVisible();
@@ -94,7 +94,7 @@ for (const { kind, shape } of SHAPES) {
 
     // The session must end up under its project's <li.project
     // data-pid="p1"> in the sidebar — the routing read is
-    // `projectId ?? project_id` (main.js:798 / 870 / 1013). If a
+    // `projectId ?? project_id` (app/sidebar.ts, app/view.ts). If a
     // future refactor drops one branch, the session would orphan
     // out of its project subtree and this assertion fails.
     const sessionRow = page.locator(

--- a/cmd/hivegui/frontend/test/e2e/renderer-recovery.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/renderer-recovery.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 
 // Layer C: integration smoke for the WebGL context-loss recovery
 // path (#190 / #198). The recovery helpers themselves are unit-
-// tested in test/unit/renderer-recovery.test.js — this spec covers
+// tested in test/unit/renderer-recovery.test.ts — this spec covers
 // the missing piece: that a real WEBGL_lose_context event on a real
 // xterm canvas, in a real DOM, doesn't throw, doesn't leave the
 // terminal mute, and doesn't surface console errors.

--- a/cmd/hivegui/frontend/test/e2e/settings.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/settings.spec.ts
@@ -37,7 +37,7 @@ test('⌘, opens settings, Esc closes it, typing reaches the terminal again', as
   // proves the class flipped, which is synchronous — but closeSettings
   // restores focus through setFocusedTile, which defers the real
   // focus() into a requestAnimationFrame with a retry chain
-  // (src/app/focus.js). Typing in that gap sends the keys nowhere and
+  // (src/app/focus.ts). Typing in that gap sends the keys nowhere and
   // the assertion below fails with an empty stdin, which is what this
   // test did once on a loaded macOS CI runner.
   await expect(

--- a/cmd/hivegui/frontend/test/e2e/silent-failures.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/silent-failures.spec.ts
@@ -84,10 +84,10 @@ test('failed tile rename shows an error (regression: UpdateSession import)', asy
 }) => {
   // Locks the fix for a latent ReferenceError: SessionTerm's
   // _beginRename commit handler called UpdateSession without it being
-  // imported in session-term.js, so the rename input closed but the
+  // imported in session-term.ts, so the rename input closed but the
   // daemon call never fired and nothing surfaced. This is the
   // tile-header rename path — distinct from the sidebar rename test
-  // above, which exercises sidebar.js's beginRenameSession instead and
+  // above, which exercises sidebar.ts's beginRenameSession instead and
   // already had the import.
   await boot(page);
   await page.evaluate(() =>

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -58,7 +58,7 @@ export function WindowSetTitle(t: string) {
   document.title = t;
 }
 
-// Clipboard bindings. main.js imports ClipboardGetText (runtime) and
+// Clipboard bindings. main.ts imports ClipboardGetText (runtime) and
 // SetClipboardText (App), both aliased here. The mock keeps an in-memory
 // clipboard so copy/paste paths don't throw at module load.
 let clipboard = '';

--- a/cmd/hivegui/frontend/test/unit/focus.test.ts
+++ b/cmd/hivegui/frontend/test/unit/focus.test.ts
@@ -91,7 +91,7 @@ describe('decideFocusAction', () => {
   });
 
   it('clears when the command palette is the open modal', () => {
-    // focusSnapshot() in main.js ORs launcher/editor/palette visibility
+    // focusSnapshot() in main.ts ORs launcher/editor/palette visibility
     // into modalOpen; decideFocusAction only sees the resulting flag.
     // This locks in that any palette-open snapshot yields ACTION_CLEAR
     // even when a tile would otherwise be a valid focus target.

--- a/cmd/hivegui/frontend/test/unit/keymap.test.ts
+++ b/cmd/hivegui/frontend/test/unit/keymap.test.ts
@@ -132,7 +132,7 @@ describe('navHistoryKey', () => {
 
   describe('Windows / Linux — Ctrl+Alt+- / Ctrl+Alt+Shift+-', () => {
     it('does NOT fire for plain Ctrl+- — that is zoom out', () => {
-      // Load-bearing negative. On non-mac, app/keyboard.js binds Ctrl+-
+      // Load-bearing negative. On non-mac, app/keyboard.ts binds Ctrl+-
       // to bumpFontSize(-1) via the cmdOrCtrl gate. Claiming it here
       // would silently remove zoom out on two of three platforms.
       expect(navHistoryKey(ev({ ctrlKey: true, key: '-' }), false)).toBe(null);

--- a/cmd/hivegui/frontend/test/unit/nav-history.test.ts
+++ b/cmd/hivegui/frontend/test/unit/nav-history.test.ts
@@ -24,8 +24,8 @@ describe('pushNav', () => {
   });
 
   it('ignores a falsy id — "no active session" is not a history entry', () => {
-    // Landing on an empty project (view.js) or a just-killed session
-    // (events.js) sets activeId to null; those must not stack entries.
+    // Landing on an empty project (view.ts) or a just-killed session
+    // (events.ts) sets activeId to null; those must not stack entries.
     const h = createNavHistory();
     pushNav(h, null);
     pushNav(h, undefined);

--- a/cmd/hivegui/frontend/test/unit/scrollback.test.ts
+++ b/cmd/hivegui/frontend/test/unit/scrollback.test.ts
@@ -496,7 +496,7 @@ describe('resetFollowIntent re-latches "land at bottom" at every attach/focus', 
 });
 
 describe('shouldRequestReplay against baseline (debounce edge case)', () => {
-  // Simulates main.js's baseline-relative debounce: compare *current*
+  // Simulates main.ts's baseline-relative debounce: compare *current*
   // cols against baseline-at-last-replay (not just-previous
   // measurement). The reviewer flagged r614 — 80→84→83 should NOT
   // trigger (final delta 3 < threshold 4). Conversely 80→90→89 SHOULD
@@ -620,7 +620,7 @@ describe('stale _followBottom bug — initial attach must snap to bottom', () =>
   // the middle instead of the bottom. The fix: reset _followBottom = true
   // in ensureAttached() before OpenSession().
   //
-  // These tests verify the scrollback.js side: when _followBottom is
+  // These tests verify the scrollback.ts side: when _followBottom is
   // true (as it should be after the ensureAttached fix), the replay
   // snaps to bottom.
 

--- a/cmd/hivegui/frontend/test/unit/version-footer.test.ts
+++ b/cmd/hivegui/frontend/test/unit/version-footer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// version-footer.js imports EventsOn from the bridge, which re-exports
+// version-footer.ts imports EventsOn from the bridge, which re-exports
 // the Wails runtime — absent under vitest (the vite-plugin substitution
 // only applies to the Playwright harnesses). Only EventsOn is needed
 // here; the functions under test are pure and take their elements

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -15,7 +15,7 @@ import (
 // keyboard behavior by going through one code path.
 //
 // Requirement: every keyboard shortcut in
-// cmd/hivegui/frontend/src/main.js MUST be reachable from this menu.
+// cmd/hivegui/frontend/src/main.ts MUST be reachable from this menu.
 // macOS shows only one accelerator per item; alternate keys (e.g.
 // ⌘← as another way to trigger Previous Session) are still wired in
 // the JS keyboard handler.

--- a/cmd/hivegui/menu_other.go
+++ b/cmd/hivegui/menu_other.go
@@ -15,7 +15,7 @@ import (
 // Ctrl+Down/Up advanced two steps and felt reversed, etc. The native
 // menu adds no user-facing value on those platforms (Wails surfaces it
 // only as a hidden accelerator table), so we drop it and let the JS
-// keyboard handler in cmd/hivegui/frontend/src/main.js own every
+// keyboard handler in cmd/hivegui/frontend/src/main.ts own every
 // shortcut. Adding a new shortcut on Windows/Linux is therefore a
 // frontend-only change.
 func buildAppMenu(_ *App) *menu.Menu { return nil }

--- a/docs/analysis/2026-07-19-improvement-plan/00-overview.md
+++ b/docs/analysis/2026-07-19-improvement-plan/00-overview.md
@@ -29,7 +29,7 @@ deliberate `ponytail:` markers only).
    v2.12.0 in CI but `@latest` in build.sh. → Phase 2.
 6. **God-files**: `internal/registry/registry.go` (1123, `Create` alone is 225
    lines), `cmd/hivegui/app.go` (912),
-   `cmd/hivegui/frontend/src/app/session-term.js` (996),
+   `cmd/hivegui/frontend/src/app/session-term.ts` (996),
    `cmd/hivegui/frontend/src/style.css` (1488). → Phase 3 (Go), Later (JS/CSS).
 7. **Docs drift**: README says v2.0.0-alpha.1 / Go 1.22 / nonexistent `spikes/`;
    CONTRIBUTING still documents the v1 TUI build; AGENTS.md links 6 missing
@@ -58,6 +58,6 @@ deliberate `ponytail:` markers only).
 - Frontend framework migration — vanilla + modules is working fine.
 - Replacing the shared `state` singleton — documented as intentional; only
   revisit if it starts causing real bugs.
-- Splitting `style.css` / `session-term.js` — cosmetic until they cause merge
+- Splitting `style.css` / `session-term.ts` — cosmetic until they cause merge
   pain; noted in phase 3 as optional.
 - Dropping `google/uuid` — 3 call sites, stable dep, not worth the churn.

--- a/docs/analysis/2026-07-19-improvement-plan/phase-1-unblock-ci.md
+++ b/docs/analysis/2026-07-19-improvement-plan/phase-1-unblock-ci.md
@@ -6,9 +6,9 @@
 `docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md`.
 
 All failures cluster in three specs:
-- `cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.js`
-- `cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.js`
-- `cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.js`
+- `cmd/hivegui/frontend/test/e2e-real/wheel-scroll.spec.ts`
+- `cmd/hivegui/frontend/test/e2e-real/scroll-codex.spec.ts`
+- `cmd/hivegui/frontend/test/e2e-real/scroll-restream-strand.spec.ts`
 
 ## Step 1 — Immediate: quarantine (same day, tiny diff)
 
@@ -21,7 +21,7 @@ not stay a required gate while being diagnosed.
 
 ## Step 2 — Root cause the setup-fragility
 
-Known concrete thread (from spec 245): `scroll-codex.spec.js` ~:244/:286
+Known concrete thread (from spec 245): `scroll-codex.spec.ts` ~:244/:286
 asserts `expect(baseY).toBeGreaterThan(4500)` as a *precondition* — it needs
 "output filled the scrollback cap" but relies on wall-clock output volume, so
 under CI CPU contention the test fails its own setup (`got 1624`), not its

--- a/docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md
+++ b/docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md
@@ -39,8 +39,8 @@ socket bridge; spec 245 already scopes it out).
 
 ### TypeScript migration (decided 2026-07-25 — its own workstream)
 
-> **IN PROGRESS 2026-08-07** — now tracked in
-> [docs/exec-plans/active/typescript-migration.md](../../exec-plans/active/typescript-migration.md).
+> **DONE 2026-08-09** — the frontend is fully TypeScript and `tsc --noEmit` gates CI.
+> Executed in [docs/exec-plans/completed/typescript-migration.md](../../exec-plans/completed/typescript-migration.md).
 > That plan supersedes this section on two points: **tests migrate too** (`test/` as well
 > as `src/`), and **`strict: true` lands in PR 1** rather than in a final ramp wave —
 > `checkJs: false` already covers the "don't block CI on pre-existing holes" rationale

--- a/docs/analysis/2026-07-19-improvement-plan/phase-3-go-consolidation.md
+++ b/docs/analysis/2026-07-19-improvement-plan/phase-3-go-consolidation.md
@@ -101,7 +101,7 @@ registry in 3b.
 
 ## Later / only-if-it-hurts (JS side, from the same audit)
 
-- Split `cmd/hivegui/frontend/src/app/session-term.js` (996 lines: lifecycle,
+- Split `cmd/hivegui/frontend/src/app/session-term.ts` (996 lines: lifecycle,
   scroll/replay, wheel, link hit-testing in one class) — do it the next time a
   change there goes wrong, not before.
 - Split `cmd/hivegui/frontend/src/style.css` (1488 lines) — cosmetic; only if
@@ -109,7 +109,7 @@ registry in 3b.
 - Fire-and-forget Wails-binding calls wrapped in `try/catch` only catch the
   *synchronous* failure (binding absent in tests); an async **rejection** of
   the returned promise still escapes as an unhandled rejection. Affects
-  `LogFrontend(...)` in `src/main.js` and `src/app/events.js`, and any similar
+  `LogFrontend(...)` in `src/main.ts` and `src/app/events.ts`, and any similar
   fire-and-forget binding call. Fix once with a tiny `fireAndForget(p)` helper
   (`p?.catch(() => {})`) applied at every call site — not per-line. Surfaced by
   CodeRabbit on PR #249 (the Biome PR); deferred out of that formatting PR to

--- a/docs/exec-plans/completed/typescript-migration.md
+++ b/docs/exec-plans/completed/typescript-migration.md
@@ -2,9 +2,8 @@
 
 - **Spec:** [docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md](../../analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md) §2c
 - **Issue:** TBD
-- **Stage:** IMPLEMENT (waves 1–7c done — every file converted; wave 7d, the
-  stale-path sweep + closeout, is the last)
-- **Status:** active
+- **Stage:** DONE (waves 1–7d, 2026-08-07 → 2026-08-09)
+- **Status:** completed
 
 ## Summary
 
@@ -856,6 +855,38 @@ Check: session opens and renders, scrollback scrolls, keyboard shortcuts fire, m
 
   **The stale-path sweep is NOT in this wave** — see the follow-up below.
 
+- **2026-08-09** — Wave 7d complete: the stale-path sweep and closeout. 126
+  lines across 64 files, **comments and docs only** — no runtime line changed,
+  which is why the flaky e2e-real suite was not re-run for it.
+  - **Specifier vs. reference is the whole distinction.** `from './x.js'`,
+    `vi.mock('../x.js')` and `await import('../x.js')` all stay `.js`; a comment
+    that *names* a module gets retargeted. The multi-line `await import(\n
+    '../../src/app/banners.js'\n)` form in `test/dom/{restart-hive,settings}` and
+    `test/unit/version-footer` slipped past the specifier filter and `tsc` caught
+    all three as `TS5097` — the reason typecheck runs before the docs edits, not
+    after.
+  - **Provenance is not a path.** "Moved verbatim from main.js" / "Extracted from
+    main.js" name the file as it was at extraction time and are left alone (13
+    sites). Every pointer to the *current* composition root became `main.ts`.
+  - **Dead line cites were retargeted to modules, not re-numbered.**
+    `payload-shapes.spec.ts` cited `main.js:1119` and `main.js:798 / 870 / 1013`
+    into a file that is now 419 lines; both now name `app/sidebar.ts` /
+    `app/view.ts`, where the reads actually live. Line numbers in cites to files
+    that merely *renamed* (`state.ts:43`, `view.ts:51`) were left as-is — that
+    drift predates this migration.
+  - Out of scope, deliberately: `playwright*.config.js`, `vite.config.js`,
+    `vitest.config.js` and `scripts/*.mjs` are real filenames and stay;
+    `vitest.config.js:16-19` documents matching *both* extensions and stays;
+    `docs/product-specs/`, `docs/native-rewrite/`, `CHANGELOG.md` are dated
+    records. Two genuine pre-existing errors fixed on the way past:
+    `globalSetup.js`/`globalTeardown.js` are `.mjs`.
+  - `src/lib/shortcuts.ts:9-15`, the five-file drift checklist, is now correct in
+    all five entries.
+
+  Gates: typecheck/build/biome green, `go build ./...` + `go vet ./...` green,
+  vitest 344 in 33 files (unchanged), Playwright mock 84 passed + 1 skipped
+  (unchanged), `check-spec-discovery` collects all 17 + all 5.
+
 ## Follow-ups
 
 Open items carried out of waves 1–7a. Each is a decision or a task, not a finding — the
@@ -864,14 +895,11 @@ findings live in the wave notes above.
 - ~~**Wave 7 should be two PRs, not one.**~~ **Accepted 2026-08-08**, and it
   became three: 7a (composition root), 7b (17 mock specs + fixture pair), 7c
   (5 e2e-real specs). Every `.js`/`.mjs` that was ever going to convert has.
-- **The stale-path sweep is all that is left of the migration**, and it is now a
-  wave of its own (7d) — it touches no `.ts` and cannot break a build, so
-  bundling it with a spec conversion only made both harder to review. Populations
-  1–3 in the wave-7 inventory still stand as written; spot-checked 2026-08-09,
-  `AGENTS.md:138`, `cmd/hivegui/{app.go:135,221, menu_darwin.go:18,
-  menu_other.go:18}`, `index.html:29`, `playwright.real.config.js:12` and the
-  in-frontend comment population are all still stale. Land it with the two
-  closeout items below.
+- ~~**The stale-path sweep is all that is left of the migration**, and it is now
+  a wave of its own (7d).~~ **Done 2026-08-09** — all three populations swept;
+  see the wave-7d note above. One correction to the inventory: it *does* touch
+  `.ts`, in comments, and it *can* break the build — three multi-line dynamic
+  imports were rewritten and `tsc` caught them.
 - **`applyFontSize`'s `st.term?.options` guard is undecided** (`session-term.ts`, raised in
   #267's review, deferred by the user). It turns what would have been a `TypeError` on a
   tile with no `term` into a silent no-op. Unreachable in production — the constructor
@@ -884,10 +912,14 @@ findings live in the wave notes above.
   that actually fail are the ones recorded in the wave-7 inventory. Fixing it needs a run
   on `main` to establish which set is real, so it is a task for whoever next debugs that
   suite — not for wave 7, which only needs the names as a same-run baseline.
-- **On wave 7 landing**: mark §2c's TypeScript subsection DONE in
-  `docs/analysis/2026-07-19-improvement-plan/phase-2-ci-and-tooling.md:40-43` (it currently
-  reads IN PROGRESS and points here), and move this plan to `docs/exec-plans/completed/`.
-  Nothing else references it.
+- ~~**On wave 7 landing**: mark §2c's TypeScript subsection DONE and move this
+  plan to `docs/exec-plans/completed/`.~~ **Done in 7d.** §2c now reads DONE and
+  links here; that link is the only reference to this file in the tree.
+
+**Still open after closeout** — the two items above that 7d did not resolve (the
+`applyFontSize` guard, and the wrong e2e-real flake list in
+`docs/product-specs/245-…:15-17`). Neither is TypeScript work; both need a run on
+`main` or a user decision, and they outlive this plan.
 
 CI follow-ups this migration surfaced but that are **not** TypeScript work — Playwright
 browser-cache scoping and the caret/exact dependency-pin split — are recorded in

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -2,7 +2,7 @@
 //
 // This is DEFENSIVE hygiene, not the fix for the "GUI frozen" reports — that
 // root cause was a synchronous full-ring scrollback replay (see the alt-screen
-// replay skip in session-term.js and ringCap in internal/session/vt.go). But
+// replay skip in session-term.ts and ringCap in internal/session/vt.go). But
 // macOS App Nap / activity-based timer coalescing can still clamp a
 // backgrounded webview's timers, and a terminal multiplexer must keep
 // streaming PTY output and repainting even when it is not the foreground app,

--- a/scripts/ci-bootstrap.sh
+++ b/scripts/ci-bootstrap.sh
@@ -5,7 +5,7 @@
 # empty frontend/dist (the //go:embed all:frontend/dist directive in
 # cmd/hivegui/main.go needs something to read before the real vite
 # build overwrites it), installs the Wails CLI, and generates the
-# wailsjs/ bindings that main.js imports.
+# wailsjs/ bindings that main.ts imports.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
Retargets every `X.js` reference that names a module the migration
renamed. 126 lines across 64 files, comments and docs only — no runtime
line changed, so the flaky e2e-real suite was not re-run.

The distinction that matters is specifier vs. reference. Module
specifiers stay `.js` (TS resolves them to the `.ts` source); only prose
that names a file gets retargeted. Three multi-line `await import(...)`
specifiers slipped past the filter and tsc caught them as TS5097.

"Moved verbatim from main.js" is provenance, not a path, and stays as
written; every pointer to the current composition root is now main.ts.
payload-shapes.spec cited main.js:1119 and main.js:798/870/1013 into a
file that is now 419 lines — those now name app/sidebar.ts / app/view.ts,
where the reads actually live. lib/shortcuts.ts's five-file drift
checklist is correct in all five entries again.

Left alone deliberately: playwright*/vite/vitest config `.js` and
scripts/*.mjs are real filenames; vitest.config.js documents matching
both extensions on purpose; docs/product-specs, docs/native-rewrite and
CHANGELOG are dated records. Two genuine pre-existing errors fixed in
passing — globalSetup.js/globalTeardown.js are .mjs.

Closeout: phase-2 §2c reads DONE, and the exec-plan moves to
docs/exec-plans/completed/ with a wave-7d note. The two follow-ups it
could not resolve (the applyFontSize guard, the wrong e2e-real flake
list in spec 245) are recorded as outliving the plan.

Gates: typecheck/build/biome green, go build+vet green, vitest 344/33
unchanged, Playwright mock 84 passed + 1 skipped unchanged,
check-spec-discovery collects all 17 + all 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated stale frontend references from JavaScript filenames to their current TypeScript equivalents across project guidance, comments, test documentation, and planning materials.
  * Marked the TypeScript migration plan as completed and refreshed its closeout details.
* **Maintenance**
  * Improved consistency and accuracy of internal references without changing application behavior, tests, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->