### PR TITLE
chore: mark #252 done after QA pass

### DIFF
--- a/cmd/hivegui/frontend/test/dom/minimize-project.test.ts
+++ b/cmd/hivegui/frontend/test/dom/minimize-project.test.ts
@@ -55,6 +55,7 @@ let switchToProject: typeof import('../../src/app/view.js').switchToProject;
 let shiftActiveProject: typeof import('../../src/app/view.js').shiftActiveProject;
 let initView: typeof import('../../src/app/view.js').initView;
 let minimizeSession: typeof import('../../src/app/view.js').minimizeSession;
+let restoreProject: typeof import('../../src/app/view.js').restoreProject;
 let navSession: typeof import('../../src/app/keyboard.js').navSession;
 let reorderActive: typeof import('../../src/app/keyboard.js').reorderActive;
 
@@ -84,6 +85,7 @@ beforeAll(async () => {
   shiftActiveProject = view.shiftActiveProject;
   initView = view.initView;
   minimizeSession = view.minimizeSession;
+  restoreProject = view.restoreProject;
   ({ navSession, reorderActive } = await import('../../src/app/keyboard.js'));
   const sidebar = await import('../../src/app/sidebar.js');
   renderSidebar = sidebar.renderSidebar;
@@ -633,6 +635,34 @@ describe('keyboard navigation skips minimized things', () => {
     state.currentProjectId = 'p1';
     state.activeId = 's1';
     shiftActiveProject(-1);
+    expect(state.currentProjectId).toBe('p2');
+  });
+
+  // The spec words criterion 1 as a FULL cycle, and criterion 6 as a
+  // round trip. The per-step cases above prove one hop each; these two
+  // prove the properties the user actually feels.
+  it('never lands in a minimized project across a full ⌘↓ cycle', () => {
+    state.sessions.push({ id: 's2b', name: 's2b', project_id: 'p2', order: 4 });
+    minimizeProject('p2');
+    state.activeId = 's1';
+    const seen: (string | null)[] = [];
+    for (let i = 0; i < 6; i++) {
+      navSession(+1);
+      seen.push(state.activeId);
+    }
+    expect(seen).not.toContain('s2');
+    expect(seen).not.toContain('s2b');
+    expect(new Set(seen)).toEqual(new Set(['s1', 's3']));
+  });
+
+  it('puts a restored project back in both rotations', () => {
+    minimizeProject('p2');
+    restoreProject('p2');
+    state.activeId = 's1';
+    navSession(+1);
+    expect(state.activeId).toBe('s2');
+    state.currentProjectId = 'p1';
+    shiftActiveProject(+1);
     expect(state.currentProjectId).toBe('p2');
   });
 

--- a/docs/exec-plans/completed/252-keyboard-switching-skips-minimized-sessions.md
+++ b/docs/exec-plans/completed/252-keyboard-switching-skips-minimized-sessions.md
@@ -4,7 +4,7 @@
 - **Issue:** —
 - **PR:** #293
 - **Branch:** feature/252-keyboard-switching-skips-minimized-sessions
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -108,3 +108,15 @@ None.
 - **2026-08-30 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 2749afd6…; threads_open: 0; action: stop; head_sha: bf0d8a8.
 - **2026-08-30 iter 1 follow-up** — applied both IMPORTANT findings and the MINOR one by hand rather than exiting on COMMENT: the no-active-session seed in `moveActiveSession` was the same bug in the sibling exit, three source comments still claimed ⌘[ / ⌘] reaches minimized projects, and `delta * i` assumed |delta| === 1.
 - **2026-08-30 iter 2** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 913d158. All three iteration-1 findings verified cleared. Two MINORs applied afterwards (dead initializer in `shiftActiveProject`, an inaccurate test comment about `keyboard-arrows.test.ts`'s mock). The third MINOR — no Active row in `docs/product-specs/index.md` — is not actionable: that file is generated on push to `main`.
+
+## QA verdict
+
+- **2026-08-30** — verdict: PASS; checks: 3 dimensions passed / 0 failed / 0 followups; followups: none; one-line: all 6 success criteria and 3 non-goals verified by execution against the merged tree, no regressions in the adjacent ⌘B / nav-history / reorder / ⌘1-9 paths.
+  - 2026-08-30 dimensions:
+    - build/lint/test — PASS — `scripts/test.sh go` all packages ok; `vitest run` 626 passed; `tsc --noEmit` clean; `biome ci .` clean (6 `noExplicitAny` warnings are pre-existing in `test/dom/theme-apply.test.ts` from #292, not this feature).
+    - acceptance — PASS — every success criterion exercised; the grid-view leg is structural (`handleArrow` routes non-single views to `gridSpatialMove` over the already-filtered `gridLayout.sessions`, so `moveActiveSession` is never reached there).
+    - non-goals — PASS — ⌘1-9 still indexes the unfiltered list; sidebar / tray / ⌘K untouched by the diff; no new keybinding.
+    - regression — PASS — reorder branch still sends a global index (pinned by test); `jumpToAttention` / `jumpBack` / `navGo` / `switchToProject` / `firstVisible` / `fallBackToSingleIfActiveHidden` unchanged; 74/74 targeted dom tests pass.
+    - doc accuracy — PASS — CHANGELOG `[Unreleased] / Fixed` accurate; README + `shortcuts.ts` labels still correct; spec #250 amendment coherent; repo-wide grep finds no remaining claim that the arrows or ⌘[ / ⌘] reach minimized things. (The shipped `[2.4.0]` CHANGELOG entry still describes the old ⌘[ / ⌘] behavior — historical, deliberately not rewritten.)
+  - Coverage gap closed during QA: added `never lands in a minimized project across a full ⌘↓ cycle` and `puts a restored project back in both rotations`, the full-cycle and round-trip forms the spec words but the merged suite only proved per-step.
+  - Manual validation: confirmed by the operator in an isolated dev build (`scripts/dev-iso.sh`).

--- a/docs/product-specs/252-keyboard-switching-skips-minimized-sessions.md
+++ b/docs/product-specs/252-keyboard-switching-skips-minimized-sessions.md
@@ -5,8 +5,9 @@
 - **Complexity:** S
 - **Priority:** P2
 - **PR:** #293
-- **Stage:** REVIEW
-- **Exec plan:** [docs/exec-plans/active/252-keyboard-switching-skips-minimized-sessions.md](../exec-plans/active/252-keyboard-switching-skips-minimized-sessions.md)
+- **Shipped:** 2026-08-30
+- **Stage:** DONE
+- **Exec plan:** [docs/exec-plans/completed/252-keyboard-switching-skips-minimized-sessions.md](../exec-plans/completed/252-keyboard-switching-skips-minimized-sessions.md)
 
 ## Problem
 


### PR DESCRIPTION
QA for feature #252 (shipped in #293).

## Verdict: PASS

| Dimension | Result |
|---|---|
| build / lint / test | PASS — `scripts/test.sh go` all packages ok; `vitest run` 626 passed; `tsc --noEmit` clean; `biome ci .` clean |
| acceptance criteria | PASS — all 6 exercised against the merged tree |
| non-goals | PASS — ⌘1-9 still unfiltered; sidebar / tray / ⌘K untouched; no new keybinding |
| regression risk | PASS — reorder path still sends a global index; ⌘B / ⇧⌘B / nav-history / `switchToProject` unchanged; 74/74 targeted dom tests |
| doc accuracy | PASS — CHANGELOG accurate, README + `shortcuts.ts` labels still correct, spec #250 amendment coherent |

The 6 `noExplicitAny` biome warnings in `test/dom/theme-apply.test.ts` are pre-existing from #292, not this feature.

## Changes here

- Spec 252 → `Stage: DONE`, with `PR: #293` and `Shipped: 2026-08-30`; exec-plan link repointed at `completed/`.
- Exec plan moved to `docs/exec-plans/completed/` with the full `## QA verdict` block.
- **Two new tests.** QA found the spec words criterion 1 as a *full* ⌘↓ cycle and criterion 6 as a restore *round-trip*, but the merged suite only proved each one hop at a time. Added `never lands in a minimized project across a full ⌘↓ cycle` and `puts a restored project back in both rotations`.

Manual validation: confirmed by the operator in an isolated dev build (`scripts/dev-iso.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)