### PR TITLE
fix(registry): keep session order dense so reorders land where asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reordering sessions sometimes moved the wrong one, or nothing at all.
+  A session's order number is the position the daemon splices at, but
+  closing a session used to leave a hole in the sequence rather than
+  closing it up. The next session opened then reused a number another
+  session still held, which made the sidebar sort ambiguous, and every
+  move after that landed a slot or more off — or clamped to the bottom
+  of the list. Order is now always recomputed from the actual position,
+  and the sessions that shift are told about it; restarting Hive
+  repairs a list that had already drifted. Deleting a project had the
+  same hole and the same fix.
+
 - Closing a session could delete the directory you were working in. When
   a project's working directory is itself a git worktree — which is how
   hive is often run, from inside its own `.worktrees/` — a session there

--- a/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
@@ -129,6 +129,35 @@ test.describe('session ordering', () => {
     expect(new Set(pids).size).toBe(1);
   });
 
+  // The regression this whole fix is about, end to end: a kill used to
+  // leave a hole in the daemon's .order sequence, the next create
+  // reused a number that was still in use, and the reorder — which
+  // sends a sibling's .order as an absolute index — landed in the
+  // wrong slot or clamped to the end.
+  test('⇧⌘↓ still moves correctly after a kill and a create', async ({
+    page,
+  }) => {
+    await boot(page, 4);
+    const before = await sidebarIds(page);
+    await page.evaluate((id) => window.__hive.killSession?.(id), before[0]);
+    await expect.poll(() => sidebarIds(page)).toHaveLength(3);
+    await page.evaluate(() => window.__hive.addSession?.('fresh'));
+    await expect.poll(() => sidebarIds(page)).toHaveLength(4);
+
+    // Nobody shares an order value, and the sequence has no holes.
+    const orders = await page.evaluate(
+      () => window.__hive.state?.sessions.map((s) => s.order) ?? [],
+    );
+    expect(orders).toEqual([0, 1, 2, 3]);
+
+    const rows = await sidebarIds(page);
+    await activate(page, rows[0]);
+    await page.keyboard.press(`${MOD}+Shift+ArrowDown`);
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([rows[1], rows[0], rows[2], rows[3]]);
+  });
+
   test('⇧⌘↑ on the first session wraps to the bottom of its project', async ({
     page,
   }) => {

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -225,6 +225,7 @@ export async function RequestScrollbackReplay(id: string) {
   replayLog.push({ id, t: Date.now() });
   return '';
 }
+let nextSessionSeq = 0;
 // state.sessions IS the order, mirroring the daemon's single global
 // r.order list; renumber rewrites each session's .order to its index,
 // the same invariant registry.renumberLocked keeps.
@@ -259,7 +260,11 @@ export async function CreateSession(
   continueConversation?: boolean,
 ) {
   maybeFail('CreateSession');
-  const id = `mock-${state.sessions.length + 1}`;
+  // Monotonic, NOT derived from the current length: after a kill the
+  // length rewinds and a length-based id collides with a session that
+  // is still alive, which silently drops the new row from the sidebar.
+  nextSessionSeq += 1;
+  const id = `mock-${nextSessionSeq}`;
   const pid = projectID || 'p1';
   const s: MockSession = {
     id,
@@ -357,10 +362,17 @@ export async function KillSession(id: string) {
     const j = state.sessions.findIndex((s) => s.id === id);
     if (j < 0) return;
     const [removed] = state.sessions.splice(j, 1);
+    // A kill shifts every later session down a slot, so the daemon
+    // recompacts .order and broadcasts the survivors (registry.Kill).
+    // Leaving holes here would model a bug the daemon no longer has —
+    // and it hid this one: stale .order made the next reorder, which
+    // sends an absolute index, land in the wrong slot.
+    renumber();
     emit(
       'session:event',
       JSON.stringify({ kind: 'removed', session: removed }),
     );
+    emitUpdatedExcept(removed.id);
   });
   return '';
 }
@@ -491,6 +503,11 @@ export async function KillProject(id: string, killSessions: boolean) {
     }
   }
   const [removed] = state.projects.splice(i, 1);
+  // Same compaction the daemon does in KillProject, for both lists.
+  renumber();
+  state.projects.forEach((p, n) => {
+    p.order = n;
+  });
   emit('project:event', JSON.stringify({ kind: 'removed', project: removed }));
   return '';
 }

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -226,12 +226,18 @@ export async function RequestScrollbackReplay(id: string) {
   return '';
 }
 let nextSessionSeq = 0;
+let nextProjectSeq = 0;
 // state.sessions IS the order, mirroring the daemon's single global
 // r.order list; renumber rewrites each session's .order to its index,
