### PR TITLE
fix(gui): session ordering, grid-mode floor, and ⌘-arrow pass-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in focused mode instead, and a grid that shrinks to one tile (the other
   session killed or minimized) returns to focused mode on its own.
 - GUI: ⇧⌘↑ / ⇧⌘↓ now move a session one row at a time within its project,
-  wrapping at the ends. They previously sent a position from the project's
-  own list while the daemon read it as a position in its global list, so a
-  session in any project but the first jumped to an unrelated spot.
+  wrapping at the ends, and never disturb another project. They previously
+  sent a position from the project's own list while the daemon read it as a
+  position in its global list, so a session in any project but the first
+  jumped to an unrelated spot — and sessions created alternately across two
+  projects would not move at all.
 - GUI: a new or duplicated session (⌘T / ⌘P) now appears directly beneath the
   session it was created from, instead of at the very bottom of the sidebar.
 - Codex sessions no longer lose their session ID when Hive happens to read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GUI: ⌘← and ⌘→ (and ⇧⌘← / ⇧⌘→) now reach the terminal in focused mode, so
+  they move the cursor to the start / end of the line — and select to it —
+  the way they do everywhere else. Grid view still uses all four arrows to
+  move between tiles. On macOS these were also registered as native menu
+  accelerators, which consumed them before the app ever saw them; those four
+  duplicate menu items are gone.
+- GUI: ⌘G, ⇧⌘G and ⌘Enter no longer enter a "grid" holding a single tile —
+  a view that looks like focused mode but loses its keybindings. They stay
+  in focused mode instead, and a grid that shrinks to one tile (the other
+  session killed or minimized) returns to focused mode on its own.
+- GUI: ⇧⌘↑ / ⇧⌘↓ now move a session one row at a time within its project,
+  wrapping at the ends. They previously sent a position from the project's
+  own list while the daemon read it as a position in its global list, so a
+  session in any project but the first jumped to an unrelated spot.
+- GUI: a new or duplicated session (⌘T / ⌘P) now appears directly beneath the
+  session it was created from, instead of at the very bottom of the sidebar.
 - Codex sessions no longer lose their session ID when Hive happens to read
   the rollout file while codex is still writing it. The file was rejected
   for good on the first unreadable poll, so nothing was captured and the

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ build.sh           # macOS universal build
 | ⇧⌘W | Close this window |
 | ⌘G / ⇧⌘G | Per-project grid / all-sessions grid |
 | ⌘Enter | Toggle grid / single |
