### PR TITLE
docs: correct the spec-245 e2e-real flake list from a real baseline

### DIFF
--- a/docs/exec-plans/completed/typescript-migration.md
+++ b/docs/exec-plans/completed/typescript-migration.md
@@ -907,11 +907,12 @@ findings live in the wave notes above.
   constructor unconditionally does `new Terminal(...)` — and the optionality
   exists only because the DOM-test stubs omit `term`. Raised in #267's review;
   closed without a change, not deferred again.
-- ~~**The e2e-real flake list in `docs/product-specs/245-…:15-17` is wrong**~~
+- ~~**The e2e-real flake list in `docs/product-specs/245-…` is wrong**~~
   **Corrected 2026-08-09** from three consecutive runs on `main` (`f5f9665`),
-  macOS: 9 passed / 3 failed, the same three every time — `scroll-codex.ts:215`,
-  `:262`, `scroll-restream-strand.ts:97`. All five `wheel-scroll` cases pass, as
-  do the two `scroll-codex` cases the old list named as the concrete thread. Two
+  macOS: 9 passed / 3 failed, the same three every time —
+  `scroll-codex.spec.ts:215`, `:262`, `scroll-restream-strand.spec.ts:97`. All
+  five `wheel-scroll` cases pass, as does the `scroll-codex` case the old list
+  singled out as the concrete thread (`unscrolled user is not stranded`). Two
   findings folded into the spec: the failures are **deterministic** on an idle
   machine, and CI's green streak is the `test.skip(!!process.env.CI)` quarantine
   (2 of 12 tests run there), not a fix.
@@ -919,9 +920,11 @@ findings live in the wave notes above.
   plan to `docs/exec-plans/completed/`.~~ **Done in 7d.** §2c now reads DONE and
   links here; that link is the only reference to this file in the tree.
 
-**Nothing is open after closeout.** Both non-TypeScript carry-overs were resolved
-on 2026-08-09: the `applyFontSize` guard stays as-is by user decision, and the
-spec-245 flake list was re-measured and corrected. What that measurement
+**No follow-ups are open after closeout** (the issue-number question under *Open
+questions* below is still unanswered, and is the only unresolved item in this
+file). Both non-TypeScript carry-overs were resolved on 2026-08-09: the
+`applyFontSize` guard stays as-is by user decision, and the spec-245 flake list
+was re-measured and corrected. What that measurement
 *surfaced* — three deterministic e2e-real failures, and a CI quarantine hiding 10
 of 12 tests — belongs to spec 245, not here.
 

--- a/docs/exec-plans/completed/typescript-migration.md
+++ b/docs/exec-plans/completed/typescript-migration.md
@@ -900,26 +900,30 @@ findings live in the wave notes above.
   see the wave-7d note above. One correction to the inventory: it *does* touch
   `.ts`, in comments, and it *can* break the build — three multi-line dynamic
   imports were rewritten and `tsc` caught them.
-- **`applyFontSize`'s `st.term?.options` guard is undecided** (`session-term.ts`, raised in
-  #267's review, deferred by the user). It turns what would have been a `TypeError` on a
-  tile with no `term` into a silent no-op. Unreachable in production — the constructor
-  unconditionally does `new Terminal(...)` — and the optionality exists only because the
-  DOM-test stubs omit `term`. Leave it, or make it throw with a named message; either is
-  defensible, nobody has picked. Not worth its own PR; fold into wave 7 if the answer is
-  "make it loud".
-- **The e2e-real flake list in `docs/product-specs/245-…:15-17` is wrong** and was not
-  corrected here. It names all five `wheel-scroll.spec.js` cases; those pass, and the five
-  that actually fail are the ones recorded in the wave-7 inventory. Fixing it needs a run
-  on `main` to establish which set is real, so it is a task for whoever next debugs that
-  suite — not for wave 7, which only needs the names as a same-run baseline.
+- ~~**`applyFontSize`'s `st.term?.options` guard is undecided**~~ **Decided
+  2026-08-09 by the user: leave it as-is, no code change.** The optional chain
+  stays. It turns what would have been a `TypeError` on a tile with no `term`
+  into a silent no-op, but that branch is unreachable in production — the
+  constructor unconditionally does `new Terminal(...)` — and the optionality
+  exists only because the DOM-test stubs omit `term`. Raised in #267's review;
+  closed without a change, not deferred again.
+- ~~**The e2e-real flake list in `docs/product-specs/245-…:15-17` is wrong**~~
+  **Corrected 2026-08-09** from three consecutive runs on `main` (`f5f9665`),
+  macOS: 9 passed / 3 failed, the same three every time — `scroll-codex.ts:215`,
+  `:262`, `scroll-restream-strand.ts:97`. All five `wheel-scroll` cases pass, as
+  do the two `scroll-codex` cases the old list named as the concrete thread. Two
+  findings folded into the spec: the failures are **deterministic** on an idle
+  machine, and CI's green streak is the `test.skip(!!process.env.CI)` quarantine
+  (2 of 12 tests run there), not a fix.
 - ~~**On wave 7 landing**: mark §2c's TypeScript subsection DONE and move this
   plan to `docs/exec-plans/completed/`.~~ **Done in 7d.** §2c now reads DONE and
   links here; that link is the only reference to this file in the tree.
 