-// the same invariant registry.renumberLocked keeps.
+// the same invariant registry.reindexLocked keeps.
 function renumber() {
   state.sessions.forEach((s, i) => {
     s.order = i;
+  });
+}
+function renumberProjects() {
+  state.projects.forEach((p, i) => {
+    p.order = i;
   });
 }
 // emitUpdatedExcept mirrors the daemon's post-reorder fan-out: every
@@ -477,7 +483,11 @@ export async function SaveCustomAgents(list: CustomAgent[] | null) {
 // UpdateSession had.
 export async function CreateProject(name: string, color: string, cwd: string) {
   maybeFail('CreateProject');
-  const id = `p-${state.projects.length + 1}`;
+  // Monotonic for the same reason as nextSessionSeq — a length-derived
+  // id collides with a live project after a delete, and the `added`
+  // handler drops the duplicate instead of adding it.
+  nextProjectSeq += 1;
+  const id = `p-${nextProjectSeq}`;
   const p: MockProject = {
     id,
     name: name || 'new',
@@ -494,21 +504,32 @@ export async function KillProject(id: string, killSessions: boolean) {
   maybeFail('KillProject');
   const i = state.projects.findIndex((p) => p.id === id);
   if (i < 0) return '';
-  if (killSessions) {
-    for (let j = state.sessions.length - 1; j >= 0; j--) {
-      if (state.sessions[j].project_id === id) {
-        const [rs] = state.sessions.splice(j, 1);
-        emit('session:event', JSON.stringify({ kind: 'removed', session: rs }));
-      }
+  // The daemon reassigns the orphaned sessions to the first surviving
+  // project rather than leaving them pointing at a deleted one
+  // (registry/projects.go KillProject).
+  const survivor = state.projects.find((p) => p.id !== id);
+  for (let j = state.sessions.length - 1; j >= 0; j--) {
+    if (state.sessions[j].project_id !== id) continue;
+    if (killSessions) {
+      const [rs] = state.sessions.splice(j, 1);
+      emit('session:event', JSON.stringify({ kind: 'removed', session: rs }));
+    } else if (survivor) {
+      state.sessions[j].project_id = survivor.id;
     }
   }
   const [removed] = state.projects.splice(i, 1);
-  // Same compaction the daemon does in KillProject, for both lists.
+  // Same compaction the daemon does in KillProject, for both lists —
+  // and the same fan-out, so the GUI doesn't keep stale .order values
+  // and misplace the next project reorder.
   renumber();
-  state.projects.forEach((p, n) => {
-    p.order = n;
-  });
+  renumberProjects();
   emit('project:event', JSON.stringify({ kind: 'removed', project: removed }));
+  for (const p of state.projects) {
+    emit('project:event', JSON.stringify({ kind: 'updated', project: p }));
+  }
+  for (const s of state.sessions) {
+    emit('session:event', JSON.stringify({ kind: 'updated', session: s }));
+  }
   return '';
 }
 // Empty string / -1 mean "no change", mirroring UpdateSession (order is

--- a/internal/registry/create.go
+++ b/internal/registry/create.go
@@ -366,18 +366,11 @@ func (r *Registry) insertEntry(spec wire.CreateSpec, p createPlan) (*Entry, erro
 		}
 	}
 	r.order = slices.Insert(r.order, pos, p.id)
-	if pos == len(r.order)-1 {
-		// Plain append: nobody else's Order moved, so skip renumbering —
-		// renumberLocked re-persists every entry, and doing that under
-		// r.mu on every session create is O(n) disk writes for nothing.
-		e.Order = pos
-	} else {
-		r.renumberLocked()
-	}
+	r.reindexLocked()
 	rollback := func() {
 		delete(r.entries, p.id)
 		r.order = slices.Delete(r.order, pos, pos+1)
-		r.renumberLocked()
+		r.reindexLocked()
 	}
 	if err := r.persistEntryLocked(e); err != nil {
 		rollback()

--- a/internal/registry/events.go
+++ b/internal/registry/events.go
@@ -17,7 +17,7 @@ type ProjectListener chan wire.ProjectEvent
 // Slow consumers are dropped — listeners must drain promptly.
 func (r *Registry) Subscribe() (Listener, func()) {
 	// 64, not 16: Update with an order change broadcasts one event per
-	// session while holding r.mu (see renumberLocked), so a listener
+	// session while holding r.mu (see reindexLocked), so a listener
 	// that's merely a beat behind on a many-session registry could
 	// overflow a small buffer and get dropped.
 	ch := make(Listener, 64)

--- a/internal/registry/ordering_test.go
+++ b/internal/registry/ordering_test.go
@@ -456,3 +456,95 @@ func TestKillProjectCompactsProjectOrder(t *testing.T) {
 		}
 	}
 }
+
+// TestKillBroadcastsSurvivorsReadAfterTeardown pins the ordering of
+// Kill's fan-out against its own teardown. Kill releases r.mu, then
+// closes the PTY and runs `git worktree remove` — seconds on a real
+// worktree — before it broadcasts. Reading the survivors BEFORE that
+// window and sending the snapshot after it clobbers whatever ran
+// meanwhile, which is how a stale .order comes back: the late
+// broadcast overwrites the client's correct values with pre-teardown
+// ones, and the next reorder (which sends an absolute index) misfires.
+//
+// r.gitMu is the seam: force=true skips the dirty pre-flight, so the
+// kill's only git work is the cleanup, and holding gitMu parks it
+// exactly inside the window with r.mu already released. The mid-window
+// mutation is a reorder rather than a create because the create path
+// takes gitMu too (create.go:263, worktree adoption) and would
+// deadlock against the very lock this test is holding.
+func TestKillBroadcastsSurvivorsReadAfterTeardown(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	// w owns the worktree, so killing it takes the git-cleanup path.
+	w := mustCreate(t, r, wire.CreateSpec{
+		Name: "w", ProjectID: p.ID, UseWorktree: true,
+	})
+	a := mustCreate(t, r, wire.CreateSpec{Name: "a", ProjectID: p.ID})
+	b := mustCreate(t, r, wire.CreateSpec{Name: "b", ProjectID: p.ID})
+
+	listener, unsub := r.Subscribe()
+	defer unsub()
+
+	r.gitMu.Lock() // freeze the teardown before it starts
+	killed := make(chan error, 1)
+	go func() { killed <- r.Kill(w.ID, true) }()
+
+	// Wait until the kill has passed the locked section (w is gone from
+	// the registry) and is parked on gitMu.
+	deadline := time.After(5 * time.Second)
+	for len(r.List()) > 2 {
+		select {
+		case <-deadline:
+			r.gitMu.Unlock()
+			t.Fatal("kill never reached the teardown window")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	// Mid-window: move b above a. A snapshot taken before this now
+	// describes the opposite order.
+	drain(listener)
+	top := 0
+	if _, err := r.Update(wire.UpdateSessionReq{SessionID: b.ID, Order: &top}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	r.gitMu.Unlock()
+	if err := <-killed; err != nil {
+		t.Fatalf("Kill w: %v", err)
+	}
+
+	if got := orderIDs(t, r); !slices.Equal(got, []string{b.ID, a.ID}) {
+		t.Fatalf("registry order: got %v, want [b a]", got)
+	}
+	// Whatever the fan-out said LAST for each session must agree with
+	// where that session actually sits. Kill broadcasts before it
+	// returns, so everything is queued by now — read until the stream
+	// goes quiet rather than stopping at the first sighting of each
+	// id, which would only ever see the reorder's (correct) events and
+	// never the kill's.
+	want := map[string]int{b.ID: 0, a.ID: 1}
+	last := map[string]int{}
+	for draining := true; draining; {
+		select {
+		case ev := <-listener:
+			if ev.Kind != wire.SessionEventUpdated {
+				continue
+			}
+			if _, ok := want[ev.Session.ID]; ok {
+				last[ev.Session.ID] = ev.Session.Order
+			}
+		case <-time.After(500 * time.Millisecond):
+			draining = false
+		}
+	}
+	if len(last) != len(want) {
+		t.Fatalf("saw %v, want an update for each of %v", last, want)
+	}
+	for id, order := range want {
+		if last[id] != order {
+			t.Errorf("session %s: last broadcast Order=%d, want %d", id, last[id], order)
+		}
+	}
+}

--- a/internal/registry/ordering_test.go
+++ b/internal/registry/ordering_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // orderIDs returns the registry's global order slice, plus a check that
-// every entry's Order field matches its index in it (renumberLocked's
-// invariant, which the splice must preserve).
+// every entry's Order field matches its index in it (reindexLocked's
+// invariant, which every r.order mutation must preserve).
 func orderIDs(t *testing.T, r *Registry) []string {
 	t.Helper()
 	r.mu.Lock()
@@ -273,5 +273,186 @@ func TestUpdateOrderMoveDownAndUpAcrossGlobalList(t *testing.T) {
 	want = []string{s[1].ID, s[2].ID, s[3].ID, s[0].ID}
 	if got := orderIDs(t, r); !slices.Equal(got, want) {
 		t.Fatalf("after move to tail: got %v, want %v", got, want)
+	}
+}
+
+// --- Kill compaction -------------------------------------------------
+//
+// Order is the index into r.order, and both GUI reorder paths hand a
+// sibling's .order straight back as an absolute index. A kill that left
+// holes behind used to break that: the holes made a later append reuse
+// an Order another entry already held, and every subsequent move
+// clamped or landed in the wrong slot.
+
+func TestKillCompactsOrderAndKeepsAppendsUnique(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	a := mustCreate(t, r, wire.CreateSpec{Name: "a"})
+	b := mustCreate(t, r, wire.CreateSpec{Name: "b"})
+	c := mustCreate(t, r, wire.CreateSpec{Name: "c"})
+
+	if err := r.Kill(a.ID, true); err != nil {
+		t.Fatalf("Kill a: %v", err)
+	}
+	// orderIDs asserts Order == index for every entry.
+	if got := orderIDs(t, r); !slices.Equal(got, []string{b.ID, c.ID}) {
+		t.Fatalf("after kill: got %v, want [b c]", got)
+	}
+
+	d := mustCreate(t, r, wire.CreateSpec{Name: "d"})
+	if got := orderIDs(t, r); !slices.Equal(got, []string{b.ID, c.ID, d.ID}) {
+		t.Fatalf("after append: got %v, want [b c d]", got)
+	}
+	seen := map[int]string{}
+	for _, info := range r.List() {
+		if prev, dup := seen[info.Order]; dup {
+			t.Fatalf("duplicate Order %d on %s and %s", info.Order, prev, info.ID)
+		}
+		seen[info.Order] = info.ID
+	}
+	for i := range 3 {
+		if _, ok := seen[i]; !ok {
+			t.Fatalf("Order %d missing — sequence is sparse: %v", i, seen)
+		}
+	}
+}
+
+func TestKillBroadcastsShiftedSessions(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	a := mustCreate(t, r, wire.CreateSpec{Name: "a"})
+	b := mustCreate(t, r, wire.CreateSpec{Name: "b"})
+	c := mustCreate(t, r, wire.CreateSpec{Name: "c"})
+
+	listener, unsub := r.Subscribe()
+	defer unsub()
+	drain(listener)
+
+	if err := r.Kill(a.ID, true); err != nil {
+		t.Fatalf("Kill a: %v", err)
+	}
+
+	// Collect until both survivors report their new Order, or time out.
+	want := map[string]int{b.ID: 0, c.ID: 1}
+	got := map[string]int{}
+	deadline := time.After(2 * time.Second)
+	for len(got) < len(want) {
+		select {
+		case ev := <-listener:
+			if ev.Kind != wire.SessionEventUpdated {
+				continue
+			}
+			if _, ok := want[ev.Session.ID]; ok {
+				got[ev.Session.ID] = ev.Session.Order
+			}
+		case <-deadline:
+			t.Fatalf("timed out; got %v, want %v", got, want)
+		}
+	}
+	for id, order := range want {
+		if got[id] != order {
+			t.Errorf("session %s: broadcast Order=%d, want %d", id, got[id], order)
+		}
+	}
+}
+
+func TestMoveAfterKillLandsWhereAsked(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	s := make([]*Entry, 4)
+	for i := range s {
+		s[i] = mustCreate(t, r, wire.CreateSpec{Name: string(rune('a' + i))})
+	}
+	if err := r.Kill(s[1].ID, true); err != nil {
+		t.Fatalf("Kill s1: %v", err)
+	}
+
+	// What the GUI does: read the target sibling's .order off List()
+	// and hand it back as the absolute index to splice at.
+	var target int
+	for _, info := range r.List() {
+		if info.ID == s[0].ID {
+			target = info.Order
+		}
+	}
+	if _, err := r.Update(wire.UpdateSessionReq{SessionID: s[3].ID, Order: &target}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	want := []string{s[3].ID, s[0].ID, s[2].ID}
+	if got := orderIDs(t, r); !slices.Equal(got, want) {
+		t.Fatalf("after move: got %v, want %v", got, want)
+	}
+}
+
+func TestLoadDerivesOrderFromIndexNotMeta(t *testing.T) {
+	skipOnWindows(t)
+	dir := t.TempDir()
+	r, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i] = mustCreate(t, r, wire.CreateSpec{Name: string(rune('a' + i))}).ID
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Skew every session.json the way a pre-compaction build would
+	// have left it: sparse, out of step with index.json's slice.
+	for i, id := range ids {
+		path := filepath.Join(SessionsDir(dir), id, "session.json")
+		var meta MetaFile
+		if err := readJSON(path, &meta); err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		meta.Order = 90 - i*10
+		if err := writeJSON(path, meta); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	r2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = r2.Close() })
+	// orderIDs asserts Order == index; the skewed (and reversed) meta
+	// values must lose to index.json.
+	if got := orderIDs(t, r2); !slices.Equal(got, ids) {
+		t.Fatalf("after reload: got %v, want %v", got, ids)
+	}
+}
+
+func TestKillProjectCompactsProjectOrder(t *testing.T) {
+	skipOnWindows(t)
+	r := freshRegistry(t)
+
+	made := make([]*Project, 3)
+	for i := range made {
+		p, err := r.CreateProject(wire.CreateProjectReq{Name: string(rune('a' + i))})
+		if err != nil {
+			t.Fatalf("CreateProject: %v", err)
+		}
+		made[i] = p
+	}
+	if err := r.KillProject(made[0].ID, false); err != nil {
+		t.Fatalf("KillProject: %v", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, id := range r.projectOrder {
+		p := r.projects[id]
+		if p == nil {
+			t.Fatalf("projectOrder[%d]=%s has no project", i, id)
+		}
+		if p.Order != i {
+			t.Errorf("project %s: Order=%d, want %d", p.Name, p.Order, i)
+		}
 	}
 }

--- a/internal/registry/persist.go
+++ b/internal/registry/persist.go
@@ -10,9 +10,13 @@ import (
 
 // MetaFile is what we write to <session_dir>/session.json.
 type MetaFile struct {
-	ID             string    `json:"id"`
-	Name           string    `json:"name"`
-	Color          string    `json:"color"`
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Color string `json:"color"`
+	// Order is advisory. index.json's id slice is the authority and
+	// is what load() derives each entry's Order from; this copy is
+	// only refreshed when the entry itself is rewritten, so it goes
+	// stale whenever a sibling is killed or moved.
 	Order          int       `json:"order"`
 	Created        time.Time `json:"created"`
 	Agent          string    `json:"agent,omitempty"`           // canonical agent ID; "" = shell
@@ -39,7 +43,7 @@ type ProjectMetaFile struct {
 	Name    string    `json:"name"`
 	Color   string    `json:"color"`
 	Cwd     string    `json:"cwd,omitempty"`
-	Order   int       `json:"order"`
+	Order   int       `json:"order"` // advisory; see MetaFile.Order
 	Created time.Time `json:"created"`
 }
 

--- a/internal/registry/projects.go
+++ b/internal/registry/projects.go
@@ -170,6 +170,7 @@ func (r *Registry) CreateProject(req wire.CreateProjectReq) (*Project, error) {
 	}
 	r.projects[id] = p
 	r.projectOrder = append(r.projectOrder, id)
+	r.reindexProjectsLocked()
 	if err := r.persistProjectLocked(p); err != nil {
 		delete(r.projects, id)
 		r.projectOrder = r.projectOrder[:len(r.projectOrder)-1]
@@ -237,8 +238,16 @@ func (r *Registry) KillProject(id string, killSessions bool) error {
 			break
 		}
 	}
-	// Intentionally NOT renumbering — same rationale as Kill().
-	// See registry.go for the full comment.
+	// Every project after the removed one shifted down a slot, so
+	// Order follows and the shifted projects are broadcast below —
+	// same reasoning as Kill(). See reindexLocked in registry.go.
+	r.reindexProjectsLocked()
+	shifted := make([]wire.ProjectInfo, 0, len(r.projectOrder))
+	for _, pid := range r.projectOrder {
+		if other := r.projects[pid]; other != nil {
+			shifted = append(shifted, other.Info())
+		}
+	}
 	r.persistProjectIndexLoggedLocked("delete project")
 
 	dir := filepath.Join(ProjectsDir(r.stateDir), id)
@@ -257,6 +266,9 @@ func (r *Registry) KillProject(id string, killSessions bool) error {
 		}
 	}
 	r.broadcastProject(wire.ProjectEventRemoved, info)
+	for _, pi := range shifted {
+		r.broadcastProject(wire.ProjectEventUpdated, pi)
+	}
 	return nil
 }
 
@@ -314,14 +326,15 @@ func (r *Registry) moveProjectLocked(id string, newOrder int) {
 		return
 	}
 	r.projectOrder = moveInOrder(r.projectOrder, id, newOrder)
-	r.renumberProjectsLocked()
+	r.reindexProjectsLocked()
 }
 
-func (r *Registry) renumberProjectsLocked() {
+// reindexProjectsLocked is reindexLocked for projects — same
+// invariant, same reason. See registry.go.
+func (r *Registry) reindexProjectsLocked() {
 	for i, id := range r.projectOrder {
 		if p := r.projects[id]; p != nil {
 			p.Order = i
-			r.persistProjectLoggedLocked(p, "renumber projects")
 		}
 	}
 }

--- a/internal/registry/projects.go
+++ b/internal/registry/projects.go
@@ -166,10 +166,12 @@ func (r *Registry) CreateProject(req wire.CreateProjectReq) (*Project, error) {
 	}
 	p := &Project{
 		ID: id, Name: name, Color: color, Cwd: req.Cwd,
-		Order: len(r.projectOrder), Created: time.Now().UTC(),
+		Created: time.Now().UTC(),
 	}
 	r.projects[id] = p
 	r.projectOrder = append(r.projectOrder, id)
+	// Order comes from reindex, never from a literal here — one place
+	// assigns it, so the append can't disagree with the slice.
 	r.reindexProjectsLocked()
 	if err := r.persistProjectLocked(p); err != nil {
 		delete(r.projects, id)
@@ -223,11 +225,16 @@ func (r *Registry) KillProject(id string, killSessions bool) error {
 		}
 	}
 
-	// Reassign or kill each affected session.
+	// Reassign or kill each affected session. The reassigned ones are
+	// snapshotted here, under the lock: `affected` holds live entries
+	// that stay in r.entries, so calling Info() on them after the
+	// unlock would race every concurrent Update/setPhase.
+	var reassigned []wire.SessionInfo
 	if !killSessions {
 		for _, e := range affected {
 			e.ProjectID = targetID
 			r.persistEntryLoggedLocked(e, "delete project (reassign)")
+			reassigned = append(reassigned, e.Info())
 		}
 	}
 
@@ -239,15 +246,9 @@ func (r *Registry) KillProject(id string, killSessions bool) error {
 		}
 	}
 	// Every project after the removed one shifted down a slot, so
-	// Order follows and the shifted projects are broadcast below —
+	// Order follows and the survivors are broadcast at the tail —
 	// same reasoning as Kill(). See reindexLocked in registry.go.
 	r.reindexProjectsLocked()
-	shifted := make([]wire.ProjectInfo, 0, len(r.projectOrder))
-	for _, pid := range r.projectOrder {
-		if other := r.projects[pid]; other != nil {
-			shifted = append(shifted, other.Info())
-		}
-	}
 	r.persistProjectIndexLoggedLocked("delete project")
 
 	dir := filepath.Join(ProjectsDir(r.stateDir), id)
@@ -261,12 +262,16 @@ func (r *Registry) KillProject(id string, killSessions bool) error {
 			_ = r.Kill(e.ID, true)
 		}
 	} else {
-		for _, e := range affected {
-			r.broadcast(wire.SessionEventUpdated, e.Info())
+		for _, si := range reassigned {
+			r.broadcast(wire.SessionEventUpdated, si)
 		}
 	}
 	r.broadcastProject(wire.ProjectEventRemoved, info)
-	for _, pi := range shifted {
+	// Read the survivors HERE, not back under the lock above: the
+	// RemoveAll and the N worktree teardowns in between can take
+	// seconds, and a stale ProjectInfo would clobber whatever ran in
+	// that window. Same hazard as Kill's fan-out.
+	for _, pi := range r.ListProjects() {
 		r.broadcastProject(wire.ProjectEventUpdated, pi)
 	}
 	return nil

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -266,9 +266,11 @@ func (r *Registry) load() error {
 		if err := readJSON(filepath.Join(pdir, id, "project.json"), &meta); err != nil {
 			continue
 		}
+		// Index position wins over meta.Order — see the session
+		// loader below for why the per-entity copy is advisory.
 		r.projects[meta.ID] = &Project{
 			ID: meta.ID, Name: meta.Name, Color: meta.Color, Cwd: meta.Cwd,
-			Order: meta.Order, Created: meta.Created,
+			Order: len(r.projectOrder), Created: meta.Created,
 		}
 		r.projectOrder = append(r.projectOrder, meta.ID)
 		pseen[meta.ID] = true
@@ -303,9 +305,13 @@ func (r *Registry) load() error {
 		if err := readJSON(filepath.Join(dir, id, "session.json"), &meta); err != nil {
 			continue
 		}
+		// Order comes from the index position, never from meta.Order:
+		// the per-session copy is advisory and goes stale whenever a
+		// sibling is killed or moved. Deriving it here also heals any
+		// state dir already skewed by an older build.
 		r.entries[meta.ID] = &Entry{
 			ID: meta.ID, Name: meta.Name, Color: meta.Color,
-			Order: meta.Order, Created: meta.Created, Agent: meta.Agent,
+			Order: len(r.order), Created: meta.Created, Agent: meta.Agent,
 			ProjectID:      meta.ProjectID,
 			WorktreePath:   meta.WorktreePath,
 			WorktreeBranch: meta.WorktreeBranch,
@@ -669,8 +675,10 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 		return ErrNotFound
 	}
 	delete(r.entries, id)
+	killedAt := len(r.order)
 	for i, sid := range r.order {
 		if sid == id {
+			killedAt = i
 			r.order = append(r.order[:i], r.order[i+1:]...)
 			break
 		}
@@ -687,12 +695,18 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 			}
 		}
 	}
-	// Intentionally NOT renumbering remaining entries here. Orders
-	// were assigned at create time and only change on an explicit
-	// user move. Kill leaves a hole in the sequence (e.g. 0,1,3,4)
-	// — the sort-by-Order render handles holes fine, and not
-	// touching the field means we never have to broadcast spurious
-	// SessionEventUpdated for sessions the user didn't touch.
+	// Removing an entry shifts every later one down a slot, so Order
+	// has to follow — it IS the index into r.order, and both GUI
+	// reorder paths hand that index straight back to moveInOrder. The
+	// shifted entries are broadcast below so clients don't keep the
+	// stale values and misplace the next move.
+	r.reindexLocked()
+	shifted := make([]wire.SessionInfo, 0, max(len(r.order)-killedAt, 0))
+	for _, sid := range r.order[min(killedAt, len(r.order)):] {
+		if other := r.entries[sid]; other != nil {
+			shifted = append(shifted, other.Info())
+		}
+	}
 	r.persistIndexLoggedLocked("kill")
 	dir := filepath.Join(SessionsDir(r.stateDir), id)
 	// Snapshot the PTY under the lock. Reading e.sess after the unlock
@@ -753,6 +767,9 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 	}
 	_ = os.RemoveAll(dir)
 	r.broadcast(wire.SessionEventRemoved, e.Info())
+	for _, info := range shifted {
+		r.broadcast(wire.SessionEventUpdated, info)
+	}
 	return nil
 }
 
@@ -845,32 +862,31 @@ func (r *Registry) moveLocked(id string, newOrder int) {
 		return
 	}
 	r.order = moveInOrder(r.order, id, newOrder)
-	r.renumberLocked()
+	r.reindexLocked()
 }
 
-func (r *Registry) renumberLocked() {
+// reindexLocked re-derives every entry's Order from its position in
+// r.order. Call it after ANY mutation of r.order — insert, delete, or
+// move. Order is not independent state: both GUI reorder paths
+// (frontend lib/reorder.ts and app/sidebar.ts) convert a display
+// position into a global index by reading a sibling's .order and
+// handing it back as UpdateSessionReq.Order, which moveInOrder splices
+// at positionally. The moment Order stops equalling the index, every
+// move lands in the wrong slot (or clamps to the end), and an append
+// can even hand out an Order another entry already holds, which makes
+// the frontend's sort-by-order ambiguous.
+//
+// In-memory only. index.json's id slice is the persisted authority and
+// is what load() re-derives Order from, so a stale Order in a
+// session.json nobody rewrote is harmless.
+func (r *Registry) reindexLocked() {
 	for i, id := range r.order {
 		if e := r.entries[id]; e != nil {
 			e.Order = i
 		}
 	}
-	// Re-persist any entries whose Order changed. We re-write all of
-	// them rather than diff: the volume is small.
-	for _, id := range r.order {
-		if e := r.entries[id]; e != nil {
-			r.persistEntryLoggedLocked(e, "renumber")
-		}
-	}
 }
 
-// ponytail: disk I/O runs under r.mu, so persist latency blocks every
-// session op; renumberLocked makes it len(order) writes per reorder,
-// not one. Not fixed by snapshot-under-lock + write-outside: r.mu is
-// also what serializes the writes, so releasing it before the write
-// lets a slow writer land a stale snapshot on top of a newer one.
-// Upgrade path if it ever hurts: a persist-ordering lock acquired
-// under r.mu and released after the write, threaded through every
-// *Locked persist call site.
 func (r *Registry) persistEntryLocked(e *Entry) error {
 	path := filepath.Join(SessionsDir(r.stateDir), e.ID, "session.json")
 	return writeJSON(path, MetaFile{

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -675,10 +675,8 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 		return ErrNotFound
 	}
 	delete(r.entries, id)
-	killedAt := len(r.order)
 	for i, sid := range r.order {
 		if sid == id {
-			killedAt = i
 			r.order = append(r.order[:i], r.order[i+1:]...)
 			break
 		}
@@ -698,15 +696,9 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 	// Removing an entry shifts every later one down a slot, so Order
 	// has to follow — it IS the index into r.order, and both GUI
 	// reorder paths hand that index straight back to moveInOrder. The
-	// shifted entries are broadcast below so clients don't keep the
-	// stale values and misplace the next move.
+	// survivors are broadcast at the tail of this function so clients
+	// don't keep the stale values and misplace the next move.
 	r.reindexLocked()
-	shifted := make([]wire.SessionInfo, 0, max(len(r.order)-killedAt, 0))
-	for _, sid := range r.order[min(killedAt, len(r.order)):] {
-		if other := r.entries[sid]; other != nil {
-			shifted = append(shifted, other.Info())
-		}
-	}
 	r.persistIndexLoggedLocked("kill")
 	dir := filepath.Join(SessionsDir(r.stateDir), id)
 	// Snapshot the PTY under the lock. Reading e.sess after the unlock
@@ -767,7 +759,13 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 	}
 	_ = os.RemoveAll(dir)
 	r.broadcast(wire.SessionEventRemoved, e.Info())
-	for _, info := range shifted {
+	// Re-read the survivors HERE rather than snapshotting them back
+	// under the lock above: the worktree teardown between the two can
+	// take seconds, and anything that ran meanwhile — a create
+	// splicing mid-list, a rename, a phase change — would be clobbered
+	// by a stale SessionInfo. Duplicate .order on the client is the
+	// exact failure this function exists to prevent.
+	for _, info := range r.List() {
 		r.broadcast(wire.SessionEventUpdated, info)
 	}
 	return nil
@@ -802,7 +800,7 @@ func (r *Registry) Update(req wire.UpdateSessionReq) (*Entry, error) {
 		return e, err
 	}
 	if orderChanged {
-		// Notify clients of every session, since renumberLocked
+		// Notify clients of every session, since reindexLocked
 		// touched all of them. Cheap: a few entries times one
 		// channel send each.
 		for _, sid := range r.order {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -113,9 +113,10 @@ func TestCreateListKill(t *testing.T) {
 	expectEvent("removed")
 
 	got = r.List()
-	// Kill leaves the surviving entries with their original Order
-	// (gaps are fine — the GUI sort handles them). Beta keeps Order=1.
-	if len(got) != 1 || got[0].ID != b.ID || got[0].Order != 1 {
+	// Kill compacts the sequence: Order is the index into r.order, so
+	// beta slides from 1 to 0. Gaps would break the GUI reorder paths,
+	// which hand a sibling's .order back as an absolute index.
+	if len(got) != 1 || got[0].ID != b.ID || got[0].Order != 0 {
 		t.Errorf("after kill: %+v", got)
 	}
 }


### PR DESCRIPTION
## Problem

Reordering sessions (⇧⌘↑/↓, sidebar drag) sometimes moved the wrong session, or nothing at all.

A session's `Order` is meant to be its index into the daemon's global `r.order` slice — both GUI reorder paths read a sibling's `.order` and send it back as an **absolute** index for `moveInOrder` to delete-then-insert at, and `sidebar.ts:409` says so explicitly. `Kill` deliberately left a hole rather than compacting ("the sort-by-Order render handles holes fine"), so the invariant broke on the first close.

Holes alone are survivable. The append path is not — it assigns `Order = len(r.order)`, which after a kill is a number another live session still holds:

```
[a,b,c] → 0,1,2
kill a  → [b,c]   1,2      (hole at 0)
open d  → [b,c,d] 1,2,2    ← c and d collide
```

`orderedSessions()` sorts by `(a.order ?? 0) - (b.order ?? 0)` with no tiebreak, so tied sessions fell through to arrival order — the flaky sort. And every subsequent move landed a slot off, or clamped to the end. Restarting didn't heal it: the loader copied the stale `order` back out of each `session.json`. `KillProject` had the identical hole for `Project.Order`.

## Fix

`Order` stops being independent state.

- `reindexLocked` / `reindexProjectsLocked` re-derive it from position, and run after **every** `r.order` mutation — insert, delete, move.
- The loader takes `Order` from `index.json`'s id slice, never `meta.Order`, so a state dir that already drifted heals on restart.
- `Kill` and `KillProject` compact and broadcast the shifted entries — the same fan-out the mid-list create splice already did — so clients don't cache stale indices.
- This also drops `renumberLocked`'s O(n) persist-under-`r.mu` and its `ponytail:` debt note. `MetaFile.Order` is now advisory; `index.json` is the authority.

No frontend `src/` changes — the invariant its comments already assume is now the one the daemon actually keeps.

### The mock was modelling the bug

`test/e2e/wails-mock.ts`'s `KillSession` spliced without renumbering or emitting updates, which is why the ordering suite never caught this. Fixed to match the daemon. Its session ids were also derived from `state.sessions.length`, so a create after a kill silently collided with a live session — now monotonic.

## Verification

5 new Go tests + 1 e2e case, **each confirmed to fail with the fix reverted**:

- kill compacts and a later append stays unique (no holes, no duplicates)
- kill broadcasts the survivors' new `Order`
- a move after a kill lands where the GUI asked
- reload derives `Order` from the index, not skewed `meta.Order`
- `KillProject` compacts project order
- e2e: ⇧⌘↓ still moves correctly after a kill and a create

Green: `go test ./internal/...`, 177 e2e, 520 vitest, `biome ci .`, `tsc --noEmit`, `wails build`.

Also exercised by hand in an isolated instance (`scripts/dev-iso.sh --reset`) — 4 sessions, close one, open another, drag and ⇧⌘-arrow. The resulting state dir shows a dense `index.json` alongside three stale advisory `meta.order=2` values, and reopening that dir renders `Order` 0..4 — the heal working as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)