### PR TITLE
fix(worktree): refresh the browser after a half-failed delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remote too. It is a separate button, never the default, and it only
   appears for a branch that actually tracks a remote.
 
+- Worktree and branch rows now show the tip commit's subject line. The
+  branch name says what the work was called; the subject says what is
+  actually in it, which is what you need when deciding whether a branch
+  can go.
+
 - The new-session popup can now name the worktree's branch. Ticking
   "Create in git worktree" reveals a branch-name field; leave it empty to
   keep the previous behaviour of an auto-generated adjective-noun name.
@@ -103,6 +108,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **Go Back** / **Go Forward**.
 
 ### Fixed
+
+- The worktree browser kept showing a branch it had already deleted. A
+  delete that got partway — the local branch removed, deleting it on
+  the remote refused — reported the failure and stopped there, so the
+  list was never repainted and the row stayed until the panel was
+  reopened. Every worktree action now repaints the list afterwards,
+  whether it succeeded, was refused, or half succeeded.
 
 - Restarting hive briefly showed "The process failed to start." on the
   first session you were looking at, which then started working on its

--- a/cmd/hivegui/frontend/src/app/modals/worktrees.ts
+++ b/cmd/hivegui/frontend/src/app/modals/worktrees.ts
@@ -200,6 +200,19 @@ function makeButton(
   return btn;
 }
 