-**Still open after closeout** — the two items above that 7d did not resolve (the
-`applyFontSize` guard, and the wrong e2e-real flake list in
-`docs/product-specs/245-…:15-17`). Neither is TypeScript work; both need a run on
-`main` or a user decision, and they outlive this plan.
+**Nothing is open after closeout.** Both non-TypeScript carry-overs were resolved
+on 2026-08-09: the `applyFontSize` guard stays as-is by user decision, and the
+spec-245 flake list was re-measured and corrected. What that measurement
+*surfaced* — three deterministic e2e-real failures, and a CI quarantine hiding 10
+of 12 tests — belongs to spec 245, not here.
 
 CI follow-ups this migration surfaced but that are **not** TypeScript work — Playwright
 browser-cache scoping and the caret/exact dependency-pin split — are recorded in

--- a/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
+++ b/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
@@ -24,10 +24,13 @@ All three runs produced the *same* 9 passed / 3 failed:
 - `test/e2e-real/scroll-codex.spec.ts:262` — viewport converges to the bottom after a mode switch under continuous output
 - `test/e2e-real/scroll-restream-strand.spec.ts:97` — single full-buffer session: no transient viewport-jump on threshold-crossing resizes
 
-Everything else passes, including **all five `wheel-scroll` cases** and the
-other two `scroll-codex` cases (`unscrolled user not stranded by a resize under
-load`, `scrolled reader not yanked to the bottom`) — the two the original list
-called out by name as the concrete thread.
+Everything else passes, including **all five `wheel-scroll` cases** and the other
+two `scroll-codex` cases: `full scrollback: an unscrolled user is not stranded in
+history by a resize under load` (now `:320`, was `:244`) and `a reader scrolled
+into history is not yanked to the bottom by a resize replay` (now `:385`, was
+`:300`). The first of those is the one the original list singled out as *the
+concrete thread* — the `baseY`-precondition failure quoted below. It passes here,
+3/3.
 
 Two things this measurement changes about the problem statement above:
 
@@ -43,15 +46,19 @@ Two things this measurement changes about the problem statement above:
    The last 8 `main` runs being green is the quarantine working, and is not
    evidence toward this spec's success criteria.
 
-Line numbers are as of the TypeScript conversion (waves 7c/7d) — the specs are
-`.ts` now, and every line number in the original list predates that rename.
+Line numbers above are as of `f5f9665`. The original list's numbers had already
+drifted before the TypeScript rename — the quarantine commit (`428e43d`) and the
+Biome reformat (`63a86fd`) moved `scroll-codex`'s four tests from
+`166/203/244/300` to `189/236/290/355` while the file was still `.js`; the rename
+(wave 7c) then added the last ~26. Do not read the old numbers as "the `.js` line,
+before the rename" — they are older than that.
 
 > **Original failure list (superseded).** Recorded against the `.js` specs before
 > the TS migration: `wheel-scroll.spec.js` `:185`/`:194`/`:203`/`:215`/`:228`;
 > `scroll-codex.spec.js` `:166`/`:203`/`:244`/`:300`;
 > `scroll-restream-strand.spec.js` `:59`.
 
