### PR TITLE
fix(gui): write the line-edit bytes for ⌘←/⌘→ on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- GUI: ⌘← and ⌘→ (and ⇧⌘← / ⇧⌘→) now reach the terminal in focused mode, so
-  they move the cursor to the start / end of the line — and select to it —
-  the way they do everywhere else. Grid view still uses all four arrows to
-  move between tiles. On macOS these were also registered as native menu
-  accelerators, which consumed them before the app ever saw them; those four
-  duplicate menu items are gone.
+- GUI: ⌘← and ⌘→ (and ⇧⌘← / ⇧⌘→) now move the cursor to the start / end of
+  the line in focused mode, the way they do in any macOS terminal. Grid view
+  still uses all four arrows to move between tiles. Two things were in the
+  way: the app swallowed the keys, and on macOS they were also registered as
+  native menu accelerators that consumed them before the app ever saw them —
+  those four duplicate menu items are gone. Since a terminal has no text
+  selection to extend, the shifted pair moves the cursor rather than
+  selecting.
 - GUI: ⌘G, ⇧⌘G and ⌘Enter no longer enter a "grid" holding a single tile —
   a view that looks like focused mode but loses its keybindings. They stay
   in focused mode instead, and a grid that shrinks to one tile (the other

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ build.sh           # macOS universal build
 | ⌘G / ⇧⌘G | Per-project grid / all-sessions grid |
 | ⌘Enter | Toggle grid / single |
 | ⌘↑ / ⌘↓ | Previous / next session (focused) / move between tiles vertically (grid) |
-| ⌘← / ⌘→ | Spatial nav between tiles in grid view. In focused mode these go to the terminal (start / end of line), as do ⇧⌘← / ⇧⌘→ |
+| ⌘← / ⌘→ | Spatial nav between tiles in grid view. In focused mode they move the cursor to the start / end of the line (macOS; ⇧⌘← / ⇧⌘→ do the same). On Windows and Linux use Ctrl+← / Ctrl+→ for word-wise movement, as in any terminal |
 | ⇧⌘↑ / ⇧⌘↓ | Move the session up / down within its project (wraps) |
 | ⌃- / ⌃⇧- | Back / forward through recently visited sessions (Ctrl+Alt+- / Ctrl+Alt+Shift+- on Windows and Linux, where ⌃- is zoom) |
 | ⌘B | Next session needing attention (rang the bell) |

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -25,7 +25,7 @@ import { flashStatus, reportFailure } from './dom.js';
 import { mustEl } from './el.js';
 import { anyModalOpen } from './modals/registry.js';
 import { isMac } from '../lib/platform.js';
-import { isShiftEnter, NEWLINE_SEQ } from '../lib/keymap.js';
+import { isShiftEnter, macLineEditSeq, NEWLINE_SEQ } from '../lib/keymap.js';
 import { DEFAULT_FONT_SIZE, clampFont } from '../lib/font.js';
 import {
   shouldRefreshOnVisibility,
@@ -446,6 +446,17 @@ export class SessionTerm {
       ) {
         e.preventDefault();
         this._writePty('\x15');
+        return false;
+      }
+      // macOS ⌘←/⌘→ → start / end of line. Same reason as ⌘⌫ above: the
+      // chord is an emulator-level mapping everywhere else, and xterm
+      // emits nothing at all for a meta-modified arrow, so releasing the
+      // key from the app's shortcut handler (which grid mode still uses)
+      // only produces silence unless we write the bytes here.
+      const lineEdit = macLineEditSeq(e, isMac);
+      if (lineEdit) {
+        e.preventDefault();
+        this._writePty(lineEdit);
         return false;
       }
       // Shift+Enter → insert a newline in the agent's input instead of

--- a/cmd/hivegui/frontend/src/lib/keymap.ts
+++ b/cmd/hivegui/frontend/src/lib/keymap.ts
@@ -32,6 +32,42 @@ export interface KeyEventLike {
   shiftKey: boolean;
 }
 
+// Bytes for "jump to start / end of the current line": Ctrl+A and
+// Ctrl+E, the readline (emacs-mode) bindings that bash, zsh, fish and
+// the agent CLIs all honour with no per-terminal configuration. This is
+// what iTerm2's "Natural Text Editing" preset sends for the same chord.
+// Escape sequences (Home/End, \x1bOH / \x1bOF) were the alternative;
+// they are honoured by fewer inner programs, and a shell in vi-mode is
+// the only place they'd win.
+export const LINE_START_SEQ = '\x01';
+export const LINE_END_SEQ = '\x05';
+
+// macLineEditSeq maps ⌘← / ⌘→ to those bytes, or null when the event
+// isn't ours.
+//
+// Why this has to exist: xterm.js deliberately emits NOTHING for a
+// meta-modified arrow key — its handler reads `case 37: if (e.metaKey)
+// break` — and the browser doesn't translate the chord either. macOS
+// terminals implement ⌘←/→ as an emulator-level key mapping, not as
+// something the PTY provides. So merely letting the key through to the
+// terminal (which is all the app can do) produces silence; the sequence
+// has to be written explicitly, the same way ⌘⌫ → Ctrl+U already is.
+//
+// Mac-only: on Windows/Linux the equivalent chord is Ctrl+←/→, which
+// means word-wise movement and which xterm already encodes correctly as
+// \x1b[1;5D / \x1b[1;5C. Remapping it there would break word jumps.
+//
+// Shift is allowed through as a plain move: ⇧⌘← is select-to-line-start
+// in a text field, but a PTY has no selection for us to extend, so the
+// cursor move is the closest honest thing. Ctrl and Alt are not — ⌥←/→
+// is word-wise movement and ⌃←/→ belongs to tmux and friends.
+export function macLineEditSeq(e: KeyEventLike, isMac: boolean): string | null {
+  if (!isMac || !e.metaKey || e.ctrlKey || e.altKey) return null;
+  if (e.key === 'ArrowLeft') return LINE_START_SEQ;
+  if (e.key === 'ArrowRight') return LINE_END_SEQ;
+  return null;
+}
+
 export function isShiftEnter(e: KeyEventLike): boolean {
   return (
     e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && e.key === 'Enter'

--- a/cmd/hivegui/frontend/test/e2e/line-edit-keys.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/line-edit-keys.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// ⌘←/⌘→ must reach the PTY as start/end-of-line, end to end.
+//
+// PR #274 stopped the app from swallowing these keys in focused mode,
+// which was necessary but not sufficient: xterm.js emits NOTHING for a
+// meta-modified arrow (`case 37: if (e.metaKey) break`), so the keys went
+// from "switched sessions" to "did nothing at all". The sequence has to be
+// written by the app. This spec asserts the bytes on the wire, because
+// that is the only layer where the difference between "not intercepted"
+// and "actually works" is visible.
+//
+// macOS only: elsewhere the chord is Ctrl+←/→, which means word-wise
+// movement and which xterm already encodes itself.
+const isMac = process.platform === 'darwin';
+
+const LINE_START = '\x01'; // Ctrl+A
+const LINE_END = '\x05'; // Ctrl+E
+
+async function bootFocusedTerminal(page: Page) {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li').length > 0,
+  );
+  await page.waitForFunction(
+    () =>
+      !!document.activeElement?.classList?.contains('xterm-helper-textarea'),
+    null,
+    { timeout: 2000 },
+  );
+  await page.evaluate(() => window.__hive.resetStdin());
+}
+
+test.describe('macOS line-edit keys reach the terminal', () => {
+  test.skip(!isMac, 'the ⌘ chord only exists on macOS');
+
+  test('⌘← sends start-of-line and ⌘→ sends end-of-line', async ({ page }) => {
+    await bootFocusedTerminal(page);
+    await page.keyboard.type('some text');
+    await page.keyboard.press('Meta+ArrowLeft');
+    await expect
+      .poll(() => page.evaluate(() => window.__hive.stdinText()), {
+        timeout: 2000,
+      })
+      .toBe(`some text${LINE_START}`);
+
+    await page.keyboard.press('Meta+ArrowRight');
+    await expect
+      .poll(() => page.evaluate(() => window.__hive.stdinText()), {
+        timeout: 2000,
+      })
+      .toBe(`some text${LINE_START}${LINE_END}`);
+  });
+
+  test('⇧⌘←/→ move the cursor too — a PTY has no selection to extend', async ({
+    page,
+  }) => {
+    await bootFocusedTerminal(page);
+    await page.keyboard.press('Shift+Meta+ArrowLeft');
+    await page.keyboard.press('Shift+Meta+ArrowRight');
+    await expect
+      .poll(() => page.evaluate(() => window.__hive.stdinText()), {
+        timeout: 2000,
+      })
+      .toBe(`${LINE_START}${LINE_END}`);
+  });
+
+  test('the keys still do not change the active session', async ({ page }) => {
+    await bootFocusedTerminal(page);
+    const activeId = () =>
+      page.evaluate(
+        () =>
+          document.querySelector<HTMLElement>('li.session-item.selected')
+            ?.dataset.sid ?? null,
+      );
+    // Add the second session FIRST: creating one switches to it, which
+    // would otherwise look like the arrows moved the selection.
+    await page.evaluate(() => window.__hive.addSession?.('second'));
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.__hive.state?.sessions.length ?? 0),
+      )
+      .toBe(2);
+    const before = await activeId();
+    expect(before).not.toBeNull();
+    await page.keyboard.press('Meta+ArrowLeft');
+    await page.keyboard.press('Meta+ArrowRight');
+    expect(await activeId()).toBe(before);
+  });
+
+  test('⌘←/→ still navigate tiles in grid mode, and send no bytes', async ({
+    page,
+  }) => {
+    await bootFocusedTerminal(page);
+    await page.evaluate(() => window.__hive.addSession?.('second'));
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.__hive.state?.sessions.length ?? 0),
+      )
+      .toBe(2);
+    await page.keyboard.press('Meta+Shift+g');
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    await page.evaluate(() => window.__hive.resetStdin());
+
+    await page.keyboard.press('Meta+ArrowRight');
+    // Grid mode owns the key: the window handler consumes it before the
+    // terminal's custom handler can turn it into a line-edit byte.
+    await expect
+      .poll(() => page.evaluate(() => window.__hive.stdinText()))
+      .toBe('');
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/keymap.test.ts
+++ b/cmd/hivegui/frontend/test/unit/keymap.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   isShiftEnter,
+  macLineEditSeq,
+  LINE_START_SEQ,
+  LINE_END_SEQ,
   isHelpOverlayKey,
   navHistoryKey,
   NEWLINE_SEQ,
@@ -178,5 +181,70 @@ describe('NEWLINE_SEQ', () => {
   it('is Ctrl+J / LF (0x0a) — the byte agents accept as a newline', () => {
     expect(NEWLINE_SEQ).toBe('\x0a');
     expect(NEWLINE_SEQ.charCodeAt(0)).toBe(10);
+  });
+});
+
+// ⌘←/⌘→ are start/end of line in every macOS terminal, but nothing
+// produces those bytes for us: xterm.js explicitly emits NOTHING for a
+// meta-modified arrow (`case 37: if (e.metaKey) break` in its key
+// handler), and the browser does not translate the chord either. So the
+// GUI has to do it, exactly as it already does for Cmd+Backspace -> Ctrl+U.
+describe('macLineEditSeq', () => {
+  const cmdLeft = ev({ metaKey: true, key: 'ArrowLeft' });
+  const cmdRight = ev({ metaKey: true, key: 'ArrowRight' });
+
+  it('maps cmd+left to start-of-line and cmd+right to end-of-line on mac', () => {
+    expect(macLineEditSeq(cmdLeft, true)).toBe(LINE_START_SEQ);
+    expect(macLineEditSeq(cmdRight, true)).toBe(LINE_END_SEQ);
+  });
+
+  it('sends the readline control bytes, not an escape sequence', () => {
+    // Ctrl+A / Ctrl+E: what iTerm2's "Natural Text Editing" preset sends,
+    // and what bash, zsh, and the agent CLIs all understand unconfigured.
+    expect(LINE_START_SEQ).toBe('\x01');
+    expect(LINE_END_SEQ).toBe('\x05');
+  });
+
+  it('does nothing off mac — ctrl+arrows are word-wise there and xterm emits them', () => {
+    expect(
+      macLineEditSeq(ev({ ctrlKey: true, key: 'ArrowLeft' }), false),
+    ).toBeNull();
+    expect(
+      macLineEditSeq(ev({ metaKey: true, key: 'ArrowLeft' }), false),
+    ).toBeNull();
+  });
+
+  it('ignores other arrows and unmodified arrows', () => {
+    expect(
+      macLineEditSeq(ev({ metaKey: true, key: 'ArrowUp' }), true),
+    ).toBeNull();
+    expect(macLineEditSeq(ev({ key: 'ArrowLeft' }), true)).toBeNull();
+  });
+
+  it('does not fire when Ctrl or Alt is also held', () => {
+    // opt+left is word-left and ctrl+left is a pane binding — neither is ours.
+    expect(
+      macLineEditSeq(
+        ev({ metaKey: true, altKey: true, key: 'ArrowLeft' }),
+        true,
+      ),
+    ).toBeNull();
+    expect(
+      macLineEditSeq(
+        ev({ metaKey: true, ctrlKey: true, key: 'ArrowLeft' }),
+        true,
+      ),
+    ).toBeNull();
+  });
+
+  it('fires with Shift held so shift+cmd+arrows at least move the cursor', () => {
+    // A PTY has no selection to extend, so shift can only be honored as
+    // the plain move. Doing nothing would be the more surprising outcome.
+    expect(
+      macLineEditSeq(
+        ev({ metaKey: true, shiftKey: true, key: 'ArrowLeft' }),
+        true,
+      ),
+    ).toBe(LINE_START_SEQ);
   });
 });


### PR DESCRIPTION
Follow-up to #274, which fixed half of this.

## Why the keys still did nothing

#274 stopped the app from swallowing ⌘←/⌘→ in focused mode. Necessary, but
not sufficient — the keys went from "switched sessions" to producing nothing
at all, which is what a user hits when editing a command line.

The reason is in xterm.js's key handler:

```js
case 37: if (e.metaKey) break   // ArrowLeft
case 39: if (e.metaKey) break   // ArrowRight
```

It deliberately emits **no** sequence for a meta-modified arrow, and the
browser doesn't translate the chord either. macOS terminals implement ⌘←/→
as an emulator-level key mapping (iTerm2's "Natural Text Editing" preset,
Terminal.app's key bindings) — the PTY never sees the chord. So "stop
intercepting it" can only ever produce silence; something has to write the
bytes.

Hive already had this exact problem once, two branches up in the same
handler: ⌘⌫ → Ctrl+U, with the comment *"Browser doesn't translate this for
us when xterm's helper-textarea is focused."*

## The fix

`macLineEditSeq()` in `lib/keymap.ts` maps ⌘← → `\x01` (Ctrl+A) and ⌘→ →
`\x05` (Ctrl+E), wired into the terminal's single custom key handler.

- **Ctrl+A/Ctrl+E over Home/End escapes:** the readline bindings are honoured
  by bash, zsh, fish and the agent CLIs with no configuration; `\x1bOH`/`\x1bOF`
  reach fewer inner programs and only win in a vi-mode shell.
- **macOS only:** on Windows/Linux the same chord is Ctrl+←/→, which means
  word-wise movement and which xterm already encodes as `\x1b[1;5D`/`\x1b[1;5C`.
  Remapping it there would break word jumps.
- **Grid mode unaffected:** the capture-phase window handler consumes the key
  for spatial tile navigation before the terminal's handler runs.
- **⇧⌘←/→ move the cursor** rather than selecting. A PTY has no selection to
  extend, so that is the closest honest behaviour — and #274's docs claiming
  it selected were wrong. Corrected here.

## Tests

- `test/unit/keymap.test.ts` — the decision helper, including the off-mac and
  other-modifier cases.
- `test/e2e/line-edit-keys.spec.ts` — asserts the bytes on the wire via the
  mock's stdin log, which is the only layer where "not intercepted" and
  "actually works" look different. macOS-only (`test.skip` elsewhere), like
  `menu_darwin_test.go`.

Both fail against `main`: stdin comes back as `some text` with no trailing
control byte — exactly the reported symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)