### PR TITLE
fix(gui): unbind ⌘/Ctrl+Enter from the grid toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ⌘Enter (Ctrl+Enter elsewhere) no longer toggles between grid and
+  single view. It was a duplicate of ⌘G, and because the app swallowed
+  the chord before the terminal saw it, it was unusable inside an agent
+  session. The chord is now unbound and left to the session. ⌘G and
+  ⇧⌘G still toggle the project grid and the all-sessions grid, and
+  Shift+Enter still inserts a newline without submitting.
+
 - Prompts that risk losing work no longer use a native OS alert. Closing
   a session with uncommitted changes, and deleting a worktree or branch,
   now open an in-app dialog that spells out what is at stake and offers

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ build.sh           # macOS universal build
 | ⌘W | Kill active session |
 | ⇧⌘W | Close this window |
 | ⌘G / ⇧⌘G | Per-project grid / all-sessions grid |
-| ⌘Enter | Toggle grid / single |
 | ⌘↑ / ⌘↓ | Previous / next session (focused) / move between tiles vertically (grid) |
 | ⌘← / ⌘→ | Spatial nav between tiles in grid view. In focused mode they move the cursor to the start / end of the line (macOS; ⇧⌘← / ⇧⌘→ do the same). On Windows and Linux use Ctrl+← / Ctrl+→ for word-wise movement, as in any terminal |
 | ⇧⌘↑ / ⇧⌘↓ | Move the session up / down within its project (wraps) |

--- a/cmd/hivegui/frontend/src/app/keyboard.ts
+++ b/cmd/hivegui/frontend/src/app/keyboard.ts
@@ -331,13 +331,6 @@ window.addEventListener(
       } else {
         setView(state.view === 'grid-project' ? 'single' : 'grid-project');
       }