-The failures are load- and timing-dependent, not deterministic: `scroll-codex.spec.js:244` fails with `baseY` at 1624 against an `expect(...).toBeGreaterThan(4500)` precondition — the buffer never reached the scrollback cap the assertion depends on, so the test is failing its *setup*, not its invariant. Several of these were introduced alongside the scroll/replay fixes in the current `[Unreleased]` block, which is where the flakiness likely entered.
+~~The failures are load- and timing-dependent, not deterministic:~~ **Superseded by the 2026-08-09 baseline above** — the three failures that remain are deterministic on an idle machine, and the test this paragraph describes now passes. Kept because the *mechanism* it identifies is still the best hypothesis for the CI-side behavior: `scroll-codex.spec.js:244` (the `unscrolled user is not stranded` case, today `scroll-codex.spec.ts:320`) failed on CI with `baseY` at 1624 against an `expect(...).toBeGreaterThan(4500)` precondition — the buffer never reached the scrollback cap the assertion depends on, so the test was failing its *setup*, not its invariant. Several of these were introduced alongside the scroll/replay fixes in the then-current `[Unreleased]` block, which is where the flakiness likely entered.
 
 Observed twice on PR #244 in a way that isolates the cause from any code change: Linux flipped green → red across `b404d1c`, and macOS flipped green → red across `365ec37`. **Both are documentation-only commits.** A subsequent re-run of the identical macOS commit passed with no changes at all.
 
@@ -78,4 +85,6 @@ CI is a trustworthy merge gate: a red check means the PR broke something. `e2e-r
 
 Surfaced while driving PR #244 (Restart Hive) through `/hs-review-loop`. That PR's own Windows failure *was* real and was fixed; these are not. Evidence is recorded in `docs/exec-plans/completed/243-restart-hive-doesnt-reliably-restart-daemon.md` under `## CI note`.
 
-Root cause is **not** diagnosed here — this spec records the evidence and the impact. The load-dependent `baseY` precondition in `scroll-codex.spec.js:286` is the most concrete starting thread: a runner under CPU contention produces less output in the same wall-clock window, which fits every observation, including why the failure set grows on the slower/busier runs.
+Root cause is **not** diagnosed here — this spec records the evidence and the impact. The load-dependent `baseY` precondition originally cited as `scroll-codex.spec.js:286` (today `scroll-codex.spec.ts:366`, the cap assertion inside the `unscrolled user is not stranded` test) was the most concrete starting thread *for the CI-side flakiness*: a runner under CPU contention produces less output in the same wall-clock window, which fits every CI observation, including why the failure set grows on the slower/busier runs.
+
+**As of the 2026-08-09 baseline that thread is no longer the best place to start.** That test passes 3/3 locally; the three that fail do so deterministically on an idle machine, so they can be debugged directly without reproducing runner contention at all. Start there.

--- a/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
+++ b/docs/product-specs/245-flaky-e2e-real-suite-blocks-every-pr.md
@@ -10,11 +10,46 @@
 
 `CI (Linux)` and `CI (macOS)` fail on `main` itself, including the current tip (`13121a0`). Over the last 8 runs on `main`: Linux failed 5, macOS failed 4, Windows failed 0 — Windows is clean because `build-windows.yml` runs only `go test ./...` and never invokes Playwright. Every failure is in the `e2e-real` suite (`playwright test --config=playwright.real.config.js`, which drives a real `hived` through `hived-ws-bridge`); the Go suites, the Vitest unit/DOM layers, and the mock-bridge `e2e` suite are all consistently green.
 
-The recurring failures cluster in three spec files:
+The recurring failures were originally recorded as clustering in three spec
+files, naming all five `wheel-scroll` cases and four `scroll-codex` cases.
+**That list was wrong** and is corrected below; the original is kept in the
+"Original failure list (superseded)" note at the end of this section so the
+CI-era evidence is not lost.
 