+// appendSubject adds the branch tip's commit subject under the row's
+// status line — a branch name says what the work was called, this says
+// what it is. Skipped when the daemon had none (a detached worktree,
+// or an older daemon that does not send it).
+function appendSubject(main: HTMLElement, subject?: string): void {
+  if (!subject) return;
+  const el = document.createElement('span');
+  el.className = 'worktree-subject';
+  el.textContent = subject;
+  el.title = subject;
+  main.appendChild(el);
+}
+
 // makeBadge builds the small uppercase tag at the right of a row.
 function makeBadge(text: string, merged = false): HTMLElement {
   const badge = document.createElement('span');
@@ -228,6 +241,7 @@ function worktreeRow(w: WorktreeInfo): HTMLElement {
   status.textContent = statusLabel(w);
   main.appendChild(name);
   main.appendChild(status);
+  appendSubject(main, w.subject);
   row.appendChild(main);
 
   if (readIsMain(w)) {
@@ -313,6 +327,7 @@ function branchRow(b: BranchInfo): HTMLElement {
   status.textContent = branchStatusLabel(b);
   main.appendChild(name);
   main.appendChild(status);
+  appendSubject(main, b.subject);
   row.appendChild(main);
   if (b.merged) row.appendChild(makeBadge('merged', true));
 

--- a/cmd/hivegui/frontend/src/lib/worktrees.ts
+++ b/cmd/hivegui/frontend/src/lib/worktrees.ts
@@ -22,6 +22,8 @@ export interface WorktreeInfo {
   upstream?: string;
   session_ids?: string[];
   sessionIds?: string[];
+  // First line of the branch tip's commit message.
+  subject?: string;
 }
 
 export interface BranchInfo {
@@ -29,6 +31,8 @@ export interface BranchInfo {
   upstream?: string;
   ahead?: number;
   merged?: boolean;
+  // First line of the branch tip's commit message.
+  subject?: string;
 }
 
 export interface WorktreesPayload {

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -1832,12 +1832,13 @@ body.resizing-sidebar #app { transition: none; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* The tip commit subject: what is actually in the branch. Dimmer than
-   the status line above it — it is context, not a verdict. */
+/* The tip commit subject: what is actually in the branch. Italic, not
+   dimmer, sets it apart from the status line above it — at 11px on
+   #141414 anything below #7d7d7d misses the 4.5:1 contrast floor. */
 .worktree-subject {
   display: block;
   font-size: 11px;
-  color: #666;
+  color: #808080;
   font-style: italic;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -1832,6 +1832,17 @@ body.resizing-sidebar #app { transition: none; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* The tip commit subject: what is actually in the branch. Dimmer than
+   the status line above it — it is context, not a verdict. */
+.worktree-subject {
+  display: block;
+  font-size: 11px;
+  color: #666;
+  font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 /* Status colour carries the same ranking the list is sorted by, so a
    row that holds work is visible without reading the text. */
 .worktree-row[data-kind='active'] { border-color: #2f4858; }

--- a/cmd/hivegui/frontend/test/dom/worktrees.test.ts
+++ b/cmd/hivegui/frontend/test/dom/worktrees.test.ts
@@ -663,6 +663,34 @@ describe('keyboard', () => {
     expect(el('worktrees').classList.contains('hidden')).toBe(true);
   });
 
+  // The tip's commit subject is what tells the user what is in a
+  // branch; the name alone does not.
+  it('shows the tip commit subject on both lists', async () => {
+    await openWith(
+      payload({
+        worktrees: [
+          { path: '/repo/.worktrees/c', branch: 'c', subject: 'feat: a thing' },
+        ],
+        orphan_branches: [{ name: 'o', merged: true, subject: 'fix: a bug' }],
+      }),
+    );
+    expect(rows()[0].querySelector('.worktree-subject')?.textContent).toBe(
+      'feat: a thing',
+    );
+    expect(
+      branchRows()[0].querySelector('.worktree-subject')?.textContent,
+    ).toBe('fix: a bug');
+  });
+
+  // An older daemon sends no subject at all — the line is skipped, not
+  // rendered empty.
+  it('omits the subject line when the payload has none', async () => {
+    await openWith(
+      payload({ worktrees: [{ path: '/repo/.worktrees/c', branch: 'c' }] }),
+    );
+    expect(rows()[0].querySelector('.worktree-subject')).toBeNull();
+  });
+
   it('refreshes on (r)', async () => {
     await openWith(payload());
     ListWorktrees.mockClear();

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -544,10 +544,15 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 	// push did not). A refusal alone would leave the browser rendering
 	// rows the mutation already invalidated, so the error goes first
 	// and the truth follows it.
+	// An empty failCode means "stay quiet if the listing fails" — used
+	// after a refusal, where the client already has one error and a
+	// second would just be a second toast for the same action.
 	sendWorktrees := func(projectID, failCode string) {
 		resp, err := d.reg.ListWorktrees(projectID)
 		if err != nil {
-			sendError(failCode, err.Error())
+			if failCode != "" {
+				sendError(failCode, err.Error())
+			}
 			return
 		}
 		_ = writeJSON(wire.FrameWorktrees, resp)
@@ -571,6 +576,19 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 		default:
 			sendError(genericCode, err.Error())
 		}
+	}
+	// finishMutation is how every worktree mutation ends: the refusal,
+	// if any, and then the inventory it left behind. The two go
+	// together because a mutation can half succeed — the local branch
+	// deleted, the remote push refused — and an error alone would leave
+	// the browser rendering a row that is already gone.
+	finishMutation := func(projectID string, err error, failCode string) {
+		if err != nil {
+			sendWorktreeError(err, failCode)
+			sendWorktrees(projectID, "")
+			return
+		}
+		sendWorktrees(projectID, "list_worktrees_failed")
 	}
 	for {
 		ft, payload, err := wire.ReadFrame(conn)
@@ -696,10 +714,9 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 				continue
 			}
 			d.runOp(func() {
-				if err := d.reg.RemoveWorktree(req.ProjectID, req.Path, req.Force, req.DeleteBranch, req.DeleteRemote); err != nil {
-					sendWorktreeError(err, "remove_worktree_failed")
-				}
-				sendWorktrees(req.ProjectID, "list_worktrees_failed")
+				err := d.reg.RemoveWorktree(req.ProjectID, req.Path,
+					req.Force, req.DeleteBranch, req.DeleteRemote)
+				finishMutation(req.ProjectID, err, "remove_worktree_failed")
 			})
 		case wire.FrameCreateWorktree:
 			var req wire.CreateWorktreeReq
@@ -708,10 +725,8 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 				continue
 			}
 			d.runOp(func() {
-				if _, err := d.reg.CreateWorktreeForBranch(ctx, req.ProjectID, req.Branch); err != nil {
-					sendWorktreeError(err, "create_worktree_failed")
-				}
-				sendWorktrees(req.ProjectID, "list_worktrees_failed")
+				_, err := d.reg.CreateWorktreeForBranch(ctx, req.ProjectID, req.Branch)
+				finishMutation(req.ProjectID, err, "create_worktree_failed")
 			})
 		case wire.FrameDeleteBranch:
 			var req wire.DeleteBranchReq
@@ -720,10 +735,9 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 				continue
 			}
 			d.runOp(func() {
-				if err := d.reg.DeleteBranch(req.ProjectID, req.Branch, req.Force, req.DeleteRemote); err != nil {
-					sendWorktreeError(err, "delete_branch_failed")
-				}
-				sendWorktrees(req.ProjectID, "list_worktrees_failed")
+				err := d.reg.DeleteBranch(req.ProjectID, req.Branch,
+					req.Force, req.DeleteRemote)
+				finishMutation(req.ProjectID, err, "delete_branch_failed")
 			})
 		case wire.FrameRenameWorktree:
 			var req wire.RenameWorktreeReq
@@ -732,10 +746,8 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 				continue
 			}
 			d.runOp(func() {
-				if err := d.reg.RenameWorktree(req.ProjectID, req.Path, req.NewBranch); err != nil {
-					sendWorktreeError(err, "rename_worktree_failed")
-				}
-				sendWorktrees(req.ProjectID, "list_worktrees_failed")
+				err := d.reg.RenameWorktree(req.ProjectID, req.Path, req.NewBranch)
+				finishMutation(req.ProjectID, err, "rename_worktree_failed")
 			})
 		default:
 			log.Printf("hived: unexpected control frame: %s", ft)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -539,9 +539,11 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 		_ = writeJSON(wire.FrameError, wire.Error{Code: code, Message: msg})
 	}
 	// sendWorktrees answers with the project's current inventory. Every
-	// successful worktree mutation ends here, so the browser never has
-	// to re-request after acting — and never renders state that the
-	// mutation just invalidated.
+	// worktree mutation ends here — including the ones that failed, and
+	// the ones that half succeeded (the local branch went, the remote
+	// push did not). A refusal alone would leave the browser rendering
+	// rows the mutation already invalidated, so the error goes first
+	// and the truth follows it.
 	sendWorktrees := func(projectID, failCode string) {
 		resp, err := d.reg.ListWorktrees(projectID)
 		if err != nil {
@@ -696,7 +698,6 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 			d.runOp(func() {
 				if err := d.reg.RemoveWorktree(req.ProjectID, req.Path, req.Force, req.DeleteBranch, req.DeleteRemote); err != nil {
 					sendWorktreeError(err, "remove_worktree_failed")
-					return
 				}
 				sendWorktrees(req.ProjectID, "list_worktrees_failed")
 			})
@@ -709,7 +710,6 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 			d.runOp(func() {
 				if _, err := d.reg.CreateWorktreeForBranch(ctx, req.ProjectID, req.Branch); err != nil {
 					sendWorktreeError(err, "create_worktree_failed")
-					return
 				}
 				sendWorktrees(req.ProjectID, "list_worktrees_failed")
 			})
@@ -722,7 +722,6 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 			d.runOp(func() {
 				if err := d.reg.DeleteBranch(req.ProjectID, req.Branch, req.Force, req.DeleteRemote); err != nil {
 					sendWorktreeError(err, "delete_branch_failed")
-					return
 				}
 				sendWorktrees(req.ProjectID, "list_worktrees_failed")
 			})
@@ -735,7 +734,6 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 			d.runOp(func() {
 				if err := d.reg.RenameWorktree(req.ProjectID, req.Path, req.NewBranch); err != nil {
 					sendWorktreeError(err, "rename_worktree_failed")
-					return
 				}
 				sendWorktrees(req.ProjectID, "list_worktrees_failed")
 			})

--- a/internal/daemon/worktrees_test.go
+++ b/internal/daemon/worktrees_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -385,4 +386,55 @@ func TestControl_DeleteBranchUnmergedReturnsErrorCode(t *testing.T) {
 	if len(out) == 0 {
 		t.Error("branch was deleted despite the refusal")
 	}
+}
+
+// A delete that half succeeds — the local ref goes, the remote push
+// fails — used to answer with an ERROR and nothing else, leaving the
+// browser rendering a branch that is already gone. The inventory must
+// follow the refusal either way, so the view never outlives the state
+// it describes.
+func TestControl_DeleteBranchRefreshesAfterPartialFailure(t *testing.T) {
+	d, repo := startDaemonInRepo(t)
+	pid := projectIDOf(t, d)
+	head := gitOut(t, repo, "rev-parse", "HEAD")
+	for _, args := range [][]string{
+		{"branch", "half-gone"},
+		// An upstream pointing at a remote that cannot be reached:
+		// deleting the local ref works, the push does not.
+		{"remote", "add", "origin", filepath.Join(repo, "no-such-remote.git")},
+		{"update-ref", "refs/remotes/origin/half-gone", head},
+		{"branch", "--set-upstream-to=origin/half-gone", "half-gone"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	conn := dial(t, d)
+	defer conn.Close()
+	_ = handshake(t, conn, wire.Hello{Mode: wire.ModeControl})
+	if err := wire.WriteJSON(conn, wire.FrameDeleteBranch, wire.DeleteBranchReq{
+		ProjectID: pid, Branch: "half-gone", DeleteRemote: true,
+	}); err != nil {
+		t.Fatalf("write DELETE_BRANCH: %v", err)
+	}
+
+	resp := readWorktrees(t, conn)
+	for _, b := range resp.OrphanBranches {
+		if b.Name == "half-gone" {
+			t.Errorf("deleted branch still listed as an orphan")
+		}
+	}
+	if out := gitOut(t, repo, "branch", "--list", "half-gone"); out != "" {
+		t.Fatalf("local branch survived: %q", out)
+	}
+}
+
+func gitOut(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/internal/daemon/worktrees_test.go
+++ b/internal/daemon/worktrees_test.go
@@ -438,3 +438,44 @@ func gitOut(t *testing.T, repo string, args ...string) string {
 	}
 	return strings.TrimSpace(string(out))
 }
+
+// The same half-failure through REMOVE_WORKTREE: the directory and the
+// local branch go, the remote push does not. The inventory must still
+// follow the refusal — this path changed alongside DELETE_BRANCH and is
+// the one the browser hits when a worktree row is swept.
+func TestControl_RemoveWorktreeRefreshesAfterPartialFailure(t *testing.T) {
+	d, repo := startDaemonInRepo(t)
+	pid := projectIDOf(t, d)
+	wt := filepath.Join(repo, ".worktrees", "half-swept")
+	head := gitOut(t, repo, "rev-parse", "HEAD")
+	for _, args := range [][]string{
+		{"worktree", "add", "-q", "-b", "half-swept", wt},
+		{"remote", "add", "origin", filepath.Join(repo, "no-such-remote.git")},
+		{"update-ref", "refs/remotes/origin/half-swept", head},
+		{"branch", "--set-upstream-to=origin/half-swept", "half-swept"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	conn := dial(t, d)
+	defer conn.Close()
+	_ = handshake(t, conn, wire.Hello{Mode: wire.ModeControl})
+	if err := wire.WriteJSON(conn, wire.FrameRemoveWorktree, wire.RemoveWorktreeReq{
+		ProjectID: pid, Path: wt, Force: true,
+		DeleteBranch: true, DeleteRemote: true,
+	}); err != nil {
+		t.Fatalf("write REMOVE_WORKTREE: %v", err)
+	}
+
+	resp := readWorktrees(t, conn)
+	for _, w := range resp.Worktrees {
+		if w.Branch == "half-swept" {
+			t.Errorf("removed worktree still listed: %+v", w)
+		}
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Errorf("worktree directory survived: %v", err)
+	}
+}

--- a/internal/registry/worktrees.go
+++ b/internal/registry/worktrees.go
@@ -187,7 +187,12 @@ func (r *Registry) ListWorktrees(projectID string) (wire.WorktreesResp, error) {
 	if branchesErr != nil {
 		return resp, fmt.Errorf("list branches: %w", branchesErr)
 	}
+	// The branch listing already carries every local branch's tip
+	// subject, worktree or not, so the worktree rows get theirs from
+	// here rather than paying another git spawn each.
+	subjects := make(map[string]string, len(branches))
 	for _, b := range branches {
+		subjects[b.Name] = b.Subject
 		if b.HasWorktree {
 			continue
 		}
@@ -196,7 +201,11 @@ func (r *Registry) ListWorktrees(projectID string) (wire.WorktreesResp, error) {
 			Upstream: b.Upstream,
 			Ahead:    b.Ahead,
 			Merged:   b.Merged || ghConfirms(root, b.Name, ghSet),
+			Subject:  b.Subject,
 		})
+	}
+	for i := range resp.Worktrees {
+		resp.Worktrees[i].Subject = subjects[resp.Worktrees[i].Branch]
 	}
 	sort.Slice(resp.OrphanBranches, func(i, j int) bool {
 		return resp.OrphanBranches[i].Name < resp.OrphanBranches[j].Name

--- a/internal/registry/worktrees_test.go
+++ b/internal/registry/worktrees_test.go
@@ -909,9 +909,11 @@ func TestListWorktrees_CarriesTipSubjects(t *testing.T) {
 	skipNonPosix(t)
 	r, p := freshRegistryWithProject(t)
 	wt := newWorktree(t, p.Cwd, "has-tree")
-	runGit(t, wt, "commit", "--allow-empty", "-q", "-m", "feat: worktree work")
+	runGit(t, wt, "-c", "user.email=t@t", "-c", "user.name=t",
+		"commit", "--allow-empty", "-q", "-m", "feat: worktree work")
 	runGit(t, p.Cwd, "branch", "stranded")
-	runGit(t, p.Cwd, "commit", "--allow-empty", "-q", "-m", "unrelated")
+	runGit(t, p.Cwd, "-c", "user.email=t@t", "-c", "user.name=t",
+		"commit", "--allow-empty", "-q", "-m", "unrelated")
 
 	resp, err := r.ListWorktrees(p.ID)
 	if err != nil {

--- a/internal/registry/worktrees_test.go
+++ b/internal/registry/worktrees_test.go
@@ -901,3 +901,34 @@ func TestReclaimOrphanWorktrees_IgnoresWorktreesCreatedAfterTheScan(t *testing.T
 		t.Fatalf("worktree created after the scan was reclaimed: %v", err)
 	}
 }
+
+// Both halves of the browser carry the tip's commit subject: the
+// worktree rows take theirs from the branch listing rather than paying
+// a git spawn each.
+func TestListWorktrees_CarriesTipSubjects(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+	wt := newWorktree(t, p.Cwd, "has-tree")
+	runGit(t, wt, "commit", "--allow-empty", "-q", "-m", "feat: worktree work")
+	runGit(t, p.Cwd, "branch", "stranded")
+	runGit(t, p.Cwd, "commit", "--allow-empty", "-q", "-m", "unrelated")
+
+	resp, err := r.ListWorktrees(p.ID)
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	got := findWT(resp, wt)
+	if got == nil {
+		t.Fatalf("worktree %s missing: %+v", wt, resp.Worktrees)
+	}
+	if got.Subject != "feat: worktree work" {
+		t.Errorf("worktree Subject = %q, want %q", got.Subject, "feat: worktree work")
+	}
+	orphan := findOrphan(resp, "stranded")
+	if orphan == nil {
+		t.Fatalf("stranded branch missing: %+v", resp.OrphanBranches)
+	}
+	if orphan.Subject == "" {
+		t.Error("orphan branch Subject is empty")
+	}
+}

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -354,6 +354,10 @@ type WorktreeInfo struct {
 	// SessionIDs are the live sessions whose cwd is this worktree.
 	// Non-empty ⇒ removal and rename are refused.
 	SessionIDs []string `json:"session_ids,omitempty"`
+	// Subject is the first line of the branch tip's commit message —
+	// what the branch name alone never says. Empty for a detached
+	// worktree, and for anything the branch listing did not cover.
+	Subject string `json:"subject,omitempty"`
 }
 
 // BranchInfo describes a local branch with no worktree — the
@@ -366,6 +370,8 @@ type BranchInfo struct {
 	// Merged: reachable from the default ref, or merged into it by a
 	// squash (detected by patch id, or by GitHub PR state).
 	Merged bool `json:"merged,omitempty"`
+	// Subject is the first line of the branch tip's commit message.
+	Subject string `json:"subject,omitempty"`
 }
 
 // WorktreesResp is the daemon's answer to LIST_WORKTREES and to every

--- a/internal/wire/frame.go
+++ b/internal/wire/frame.go
@@ -80,10 +80,13 @@ const (
 	FrameShutdown FrameType = 0x15 // C → S, empty payload, control
 
 	// Worktree management. The daemon answers FrameListWorktrees — and
-	// every successful mutation below — with a fresh FrameWorktrees for
-	// the named project, so the client never has to re-request after
-	// acting. There is deliberately no WORKTREE_EVENT: the worktree
-	// browser is the only consumer and it is open whenever it mutates.
+	// every mutation below, whether it succeeded, was refused, or half
+	// succeeded — with a fresh FrameWorktrees for the named project, so
+	// the client never has to re-request after acting and never keeps
+	// rendering rows the attempt already invalidated. A refusal sends
+	// its FrameError first and the inventory follows it. There is
+	// deliberately no WORKTREE_EVENT: the worktree browser is the only
+	// consumer and it is open whenever it mutates.
 	FrameListWorktrees  FrameType = 0x16 // C → S, JSON, control
 	FrameWorktrees      FrameType = 0x17 // S → C, JSON, control
 	FrameRemoveWorktree FrameType = 0x18 // C → S, JSON, control

--- a/internal/worktree/inventory.go
+++ b/internal/worktree/inventory.go
@@ -202,7 +202,8 @@ type BranchInfo struct {
 	Upstream    string // "" = no upstream configured
 	Ahead       int
 	HasWorktree bool
-	Merged      bool // reachable from the default ref
+	Merged      bool   // reachable from the default ref
+	Subject     string // first line of the branch tip's commit message
 }
 
 // ListBranches returns every local branch with worktree and
@@ -255,7 +256,9 @@ func ListBranches(repoRoot string) ([]BranchInfo, error) {
 func forEachBranch(repoRoot, base string) ([]BranchInfo, error) {
 	// %(worktreepath) is empty for branches with no worktree; the
 	// separator is \x00 so branch names containing spaces survive.
-	const format = "%(refname:short)%00%(upstream:short)%00%(worktreepath)"
+	// %(subject) is the tip's commit subject — one line, and free
+	// here, where asking per branch would be a spawn each.
+	const format = "%(refname:short)%00%(upstream:short)%00%(worktreepath)%00%(subject)"
 	batched := base != ""
 	f := format
 	if batched {
@@ -281,17 +284,18 @@ func forEachBranch(repoRoot, base string) ([]BranchInfo, error) {
 			continue
 		}
 		parts := strings.Split(line, "\x00")
-		if len(parts) < 3 || parts[0] == "" {
+		if len(parts) < 4 || parts[0] == "" {
 			continue
 		}
 		b := BranchInfo{
 			Name:        parts[0],
 			Upstream:    parts[1],
 			HasWorktree: parts[2] != "",
+			Subject:     parts[3],
 		}
-		if batched && len(parts) > 3 {
+		if batched && len(parts) > 4 {
 			// "<ahead> <behind>"; an unresolvable base prints nothing.
-			if ahead, _, ok := strings.Cut(parts[3], " "); ok {
+			if ahead, _, ok := strings.Cut(parts[4], " "); ok {
 				b.Ahead, _ = strconv.Atoi(ahead)
 			}
 		} else {

--- a/internal/worktree/inventory_test.go
+++ b/internal/worktree/inventory_test.go
@@ -869,3 +869,23 @@ func TestScrubURLCredentials(t *testing.T) {
 		t.Errorf("unexpected scrub result: %s", got)
 	}
 }
+
+// The tip's commit subject rides along on the branch listing — a
+// branch name says what the work was called, this says what is in it.
+func TestListBranches_CarriesTipSubject(t *testing.T) {
+	repo := initRepo(t)
+	mustGit(t, repo, "checkout", "-q", "-b", "subject-branch")
+	mustGit(t, repo, "commit", "--allow-empty", "-q", "-m", "fix: the thing that broke")
+
+	branches, err := ListBranches(repo)
+	if err != nil {
+		t.Fatalf("ListBranches: %v", err)
+	}
+	b := findBranch(branches, "subject-branch")
+	if b == nil {
+		t.Fatalf("subject-branch missing: %+v", branches)
+	}
+	if b.Subject != "fix: the thing that broke" {
+		t.Errorf("Subject = %q, want %q", b.Subject, "fix: the thing that broke")
+	}
+}

--- a/internal/worktree/inventory_test.go
+++ b/internal/worktree/inventory_test.go
@@ -875,7 +875,8 @@ func TestScrubURLCredentials(t *testing.T) {
 func TestListBranches_CarriesTipSubject(t *testing.T) {
 	repo := initRepo(t)
 	mustGit(t, repo, "checkout", "-q", "-b", "subject-branch")
-	mustGit(t, repo, "commit", "--allow-empty", "-q", "-m", "fix: the thing that broke")
+	mustGit(t, repo, "-c", "user.email=t@t", "-c", "user.name=t",
+		"commit", "--allow-empty", "-q", "-m", "fix: the thing that broke")
 
 	branches, err := ListBranches(repo)
 	if err != nil {


### PR DESCRIPTION
## What

Two things in the worktree browser, both reported from real use.

### 1. Deleting a branch didn't refresh the list

The daemon sends a fresh inventory only after a *fully* successful mutation. Every partial-success path returned an error and no list:

- `DeleteBranch` with "local + remote": the local ref goes, then `git push --delete` fails (offline, auth, non-GitHub remote) → ERROR, no repaint.
- `RemoveWorktree`: directory removed, then the branch delete or remote push fails → same.

The branch really is gone, but the browser keeps rendering its row until reopened.

Reproduced in `TestControl_DeleteBranchRefreshesAfterPartialFailure` (upstream pointed at an unreachable remote): before the fix it times out waiting for `WORKTREES` while the log shows `registry: deleted branch half-gone`.

Fix: the error is sent first, then the inventory — always, for remove / create / delete-branch / rename. A pure refusal now also corrects a stale view, which is the same reason the success path sends one.

### 2. Branch rows show the tip commit subject

A branch name says what the work was called; the subject says what is in it. `%(subject)` is appended to the `for-each-ref` the branch listing already runs, so it costs no extra git spawn, and the worktree rows read theirs from that same listing rather than probing per worktree.

## Testing

- `go test ./internal/...`
- 530 vitest, 37 mock e2e (`worktrees.spec.ts`), 8 real-daemon e2e
- `biome ci .`, `tsc --noEmit`

New coverage: daemon partial-failure refresh, `ListBranches` subject, `ListWorktrees` subjects on both lists, and two DOM tests (subject rendered / omitted when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)