-    } else if (e.key === 'Enter') {
-      // ⌘Enter mirrors ⌘G: in a grid mode it maximizes the active
-      // tile back to single mode; in single mode it expands to a
-      // per-project grid for context.
-      swallow();
-      if (state.view === 'single') setView('grid-project');
-      else setView('single');
     } else if (e.key === 'n' || e.key === 'N') {
       swallow();
       if (e.shiftKey) {

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -503,8 +503,9 @@ export class SessionTerm {
       // Shift, so Claude/Codex can't tell it from Enter and submit.
       // NEWLINE_SEQ (Ctrl+J / \x0a) is the newline byte both agents accept
       // with no terminal config. Plain Enter still submits. Cmd/Ctrl+Enter
-      // is intentionally not used here — it is the grid-project toggle, and
-      // the capture-phase window handler consumes it before xterm sees it.
+      // is deliberately NOT bound here either: it used to be the
+      // grid-project toggle and was unbound outright in #249, with no
+      // replacement behavior asked for.
       if (isShiftEnter(e)) {
         e.preventDefault();
         this._writePty(NEWLINE_SEQ);

--- a/cmd/hivegui/frontend/src/app/view.ts
+++ b/cmd/hivegui/frontend/src/app/view.ts
@@ -589,7 +589,7 @@ export function renderEmptyState() {
 
 export function setView(view: ViewMode) {
   // A grid of one tile looks like focused mode but loses the focused-mode
-  // keybindings, so ⌘G / ⇧⌘G / ⌘↩ below the floor stay where they are.
+  // keybindings, so ⌘G / ⇧⌘G below the floor stay where they are.
   // The startup restore of a persisted view goes through here too.
   const target = resolveView(
     view,

--- a/cmd/hivegui/frontend/src/lib/keymap.ts
+++ b/cmd/hivegui/frontend/src/lib/keymap.ts
@@ -17,10 +17,11 @@ export const NEWLINE_SEQ = '\x0a';
 // (no other modifier). xterm sends a plain \r for Shift+Enter — the
 // Shift is dropped — so Claude/Codex can't tell it from Enter and
 // submit. We intercept it here and send NEWLINE_SEQ instead. Shift+Enter
-// is the cross-platform "newline in a chat input" convention and, unlike
-// Cmd/Ctrl+Enter, carries no Cmd/Ctrl modifier, so it is not consumed by
-// the capture-phase window shortcut handler (which gates on Cmd/Ctrl) and
-// actually reaches the terminal. Plain Enter still submits.
+// is the cross-platform "newline in a chat input" convention, and it
+// carries no Cmd/Ctrl modifier, so the capture-phase window shortcut
+// handler (which gates on Cmd/Ctrl) never sees it and the key reaches
+// the terminal. Plain Enter still submits. Cmd/Ctrl+Enter was the
+// grid-project toggle until #249 unbound it; it is now inert.
 // Structural, not `KeyboardEvent`: the unit tests build plain fakes.
 // `code` is optional — only navHistoryKey's layout fallback reads it.
 export interface KeyEventLike {

--- a/cmd/hivegui/frontend/src/lib/shortcuts.ts
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.ts
@@ -147,7 +147,6 @@ export function shortcutGroups({ isMac }: { isMac: boolean }): ShortcutGroup[] {
       items: [
         { keys: m('G'), label: 'Toggle project grid' },
         { keys: m('G', { shift: true }), label: 'Toggle all-sessions grid' },
-        { keys: m('enter'), label: 'Toggle grid ⇄ single' },
         { keys: m('S'), label: 'Toggle sidebar' },
         {
           keys: `${m('=')} / ${m('-')} / ${m('0')}`,

--- a/cmd/hivegui/frontend/test/dom/view-floor.test.ts
+++ b/cmd/hivegui/frontend/test/dom/view-floor.test.ts
@@ -3,7 +3,7 @@
 // The two-tile floor on grid views, against the REAL view.ts.
 //
 // A grid holding one tile looks exactly like focused mode but loses the
-// focused-mode keybindings, so ⌘G / ⇧⌘G / ⌘↩ must be no-ops below the
+// focused-mode keybindings, so ⌘G / ⇧⌘G must be no-ops below the
 // floor — and a live grid that shrinks to one tile (session killed, or
 // minimized away) must fall back on its own. The sibling
 // keyboard-arrows.test.ts mocks view.ts, so it cannot see any of this.

--- a/cmd/hivegui/frontend/test/e2e/cmd-enter-unbound.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/cmd-enter-unbound.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// E2E coverage for #249: ⌘/Ctrl+Enter is no longer an app binding. It used
+// to toggle single ⇄ grid-project (mirroring ⌘G) and was swallowed by the
+// capture-phase window handler before xterm could see it, which made the
+// chord unusable inside an agent session. It is now unbound — no view
+// change, no replacement behavior. ⌘G / ⇧⌘G remain the grid toggles.
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function bootWithSessions(page: Page, count = 2) {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li').length > 0,
+  );
+  for (let i = 1; i < count; i++) {
+    await page.evaluate((n) => window.__hive.addSession?.(n), `s${i + 1}`);
+  }
+  await page.waitForFunction(
+    (n) => (window.__hive.state?.sessions.length ?? 0) >= n,
+    count,
+  );
+  await page.evaluate(() => window.__hive.resetStdin());
+}
+
+// The view is read off #terms' class list, the same signal focus.spec.ts
+// asserts on: grid modes add a `grid` class, focused mode does not.
+const termsClass = (page: Page) =>
+  page.evaluate(() => {
+    const terms = document.getElementById('terms');
+    if (!terms) throw new Error('#terms missing');
+    return terms.className;
+  });
+
+test.describe('#249 ⌘Enter unbound', () => {
+  test('⌘Enter in single mode does not enter grid', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+    const before = await termsClass(page);
+
+    await page.keyboard.press(`${MOD}+Enter`);
+    // No transition to wait for, so give the handler a frame to be wrong in.
+    await page.waitForTimeout(250);
+
+    expect(await termsClass(page)).toBe(before);
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+  });
+
+  test('⌘Enter in grid mode does not maximize back to single', async ({
+    page,
+  }) => {
+    await bootWithSessions(page, 2);
+    await page.keyboard.press(`${MOD}+g`);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    const before = await termsClass(page);
+
+    await page.keyboard.press(`${MOD}+Enter`);
+    await page.waitForTimeout(250);
+
+    expect(await termsClass(page)).toBe(before);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+  });
+
+  // The control: proves the deletion took only the ⌘Enter binding and left
+  // the real grid toggles working.
+  test('⌘G still toggles grid ⇄ single', async ({ page }) => {
+    await bootWithSessions(page, 2);
+    await page.keyboard.press(`${MOD}+g`);
+    await expect(page.locator('#terms')).toHaveClass(/grid/);
+    await page.keyboard.press(`${MOD}+g`);
+    await expect(page.locator('#terms')).not.toHaveClass(/grid/);
+  });
+});

--- a/cmd/hivegui/frontend/test/e2e/focus.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/focus.spec.ts
@@ -74,7 +74,10 @@ test.describe('grid-mode focus pipeline', () => {
 
   test('single → grid-project preserves keyboard focus', async ({ page }) => {
     await bootWithSessions(page, 2);
-    await page.keyboard.press(`${MOD}+Enter`);
+    // ⌘G, not ⌘Enter: the ⌘Enter grid toggle was unbound in #249. This
+    // test is about the focus pipeline, so it just needs any route into
+    // grid-project mode.
+    await page.keyboard.press(`${MOD}+g`);
     await expect(page.locator('#terms')).toHaveClass(/grid/);
     await page.waitForFunction(
       () => {

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -88,8 +88,6 @@ func buildAppMenu(a *App) *menu.Menu {
 	view.AddText("Toggle All Sessions Grid",
 		keys.Combo("g", keys.ShiftKey, keys.CmdOrCtrlKey),
 		emit("menu:toggle-all-grid"))
-	view.AddText("Toggle Grid (⌘↩ alternate)",
-		keys.CmdOrCtrl("enter"), emit("menu:toggle-project-grid"))
 
 	sess := m.AddSubmenu("Session")
 	sess.AddText("Next Session", keys.CmdOrCtrl("down"), emit("menu:next-session"))

--- a/cmd/hivegui/menu_darwin_test.go
+++ b/cmd/hivegui/menu_darwin_test.go
@@ -90,7 +90,7 @@ func walkAccelerators(items []*menu.MenuItem, out map[string]*keys.Accelerator) 
 }
 
 // TestMenuHasNoEnterAccelerator keeps ⌘↩ out of the native menu (#249).
-// Same mechanism as the arrow guard above: AppKit consumes a registered
+// Same mechanism as the arrow guard below: AppKit consumes a registered
 // key equivalent before the webview sees a keydown, so a menu item here
 // would toggle grid no matter what the frontend does — which is exactly
 // how the "⌘Enter is unusable inside an agent session" bug worked. The

--- a/cmd/hivegui/menu_darwin_test.go
+++ b/cmd/hivegui/menu_darwin_test.go
@@ -89,6 +89,38 @@ func walkAccelerators(items []*menu.MenuItem, out map[string]*keys.Accelerator) 
 	}
 }
 
+// TestMenuHasNoEnterAccelerator keeps ⌘↩ out of the native menu (#249).
+// Same mechanism as the arrow guard above: AppKit consumes a registered
+// key equivalent before the webview sees a keydown, so a menu item here
+// would toggle grid no matter what the frontend does — which is exactly
+// how the "⌘Enter is unusable inside an agent session" bug worked. The
+// Playwright specs cannot catch a re-add: they drive the browser mock,
+// which has no native menu.
+func TestMenuHasNoEnterAccelerator(t *testing.T) {
+	m := buildAppMenu(&App{})
+	if m == nil {
+		t.Fatal("buildAppMenu returned nil on darwin")
+	}
+	accels := map[string]*keys.Accelerator{}
+	walkAccelerators(m.Items, accels)
+	for label, acc := range accels {
+		if acc.Key == "enter" || acc.Key == "return" {
+			t.Errorf("menu item %q binds %q; ⌘↩ must reach the terminal", label, acc.Key)
+		}
+	}
+	// Guard the walker itself: ⌘G, the binding that replaced ⌘↩, must
+	// still be found — otherwise this test passes on an empty walk.
+	var g bool
+	for _, acc := range accels {
+		if acc.Key == "g" {
+			g = true
+		}
+	}
+	if !g {
+		t.Error("walkAccelerators found no 'g' binding; the walker is broken")
+	}
+}
+
 // TestMenuHasNoArrowLeftRightAccelerators keeps ⌘←/⌘→ (and their shifted
 // forms) out of the native menu. AppKit consumes a registered key
 // equivalent before the webview ever sees a keydown, so a menu item here

--- a/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
+++ b/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
@@ -58,14 +58,24 @@ The macOS menu line is the load-bearing removal: with the AppKit accelerator sti
 
 ## Decision log
 
+- **2026-08-28** — Added `TestMenuHasNoEnterAccelerator` in response to the iter-1 review. Why: the Playwright specs drive the browser mock, which has no native menu, so nothing would catch a re-added `keys.CmdOrCtrl("enter")` menu item — the load-bearing site. Mirrors the existing `TestMenuHasNoArrowLeftRightAccelerators` and reuses `walkAccelerators`.
+
 - **2026-08-28** — Unbind only; no pass-through byte for ⌘Enter. Why: explicitly chosen by the user at the loop's behavior gate; a pass-through would require new `_writePty` code in the xterm handler with no requested behavior behind it.
 - **2026-08-28** — Numbered 249, not 248. Why: no GitHub issue was created for this feature, and 248 is already a PR number in this repo.
 
 ## Progress
 
+- **2026-08-28** — Review-loop iter 1: COMMENT, 0 unresolved threads. Applied the IMPORTANT finding (native-accelerator regression test) and both MINOR stale-comment findings; re-ran all checks green.
+
 - **2026-08-28** — Spec written, triaged bug / S / P2, research verified against the e2e harness.
 - **2026-08-28** — PR #287 opened; stage → REVIEW.
 - **2026-08-28** — Implemented on `feature/249-unbind-cmd-enter-grid-toggle`: all four bindings removed, `focus.spec.ts` re-pointed at ⌘G, `cmd-enter-unbound.spec.ts` added, CHANGELOG entry under Unreleased → Changed. New tests confirmed red against the pre-fix branch before being green after it. Checks: `go build ./...`, `go test ./cmd/hivegui/...`, `biome ci .`, `npm run typecheck`, `scripts/test.sh unit dom e2e` (185 passed, 1 skipped) — all pass.
+
+## PR convergence ledger
+
+<!-- append-only, one line per review-loop iteration -->
+
+- **2026-08-28 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0af39b3f9edfcc04f9e881f693f2c2015e8174e69db13336f28bca8735a05f08; threads_open: 0; action: stop (1 IMPORTANT + 2 MINOR applied by hand rather than shipped as a gap); head_sha: 42dbaa4f.
 
 ## Open questions
 

--- a/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
+++ b/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/249-unbind-cmd-enter-grid-toggle.md](../../product-specs/249-unbind-cmd-enter-grid-toggle.md)
 - **Issue:** —
+- **PR:** #287
+- **Branch:** `feature/249-unbind-cmd-enter-grid-toggle`
 - **Status:** active
 
 ## Summary
@@ -62,6 +64,7 @@ The macOS menu line is the load-bearing removal: with the AppKit accelerator sti
 ## Progress
 
 - **2026-08-28** — Spec written, triaged bug / S / P2, research verified against the e2e harness.
+- **2026-08-28** — PR #287 opened; stage → REVIEW.
 - **2026-08-28** — Implemented on `feature/249-unbind-cmd-enter-grid-toggle`: all four bindings removed, `focus.spec.ts` re-pointed at ⌘G, `cmd-enter-unbound.spec.ts` added, CHANGELOG entry under Unreleased → Changed. New tests confirmed red against the pre-fix branch before being green after it. Checks: `go build ./...`, `go test ./cmd/hivegui/...`, `biome ci .`, `npm run typecheck`, `scripts/test.sh unit dom e2e` (185 passed, 1 skipped) — all pass.
 
 ## Open questions

--- a/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
+++ b/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
@@ -1,0 +1,69 @@
+# GUI: unbind ⌘/Ctrl+Enter from the grid toggle
+
+- **Spec:** [docs/product-specs/249-unbind-cmd-enter-grid-toggle.md](../../product-specs/249-unbind-cmd-enter-grid-toggle.md)
+- **Issue:** —
+- **Status:** active
+
+## Summary
+
+Delete the ⌘/Ctrl+Enter → grid-project toggle from the renderer, the macOS View menu, the shortcuts panel, and the README. No replacement behavior: the chord becomes app-inert and whatever xterm does with a meta-modified Enter is what happens (in practice, nothing).
+
+## Research
+
+Verified against the Playwright Wails-mock harness (`cmd/hivegui/frontend/test/e2e/`) on 2026-08-28: ⌘Enter toggles single ⇄ grid-project in both directions and writes zero bytes to the PTY, so today's behavior is exactly what the code says.
+
+Relevant code:
+
+- `cmd/hivegui/frontend/src/app/keyboard.ts:334-340` — the `else if (e.key === 'Enter')` branch inside the capture-phase window keydown handler, behind the `cmdOrCtrl(e)` gate at line 264. `swallow()` calls `preventDefault()` + `stopPropagation()`, which is why the key never reaches xterm.
+- `cmd/hivegui/frontend/src/lib/shortcuts.ts:150` — `{ keys: m('enter'), label: 'Toggle grid ⇄ single' }` in the View group of the help panel. `enter` is also a key label used by unrelated rows (line 182 `⇧↩`, line 196 `Confirm`), so only the View row goes; the `enter` entry in the label map at line 37 stays.
+- `cmd/hivegui/menu_darwin.go:91-92` — `view.AddText("Toggle Grid (⌘↩ alternate)", keys.CmdOrCtrl("enter"), emit("menu:toggle-project-grid"))`. This is a duplicate emitter for the same event as the ⌘G item at line 87, so removing it needs no handler change in `app/events.ts`. On macOS an AppKit accelerator is matched before the webview sees the keydown, so this line must go or ⌘Enter keeps toggling regardless of the renderer edit.
+- `README.md:97` — `| ⌘Enter | Toggle grid / single |` in the shortcut table.
+
+Constraints / non-issues:
+
+- `cmd/hivegui/menu_darwin_test.go` has no assertion naming the alternate item (`TestSessionMenuAttentionItems`, `TestMenuHasNoArrowLeftRightAccelerators` only), so no Go test needs editing — only re-running.
+- `test/e2e/focus.spec.ts:75` (`single → grid-project preserves keyboard focus`) drives `${MOD}+Enter` to reach grid mode. It must be re-pointed at ⌘G, otherwise it fails; its subject is the focus pipeline, not the binding.
+- Shift+Enter (#217, `lib/keymap.ts` `isShiftEnter` / `NEWLINE_SEQ`) is orthogonal — it carries no Cmd/Ctrl, so it never entered this branch. `test/e2e/shift-enter-newline.spec.ts` stays green untouched.
+- `docs/product-specs/217-*.md` documents ⌘Enter as the grid toggle in prose. Historical record of a shipped decision; left as-is, with the reversal recorded here and in spec 249's Notes.
+
+## Approach
+
+Straight deletion at all four sites rather than remapping the chord to a PTY byte. The user asked for unbind-only, and any pass-through would need an explicit `_writePty` in the xterm custom key handler (xterm emits nothing for meta+Enter on its own) — code with no requested behavior behind it.
+
+The macOS menu line is the load-bearing removal: with the AppKit accelerator still registered, deleting the renderer branch alone would leave ⌘Enter toggling grid on the platform where it was reported.
+
+### Files to change
+
+1. `cmd/hivegui/frontend/src/app/keyboard.ts` — delete the `else if (e.key === 'Enter')` branch (lines 334-340) and its comment.
+2. `cmd/hivegui/menu_darwin.go` — delete the `view.AddText("Toggle Grid (⌘↩ alternate)", ...)` call (lines 91-92).
+3. `cmd/hivegui/frontend/src/lib/shortcuts.ts` — delete the `Toggle grid ⇄ single` row (line 150).
+4. `README.md` — delete the `⌘Enter` row from the shortcut table (line 97).
+5. `cmd/hivegui/frontend/test/e2e/focus.spec.ts` — re-point the `single → grid-project preserves keyboard focus` test from `${MOD}+Enter` to `${MOD}+g`; rename it accordingly.
+6. `.changesets/` — one changeset for the user-visible shortcut removal.
+
+### New files
+
+- `cmd/hivegui/frontend/test/e2e/cmd-enter-unbound.spec.ts` — regression coverage for the removal.
+
+### Tests
+
+- `cmd-enter-unbound.spec.ts` → `⌘Enter in single mode does not enter grid` — boot 2 sessions, press `${MOD}+Enter`, assert `#terms` class is unchanged and still not `/grid/`.
+- `cmd-enter-unbound.spec.ts` → `⌘Enter in grid mode does not maximize` — enter grid via `${MOD}+g`, press `${MOD}+Enter`, assert still `/grid/`.
+- `cmd-enter-unbound.spec.ts` → `⌘G still toggles grid` — the control that proves the deletion did not take the working binding with it.
+- `focus.spec.ts` → existing focus test re-pointed at ⌘G (edit, not new).
+- `shift-enter-newline.spec.ts` → unchanged; must stay green (Shift+Enter still 0x0a, Enter still 0x0d).
+- `go test ./cmd/hivegui/...` → existing menu tests must stay green after the menu line is removed.
+
+## Decision log
+
+- **2026-08-28** — Unbind only; no pass-through byte for ⌘Enter. Why: explicitly chosen by the user at the loop's behavior gate; a pass-through would require new `_writePty` code in the xterm handler with no requested behavior behind it.
+- **2026-08-28** — Numbered 249, not 248. Why: no GitHub issue was created for this feature, and 248 is already a PR number in this repo.
+
+## Progress
+
+- **2026-08-28** — Spec written, triaged bug / S / P2, research verified against the e2e harness.
+- **2026-08-28** — Implemented on `feature/249-unbind-cmd-enter-grid-toggle`: all four bindings removed, `focus.spec.ts` re-pointed at ⌘G, `cmd-enter-unbound.spec.ts` added, CHANGELOG entry under Unreleased → Changed. New tests confirmed red against the pre-fix branch before being green after it. Checks: `go build ./...`, `go test ./cmd/hivegui/...`, `biome ci .`, `npm run typecheck`, `scripts/test.sh unit dom e2e` (185 passed, 1 skipped) — all pass.
+
+## Open questions
+
+None.

--- a/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
+++ b/docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md
@@ -65,6 +65,8 @@ The macOS menu line is the load-bearing removal: with the AppKit accelerator sti
 
 ## Progress
 
+- **2026-08-28** — Review-loop iter 2: APPROVE, 0 unresolved threads, no BLOCKING or IMPORTANT. Swept the three remaining MINOR stale-`⌘↩` comments. Loop converged.
+
 - **2026-08-28** — Review-loop iter 1: COMMENT, 0 unresolved threads. Applied the IMPORTANT finding (native-accelerator regression test) and both MINOR stale-comment findings; re-ran all checks green.
 
 - **2026-08-28** — Spec written, triaged bug / S / P2, research verified against the e2e harness.
@@ -76,6 +78,7 @@ The macOS menu line is the load-bearing removal: with the AppKit accelerator sti
 <!-- append-only, one line per review-loop iteration -->
 
 - **2026-08-28 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0af39b3f9edfcc04f9e881f693f2c2015e8174e69db13336f28bca8735a05f08; threads_open: 0; action: stop (1 IMPORTANT + 2 MINOR applied by hand rather than shipped as a gap); head_sha: 42dbaa4f.
+- **2026-08-28 iter 2** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop (3 MINOR stale-comment nits swept in a follow-up commit); head_sha: cb2ce2a.
 
 ## Open questions
 

--- a/docs/product-specs/249-unbind-cmd-enter-grid-toggle.md
+++ b/docs/product-specs/249-unbind-cmd-enter-grid-toggle.md
@@ -1,10 +1,11 @@
 # GUI: unbind ⌘/Ctrl+Enter from the grid toggle
 
 - **Issue:** —
+- **PR:** #287
 - **Type:** bug
 - **Complexity:** S
 - **Priority:** P2
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Exec plan:** [docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md](../exec-plans/active/249-unbind-cmd-enter-grid-toggle.md)
 
 ## Problem

--- a/docs/product-specs/249-unbind-cmd-enter-grid-toggle.md
+++ b/docs/product-specs/249-unbind-cmd-enter-grid-toggle.md
@@ -1,0 +1,37 @@
+# GUI: unbind ⌘/Ctrl+Enter from the grid toggle
+
+- **Issue:** —
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P2
+- **Stage:** IMPLEMENT
+- **Exec plan:** [docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md](../exec-plans/active/249-unbind-cmd-enter-grid-toggle.md)
+
+## Problem
+
+⌘Enter (Ctrl+Enter off macOS) currently toggles single ⇄ grid-project, mirroring ⌘G. That is the wrong owner for the chord: Enter belongs to the focused agent session, and the capture-phase window handler (`cmd/hivegui/frontend/src/app/keyboard.ts:334`) swallows the event before xterm ever sees it, so ⌘Enter is unusable inside a session. Users pressing it in Claude or Codex get an unwanted view change instead of the terminal behavior they expect. ⌘G and ⇧⌘G already cover both grid toggles, so the alternate binding buys nothing.
+
+## Desired behavior
+
+⌘/Ctrl+Enter has no app-level meaning. Pressing it in a session does not change the view; whatever xterm does with a meta-modified Enter (in practice: nothing) is what happens. ⌘G / ⇧⌘G remain the grid toggles, and Shift+Enter's newline behavior (#217) is untouched.
+
+## Success criteria
+
+- ⌘/Ctrl+Enter in single mode does not switch to grid-project.
+- ⌘/Ctrl+Enter in grid mode does not maximize to single.
+- ⌘G still toggles grid-project and ⇧⌘G still toggles grid-all.
+- Shift+Enter still sends `0x0a`; plain Enter still sends `\r`.
+- The "Toggle Grid (⌘↩ alternate)" View-menu item is gone on macOS.
+- The shortcuts panel no longer lists ↩ / Enter as a grid toggle.
+
+## Non-goals
+
+- Giving ⌘Enter a replacement behavior (submit, newline, or anything else).
+- Changing ⌘G / ⇧⌘G, Shift+Enter, or plain Enter.
+- Making the binding configurable.
+
+## Notes
+
+Touch points: `cmd/hivegui/frontend/src/app/keyboard.ts:334` (the branch), `cmd/hivegui/frontend/src/lib/shortcuts.ts:150` (help panel row), `cmd/hivegui/menu_darwin.go:91` plus `menu_darwin_test.go`, and the README shortcut table. Related: #217, which documented ⌘Enter as the grid toggle and routed newline insertion to Shift+Enter instead — that reasoning is now obsolete for ⌘Enter but Shift+Enter stays.
+
+Numbering: no GitHub issue was created; 248 was skipped because it is already a PR number.

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -16,6 +16,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | P2 | #202 | GUI: minimize sessions to remove from grid view; restore from a tray | REVIEW | [202-minimize-session-from-grid](202-minimize-session-from-grid.md) |
 | P2 | #213 | GUI: always scroll to bottom on mode switch; never auto-scroll up | QA | [213-always-scroll-to-bottom-on-mode-switch-resize](213-always-scroll-to-bottom-on-mode-switch-resize.md) |
 | P2 | #217 | GUI: Cmd+Enter should insert a newline, not submit, in agent sessions on macOS | REVIEW | [217-cmd-enter-insert-newline-not-submit](217-cmd-enter-insert-newline-not-submit.md) |
+| P2 | — | GUI: unbind ⌘/Ctrl+Enter from the grid toggle | IMPLEMENT | [249-unbind-cmd-enter-grid-toggle](249-unbind-cmd-enter-grid-toggle.md) |
 | P2 | — | Add user-configurable custom agents | REVIEW | [240-user-configurable-custom-agents](240-user-configurable-custom-agents.md) |
 
 ## Completed

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -16,7 +16,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | P2 | #202 | GUI: minimize sessions to remove from grid view; restore from a tray | REVIEW | [202-minimize-session-from-grid](202-minimize-session-from-grid.md) |
 | P2 | #213 | GUI: always scroll to bottom on mode switch; never auto-scroll up | QA | [213-always-scroll-to-bottom-on-mode-switch-resize](213-always-scroll-to-bottom-on-mode-switch-resize.md) |
 | P2 | #217 | GUI: Cmd+Enter should insert a newline, not submit, in agent sessions on macOS | REVIEW | [217-cmd-enter-insert-newline-not-submit](217-cmd-enter-insert-newline-not-submit.md) |
-| P2 | — | GUI: unbind ⌘/Ctrl+Enter from the grid toggle | IMPLEMENT | [249-unbind-cmd-enter-grid-toggle](249-unbind-cmd-enter-grid-toggle.md) |
+| P2 | — | GUI: unbind ⌘/Ctrl+Enter from the grid toggle | REVIEW | [249-unbind-cmd-enter-grid-toggle](249-unbind-cmd-enter-grid-toggle.md) |
 | P2 | — | Add user-configurable custom agents | REVIEW | [240-user-configurable-custom-agents](240-user-configurable-custom-agents.md) |
 
 ## Completed


### PR DESCRIPTION
## What

⌘Enter (Ctrl+Enter off macOS) mirrored ⌘G as a single ⇄ grid-project toggle. The capture-phase window handler swallowed the chord before xterm saw it, so it was unusable inside an agent session — pressing it changed the view instead of doing anything useful in Claude or Codex.

The binding is removed with no replacement behavior: ⌘Enter is now inert. ⌘G / ⇧⌘G remain the grid toggles and Shift+Enter (#217) still inserts a newline without submitting.

## Sites removed

1. `cmd/hivegui/frontend/src/app/keyboard.ts` — the `else if (e.key === 'Enter')` branch behind the `cmdOrCtrl` gate.
2. `cmd/hivegui/menu_darwin.go` — the `Toggle Grid (⌘↩ alternate)` View-menu item. **Load-bearing:** AppKit matches its accelerator before the webview sees a keydown, so deleting only the renderer branch would have left ⌘Enter toggling grid on the platform where this was reported.
3. `cmd/hivegui/frontend/src/lib/shortcuts.ts` — the help-panel row.
4. `README.md` — the keybind table row.

Per the Keybindings Policy in AGENTS.md, all surfaces are updated (help overlay, README, changelog); the command palette carried no ⌘Enter entry.

## Tests

New `test/e2e/cmd-enter-unbound.spec.ts`:
- ⌘Enter in single mode does not enter grid
- ⌘Enter in grid mode does not maximize back to single
- ⌘G still toggles grid ⇄ single (the control — proves the deletion took only the intended binding)

Confirmed **red** against the pre-fix code (the first two fail, the control passes) before going green.

`test/e2e/focus.spec.ts` used ⌘Enter to reach grid mode; its subject is the focus pipeline, so it now takes ⌘G there instead. `shift-enter-newline.spec.ts` is untouched and green.

## Checks

- `go build ./...`, `go test ./cmd/hivegui/...` — pass
- `biome ci .`, `npm run typecheck` — pass
- `scripts/test.sh unit dom e2e` — 185 passed, 1 skipped

Spec: `docs/product-specs/249-unbind-cmd-enter-grid-toggle.md` · Plan: `docs/exec-plans/active/249-unbind-cmd-enter-grid-toggle.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the ⌘/Ctrl+Enter grid-toggle binding so the chord is no longer intercepted by the application.
- Removes the renderer and macOS native-menu bindings.
- Updates shortcut documentation and the in-app help listing.
- Adds browser coverage for unchanged view state and a macOS menu regression test.
- Retains ⌘G and ⇧⌘G as the grid controls.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| cmd/hivegui/frontend/src/app/keyboard.ts | Removes the capture-phase Enter branch while preserving the existing grid shortcuts. |
| cmd/hivegui/menu_darwin.go | Removes the native macOS ⌘Enter accelerator that could intercept the chord before the webview. |
| cmd/hivegui/menu_darwin_test.go | Adds regression coverage ensuring the native menu does not register an Enter or Return accelerator. |
| cmd/hivegui/frontend/test/e2e/cmd-enter-unbound.spec.ts | Verifies ⌘/Ctrl+Enter leaves both single and grid views unchanged while ⌘/Ctrl+G continues toggling. |
| cmd/hivegui/frontend/test/e2e/focus.spec.ts | Repoints the focus-pipeline test to the retained ⌘/Ctrl+G grid shortcut. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs(gui): sweep the last stale ⌘↩ comme..."](https://github.com/lucascaro/hive/commit/d276c7abec520fc882b44ec37bb9bcdbd275001e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58099593)</sub>

<!-- /greptile_comment -->