-- `test/e2e-real/wheel-scroll.spec.js` — `:185` pixel-mode, `:194` line-mode, `:203` legacy `wheelDeltaY`, `:215` mouse-tracking forwards the wheel, `:228` alternate-buffer does not swallow the wheel
-- `test/e2e-real/scroll-codex.spec.js` — `:166` markers survive grid↔single toggles, `:203` viewport converges after a mode switch, `:244` unscrolled user not stranded by a resize under load, `:300` scrolled reader not yanked to the bottom
-- `test/e2e-real/scroll-restream-strand.spec.js` — `:59` no transient viewport-jump on threshold crossing
+**Measured 2026-08-09 on `main` (`f5f9665`), macOS, three consecutive local
+runs** (`npx playwright test --config=playwright.real.config.js`, no `CI` env).
+All three runs produced the *same* 9 passed / 3 failed:
+
+- `test/e2e-real/scroll-codex.spec.ts:215` — markers survive grid↔single toggles under continuous output
+- `test/e2e-real/scroll-codex.spec.ts:262` — viewport converges to the bottom after a mode switch under continuous output
+- `test/e2e-real/scroll-restream-strand.spec.ts:97` — single full-buffer session: no transient viewport-jump on threshold-crossing resizes
+
+Everything else passes, including **all five `wheel-scroll` cases** and the
+other two `scroll-codex` cases (`unscrolled user not stranded by a resize under
+load`, `scrolled reader not yanked to the bottom`) — the two the original list
+called out by name as the concrete thread.
+
+Two things this measurement changes about the problem statement above:
+
+1. **The three failures are deterministic on this machine, not flaky** — 3/3
+   runs, identical set. That does not contradict the CI observations (a busy
+   shared runner is a different load profile, and the original green→red flips
+   across doc-only commits are still real), but it means a fix does not need a
+   loaded runner to reproduce: it reproduces on an idle laptop, every time.
+2. **CI has been green since the quarantine landed, not since the flake was
+   fixed.** `scroll-codex`, `scroll-restream-strand` and `wheel-scroll` all carry
+   `test.skip(!!process.env.CI, 'quarantined on CI — flaky setup, spec 245')`, so
+   the CI leg runs **2 of the 12** e2e-real tests (`glyph-utf8`, `lifecycle`).
+   The last 8 `main` runs being green is the quarantine working, and is not
+   evidence toward this spec's success criteria.
+
+Line numbers are as of the TypeScript conversion (waves 7c/7d) — the specs are
+`.ts` now, and every line number in the original list predates that rename.
+
+> **Original failure list (superseded).** Recorded against the `.js` specs before
+> the TS migration: `wheel-scroll.spec.js` `:185`/`:194`/`:203`/`:215`/`:228`;
+> `scroll-codex.spec.js` `:166`/`:203`/`:244`/`:300`;
+> `scroll-restream-strand.spec.js` `:59`.
 
 The failures are load- and timing-dependent, not deterministic: `scroll-codex.spec.js:244` fails with `baseY` at 1624 against an `expect(...).toBeGreaterThan(4500)` precondition — the buffer never reached the scrollback cap the assertion depends on, so the test is failing its *setup*, not its invariant. Several of these were introduced alongside the scroll/replay fixes in the current `[Unreleased]` block, which is where the flakiness likely entered.
 


### PR DESCRIPTION
The list named all five wheel-scroll cases and four scroll-codex cases.
Three consecutive runs on main (f5f9665, macOS, no CI env) give the same
9 passed / 3 failed every time: scroll-codex.spec.ts:215, :262 and
scroll-restream-strand.spec.ts:97. Every wheel-scroll case passes, and so
do the two scroll-codex cases the old list called out as the concrete
thread. The original list is kept as a superseded note — its line numbers
predate the TS rename and re-pointing them would make dead references
look current.

Two things the baseline changes about the problem statement:

The three failures are deterministic on an idle machine, 3/3 runs, not
load-dependent. That does not retract the CI observations — a shared
runner is a different load profile — but a fix no longer needs a loaded
runner to reproduce.

CI has been green since the quarantine landed, not since the flake was
fixed. scroll-codex, scroll-restream-strand and wheel-scroll all carry
test.skip(!!process.env.CI), so the CI leg runs 2 of the 12 e2e-real
tests. Eight green runs on main is the quarantine working, and is not
evidence toward this spec's success criteria.

Also closes the two carry-overs on the completed TypeScript migration
plan: the applyFontSize optional-chain guard stays as-is per the user,
and this flake list is now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the TypeScript migration plan to record resolved follow-up items and confirm no remaining migration work.
  * Clarified flaky end-to-end test results, including deterministic failures, passing cases, and CI quarantine status.
  * Updated references to the converted test specifications and preserved the original failure list for historical context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->