-| ⌘arrows | Spatial nav (grid) / session nav (single) |
+| ⌘↑ / ⌘↓ | Previous / next session (focused) / move between tiles vertically (grid) |
+| ⌘← / ⌘→ | Spatial nav between tiles in grid view. In focused mode these go to the terminal (start / end of line), as do ⇧⌘← / ⇧⌘→ |
+| ⇧⌘↑ / ⇧⌘↓ | Move the session up / down within its project (wraps) |
 | ⌃- / ⌃⇧- | Back / forward through recently visited sessions (Ctrl+Alt+- / Ctrl+Alt+Shift+- on Windows and Linux, where ⌃- is zoom) |
 | ⌘B | Next session needing attention (rang the bell) |
 | ⇧⌘B | Jump back to where you were before the first ⌘B |

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -532,19 +532,22 @@ func (a *App) SaveCustomAgents(list []CustomAgent) error {
 // <gitRoot>/.worktrees/. The daemon broadcasts a SESSION_EVENT(added)
 // over the control connection; the frontend updates the sidebar from
 // that.
-func (a *App) CreateSession(agentID, projectID, name, color string, cols, rows int, useWorktree bool) error {
+// insertAfter names the session the new one should sit directly beneath
+// in the display order (usually the active session); "" appends.
+func (a *App) CreateSession(agentID, projectID, name, color string, cols, rows int, useWorktree bool, insertAfter string) error {
 	cs, err := a.requireControl()
 	if err != nil {
 		return err
 	}
 	return cs.WriteJSON(wire.FrameCreateSession, wire.CreateSpec{
-		Agent:       agentID,
-		ProjectID:   projectID,
-		Name:        name,
-		Color:       color,
-		Cols:        cols,
-		Rows:        rows,
-		UseWorktree: useWorktree,
+		Agent:                agentID,
+		ProjectID:            projectID,
+		Name:                 name,
+		Color:                color,
+		Cols:                 cols,
+		Rows:                 rows,
+		UseWorktree:          useWorktree,
+		InsertAfterSessionID: insertAfter,
 	})
 }
 
@@ -557,16 +560,19 @@ func (a *App) CreateSession(agentID, projectID, name, color string, cols, rows i
 // UseWorktree is forced to false here: when cwd already points inside a
 // worktree, we want to *reuse* it, not stack a nested worktree on top.
 // Passing agentID="" creates a generic shell session.
-func (a *App) DuplicateSession(agentID, projectID, cwd string) error {
+// insertAfter is normally the id of the session being duplicated, so
+// the copy lands directly beneath its source; "" appends.
+func (a *App) DuplicateSession(agentID, projectID, cwd string, insertAfter string) error {
 	cs, err := a.requireControl()
 	if err != nil {
 		return err
 	}
 	return cs.WriteJSON(wire.FrameCreateSession, wire.CreateSpec{
-		Agent:       agentID,
-		ProjectID:   projectID,
-		Cwd:         cwd,
-		UseWorktree: false,
+		Agent:                agentID,
+		ProjectID:            projectID,
+		Cwd:                  cwd,
+		UseWorktree:          false,
+		InsertAfterSessionID: insertAfter,
 	})
 }
 

--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -26,6 +26,11 @@ import type { ScrollTrace } from '../lib/scroll-debug.js';
 export interface EventsDeps {
   switchTo: (id: string) => void;
   renderMinimizedTray: () => void;
+  // renderGrid / enforceViewFloor come through the deps seam rather
+  // than a direct view.ts import: view.ts pulls in sidebar and the
+  // modals, and events.ts is deliberately kept out of that graph.
+  renderGrid: () => void;
+  enforceViewFloor: () => void;
   updateAppTitle: () => void;
   focusActiveTerm: () => void;
   refocusActiveTerm: () => void;
@@ -42,6 +47,8 @@ export interface EventsDeps {
 let deps: EventsDeps = {
   switchTo: () => {},
   renderMinimizedTray: () => {},
+  renderGrid: () => {},
+  enforceViewFloor: () => {},
   updateAppTitle: () => {},
   focusActiveTerm: () => {},
   refocusActiveTerm: () => {},
@@ -335,8 +342,19 @@ export function wireDaemonEvents(injected: EventsDeps) {
         state.activeId = null;
         if (nextId) deps.switchTo(nextId);
       }
+      // Killing the second-to-last tile leaves a one-tile grid, which is
+      // the degenerate state setView refuses to enter.
+      deps.enforceViewFloor();
     } else if (ev.kind === 'updated') {
+      // A reorder arrives as `updated` events carrying new .order
+      // values. renderGrid appends tiles in gridScopeSessions order, so
+      // without a repaint the sidebar reorders while the tiles keep
+      // their stale DOM order.
+      const prevOrder = i >= 0 ? state.sessions[i].order : undefined;
       if (i >= 0) state.sessions[i] = ev.session;
+      if (prevOrder !== ev.session.order && state.view !== 'single') {
+        deps.renderGrid();
+      }
       // Push the new name/color/worktree branch into the cached
       // SessionTerm so the grid tile-header refreshes immediately.
       // Without this, renames look broken in grid mode — the sidebar

--- a/cmd/hivegui/frontend/src/app/keyboard.ts
+++ b/cmd/hivegui/frontend/src/app/keyboard.ts
@@ -53,6 +53,7 @@ import { manualUpdateCheck, restartHive } from './banners.js';
 import { clearAttention } from './events.js';
 import { updateSidebarSelection } from './sidebar.js';
 import { goBack, goForward } from '../lib/nav-history.js';
+import { reorderTarget } from '../lib/reorder.js';
 import { scrollTrace } from './trace.js';
 import { mustEl } from './el.js';
 import type { ProjectInfo } from './state.js';
@@ -638,22 +639,13 @@ export function moveActiveSession(delta: number, reorder: boolean) {
     return;
   }
   if (reorder) {
-    const cur = state.sessions.find((s) => s.id === state.activeId);
-    // idx >= 0 already proves the active session is in the ordered list,
-    // so this can't miss — but the guard is what tells tsc that, and it
-    // replaces the TypeError the old code would have thrown on the
-    // impossible branch. cur.id is state.activeId, non-null by the same
-    // argument, so the UpdateSession call reads it off cur.
-    if (!cur) return;
-    const sib = state.sessions
-      .filter(
-        (s) =>
-          (s.projectId ?? s.project_id) === (cur.projectId ?? cur.project_id),
-      )
-      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-    const sIdx = sib.findIndex((s) => s.id === cur.id);
-    const next = (sIdx + delta + sib.length) % sib.length;
-    UpdateSession(cur.id, '', '', next).catch(reportFailure('reorder'));
+    // reorderTarget returns an index into the GLOBAL ordered list, which
+    // is the index space the daemon's Update expects. Sending a
+    // per-project index here is what used to scatter sessions across
+    // project boundaries.
+    const target = reorderTarget(ord, state.activeId, delta);
+    if (target == null) return;
+    UpdateSession(ord[idx].id, '', '', target).catch(reportFailure('reorder'));
     return;
   }
   const next = (idx + delta + n) % n;

--- a/cmd/hivegui/frontend/src/app/keyboard.ts
+++ b/cmd/hivegui/frontend/src/app/keyboard.ts
@@ -305,21 +305,17 @@ window.addEventListener(
         switchTo(ord[idx].id);
       }
     } else if (e.key === 'ArrowLeft') {
-      swallow();
-      if (state.view !== 'single') gridSpatialMove(-1, 0);
-      else moveActiveSession(-1, e.shiftKey);
+      // Horizontal arrows are only ours in grid mode; handleArrow says
+      // so by returning false, and we leave the key to the terminal.
+      if (handleArrow(-1, 0, e.shiftKey)) swallow();
     } else if (e.key === 'ArrowRight') {
-      swallow();
-      if (state.view !== 'single') gridSpatialMove(+1, 0);
-      else moveActiveSession(+1, e.shiftKey);
+      if (handleArrow(+1, 0, e.shiftKey)) swallow();
     } else if (e.key === 'ArrowUp') {
       swallow();
-      if (state.view !== 'single') gridSpatialMove(0, -1);
-      else moveActiveSession(-1, e.shiftKey);
+      handleArrow(0, -1, e.shiftKey);
     } else if (e.key === 'ArrowDown') {
       swallow();
-      if (state.view !== 'single') gridSpatialMove(0, +1);
-      else moveActiveSession(+1, e.shiftKey);
+      handleArrow(0, +1, e.shiftKey);
     } else if (e.key === '[') {
       swallow();
       shiftActiveProject(-1);
@@ -365,17 +361,37 @@ export function toggleAllGrid() {
   setView(state.view === 'grid-all' ? 'single' : 'grid-all');
 }
 
-export function navSession(delta: number) {
+// handleArrow is the single implementation behind both the ⌘-arrow
+// keydowns and the Session-menu events, so the two can't drift (they
+// had: the menu's next/prev-session mapped ⌘↓ to a horizontal grid
+// move).
+//
+// Returns true when the app consumed the key. Horizontal arrows in
+// focused mode return false: ⌘←/⌘→ and ⇧⌘←/⇧⌘→ are start/end-of-line
+// (and select-to-start/end) in the terminal, and the app must not take
+// them.
+export function handleArrow(
+  dCol: number,
+  dRow: number,
+  shift: boolean,
+): boolean {
   if (state.view !== 'single') {
-    gridSpatialMove(delta > 0 ? +1 : -1, 0);
-  } else {
-    moveActiveSession(delta, false);
+    gridSpatialMove(dCol, dRow);
+    return true;
   }
+  if (dCol !== 0) return false; // ⌘←/→ belong to the terminal in focused mode
+  moveActiveSession(dRow, shift);
+  return true;
 }
 
+export function navSession(delta: number) {
+  handleArrow(0, delta, false);
+}
+
+// A menu item labelled "Move Session Forward" must reorder in every
+// view — it used to silently become a horizontal grid move.
 export function reorderActive(delta: number) {
-  if (state.view === 'single') moveActiveSession(delta, true);
-  else gridSpatialMove(delta > 0 ? +1 : -1, 0);
+  moveActiveSession(delta, true);
 }
 
 // jumpToAttention (⌘B) goes to the next session with an unread bell,

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -145,11 +145,16 @@ function moveLauncherSelection(delta: number) {
 function launchSelected(agentId: string) {
   bumpAgentUsage(agentId);
   flashStatus('creating session…');
+  // Anchor the new session under the one it came from (duplicate) or
+  // under the active one, so it lands next to its context instead of at
+  // the bottom of the sidebar.
+  const anchor = launcherState.duplicateFrom?.id || state.activeId || '';
   if (launcherState.duplicateFrom) {
     DuplicateSession(
       agentId,
       launcherState.projectId || '',
       launcherState.duplicateCwd,
+      anchor,
     ).catch(reportFailure('duplicate session'));
   } else {
     CreateSession(
@@ -160,6 +165,7 @@ function launchSelected(agentId: string) {
       0,
       0,
       !!launcherState.useWorktree,
+      anchor,
     ).catch(reportFailure('new session'));
   }
   closeLauncher();
@@ -465,7 +471,7 @@ export function duplicateActiveSession() {
   }
   const pid = s.projectId ?? s.project_id ?? '';
   if (s.agent) bumpAgentUsage(s.agent);
-  DuplicateSession(s.agent || '', pid, cwd).catch(
+  DuplicateSession(s.agent || '', pid, cwd, s.id).catch(
     reportFailure('duplicate session'),
   );
 }

--- a/cmd/hivegui/frontend/src/app/sidebar.ts
+++ b/cmd/hivegui/frontend/src/app/sidebar.ts
@@ -369,6 +369,13 @@ function renderSession(s: SessionInfo, projectColor: string): HTMLLIElement {
 
 // reorderDroppedSession converts a drop position ("above" or "below"
 // the target row) into a global Order argument for UpdateSession.
+//
+// Kept separate from lib/reorder.ts's reorderTarget on purpose: that one
+// answers "swap with the adjacent sibling" (⇧⌘↑/↓) and can name the
+// target's own .order directly, while a drop can land between any two
+// rows and needs the shift compensation below. Both rely on the same
+// invariant — .order IS the index into the daemon's r.order — so if you
+// change that assumption, change it in both.
 // The daemon's moveLocked treats the argument as a global index into
 // r.order; we pick the global Order of whichever neighbor sits at
 // the project-relative drop slot (after pretending the dragged

--- a/cmd/hivegui/frontend/src/app/view.ts
+++ b/cmd/hivegui/frontend/src/app/view.ts
@@ -7,7 +7,7 @@
 
 import { WindowSetTitle, LogFrontend } from '../bridge.js';
 import { state, type SessionInfo, type TermTile } from './state.js';
-import { termsHost, setStatus } from './dom.js';
+import { termsHost, setStatus, flashStatus } from './dom.js';
 import { orderedSessions, activeProjectId } from './selectors.js';
 import { updateSidebarSelection } from './sidebar.js';
 import { openLauncher } from './modals/launcher.js';
@@ -17,7 +17,7 @@ import {
   computeSpatialMove,
   type GridLayout,
 } from '../lib/grid.js';
-import { VIEW_STORAGE_KEY, type ViewMode } from '../lib/view.js';
+import { VIEW_STORAGE_KEY, resolveView, type ViewMode } from '../lib/view.js';
 import { filterMinimized } from '../lib/minimized.js';
 import { snapVisibleTermsToBottom } from '../lib/view-scroll.js';
 import { emptyStateModel } from '../lib/empty-state.js';
@@ -380,20 +380,26 @@ export function shiftActiveProject(delta: number) {
   setStatus(`${next.name}${sessions.length === 0 ? ' (empty)' : ''}`);
 }
 
-// gridScopeSessions returns the list of sessions that should be tiled
-// in the current grid view.
-export function gridScopeSessions() {
-  if (state.view === 'grid-all') {
+// gridScopeFor returns the sessions a given grid view would tile, for a
+// view the app is not necessarily in yet — setView needs the count
+// before it commits to the mode.
+export function gridScopeFor(view: ViewMode, projectId?: string) {
+  if (view === 'grid-all') {
     return filterMinimized(orderedSessions(), state.minimized);
   }
-  if (state.view === 'grid-project') {
-    const pid = state.gridProjectId || activeProjectId();
+  if (view === 'grid-project') {
     const scoped = state.sessions
-      .filter((s) => (s.projectId ?? s.project_id) === pid)
+      .filter((s) => (s.projectId ?? s.project_id) === projectId)
       .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
     return filterMinimized(scoped, state.minimized);
   }
   return [];
+}
+
+// gridScopeSessions returns the list of sessions that should be tiled
+// in the current grid view.
+export function gridScopeSessions() {
+  return gridScopeFor(state.view, state.gridProjectId || activeProjectId());
 }
 
 // minimizeSession hides a session from grid views by adding its id to
@@ -415,6 +421,16 @@ export function minimizeSession(id: string | null) {
     rebaselineGridReplayCols();
   }
   renderMinimizedTray();
+  enforceViewFloor();
+}
+
+// enforceViewFloor drops back to focused mode when the current grid's
+// scope has fallen below two tiles (last sibling killed, or minimized
+// away) — the same degenerate one-tile grid setView refuses to enter.
+export function enforceViewFloor() {
+  if (state.view === 'single') return;
+  if (gridScopeSessions().length >= 2) return;
+  setView('single');
 }
 
 // restoreSession removes a session from state.minimized and switches
@@ -572,6 +588,15 @@ export function renderEmptyState() {
 }
 
 export function setView(view: ViewMode) {
+  // A grid of one tile looks like focused mode but loses the focused-mode
+  // keybindings, so ⌘G / ⇧⌘G / ⌘↩ below the floor stay where they are.
+  // The startup restore of a persisted view goes through here too.
+  const target = resolveView(
+    view,
+    view === 'single' ? 0 : gridScopeFor(view, activeProjectId()).length,
+  );
+  if (target !== view) flashStatus('only one session — staying focused');
+  view = target;
   state.view = view;
   try {
     localStorage.setItem(VIEW_STORAGE_KEY, view);

--- a/cmd/hivegui/frontend/src/lib/reorder.ts
+++ b/cmd/hivegui/frontend/src/lib/reorder.ts
@@ -1,0 +1,33 @@
+// reorderTarget converts "move the active session one slot up/down inside its
+// own project" into the index the daemon wants.
+//
+// The daemon's session order (internal/registry: r.order) is ONE global list
+// spanning every project; Entry.Order is an index into it, and
+// registry.moveInOrder deletes the id then inserts at the given index. So the
+// correct request for "swap with the adjacent sibling" is that sibling's
+// CURRENT index in the global ordered list — which stays correct after the
+// delete-then-insert in both directions and in both wrap cases.
+//
+// `ordered` must be the display order (app/selectors.ts orderedSessions()):
+// sorted by project, then by session order. Wrapping is within the project —
+// the last session in a project moves to the top of that same project.
+// Returns null when there is nothing to do (unknown active session, or a
+// project with fewer than two sessions).
+export function reorderTarget(
+  ordered: { id: string; projectId?: string; project_id?: string }[],
+  activeId: string | null,
+  delta: number,
+): number | null {
+  if (!activeId || delta === 0) return null;
+  const cur = ordered.find((s) => s.id === activeId);
+  if (!cur) return null;
+  const pid = cur.projectId ?? cur.project_id ?? '';
+  const sibs = ordered.filter(
+    (s) => (s.projectId ?? s.project_id ?? '') === pid,
+  );
+  if (sibs.length < 2) return null;
+  const sIdx = sibs.findIndex((s) => s.id === activeId);
+  const tgt = sibs[(sIdx + delta + sibs.length) % sibs.length];
+  if (tgt.id === activeId) return null;
+  return ordered.findIndex((s) => s.id === tgt.id);
+}

--- a/cmd/hivegui/frontend/src/lib/reorder.ts
+++ b/cmd/hivegui/frontend/src/lib/reorder.ts
@@ -2,19 +2,33 @@
 // own project" into the index the daemon wants.
 //
 // The daemon's session order (internal/registry: r.order) is ONE global list
-// spanning every project; Entry.Order is an index into it, and
-// registry.moveInOrder deletes the id then inserts at the given index. So the
-// correct request for "swap with the adjacent sibling" is that sibling's
-// CURRENT index in the global ordered list — which stays correct after the
+// spanning every project, and registry.moveInOrder deletes the id then inserts
+// at the given index. So the request for "swap with the adjacent sibling" is
+// that sibling's CURRENT index in r.order, which stays correct after the
 // delete-then-insert in both directions and in both wrap cases.
 //
+// That index is the sibling's own `order` field — NOT its position in
+// `ordered`. r.order is a flat creation-order list that is not grouped by
+// project, while orderedSessions() groups by project first, so the two agree
+// only when sessions happen to have been created project-by-project. Creating
+// sessions alternately across projects makes every display position wrong, and
+// the resulting move silently lands in the wrong place or does nothing.
+// (app/sidebar.ts's drag-to-reorder path resolves the same conversion off
+// `.order` for the same reason — keep the two consistent.)
+//
 // `ordered` must be the display order (app/selectors.ts orderedSessions()):
-// sorted by project, then by session order. Wrapping is within the project —
-// the last session in a project moves to the top of that same project.
-// Returns null when there is nothing to do (unknown active session, or a
-// project with fewer than two sessions).
+// sorted by project, then by session order. Only *adjacency* is read from it;
+// the returned index comes from the target's own `order`. Wrapping is within
+// the project — the last session in a project moves to the top of that same
+// project. Returns null when there is nothing to do (unknown active session, a
+// project with fewer than two sessions, or a target with no `order` value).
 export function reorderTarget(
-  ordered: { id: string; projectId?: string; project_id?: string }[],
+  ordered: {
+    id: string;
+    projectId?: string;
+    project_id?: string;
+    order?: number;
+  }[],
   activeId: string | null,
   delta: number,
 ): number | null {
@@ -29,5 +43,5 @@ export function reorderTarget(
   const sIdx = sibs.findIndex((s) => s.id === activeId);
   const tgt = sibs[(sIdx + delta + sibs.length) % sibs.length];
   if (tgt.id === activeId) return null;
-  return ordered.findIndex((s) => s.id === tgt.id);
+  return tgt.order ?? null;
 }

--- a/cmd/hivegui/frontend/src/lib/shortcuts.ts
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.ts
@@ -95,7 +95,8 @@ export function shortcutGroups({ isMac }: { isMac: boolean }): ShortcutGroup[] {
   const m = (key: string, opts?: ModOpts) => mod(isMac, key, opts);
   const c = (key: string, opts?: ModOpts) => ctrl(isMac, key, opts);
   const ca = (key: string, opts?: ModOpts) => ctrlAlt(isMac, key, opts);
-  const arrows = arrowSeq(isMac, 'up', 'down', 'left', 'right');
+  const vArrows = arrowSeq(isMac, 'up', 'down');
+  const hArrows = arrowSeq(isMac, 'left', 'right');
   return [
     {
       title: 'Sessions',
@@ -110,12 +111,17 @@ export function shortcutGroups({ isMac }: { isMac: boolean }): ShortcutGroup[] {
         { keys: m('W'), label: 'Close session' },
         { keys: `${m('1')}–${m('9')}`, label: 'Switch to session 1–9' },
         {
-          keys: `${isMac ? '⌘' : 'Ctrl+'}${arrows}`,
-          label: 'Next / previous session (spatial move in grid)',
+          keys: `${isMac ? '⌘' : 'Ctrl+'}${vArrows}`,
+          label: 'Next / previous session (grid: move between tiles)',
         },
         {
-          keys: `${isMac ? '⇧⌘' : 'Ctrl+Shift+'}${arrows}`,
-          label: 'Reorder session',
+          keys: `${isMac ? '⌘' : 'Ctrl+'}${hArrows}`,
+          label:
+            'Grid: move between tiles — in focused mode these reach the terminal (start / end of line)',
+        },
+        {
+          keys: `${isMac ? '⇧⌘' : 'Ctrl+Shift+'}${vArrows}`,
+          label: 'Reorder session within its project (wraps)',
         },
         { keys: ca('-'), label: 'Go back to the previously visited session' },
         { keys: ca('-', { shift: true }), label: 'Go forward again' },

--- a/cmd/hivegui/frontend/src/lib/view.ts
+++ b/cmd/hivegui/frontend/src/lib/view.ts
@@ -26,3 +26,12 @@ export function normalizeView(v: unknown): ViewMode {
     ? (v as ViewMode)
     : VIEW_SINGLE;
 }
+
+// resolveView downgrades a grid request to 'single' when the grid would
+// contain fewer than two tiles. A one-tile grid is visually identical to
+// focused mode but loses the focused-mode keybindings, so entering one is
+// never what the user meant.
+export function resolveView(requested: ViewMode, scopeCount: number): ViewMode {
+  if (requested !== VIEW_SINGLE && scopeCount < 2) return VIEW_SINGLE;
+  return requested;
+}

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -46,6 +46,8 @@ import {
   renderMinimizedTray,
   renderEmptyState,
   shiftActiveProject,
+  renderGrid,
+  enforceViewFloor,
   initView,
 } from './app/view.js';
 import {
@@ -217,6 +219,8 @@ initKeyboard({
 wireDaemonEvents({
   switchTo,
   renderMinimizedTray,
+  renderGrid,
+  enforceViewFloor,
   updateAppTitle,
   focusActiveTerm,
   refocusActiveTerm,

--- a/cmd/hivegui/frontend/test/dom/events-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/events-focus.test.ts
@@ -69,6 +69,8 @@ describe('wireDaemonEvents window-focus handler', () => {
     wireDaemonEvents({
       switchTo: vi.fn(),
       renderMinimizedTray: vi.fn(),
+      renderGrid: vi.fn(),
+      enforceViewFloor: vi.fn(),
       updateAppTitle: vi.fn(),
       focusActiveTerm: vi.fn(),
       refocusActiveTerm,

--- a/cmd/hivegui/frontend/test/dom/keyboard-arrows.test.ts
+++ b/cmd/hivegui/frontend/test/dom/keyboard-arrows.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+//
+// ⌘-arrow routing (src/app/keyboard.ts handleArrow).
+//
+// Three things are pinned here, all of which shipped broken:
+//   • ⌘←/⌘→ (and ⇧⌘←/⇧⌘→) are start/end-of-line in the terminal, so in
+//     focused mode the app must NOT preventDefault them.
+//   • In grid mode the same keys are spatial navigation, and a vertical
+//     arrow must move vertically — the menu path used to map ⌘↓ to a
+//     horizontal move.
+//   • ⇧⌘↑/↓ reorder inside the project and send an index into the
+//     daemon's GLOBAL order list, wrapping within the project.
+//
+// view.ts is mocked so the assertions are about routing, not geometry:
+// gridSpatialMove's real implementation needs layout jsdom doesn't have.
+// The grid-floor behaviour runs against the real view.ts in the sibling
+// view-floor.test.ts.
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  type MockedFunction,
+} from 'vitest';
+
+vi.mock('../../src/bridge.js', () => {
+  const fn = () => vi.fn(() => Promise.resolve());
+  return {
+    ConnectControl: fn(),
+    OpenSession: fn(),
+    CloseAttach: fn(),
+    WriteStdin: fn(),
+    ResizeSession: fn(),
+    RequestScrollbackReplay: fn(),
+    CreateSession: fn(),
+    DuplicateSession: fn(),
+    KillSession: fn(),
+    RestartSession: fn(),
+    UpdateSession: fn(),
+    ListAgents: fn(),
+    CreateProject: fn(),
+    KillProject: fn(),
+    UpdateProject: fn(),
+    LaunchDir: fn(),
+    PickDirectory: fn(),
+    OpenNewWindow: fn(),
+    CloseWindow: fn(),
+    IsGitRepo: fn(),
+    OpenURL: fn(),
+    OpenTerminalAt: fn(),
+    Notify: fn(),
+    Confirm: fn(),
+    RestartDaemon: fn(),
+    CheckForUpdate: fn(),
+    SetClipboardText: fn(),
+    EventsOn: vi.fn(),
+    WindowSetTitle: vi.fn(),
+    ClipboardGetText: fn(),
+  };
+});
+
+// Every view export keyboard.ts imports must be listed: a missing entry
+// surfaces as an undefined call deep in a handler, not a clear failure.
+vi.mock('../../src/app/view.js', () => ({
+  switchTo: vi.fn(),
+  setView: vi.fn(),
+  gridSpatialMove: vi.fn(),
+  shiftActiveProject: vi.fn(),
+  restoreSession: vi.fn(),
+  minimizeSession: vi.fn(),
+}));
+
+type View = typeof import('../../src/app/view.js');
+type Bridge = typeof import('../../src/bridge.js');
+
+let state: typeof import('../../src/app/state.js').state;
+let gridSpatialMove: MockedFunction<View['gridSpatialMove']>;
+let switchTo: MockedFunction<View['switchTo']>;
+let UpdateSession: MockedFunction<Bridge['UpdateSession']>;
+let EventsOn: MockedFunction<Bridge['EventsOn']>;
+
+beforeAll(async () => {
+  // The keydown listener dereferences every modal before reaching the
+  // shortcut chain; without these it throws before any binding runs.
+  document.body.innerHTML = `
+    <div id="terms"></div><ul id="projects"></ul><div id="status"></div>
+    <div id="launcher" class="hidden"></div>
+    <div id="project-editor" class="hidden"></div>
+    <div id="command-palette" class="hidden"></div>
+    <div id="help-overlay" class="hidden"></div>`;
+  ({ state } = await import('../../src/app/state.js'));
+  const view = await import('../../src/app/view.js');
+  gridSpatialMove = vi.mocked(view.gridSpatialMove);
+  switchTo = vi.mocked(view.switchTo);
+  const bridge = await import('../../src/bridge.js');
+  UpdateSession = vi.mocked(bridge.UpdateSession);
+  EventsOn = vi.mocked(bridge.EventsOn);
+  await import('../../src/app/keyboard.js');
+});
+
+// cmdOrCtrl() reads the real platform: metaKey on mac, ctrlKey elsewhere.
+const primary = /mac|iphone|ipad/i.test(navigator.platform)
+  ? { metaKey: true }
+  : { ctrlKey: true };
+
+function press(key: string, opts: KeyboardEventInit = {}) {
+  const e = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...primary,
+    ...opts,
+  });
+  window.dispatchEvent(e);
+  return e;
+}
+
+beforeEach(() => {
+  gridSpatialMove.mockClear();
+  switchTo.mockClear();
+  UpdateSession.mockClear();
+  // Global display order: [a0, a1, b0, b1, b2] — indices 0..4, which is
+  // the index space the daemon's Update expects.
+  state.projects = [{ id: 'A' }, { id: 'B' }];
+  state.sessions = [
+    { id: 'a0', project_id: 'A', order: 0 },
+    { id: 'a1', project_id: 'A', order: 1 },
+    { id: 'b0', project_id: 'B', order: 2 },
+    { id: 'b1', project_id: 'B', order: 3 },
+    { id: 'b2', project_id: 'B', order: 4 },
+  ];
+  state.activeId = 'b1';
+  state.view = 'single';
+  state.minimized = new Set();
+  state.attention = new Set();
+});
+
+describe('horizontal arrows in focused mode belong to the terminal', () => {
+  for (const key of ['ArrowLeft', 'ArrowRight']) {
+    for (const shift of [false, true]) {
+      it(`${shift ? 'shift+' : ''}cmd+${key} is not consumed`, () => {
+        const e = press(key, { shiftKey: shift });
+        expect(e.defaultPrevented).toBe(false);
+        expect(state.activeId).toBe('b1');
+        expect(switchTo).not.toHaveBeenCalled();
+        expect(UpdateSession).not.toHaveBeenCalled();
+        expect(gridSpatialMove).not.toHaveBeenCalled();
+      });
+    }
+  }
+});
+
+describe('arrows in grid mode are spatial navigation', () => {
+  beforeEach(() => {
+    state.view = 'grid-all';
+  });
+
+  it('cmd+ArrowLeft is consumed and moves the active tile', () => {
+    const e = press('ArrowLeft');
+    expect(e.defaultPrevented).toBe(true);
+    expect(gridSpatialMove).toHaveBeenCalledWith(-1, 0);
+  });
+
+  it('cmd+ArrowDown moves DOWN, not right', () => {
+    press('ArrowDown');
+    expect(gridSpatialMove).toHaveBeenCalledWith(0, +1);
+  });
+
+  it('cmd+ArrowRight moves right', () => {
+    press('ArrowRight');
+    expect(gridSpatialMove).toHaveBeenCalledWith(+1, 0);
+  });
+});
+
+describe('shift+cmd vertical arrows reorder within the project', () => {
+  it('moves down to the next sibling’s global index', () => {
+    press('ArrowDown', { shiftKey: true });
+    // b1 → swaps with b2, whose current global index is 4.
+    expect(UpdateSession).toHaveBeenCalledWith('b1', '', '', 4);
+  });
+
+  it('moves up to the previous sibling’s global index', () => {
+    press('ArrowUp', { shiftKey: true });
+    expect(UpdateSession).toHaveBeenCalledWith('b1', '', '', 2);
+  });
+
+  it("wraps from a project's last session to its first", () => {
+    state.activeId = 'b2';
+    press('ArrowDown', { shiftKey: true });
+    expect(UpdateSession).toHaveBeenCalledWith('b2', '', '', 2);
+  });
+
+  it("wraps from a project's first session to its last", () => {
+    state.activeId = 'b0';
+    press('ArrowUp', { shiftKey: true });
+    expect(UpdateSession).toHaveBeenCalledWith('b0', '', '', 4);
+  });
+
+  it('never targets a session in another project', () => {
+    // a0/a1 are the whole of project A: down from a1 wraps to a0 (0),
+    // it must not walk into project B.
+    state.activeId = 'a1';
+    press('ArrowDown', { shiftKey: true });
+    expect(UpdateSession).toHaveBeenCalledWith('a1', '', '', 0);
+  });
+});
+
+describe('Session-menu arrow actions', () => {
+  const fire = (name: string) => {
+    const call = EventsOn.mock.calls.find(([n]) => n === name);
+    if (!call) throw new Error(`no handler registered for ${name}`);
+    (call[1] as () => void)();
+  };
+
+  it('menu:move-session-forward reorders while in grid mode', () => {
+    state.view = 'grid-all';
+    fire('menu:move-session-forward');
+    expect(UpdateSession).toHaveBeenCalledWith('b1', '', '', 4);
+    expect(gridSpatialMove).not.toHaveBeenCalled();
+  });
+
+  it('menu:next-session navigates vertically in grid mode', () => {
+    state.view = 'grid-all';
+    fire('menu:next-session');
+    expect(gridSpatialMove).toHaveBeenCalledWith(0, +1);
+  });
+
+  it('menu:next-session switches session in focused mode', () => {
+    fire('menu:next-session');
+    expect(switchTo).toHaveBeenCalledWith('b2');
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/view-floor.test.ts
+++ b/cmd/hivegui/frontend/test/dom/view-floor.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+//
+// The two-tile floor on grid views, against the REAL view.ts.
+//
+// A grid holding one tile looks exactly like focused mode but loses the
+// focused-mode keybindings, so ⌘G / ⇧⌘G / ⌘↩ must be no-ops below the
+// floor — and a live grid that shrinks to one tile (session killed, or
+// minimized away) must fall back on its own. The sibling
+// keyboard-arrows.test.ts mocks view.ts, so it cannot see any of this.
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { createScrollTrace } from '../../src/lib/scroll-debug.js';
+import type { TermTile } from '../../src/app/state.js';
+
+vi.mock('../../src/bridge.js', () => {
+  const fn = () => vi.fn(() => Promise.resolve());
+  return {
+    ConnectControl: fn(),
+    OpenSession: fn(),
+    CloseAttach: fn(),
+    WriteStdin: fn(),
+    ResizeSession: fn(),
+    RequestScrollbackReplay: fn(),
+    CreateSession: fn(),
+    DuplicateSession: fn(),
+    KillSession: fn(),
+    RestartSession: fn(),
+    UpdateSession: fn(),
+    ListAgents: fn(),
+    CreateProject: fn(),
+    KillProject: fn(),
+    UpdateProject: fn(),
+    LaunchDir: fn(),
+    PickDirectory: fn(),
+    OpenNewWindow: fn(),
+    CloseWindow: fn(),
+    IsGitRepo: fn(),
+    OpenURL: fn(),
+    OpenTerminalAt: fn(),
+    Notify: fn(),
+    Confirm: fn(),
+    RestartDaemon: fn(),
+    CheckForUpdate: fn(),
+    SetClipboardText: fn(),
+    EventsOn: vi.fn(),
+    WindowSetTitle: vi.fn(),
+    ClipboardGetText: fn(),
+  };
+});
+
+let state: typeof import('../../src/app/state.js').state;
+let view: typeof import('../../src/app/view.js');
+
+function fakeTerm(): TermTile {
+  return {
+    host: document.createElement('div'),
+    attached: true,
+    needsReattach: false,
+    deadOverlayShown: false,
+    ensureAttached() {},
+    show() {},
+    hide() {},
+    rebaselineReplayCols() {},
+    _onBodyResize() {},
+    setInfo() {},
+    setProject() {},
+    setDead() {},
+    writeData() {},
+    destroy() {},
+    _closeDead() {},
+    _dismissDead() {},
+  };
+}
+
+function tile(id: string): TermTile {
+  const t = state.terms.get(id);
+  expect(t, `no term stub for ${id}`).toBeDefined();
+  return t as TermTile;
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  document.body.innerHTML = `
+    <div id="app"><ul id="projects"></ul><div id="status"></div>
+    <div id="terms"></div><div id="minimized-tray"></div>
+    <div id="empty-state"></div></div>`;
+  ({ state } = await import('../../src/app/state.js'));
+  view = await import('../../src/app/view.js');
+  const { setActive } = await import('../../src/app/focus.js');
+  view.initView({
+    ensureTerm: (info) => tile(info.id),
+    setActive,
+    focusActiveTerm: () => {},
+    scrollTrace: createScrollTrace({ enabled: false }),
+  });
+});
+
+beforeEach(() => {
+  vi.useFakeTimers(); // setView arms a 250ms post-switch snap
+  // p1 has two sessions, p2 has one.
+  state.projects = [{ id: 'p1' }, { id: 'p2' }];
+  state.sessions = [
+    { id: 'a', project_id: 'p1', order: 0 },
+    { id: 'b', project_id: 'p1', order: 1 },
+    { id: 'z', project_id: 'p2', order: 2 },
+  ];
+  state.terms = new Map(state.sessions.map((s) => [s.id, fakeTerm()]));
+  state.activeId = 'a';
+  state.currentProjectId = 'p1';
+  state.view = 'single';
+  state.gridProjectId = null;
+  state.minimized = new Set();
+  state.attention = new Set();
+});
+
+// setView's snap timer would otherwise fire against a torn-down jsdom.
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+});
+
+describe('setView floor', () => {
+  it('stays focused when the project has a single session (⌘G)', () => {
+    state.activeId = 'z';
+    state.currentProjectId = 'p2';
+    view.setView('grid-project');
+    expect(state.view).toBe('single');
+  });
+
+  it('stays focused when there is a single session overall (⇧⌘G)', () => {
+    state.sessions = [state.sessions[0]];
+    view.setView('grid-all');
+    expect(state.view).toBe('single');
+  });
+
+  it('enters grid-project with two sessions in the project', () => {
+    view.setView('grid-project');
+    expect(state.view).toBe('grid-project');
+  });
+
+  it('enters grid-all with two sessions overall', () => {
+    view.setView('grid-all');
+    expect(state.view).toBe('grid-all');
+  });
+
+  it('does not count minimized sessions toward the floor', () => {
+    state.minimized = new Set(['b']);
+    view.setView('grid-project');
+    expect(state.view).toBe('single');
+  });
+});
+
+describe('enforceViewFloor', () => {
+  it('leaves a grid with two or more tiles alone', () => {
+    view.setView('grid-project');
+    view.enforceViewFloor();
+    expect(state.view).toBe('grid-project');
+  });
+
+  it('exits grid mode when a session is removed down to one', () => {
+    view.setView('grid-all');
+    expect(state.view).toBe('grid-all');
+    // What events.ts's `removed` branch does before calling the floor.
+    state.sessions = state.sessions.slice(0, 1);
+    view.enforceViewFloor();
+    expect(state.view).toBe('single');
+  });
+
+  it('exits grid mode when a session is minimized down to one', () => {
+    state.sessions = state.sessions.slice(0, 2); // just p1's pair
+    view.setView('grid-all');
+    expect(state.view).toBe('grid-all');
+    view.minimizeSession('b');
+    expect(state.view).toBe('single');
+  });
+
+  it('is a no-op in focused mode', () => {
+    view.enforceViewFloor();
+    expect(state.view).toBe('single');
+  });
+});

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
@@ -152,6 +152,7 @@ export async function CreateSession(
   cols: number,
   rows: number,
   useWorktree: boolean,
+  insertAfter?: string,
 ) {
   // The Wails signature uses positional args; map to the bridge's
   // CreateSpec shape.
@@ -163,10 +164,16 @@ export async function CreateSession(
     cols: cols || 80,
     rows: rows || 24,
     use_worktree: !!useWorktree,
+    insert_after_session_id: insertAfter || '',
   });
 }
-export async function DuplicateSession() {
-  return CreateSession('', '', 'dup', '', 80, 24, false);
+export async function DuplicateSession(
+  _agentID?: string,
+  _projectID?: string,
+  _cwd?: string,
+  insertAfter?: string,
+) {
+  return CreateSession('', '', 'dup', '', 80, 24, false, insertAfter);
 }
 export async function KillSession(id: string, force: boolean) {
   return call('KillSession', { session_id: id, force: !!force });

--- a/cmd/hivegui/frontend/test/e2e/hive-global.d.ts
+++ b/cmd/hivegui/frontend/test/e2e/hive-global.d.ts
@@ -31,7 +31,11 @@ interface HiveTestApi {
 
   // --- Mock only (test/e2e/wails-mock.ts). Absent under VITE_WAILS_REAL. ---
   state?: { projects: MockProject[]; sessions: MockSession[] };
-  addSession?(name: string, insertAfter?: string): Promise<string>;
+  addSession?(
+    name: string,
+    insertAfter?: string,
+    projectId?: string,
+  ): Promise<string>;
   killSession?(id: string): Promise<string>;
   replayLog?: { id: string; t: number }[];
   replayCount?(id?: string): number;

--- a/cmd/hivegui/frontend/test/e2e/hive-global.d.ts
+++ b/cmd/hivegui/frontend/test/e2e/hive-global.d.ts
@@ -31,7 +31,7 @@ interface HiveTestApi {
 
   // --- Mock only (test/e2e/wails-mock.ts). Absent under VITE_WAILS_REAL. ---
   state?: { projects: MockProject[]; sessions: MockSession[] };
-  addSession?(name: string): Promise<string>;
+  addSession?(name: string, insertAfter?: string): Promise<string>;
   killSession?(id: string): Promise<string>;
   replayLog?: { id: string; t: number }[];
   replayCount?(id?: string): number;
@@ -48,6 +48,10 @@ declare global {
     // Assigned by test/e2e/fixtures/xterm-reflow.ts, read by its spec through
     // the fixture page only — hence optional, like the debug globals in
     // src/globals.d.ts.
+    // Set by test/e2e/ordering.spec.ts to record whether anything
+    // consumed a ⌘-arrow keydown. Optional for the same reason as
+    // __reflow: only that one spec assigns it.
+    __arrowPrevented?: boolean | null;
     __reflow?: ReflowApi;
     __reflowReady?: boolean;
   }

--- a/cmd/hivegui/frontend/test/e2e/minimize.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/minimize.spec.ts
@@ -53,18 +53,34 @@ test.describe('session minimize', () => {
     await expect(tray.locator(`.min-chip[data-sid="${sid}"]`)).toBeVisible();
   });
 
+  // Three sessions, not two: a grid that drops below two tiles now
+  // returns to focused mode (see ordering.spec.ts), so minimizing one of
+  // a pair would leave no grid to restore into.
   test('restore from tray returns session to grid', async ({ page }) => {
-    await bootWithSessions(page, 2);
+    await bootWithSessions(page, 3);
     await enterGridAll(page);
 
     const firstTile = page.locator('.term-host.in-grid').first();
     const sid = await firstTile.evaluate((el) => el.dataset.sid);
     await firstTile.locator('.tile-minimize').click();
-    await expect(page.locator('.term-host.in-grid')).toHaveCount(1);
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(2);
 
     await page.locator(`#minimized-tray .min-chip[data-sid="${sid}"]`).click();
-    await expect(page.locator('.term-host.in-grid')).toHaveCount(2);
+    await expect(page.locator('.term-host.in-grid')).toHaveCount(3);
     await expect(page.locator('#minimized-tray')).toHaveClass(/hidden/);
+  });
+
+  test('minimizing a grid down to one tile returns to focused mode', async ({
+    page,
+  }) => {
+    await bootWithSessions(page, 2);
+    await enterGridAll(page);
+    await page
+      .locator('.term-host.in-grid')
+      .first()
+      .locator('.tile-minimize')
+      .click();
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
   });
 
   test('minimizing the active session moves focus to another visible tile', async ({

--- a/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
@@ -141,6 +141,71 @@ test.describe('session ordering', () => {
       .toEqual([before[1], before[2], before[0]]);
   });
 
+  // The regression the unit suite pins at the pure-function level, run
+  // end to end: alternate creates across two projects so the daemon's
+  // flat order interleaves them and every session's display position
+  // stops matching its .order. Sending a display position here used to
+  // be accepted and change nothing.
+  test('reorders correctly when projects interleave in the daemon order', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.waitForFunction(
+      () => document.querySelectorAll('#projects li').length > 0,
+    );
+    // Second project, announced the way the daemon would.
+    await page.evaluate(() => {
+      const p = {
+        id: 'p2',
+        name: 'other',
+        color: '#f80',
+        cwd: '',
+        order: 1,
+        created: new Date().toISOString(),
+      };
+      window.__hive.state?.projects.push(p);
+      window.__hive.emit?.(
+        'project:event',
+        JSON.stringify({ kind: 'added', project: p }),
+      );
+    });
+    // r.order ends up p1, p2, p1, p2, p1 — interleaved.
+    await page.evaluate(async () => {
+      await window.__hive.addSession?.('t1', undefined, 'p2');
+      await window.__hive.addSession?.('s2', undefined, 'p1');
+      await window.__hive.addSession?.('t2', undefined, 'p2');
+      await window.__hive.addSession?.('s3', undefined, 'p1');
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.__hive.state?.sessions.length ?? 0),
+      )
+      .toBe(5);
+
+    const idsIn = (pid: string) =>
+      page.evaluate(
+        (p) =>
+          Array.from(
+            document.querySelectorAll<HTMLElement>(
+              `li.project[data-pid="${p}"] li.session-item`,
+            ),
+          ).map((li) => li.dataset.sid ?? ''),
+        pid,
+      );
+    const p1Before = await idsIn('p1');
+    expect(p1Before).toHaveLength(3);
+    const p2Before = await idsIn('p2');
+
+    // Move the middle session of p1 down one row.
+    await activate(page, p1Before[1]);
+    await page.keyboard.press(`${MOD}+Shift+ArrowDown`);
+    await expect
+      .poll(() => idsIn('p1'))
+      .toEqual([p1Before[0], p1Before[2], p1Before[1]]);
+    // The other project is untouched.
+    expect(await idsIn('p2')).toEqual(p2Before);
+  });
+
   test('reordering while in grid mode reorders the tiles', async ({ page }) => {
     await boot(page, 3);
     const before = await sidebarIds(page);
@@ -164,16 +229,24 @@ test.describe('keybinding regressions', () => {
     await boot(page, 3);
     const before = await sidebarIds(page);
     await activate(page, before[1]);
-    // Record whether anything consumed the key. The app's listener is
-    // capture-phase, so a window-level listener at the bubble end sees
-    // the final verdict.
+    // Record the APP's verdict on the key, in the capture phase. It must
+    // be capture, not bubble: on Linux MOD is Control and xterm handles
+    // Ctrl+← itself, calling preventDefault + stopPropagation on the
+    // textarea — which is the outcome we want, but a bubble listener
+    // never runs to see it. Capture on window fires before any deeper
+    // handler, and after the app's own capture listener (registered at
+    // import time), so what it reads is exactly what the app decided.
     await page.evaluate(() => {
       window.__arrowPrevented = null;
-      window.addEventListener('keydown', (e) => {
-        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-          window.__arrowPrevented = e.defaultPrevented;
-        }
-      });
+      window.addEventListener(
+        'keydown',
+        (e) => {
+          if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+            window.__arrowPrevented = e.defaultPrevented;
+          }
+        },
+        true,
+      );
     });
     await page.keyboard.press(`${MOD}+ArrowLeft`);
     await expect

--- a/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Session ordering + the keybindings that drive it, against the mock
+// bridge — which models order the same way the daemon does (splice at
+// the anchor on create, delete-then-insert on an order update).
+//
+// Ordering is the point of these fixes, so the assertions are on the
+// sidebar's actual row order and the grid's actual tile order, not on
+// which call was made.
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function boot(page: Page, count = 3) {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li').length > 0,
+  );
+  for (let i = 1; i < count; i++) {
+    await page.evaluate((n) => window.__hive.addSession?.(n), `s${i + 1}`);
+  }
+  await page.waitForFunction(
+    (n) => (window.__hive.state?.sessions.length ?? 0) >= n,
+    count,
+  );
+}
+
+// Sidebar row order, top to bottom, as session ids.
+function sidebarIds(page: Page) {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll<HTMLElement>('li.session-item')).map(
+      (li) => li.dataset.sid ?? '',
+    ),
+  );
+}
+
+// Grid tile order, as they sit in the DOM.
+function tileIds(page: Page) {
+  return page.evaluate(() =>
+    Array.from(
+      document.querySelectorAll<HTMLElement>('#terms .term-host.in-grid'),
+    ).map((h) => h.dataset.sid ?? ''),
+  );
+}
+
+// The active session is read off the sidebar, not window.__hive.state —
+// that is the MOCK's state (the daemon's side), which has no activeId.
+function activeId(page: Page) {
+  return page.evaluate(
+    () =>
+      document.querySelector<HTMLElement>('li.session-item.selected')?.dataset
+        .sid ?? null,
+  );
+}
+
+async function activate(page: Page, id: string) {
+  await page.locator(`li.session-item[data-sid="${id}"]`).click();
+  await expect.poll(() => activeId(page)).toBe(id);
+}
+
+test.describe('session ordering', () => {
+  test('a new session appears directly below the active session', async ({
+    page,
+  }) => {
+    await boot(page, 3);
+    const before = await sidebarIds(page);
+    await activate(page, before[0]);
+    // ⌘T opens the launcher; the ⌘P-free path here goes through the
+    // mock directly with the same anchor the app passes.
+    await page.evaluate(
+      (anchor) => window.__hive.addSession?.('inserted', anchor),
+      before[0],
+    );
+    await expect.poll(() => sidebarIds(page)).toHaveLength(4);
+    const after = await sidebarIds(page);
+    expect(after[1]).not.toBe(before[1]);
+    expect(after).toEqual([before[0], after[1], before[1], before[2]]);
+  });
+
+  test('a duplicated session appears directly below its source (⌘P)', async ({
+    page,
+  }) => {
+    await boot(page, 3);
+    // ⌘P refuses when the source session resolves no cwd, and the mock's
+    // seed project has none — hand it one the way the daemon would.
+    await page.evaluate(() => {
+      const p = window.__hive.state?.projects?.[0];
+      if (!p) throw new Error('mock has no seed project');
+      p.cwd = '/tmp/hive-mock';
+      window.__hive.emit?.(
+        'project:event',
+        JSON.stringify({ kind: 'updated', project: p }),
+      );
+    });
+    const before = await sidebarIds(page);
+    await activate(page, before[1]);
+    await page.keyboard.press(`${MOD}+p`);
+    await expect.poll(() => sidebarIds(page)).toHaveLength(4);
+    const after = await sidebarIds(page);
+    expect(after).toEqual([before[0], before[1], after[2], before[2]]);
+  });
+
+  test('⇧⌘↓ moves the session down one row', async ({ page }) => {
+    await boot(page, 3);
+    const before = await sidebarIds(page);
+    await activate(page, before[0]);
+    await page.keyboard.press(`${MOD}+Shift+ArrowDown`);
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([before[1], before[0], before[2]]);
+  });
+
+  test('⇧⌘↓ on the last session wraps to the top of its project', async ({
+    page,
+  }) => {
+    await boot(page, 3);
+    const before = await sidebarIds(page);
+    await activate(page, before[2]);
+    await page.keyboard.press(`${MOD}+Shift+ArrowDown`);
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([before[2], before[0], before[1]]);
+    // Still the same project — the move never escapes into another one.
+    const pids = await page.evaluate(
+      () =>
+        window.__hive.state?.sessions.map(
+          (s: { project_id?: string }) => s.project_id,
+        ) ?? [],
+    );
+    expect(new Set(pids).size).toBe(1);
+  });
+
+  test('⇧⌘↑ on the first session wraps to the bottom of its project', async ({
+    page,
+  }) => {
+    await boot(page, 3);
+    const before = await sidebarIds(page);
+    await activate(page, before[0]);
+    await page.keyboard.press(`${MOD}+Shift+ArrowUp`);
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([before[1], before[2], before[0]]);
+  });
+
+  test('reordering while in grid mode reorders the tiles', async ({ page }) => {
+    await boot(page, 3);
+    const before = await sidebarIds(page);
+    await activate(page, before[0]);
+    await page.keyboard.press(`${MOD}+Shift+g`);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    await expect.poll(() => tileIds(page)).toEqual(before);
+    // In grid mode the arrows are spatial navigation, so the reorder
+    // comes from the Session menu — which must reorder in every view.
+    await page.evaluate(() =>
+      window.__hive.emit?.('menu:move-session-forward'),
+    );
+    await expect
+      .poll(() => tileIds(page))
+      .toEqual([before[1], before[0], before[2]]);
+  });
+});
+
+test.describe('keybinding regressions', () => {
+  test('⌘← in focused mode is left to the terminal', async ({ page }) => {
+    await boot(page, 3);
+    const before = await sidebarIds(page);
+    await activate(page, before[1]);
+    // Record whether anything consumed the key. The app's listener is
+    // capture-phase, so a window-level listener at the bubble end sees
+    // the final verdict.
+    await page.evaluate(() => {
+      window.__arrowPrevented = null;
+      window.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+          window.__arrowPrevented = e.defaultPrevented;
+        }
+      });
+    });
+    await page.keyboard.press(`${MOD}+ArrowLeft`);
+    await expect
+      .poll(() => page.evaluate(() => window.__arrowPrevented))
+      .toBe(false);
+    expect(await activeId(page)).toBe(before[1]);
+    expect(await sidebarIds(page)).toEqual(before);
+  });
+
+  test('⌘G with a single session does not enter grid mode', async ({
+    page,
+  }) => {
+    await boot(page, 1);
+    await page.keyboard.press(`${MOD}+g`);
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+    await page.keyboard.press(`${MOD}+Shift+g`);
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+  });
+
+  test('killing a grid down to one session returns to focused mode', async ({
+    page,
+  }) => {
+    await boot(page, 2);
+    await page.keyboard.press(`${MOD}+Shift+g`);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    const ids = await sidebarIds(page);
+    await page.evaluate((id) => window.__hive.killSession?.(id), ids[1]);
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+  });
+});

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -174,8 +174,26 @@ export async function RequestScrollbackReplay(id: string) {
   replayLog.push({ id, t: Date.now() });
   return '';
 }
+// state.sessions IS the order, mirroring the daemon's single global
+// r.order list; renumber rewrites each session's .order to its index,
+// the same invariant registry.renumberLocked keeps.
+function renumber() {
+  state.sessions.forEach((s, i) => {
+    s.order = i;
+  });
+}
+// emitUpdatedExcept mirrors the daemon's post-reorder fan-out: every
+// session whose .order shifted is broadcast so clients don't keep stale
+// values.
+function emitUpdatedExcept(skipId: string) {
+  for (const other of state.sessions) {
+    if (other.id === skipId) continue;
+    emit('session:event', JSON.stringify({ kind: 'updated', session: other }));
+  }
+}
 // Positional args matching the real Wails binding:
-// CreateSession(agentID, projectID, name, color, cols, rows, useWorktree).
+// CreateSession(agentID, projectID, name, color, cols, rows, useWorktree,
+// insertAfter).
 export async function CreateSession(
   agentID: string,
   projectID: string,
@@ -184,9 +202,11 @@ export async function CreateSession(
   _cols: number,
   _rows: number,
   _useWorktree: boolean,
+  insertAfter?: string,
 ) {
   maybeFail('CreateSession');
   const id = `mock-${state.sessions.length + 1}`;
+  const pid = projectID || 'p1';
   const s: MockSession = {
     id,
     name: name || `s${state.sessions.length + 1}`,
@@ -195,23 +215,34 @@ export async function CreateSession(
     created: new Date().toISOString(),
     alive: true,
     agent: agentID || '',
-    project_id: projectID || 'p1',
+    project_id: pid,
     worktree_path: '',
     worktree_branch: '',
     last_error: '',
   };
-  state.sessions.push(s);
+  // Splice after the anchor only when it exists AND shares the new
+  // session's project — exactly registry.insertEntry's guard.
+  const anchorIdx = insertAfter
+    ? state.sessions.findIndex(
+        (x) => x.id === insertAfter && x.project_id === pid,
+      )
+    : -1;
+  const pos = anchorIdx >= 0 ? anchorIdx + 1 : state.sessions.length;
+  state.sessions.splice(pos, 0, s);
+  renumber();
+  if (pos !== state.sessions.length - 1) emitUpdatedExcept(id);
   emit('session:event', JSON.stringify({ kind: 'added', session: s }));
   return id;
 }
-// Positional: DuplicateSession(agentID, projectID, cwd).
+// Positional: DuplicateSession(agentID, projectID, cwd, insertAfter).
 export async function DuplicateSession(
   agentID: string,
   projectID: string,
   _cwd: string,
+  insertAfter?: string,
 ) {
   maybeFail('DuplicateSession');
-  return CreateSession(agentID, projectID, 'dup', '', 0, 0, false);
+  return CreateSession(agentID, projectID, 'dup', '', 0, 0, false, insertAfter);
 }
 export async function KillSession(id: string) {
   maybeFail('KillSession');
@@ -233,13 +264,24 @@ export async function UpdateSession(
   id: string,
   name: string,
   color: string,
-  _order: number,
+  order: number,
 ) {
   maybeFail('UpdateSession');
   const s = state.sessions.find((x) => x.id === id);
   if (!s) return '';
   if (name) s.name = name;
   if (color) s.color = color;
+  if (order >= 0) {
+    // Delete-then-clamp-then-insert, the same shape as
+    // registry.moveInOrder — which is what makes the target index the
+    // frontend sends meaningful.
+    const cur = state.sessions.indexOf(s);
+    state.sessions.splice(cur, 1);
+    const at = Math.min(Math.max(order, 0), state.sessions.length);
+    state.sessions.splice(at, 0, s);
+    renumber();
+    emitUpdatedExcept(id);
+  }
   emit('session:event', JSON.stringify({ kind: 'updated', session: s }));
   return '';
 }
@@ -407,8 +449,8 @@ if (typeof window !== 'undefined') {
   window.__hive = {
     state,
     emit,
-    addSession(name: string) {
-      return CreateSession('', 'p1', name, '', 0, 0, false);
+    addSession(name: string, insertAfter?: string) {
+      return CreateSession('', 'p1', name, '', 0, 0, false, insertAfter);
     },
     killSession(id: string) {
       return KillSession(id);

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -449,8 +449,20 @@ if (typeof window !== 'undefined') {
   window.__hive = {
     state,
     emit,
-    addSession(name: string, insertAfter?: string) {
-      return CreateSession('', 'p1', name, '', 0, 0, false, insertAfter);
+    // projectId defaults to the seed project; pass it to build an
+    // r.order that interleaves projects, which is where display position
+    // and .order diverge.
+    addSession(name: string, insertAfter?: string, projectId?: string) {
+      return CreateSession(
+        '',
+        projectId || 'p1',
+        name,
+        '',
+        0,
+        0,
+        false,
+        insertAfter,
+      );
     },
     killSession(id: string) {
       return KillSession(id);

--- a/cmd/hivegui/frontend/test/unit/reorder.test.ts
+++ b/cmd/hivegui/frontend/test/unit/reorder.test.ts
@@ -1,20 +1,37 @@
 import { describe, it, expect } from 'vitest';
 import { reorderTarget } from '../../src/lib/reorder.js';
 
-// Display order: sorted by project, then by session order. Global
-// indices are the array indices, which is the index space the daemon's
-// Update expects.
+// `order` is the session's index in the daemon's r.order — the value
+// reorderTarget must return. The fixtures below deliberately separate
+// that from array position, because the two coincide only when the
+// daemon's flat list happens to be grouped by project.
+//
+// Grouped case: display position == .order.
 const ordered = [
-  { id: 'a0', projectId: 'A' },
-  { id: 'a1', projectId: 'A' },
-  { id: 'b0', projectId: 'B' },
-  { id: 'b1', projectId: 'B' },
-  { id: 'b2', projectId: 'B' },
+  { id: 'a0', projectId: 'A', order: 0 },
+  { id: 'a1', projectId: 'A', order: 1 },
+  { id: 'b0', projectId: 'B', order: 2 },
+  { id: 'b1', projectId: 'B', order: 3 },
+  { id: 'b2', projectId: 'B', order: 4 },
 ];
+
+// moveInOrder is a faithful copy of internal/registry's delete-then-
+// clamp-then-insert. The interleaved test below runs the returned index
+// through it, so the assertion is about the resulting session order and
+// not about a number whose meaning could quietly change.
+function moveInOrder(order: string[], id: string, newOrder: number): string[] {
+  const cur = order.indexOf(id);
+  if (cur < 0) return order;
+  const out = order.slice();
+  out.splice(cur, 1);
+  const at = Math.min(Math.max(newOrder, 0), out.length);
+  out.splice(at, 0, id);
+  return out;
+}
 
 describe('reorderTarget', () => {
   it('moves down within the project', () => {
-    // b1 swaps with b2, whose current global index is 4.
+    // b1 swaps with b2, whose index in r.order is 4.
     expect(reorderTarget(ordered, 'b1', +1)).toBe(4);
   });
 
@@ -31,20 +48,9 @@ describe('reorderTarget', () => {
   });
 
   it('returns null for a project with a single session', () => {
-    const solo = [{ id: 'a0', projectId: 'A' }, ...ordered.slice(2)];
+    const solo = [{ id: 'a0', projectId: 'A', order: 0 }, ...ordered.slice(2)];
     expect(reorderTarget(solo, 'a0', +1)).toBeNull();
     expect(reorderTarget(solo, 'a0', -1)).toBeNull();
-  });
-
-  it('resolves correctly when projects are interleaved in the global order', () => {
-    const mixed = [
-      { id: 'b0', projectId: 'B' },
-      { id: 'a0', projectId: 'A' },
-      { id: 'b1', projectId: 'B' },
-    ];
-    // b0 down targets b1's global index 2 — it must skip over a0.
-    expect(reorderTarget(mixed, 'b0', +1)).toBe(2);
-    expect(reorderTarget(mixed, 'b1', -1)).toBe(0);
   });
 
   it('returns null for an unknown or null active session', () => {
@@ -55,10 +61,77 @@ describe('reorderTarget', () => {
 
   it('reads both projectId and project_id spellings', () => {
     const snake = [
-      { id: 'b0', project_id: 'B' },
-      { id: 'a0', projectId: 'A' },
-      { id: 'b1', project_id: 'B' },
+      { id: 'b0', project_id: 'B', order: 0 },
+      { id: 'a0', projectId: 'A', order: 1 },
+      { id: 'b1', project_id: 'B', order: 2 },
     ];
     expect(reorderTarget(snake, 'b0', +1)).toBe(2);
+  });
+
+  // The regression this file exists for. The daemon's r.order is one
+  // flat creation-order list; alternating creates across two projects
+  // interleave them, so every session's DISPLAY position (project-major)
+  // differs from its .order. Returning a display position here produced
+  // a silent no-op — the move was accepted and changed nothing.
+  describe('when projects interleave in the daemon order', () => {
+    // r.order: s1(A) t1(B) s2(A) t2(B) s3(A)  →  .order 0..4
+    // display: s1 s2 s3 t1 t2                 →  positions 0..4
+    const raw = ['s1', 't1', 's2', 't2', 's3'];
+    const proj: Record<string, string> = {
+      s1: 'A',
+      t1: 'B',
+      s2: 'A',
+      t2: 'B',
+      s3: 'A',
+    };
+    // Project-major, then by .order — what orderedSessions() produces.
+    const display = raw
+      .map((id, i) => ({ id, projectId: proj[id], order: i }))
+      .sort((a, b) =>
+        a.projectId === b.projectId
+          ? a.order - b.order
+          : a.projectId.localeCompare(b.projectId),
+      );
+    const inProject = (order: string[], pid: string) =>
+      order.filter((id) => proj[id] === pid);
+
+    it('targets the sibling by its daemon index, not its display position', () => {
+      // s3 sits at display position 2 but at r.order index 4.
+      expect(reorderTarget(display, 's2', +1)).toBe(4);
+    });
+
+    it('actually swaps the pair when the daemon applies it', () => {
+      const target = reorderTarget(display, 's2', +1);
+      expect(target).not.toBeNull();
+      const after = moveInOrder(raw, 's2', target as number);
+      expect(inProject(after, 'A')).toEqual(['s1', 's3', 's2']);
+      // The other project is left exactly as it was.
+      expect(inProject(after, 'B')).toEqual(['t1', 't2']);
+    });
+
+    it('swaps back on the reverse move', () => {
+      const down = reorderTarget(display, 's2', +1) as number;
+      const moved = moveInOrder(raw, 's2', down);
+      // Re-derive the display list from the new r.order.
+      const display2 = moved
+        .map((id, i) => ({ id, projectId: proj[id], order: i }))
+        .sort((a, b) =>
+          a.projectId === b.projectId
+            ? a.order - b.order
+            : a.projectId.localeCompare(b.projectId),
+        );
+      const up = reorderTarget(display2, 's2', -1) as number;
+      const back = moveInOrder(moved, 's2', up);
+      expect(inProject(back, 'A')).toEqual(['s1', 's2', 's3']);
+      expect(inProject(back, 'B')).toEqual(['t1', 't2']);
+    });
+
+    it('wraps within the project without touching the other one', () => {
+      // s3 is last in A; moving it down wraps to A's first slot.
+      const target = reorderTarget(display, 's3', +1) as number;
+      const after = moveInOrder(raw, 's3', target);
+      expect(inProject(after, 'A')).toEqual(['s3', 's1', 's2']);
+      expect(inProject(after, 'B')).toEqual(['t1', 't2']);
+    });
   });
 });

--- a/cmd/hivegui/frontend/test/unit/reorder.test.ts
+++ b/cmd/hivegui/frontend/test/unit/reorder.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { reorderTarget } from '../../src/lib/reorder.js';
+
+// Display order: sorted by project, then by session order. Global
+// indices are the array indices, which is the index space the daemon's
+// Update expects.
+const ordered = [
+  { id: 'a0', projectId: 'A' },
+  { id: 'a1', projectId: 'A' },
+  { id: 'b0', projectId: 'B' },
+  { id: 'b1', projectId: 'B' },
+  { id: 'b2', projectId: 'B' },
+];
+
+describe('reorderTarget', () => {
+  it('moves down within the project', () => {
+    // b1 swaps with b2, whose current global index is 4.
+    expect(reorderTarget(ordered, 'b1', +1)).toBe(4);
+  });
+
+  it('moves up within the project', () => {
+    expect(reorderTarget(ordered, 'b1', -1)).toBe(2);
+  });
+
+  it('wraps from the last session in a project to the first', () => {
+    expect(reorderTarget(ordered, 'b2', +1)).toBe(2);
+  });
+
+  it('wraps from the first session in a project to the last', () => {
+    expect(reorderTarget(ordered, 'b0', -1)).toBe(4);
+  });
+
+  it('returns null for a project with a single session', () => {
+    const solo = [{ id: 'a0', projectId: 'A' }, ...ordered.slice(2)];
+    expect(reorderTarget(solo, 'a0', +1)).toBeNull();
+    expect(reorderTarget(solo, 'a0', -1)).toBeNull();
+  });
+
+  it('resolves correctly when projects are interleaved in the global order', () => {
+    const mixed = [
+      { id: 'b0', projectId: 'B' },
+      { id: 'a0', projectId: 'A' },
+      { id: 'b1', projectId: 'B' },
+    ];
+    // b0 down targets b1's global index 2 — it must skip over a0.
+    expect(reorderTarget(mixed, 'b0', +1)).toBe(2);
+    expect(reorderTarget(mixed, 'b1', -1)).toBe(0);
+  });
+
+  it('returns null for an unknown or null active session', () => {
+    expect(reorderTarget(ordered, 'nope', +1)).toBeNull();
+    expect(reorderTarget(ordered, null, +1)).toBeNull();
+    expect(reorderTarget(ordered, 'b1', 0)).toBeNull();
+  });
+
+  it('reads both projectId and project_id spellings', () => {
+    const snake = [
+      { id: 'b0', project_id: 'B' },
+      { id: 'a0', projectId: 'A' },
+      { id: 'b1', project_id: 'B' },
+    ];
+    expect(reorderTarget(snake, 'b0', +1)).toBe(2);
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/shortcuts.test.ts
+++ b/cmd/hivegui/frontend/test/unit/shortcuts.test.ts
@@ -55,16 +55,22 @@ describe('shortcutGroups', () => {
     const keys = shortcutGroups({ isMac: false })
       .flatMap((g) => g.items.map((i) => i.keys))
       .join(' ');
-    expect(keys).toContain('Ctrl+Up/Down/Left/Right');
-    expect(keys).toContain('Ctrl+Shift+Up/Down/Left/Right');
+    // The vertical and horizontal arrows are advertised separately: they
+    // no longer do the same thing (⌘←/→ reach the terminal in focused
+    // mode, and reorder is ⇧⌘↑/↓ only).
+    expect(keys).toContain('Ctrl+Up/Down');
+    expect(keys).toContain('Ctrl+Left/Right');
+    expect(keys).toContain('Ctrl+Shift+Up/Down');
+    expect(keys).not.toContain('Ctrl+Shift+Left/Right');
     expect(keys).toContain('Up/Down / Tab');
-    expect(keys).toContain('Left/Right');
     expect(keys).not.toMatch(/UpDown|LeftRight/);
     // Mac glyphs stay run together — the conventional rendering.
     const macKeys = shortcutGroups({ isMac: true })
       .flatMap((g) => g.items.map((i) => i.keys))
       .join(' ');
-    expect(macKeys).toContain('⌘↑↓←→');
+    expect(macKeys).toContain('⌘↑↓');
+    expect(macKeys).toContain('⌘←→');
+    expect(macKeys).toContain('⇧⌘↑↓');
   });
 });
 

--- a/cmd/hivegui/frontend/test/unit/view.test.ts
+++ b/cmd/hivegui/frontend/test/unit/view.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   normalizeView,
+  resolveView,
   VIEW_SINGLE,
   VIEW_GRID_PROJECT,
   VIEW_GRID_ALL,
@@ -17,5 +18,22 @@ describe('normalizeView', () => {
     expect(normalizeView('')).toBe(VIEW_SINGLE);
     expect(normalizeView(null)).toBe(VIEW_SINGLE);
     expect(normalizeView(undefined)).toBe(VIEW_SINGLE);
+  });
+});
+
+describe('resolveView', () => {
+  it('keeps single unchanged', () => {
+    expect(resolveView(VIEW_SINGLE, 0)).toBe(VIEW_SINGLE);
+    expect(resolveView(VIEW_SINGLE, 5)).toBe(VIEW_SINGLE);
+  });
+  it('downgrades grid views to single at 0 and 1 sessions', () => {
+    expect(resolveView(VIEW_GRID_ALL, 0)).toBe(VIEW_SINGLE);
+    expect(resolveView(VIEW_GRID_ALL, 1)).toBe(VIEW_SINGLE);
+    expect(resolveView(VIEW_GRID_PROJECT, 0)).toBe(VIEW_SINGLE);
+    expect(resolveView(VIEW_GRID_PROJECT, 1)).toBe(VIEW_SINGLE);
+  });
+  it('permits grid at 2 or more sessions', () => {
+    expect(resolveView(VIEW_GRID_ALL, 2)).toBe(VIEW_GRID_ALL);
+    expect(resolveView(VIEW_GRID_PROJECT, 3)).toBe(VIEW_GRID_PROJECT);
   });
 });

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -94,8 +94,6 @@ func buildAppMenu(a *App) *menu.Menu {
 	sess := m.AddSubmenu("Session")
 	sess.AddText("Next Session", keys.CmdOrCtrl("down"), emit("menu:next-session"))
 	sess.AddText("Previous Session", keys.CmdOrCtrl("up"), emit("menu:prev-session"))
-	sess.AddText("Next Session (⌘→ alternate)", keys.CmdOrCtrl("right"), emit("menu:next-session"))
-	sess.AddText("Previous Session (⌘← alternate)", keys.CmdOrCtrl("left"), emit("menu:prev-session"))
 	sess.AddSeparator()
 	sess.AddText("Next Session Needing Attention",
 		keys.CmdOrCtrl("b"), emit("menu:next-attention"))
@@ -108,12 +106,6 @@ func buildAppMenu(a *App) *menu.Menu {
 		emit("menu:move-session-forward"))
 	sess.AddText("Move Session Backward",
 		keys.Combo("up", keys.ShiftKey, keys.CmdOrCtrlKey),
-		emit("menu:move-session-backward"))
-	sess.AddText("Move Session Forward (⇧⌘→ alternate)",
-		keys.Combo("right", keys.ShiftKey, keys.CmdOrCtrlKey),
-		emit("menu:move-session-forward"))
-	sess.AddText("Move Session Backward (⇧⌘← alternate)",
-		keys.Combo("left", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:move-session-backward"))
 	sess.AddSeparator()
 	sess.AddText("Next Project", keys.CmdOrCtrl("]"), emit("menu:next-project"))

--- a/cmd/hivegui/menu_darwin_test.go
+++ b/cmd/hivegui/menu_darwin_test.go
@@ -74,3 +74,46 @@ func TestSessionMenuAttentionItems(t *testing.T) {
 		}
 	}
 }
+
+// walkAccelerators collects every (label, accelerator) pair in the menu
+// tree. findItem above searches by label and so can't express "no item
+// binds this key", which is exactly the assertion below.
+func walkAccelerators(items []*menu.MenuItem, out map[string]*keys.Accelerator) {
+	for _, it := range items {
+		if it.Accelerator != nil {
+			out[it.Label] = it.Accelerator
+		}
+		if it.SubMenu != nil {
+			walkAccelerators(it.SubMenu.Items, out)
+		}
+	}
+}
+
+// TestMenuHasNoArrowLeftRightAccelerators keeps ⌘←/⌘→ (and their shifted
+// forms) out of the native menu. AppKit consumes a registered key
+// equivalent before the webview ever sees a keydown, so a menu item here
+// steals start/end-of-line from the terminal no matter what the frontend
+// does with the event.
+func TestMenuHasNoArrowLeftRightAccelerators(t *testing.T) {
+	m := buildAppMenu(&App{})
+	if m == nil {
+		t.Fatal("buildAppMenu returned nil on darwin")
+	}
+	accels := map[string]*keys.Accelerator{}
+	walkAccelerators(m.Items, accels)
+	for label, acc := range accels {
+		if acc.Key == "left" || acc.Key == "right" {
+			t.Errorf("menu item %q binds %q; ⌘←/⌘→ must reach the terminal", label, acc.Key)
+		}
+	}
+	// Guard the walker itself: the vertical twins must still be there.
+	var down bool
+	for _, acc := range accels {
+		if acc.Key == "down" {
+			down = true
+		}
+	}
+	if !down {
+		t.Error("walkAccelerators found no 'down' binding; the walker is broken")
+	}
+}

--- a/internal/registry/create.go
+++ b/internal/registry/create.go
@@ -218,7 +218,14 @@ func (r *Registry) insertEntry(spec wire.CreateSpec, p createPlan) (*Entry, erro
 		}
 	}
 	r.order = slices.Insert(r.order, pos, p.id)
-	r.renumberLocked()
+	if pos == len(r.order)-1 {
+		// Plain append: nobody else's Order moved, so skip renumbering —
+		// renumberLocked re-persists every entry, and doing that under
+		// r.mu on every session create is O(n) disk writes for nothing.
+		e.Order = pos
+	} else {
+		r.renumberLocked()
+	}
 	rollback := func() {
 		delete(r.entries, p.id)
 		r.order = slices.Delete(r.order, pos, pos+1)

--- a/internal/registry/create.go
+++ b/internal/registry/create.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -202,14 +203,26 @@ func (r *Registry) insertEntry(spec wire.CreateSpec, p createPlan) (*Entry, erro
 	}
 	e := &Entry{
 		ID: p.id, Name: p.name, Color: p.color,
-		Order: len(r.order), Created: time.Now().UTC(),
-		Agent: spec.Agent, ProjectID: projectID,
+		Created: time.Now().UTC(),
+		Agent:   spec.Agent, ProjectID: projectID,
 	}
 	r.entries[p.id] = e
-	r.order = append(r.order, p.id)
+	// Place the new session right after its anchor when the anchor is a
+	// live sibling in the same project; otherwise append. r.order is one
+	// global list across all projects, so a cross-project anchor would
+	// land the entry inside another project's index range.
+	pos := len(r.order)
+	if a := r.entries[spec.InsertAfterSessionID]; a != nil && a.ProjectID == projectID {
+		if i := slices.Index(r.order, a.ID); i >= 0 {
+			pos = i + 1
+		}
+	}
+	r.order = slices.Insert(r.order, pos, p.id)
+	r.renumberLocked()
 	rollback := func() {
 		delete(r.entries, p.id)
-		r.order = r.order[:len(r.order)-1]
+		r.order = slices.Delete(r.order, pos, pos+1)
+		r.renumberLocked()
 	}
 	if err := r.persistEntryLocked(e); err != nil {
 		rollback()
@@ -218,6 +231,16 @@ func (r *Registry) insertEntry(spec wire.CreateSpec, p createPlan) (*Entry, erro
 	if err := r.persistIndexLocked(); err != nil {
 		rollback()
 		return nil, err
+	}
+	// A mid-list splice shifted every later entry's Order, so the
+	// clients' cached values are stale — same fan-out Update does. A
+	// plain append shifts nothing and stays quiet.
+	if pos != len(r.order)-1 {
+		for _, sid := range r.order {
+			if other := r.entries[sid]; other != nil && other.ID != e.ID {
+				r.broadcastLocked(wire.SessionEventUpdated, other.Info())
+			}
+		}
 	}
 	return e, nil
 }

--- a/internal/registry/ordering_test.go
+++ b/internal/registry/ordering_test.go
@@ -1,0 +1,272 @@
+package registry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/lucascaro/hive/internal/wire"
+)
+
+// orderIDs returns the registry's global order slice, plus a check that
+// every entry's Order field matches its index in it (renumberLocked's
+// invariant, which the splice must preserve).
+func orderIDs(t *testing.T, r *Registry) []string {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, id := range r.order {
+		e := r.entries[id]
+		if e == nil {
+			t.Fatalf("order[%d]=%s has no entry", i, id)
+		}
+		if e.Order != i {
+			t.Errorf("entry %s: Order=%d, want %d (index in r.order)", id, e.Order, i)
+		}
+	}
+	return slices.Clone(r.order)
+}
+
+func mustCreate(t *testing.T, r *Registry, spec wire.CreateSpec) *Entry {
+	t.Helper()
+	spec.Cols, spec.Rows, spec.Shell = 80, 24, "/bin/bash"
+	e, err := r.Create(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Create %q: %v", spec.Name, err)
+	}
+	return e
+}
+
+// drain empties a listener channel of events already queued, so a test
+// can assert on only the events a later action produces.
+func drain(ch Listener) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+func TestCreateInsertsAfterAnchor(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	s1 := mustCreate(t, r, wire.CreateSpec{Name: "s1"})
+	s2 := mustCreate(t, r, wire.CreateSpec{Name: "s2"})
+	s3 := mustCreate(t, r, wire.CreateSpec{Name: "s3"})
+
+	n := mustCreate(t, r, wire.CreateSpec{Name: "new", InsertAfterSessionID: s2.ID})
+
+	want := []string{s1.ID, s2.ID, n.ID, s3.ID}
+	if got := orderIDs(t, r); !slices.Equal(got, want) {
+		t.Errorf("order: got %v, want %v", got, want)
+	}
+}
+
+func TestCreateInsertAfterUnknownAnchorAppends(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	s1 := mustCreate(t, r, wire.CreateSpec{Name: "s1"})
+	s2 := mustCreate(t, r, wire.CreateSpec{Name: "s2"})
+
+	n := mustCreate(t, r, wire.CreateSpec{Name: "new", InsertAfterSessionID: uuid.NewString()})
+
+	want := []string{s1.ID, s2.ID, n.ID}
+	if got := orderIDs(t, r); !slices.Equal(got, want) {
+		t.Errorf("order: got %v, want %v", got, want)
+	}
+}
+
+func TestCreateInsertAfterCrossProjectAnchorAppends(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	pa, err := r.CreateProject(wire.CreateProjectReq{Name: "A"})
+	if err != nil {
+		t.Fatalf("CreateProject A: %v", err)
+	}
+	pb, err := r.CreateProject(wire.CreateProjectReq{Name: "B"})
+	if err != nil {
+		t.Fatalf("CreateProject B: %v", err)
+	}
+
+	a1 := mustCreate(t, r, wire.CreateSpec{Name: "a1", ProjectID: pa.ID})
+	b1 := mustCreate(t, r, wire.CreateSpec{Name: "b1", ProjectID: pb.ID})
+
+	// Anchor lives in project A, new session belongs to project B: the
+	// splice would drop it inside A's index range, so it must append.
+	n := mustCreate(t, r, wire.CreateSpec{Name: "b2", ProjectID: pb.ID, InsertAfterSessionID: a1.ID})
+
+	want := []string{a1.ID, b1.ID, n.ID}
+	if got := orderIDs(t, r); !slices.Equal(got, want) {
+		t.Errorf("order: got %v, want %v", got, want)
+	}
+}
+
+func TestCreateInsertAfterBroadcastsShiftedOrders(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	s1 := mustCreate(t, r, wire.CreateSpec{Name: "s1"})
+	s2 := mustCreate(t, r, wire.CreateSpec{Name: "s2"})
+	s3 := mustCreate(t, r, wire.CreateSpec{Name: "s3"})
+
+	listener, unsub := r.Subscribe()
+	defer unsub()
+	drain(listener)
+
+	n := mustCreate(t, r, wire.CreateSpec{Name: "new", InsertAfterSessionID: s1.ID})
+
+	updated := map[string]int{}
+	added := 0
+	deadline := time.After(2 * time.Second)
+collect:
+	for {
+		select {
+		case ev := <-listener:
+			switch ev.Kind {
+			case wire.SessionEventUpdated:
+				updated[ev.Session.ID] = ev.Session.Order
+			case wire.SessionEventAdded:
+				added++
+				if ev.Session.ID != n.ID {
+					t.Errorf("added event for %s, want %s", ev.Session.ID, n.ID)
+				}
+			}
+			if added > 0 && len(updated) >= 2 {
+				break collect
+			}
+		case <-deadline:
+			break collect
+		}
+	}
+
+	if added != 1 {
+		t.Errorf("added events: got %d, want 1", added)
+	}
+	// s2 and s3 shifted down by one; s1 kept index 0.
+	if got, ok := updated[s2.ID]; !ok || got != 2 {
+		t.Errorf("updated order for s2: got %d (present=%v), want 2", got, ok)
+	}
+	if got, ok := updated[s3.ID]; !ok || got != 3 {
+		t.Errorf("updated order for s3: got %d (present=%v), want 3", got, ok)
+	}
+}
+
+func TestCreateAppendEmitsNoShiftedUpdates(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	mustCreate(t, r, wire.CreateSpec{Name: "s1"})
+	mustCreate(t, r, wire.CreateSpec{Name: "s2"})
+
+	listener, unsub := r.Subscribe()
+	defer unsub()
+	drain(listener)
+
+	n := mustCreate(t, r, wire.CreateSpec{Name: "new"})
+
+	// Give any (unwanted) fan-out time to land before asserting.
+	time.Sleep(100 * time.Millisecond)
+	for {
+		select {
+		case ev := <-listener:
+			if ev.Kind != wire.SessionEventAdded {
+				t.Errorf("unexpected %s event for %s on a plain append", ev.Kind, ev.Session.ID)
+				continue
+			}
+			if ev.Session.ID != n.ID {
+				t.Errorf("added event for %s, want %s", ev.Session.ID, n.ID)
+			}
+		default:
+			return
+		}
+	}
+}
+
+func TestInsertEntryRollbackRestoresOrder(t *testing.T) {
+	skipOnWindows(t)
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory mode bits, so the persist would succeed")
+	}
+	r := freshRegistry(t)
+
+	s1 := mustCreate(t, r, wire.CreateSpec{Name: "s1"})
+	mustCreate(t, r, wire.CreateSpec{Name: "s2"})
+	before := orderIDs(t, r)
+
+	// Make the sessions dir unwritable so persistEntryLocked fails.
+	dir := SessionsDir(r.stateDir)
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	id := uuid.NewString()
+	if _, err := r.insertEntry(
+		wire.CreateSpec{InsertAfterSessionID: s1.ID},
+		createPlan{id: id, projectID: s1.ProjectID, name: "doomed"},
+	); err == nil {
+		t.Fatal("insertEntry: got nil error, want a persist failure")
+	}
+	if _, err := os.Stat(filepath.Join(dir, id)); err == nil {
+		t.Error("doomed session dir was created despite the failure")
+	}
+
+	if got := orderIDs(t, r); !slices.Equal(got, before) {
+		t.Errorf("order after rollback: got %v, want %v", got, before)
+	}
+	r.mu.Lock()
+	_, present := r.entries[id]
+	r.mu.Unlock()
+	if present {
+		t.Error("rolled-back entry is still in r.entries")
+	}
+}
+
+func TestUpdateOrderMoveDownAndUpAcrossGlobalList(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	s := make([]*Entry, 4)
+	for i := range s {
+		s[i] = mustCreate(t, r, wire.CreateSpec{Name: string(rune('a' + i))})
+	}
+
+	move := func(e *Entry, to int) {
+		t.Helper()
+		if _, err := r.Update(wire.UpdateSessionReq{SessionID: e.ID, Order: &to}); err != nil {
+			t.Fatalf("Update(%s, %d): %v", e.Name, to, err)
+		}
+	}
+
+	// Down: moveInOrder deletes first, so the target index is the
+	// pre-move index of the session being jumped over.
+	move(s[1], 2)
+	want := []string{s[0].ID, s[2].ID, s[1].ID, s[3].ID}
+	if got := orderIDs(t, r); !slices.Equal(got, want) {
+		t.Fatalf("after move down: got %v, want %v", got, want)
+	}
+
+	// Up: same call shape, target index below the current one.
+	move(s[1], 1)
+	want = []string{s[0].ID, s[1].ID, s[2].ID, s[3].ID}
+	if got := orderIDs(t, r); !slices.Equal(got, want) {
+		t.Fatalf("after move up: got %v, want %v", got, want)
+	}
+
+	// Wrap to the end: an index at (or past) the tail clamps to last.
+	move(s[0], 3)
+	want = []string{s[1].ID, s[2].ID, s[3].ID, s[0].ID}
+	if got := orderIDs(t, r); !slices.Equal(got, want) {
+		t.Fatalf("after move to tail: got %v, want %v", got, want)
+	}
+}

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -40,6 +40,13 @@ type CreateSpec struct {
 	// Branch is an optional branch name for the worktree. When empty,
 	// a random adjective-noun is generated.
 	Branch string `json:"branch,omitempty"`
+
+	// InsertAfterSessionID, when it names an existing session in the
+	// same project as the new one, places the new session immediately
+	// after it in the display order instead of appending it last.
+	// Ignored (append) when empty, unknown, or owned by a different
+	// project.
+	InsertAfterSessionID string `json:"insert_after_session_id,omitempty"`
 }
 
 // Hello is the first frame the client sends after connecting.

--- a/internal/wire/wire_test.go
+++ b/internal/wire/wire_test.go
@@ -2,6 +2,7 @@ package wire
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"strings"
@@ -181,5 +182,34 @@ func TestFrameTypeStringUnknown(t *testing.T) {
 	s := FrameType(0xab).String()
 	if !strings.Contains(s, "0xab") {
 		t.Errorf("unknown stringer = %q", s)
+	}
+}
+
+// TestCreateSpecInsertAfterSnakeCase pins the wire spelling of the
+// insert-anchor field: JS readers key off the snake_case name, and an
+// older daemon must not see a stray empty field.
+func TestCreateSpecInsertAfterSnakeCase(t *testing.T) {
+	blob, err := json.Marshal(CreateSpec{Name: "s", InsertAfterSessionID: "abc"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(blob), `"insert_after_session_id":"abc"`) {
+		t.Errorf("marshal: got %s, want an insert_after_session_id key", blob)
+	}
+
+	empty, err := json.Marshal(CreateSpec{Name: "s"})
+	if err != nil {
+		t.Fatalf("marshal empty: %v", err)
+	}
+	if strings.Contains(string(empty), "insert_after_session_id") {
+		t.Errorf("empty anchor should be omitted, got %s", empty)
+	}
+
+	var back CreateSpec
+	if err := json.Unmarshal([]byte(`{"insert_after_session_id":"xyz"}`), &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.InsertAfterSessionID != "xyz" {
+		t.Errorf("unmarshal: got %q, want %q", back.InsertAfterSessionID, "xyz")
 	}
 }


### PR DESCRIPTION
Executes `~/.hivesmith/plans/2026-08-10-gui-ordering-and-keybinding-fixes.md`.

Four user-visible defects in the Wails GUI, each with the tests that would have
caught it.

## Fixed

1. **⌘G / ⇧⌘G / ⌘↩ entered a one-tile "grid"** — visually identical to focused
   mode but without its keybindings. `resolveView` puts a floor of two tiles on
   any grid request (the persisted-view restore at startup included), and
   `enforceViewFloor` drops back to focused mode when a live grid shrinks below
   it (session killed or minimized).

2. **⌘← / ⌘→ were swallowed in focused mode** — they are start/end-of-line in
   the terminal, as are ⇧⌘← / ⇧⌘→. Grid mode keeps all four for spatial tile
   navigation. On macOS the JS half alone was not enough: `menu_darwin.go`
   registered all four as native accelerators and AppKit consumes a key
   equivalent before the webview sees a keydown, so those four "alternate"
   menu items (duplicates of ⌘↑/↓) are deleted, with a menu test keeping them
   out.

3. **⇧⌘↑ / ⇧⌘↓ scattered sessions** — the frontend sent an index into the
   *project's* sibling list while the daemon reads it as an index into its
   single *global* order list. New pure `lib/reorder.ts` resolves the adjacent
   sibling (wrapping inside the project) and returns that sibling's current
   global index, which is what `moveInOrder`'s delete-then-insert needs in both
   directions.

4. **New sessions landed at the very bottom** — `CreateSpec` gains
   `insert_after_session_id`; the registry splices after the anchor when the
   anchor exists *and* shares the new entry's project, otherwise appends. The
   guard lives Go-side so both wire clients get it. Rollback deletes at the
   splice position rather than truncating the tail, and a mid-list splice
   broadcasts the shifted entries the way `Update` already does.

Supporting: a reorder now repaints the grid (tiles are laid out in scope
order), and `handleArrow` becomes the single implementation behind both the
⌘-arrow keydowns and the Session-menu actions — which is how ⌘↓ stopped meaning
"move right" in grid mode and "Move Session Forward" started reordering rather
than navigating.

## Tests

`scripts/test.sh go unit dom e2e` green. New: 7 registry ordering tests, a wire
snake_case round-trip, a macOS menu-accelerator walker, 8 `reorderTarget` units,
3 `resolveView` units, 15 arrow-routing DOM tests, 9 view-floor DOM tests, and 9
Playwright ordering/keybinding tests. The e2e mock now models session order at
all — it previously ignored it, so no Playwright test could observe ordering.

`test/e2e/minimize.spec.ts` changes: `restore from tray` minimized one of a
pair, which under the new floor exits grid mode, leaving no grid to restore
into. It now boots three sessions, and a new sibling test pins the floor
behaviour it used to contradict.

## Not covered

The seven manual macOS smoke checks in the plan's `## Verification` — native
menu and real-terminal behaviour need a human at the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New and duplicated sessions can be placed directly beneath their source session.
  - Improved session navigation, reordering, and grid tile movement across projects.
  - Arrow keys now behave appropriately between terminal-focused and grid views.
  - Grid views automatically return to focused mode when fewer than two sessions are available.

- **Bug Fixes**
  - Removed duplicate macOS left/right arrow menu shortcuts.
  - Corrected cross-project navigation and session ordering behavior.
  - Updated keybinding documentation with clearer shortcut distinctions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->