### PR TITLE
fix(update): strip ANSI escapes from build progress lines

### DIFF
--- a/.changesets/253-update-progress-ansi.md
+++ b/.changesets/253-update-progress-ansi.md
@@ -1,0 +1,5 @@
+# Fix raw escape characters in the update banner
+
+Build output shown in the update banner is now plain text — ANSI colour codes,
+cursor-control sequences and carriage-return redraws from `build.sh` no longer
+leak through as literal `ESC[32m` garbage.

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -388,6 +388,60 @@ func verifyUpstreamRemote(repo string) error {
 	return nil
 }
 
+// plainProgressLine reduces one line of build output to what a terminal
+// would actually show, as plain text. build.sh drives npm/vite/wails,
+// which colour their output and redraw progress with carriage returns —
+// and the update banner renders its message as text, so anything left
+// in here reaches the user as literal `ESC[32m` garbage.
+//
+// Only what that output really contains is handled: CR redraws, CSI and
+// OSC sequences, and any other C0 control byte. A full VT parser lives
+// in internal/session for the terminal; the banner has one short line.
+func plainProgressLine(s string) string {
+	// A CR redraw means everything before the last CR was overwritten.
+	if i := strings.LastIndexByte(s, '\r'); i >= 0 {
+		s = s[i+1:]
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		c := s[i]
+		switch {
+		case c == 0x1B && i+1 < len(s) && s[i+1] == '[':
+			// CSI: parameter/intermediate bytes, then a final byte in 0x40–0x7E.
+			i += 2
+			for i < len(s) && (s[i] < 0x40 || s[i] > 0x7E) {
+				i++
+			}
+			if i < len(s) {
+				i++
+			}
+		case c == 0x1B && i+1 < len(s) && s[i+1] == ']':
+			// OSC: terminated by BEL or ST (ESC \).
+			i += 2
+			for i < len(s) {
+				if s[i] == 0x07 {
+					i++
+					break
+				}
+				if s[i] == 0x1B && i+1 < len(s) && s[i+1] == '\\' {
+					i += 2
+					break
+				}
+				i++
+			}
+		case c == 0x1B:
+			// Any other escape: drop ESC and the byte it introduces.
+			i += 2
+		case c < 0x20 && c != '\t', c == 0x7F:
+			i++
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
 // runBuildScript runs ./build.sh and streams its output into progress.
 // Only the most recent line is reported — build.sh is chatty and the
 // button has one line to show it in.
@@ -408,7 +462,7 @@ func runBuildScript(repo string, progress func(string)) error {
 	sc := bufio.NewScanner(stdout)
 	sc.Buffer(make([]byte, 0, 64<<10), 1<<20)
 	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
+		line := plainProgressLine(sc.Text())
 		if line == "" {
 			continue
 		}

--- a/cmd/hivegui/update_shellout_darwin_test.go
+++ b/cmd/hivegui/update_shellout_darwin_test.go
@@ -276,6 +276,60 @@ func TestRunBuildScriptReportsLastLineOnFailure(t *testing.T) {
 	}
 }
 
+// build.sh drives npm/vite/wails, which colour their output and redraw
+// progress with carriage returns. The banner renders its message as
+// text, so anything not stripped here reaches the user as literal
+// `ESC[32m` garbage.
+func TestPlainProgressLineStripsTerminalControls(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text passes through", "compiling hivegui", "compiling hivegui"},
+		{"sgr colours", "\x1b[32mbuilding\x1b[0m", "building"},
+		{"cr redraw keeps last segment", "50%\r80%\r100%", "100%"},
+		{"osc title with bel", "\x1b]0;npm run build\x07done", "done"},
+		{"osc title with st", "\x1b]0;npm\x1b\\done", "done"},
+		{"control only collapses to empty", "\x1b[2K\x1b[1G", ""},
+		{"utf8 survives", "\x1b[32m✓ built\x1b[0m", "✓ built"},
+		{"stray control bytes dropped", "a\x07b", "ab"},
+		{"tabs kept, surrounding space trimmed", "  a\tb  ", "a\tb"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := plainProgressLine(tc.in); got != tc.want {
+				t.Errorf("plainProgressLine(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The end-to-end guarantee: no escape byte can reach the progress
+// callback or the failure message, whatever build.sh prints.
+func TestRunBuildScriptReportsSanitizedProgress(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, "build.sh"),
+		"#!/bin/sh\nprintf '\\033[32mcompiling\\033[0m\\n'\nprintf '10%%\\r100%%\\n'\n"+
+			"printf '\\033[2K\\033[1G\\n'\nprintf '\\033[31merror: boom\\033[0m\\n' >&2\nexit 1\n")
+	if err := os.Chmod(filepath.Join(repo, "build.sh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var lines []string
+	err := runBuildScript(repo, func(s string) { lines = append(lines, s) })
+	if err == nil {
+		t.Fatal("runBuildScript = nil error for a failing build, want the failure surfaced")
+	}
+	want := []string{"compiling", "100%", "error: boom"}
+	if strings.Join(lines, "|") != strings.Join(want, "|") {
+		t.Errorf("progress = %v, want %v", lines, want)
+	}
+	if strings.ContainsRune(err.Error(), 0x1B) {
+		t.Errorf("error = %q, want no escape bytes", err)
+	}
+}
+
 func TestRunBuildScriptReportsMissingScript(t *testing.T) {
 	if err := runBuildScript(t.TempDir(), func(string) {}); err == nil {
 		t.Fatal("runBuildScript = nil error with no build.sh, want a failure")

--- a/docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md
@@ -67,3 +67,7 @@ None.
 ## Open questions
 
 None.
+
+## PR convergence ledger
+
+- **2026-08-30 iter 1** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 05bec86.

--- a/docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/253-strip-ansi-escapes-from-update-progress.md](../../product-specs/253-strip-ansi-escapes-from-update-progress.md)
 - **Issue:** —
+- **PR:** #296
+- **Branch:** feature/253-strip-ansi-escapes-from-update-progress
 - **Status:** active
 
 ## Summary
@@ -60,6 +62,7 @@ None.
 ## Progress
 
 - **2026-08-30** — Plan-first scaffold; stage = IMPLEMENT.
+- **2026-08-30** — Implemented, tests green, PR #296 opened; stage = REVIEW.
 
 ## Open questions
 

--- a/docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md
@@ -1,0 +1,66 @@
+# Strip ANSI escape sequences from update build progress lines
+
+- **Spec:** [docs/product-specs/253-strip-ansi-escapes-from-update-progress.md](../../product-specs/253-strip-ansi-escapes-from-update-progress.md)
+- **Issue:** —
+- **Status:** active
+
+## Summary
+
+Sanitize `build.sh` output before it becomes an update progress message, so the
+green update banner shows plain text instead of raw ANSI escape sequences.
+
+## Research
+
+Authored via plan-first mode. Relevant code:
+
+- `cmd/hivegui/update_apply_darwin.go` — `runBuildScript` scans `./build.sh`
+  stdout+stderr and calls `progress(line)` per line; `tail` feeds the
+  `build.sh failed: %s` error.
+- `cmd/hivegui/update_action.go:121` — progress snapshots are emitted to the
+  frontend as `update:progress`.
+- `cmd/hivegui/frontend/src/lib/update-state.ts` — maps `info.message` to the
+  banner status string; `banners.ts` / `settings.ts` render it as text.
+- `cmd/hivegui/update_apply_other.go` has no build shell-out; nothing to fix.
+
+## Approach
+
+Strip terminal control sequences at the single point where child-process output
+enters the update path — `runBuildScript` — rather than defensively in the
+frontend. One helper applied to both the progress callback and the failure tail.
+
+A hand-rolled scanner instead of a regexp: the state machine is short, runs per
+output line, and avoids a package-level regexp for a one-caller helper.
+
+Handled cases: `\r` redraws (keep the segment after the last `\r`), CSI
+(`ESC [ … final byte`), OSC (`ESC ] … BEL` or `ESC \`), and any leftover C0
+control byte except tab.
+
+### Files to change
+
+- `cmd/hivegui/update_apply_darwin.go` — add `plainProgressLine(string) string`;
+  apply it in `runBuildScript`'s scan loop so both `progress(line)` and `tail`
+  carry the sanitized value.
+
+### New files
+
+None.
+
+### Tests
+
+- `TestPlainProgressLineStripsTerminalControls` — table test in
+  `cmd/hivegui/update_shellout_darwin_test.go`.
+- `TestRunBuildScriptReportsSanitizedProgress` — stub `./build.sh` emitting an
+  ANSI-colored line; assert no `\x1b` reaches the progress callback.
+
+## Decision log
+
+- **2026-08-30** — Sanitize in Go, not in the frontend. Why: single choke point,
+  and the error string benefits too.
+
+## Progress
+
+- **2026-08-30** — Plan-first scaffold; stage = IMPLEMENT.
+
+## Open questions
+
+None.

--- a/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
@@ -1,0 +1,43 @@
+# Strip ANSI escape sequences from update build progress lines
+
+- **Issue:** —
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P2
+- **Stage:** IMPLEMENT
+- **Exec plan:** [docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md](../exec-plans/active/253-strip-ansi-escapes-from-update-progress.md)
+
+## Problem
+
+On the `latest` update channel, clicking Update runs `./build.sh` in the source
+checkout and streams its output into the green update banner. `build.sh` drives
+`npm` / `vite` / `wails`, which emit ANSI color and cursor-control sequences and
+redraw progress with carriage returns. Those bytes reach the GUI verbatim and
+the banner renders them as text, so the user sees literal `ESC[32m…` garbage
+instead of a readable build status.
+
+## Desired behavior
+
+The update banner shows a plain, readable line of build progress. Terminal
+control bytes never appear; a carriage-return redraw shows only the final
+segment, the way a terminal would render it.
+
+## Success criteria
+
+- No `\x1b` byte can reach the update progress message or the `build.sh failed:`
+  error text.
+- `50%\r80%\r100%` renders as `100%`.
+- A line that is nothing but control sequences is skipped, not shown blank.
+- UTF-8 content (e.g. `✓ built`) survives unchanged.
+
+## Non-goals
+
+- Rendering colors in the banner.
+- A general-purpose ANSI parser; `internal/session` already owns VT parsing for
+  the terminal.
+- Any frontend change — the banner correctly renders whatever text it is given.
+
+## Notes
+
+Root cause: `runBuildScript` in `cmd/hivegui/update_apply_darwin.go` forwards
+each scanned line straight to `progress(line)`.

--- a/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
@@ -4,7 +4,8 @@
 - **Type:** bug
 - **Complexity:** S
 - **Priority:** P2
-- **Stage:** IMPLEMENT
+- **PR:** #296
+- **Stage:** REVIEW
 - **Exec plan:** [docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md](../exec-plans/active/253-strip-ansi-escapes-from-update-progress.md)
 
 ## Problem


### PR DESCRIPTION
## Problem

On the `latest` update channel, clicking Update streams `./build.sh` output into
the green update banner. `build.sh` drives npm/vite/wails, which colour their
output and redraw progress with carriage returns. Those bytes reached the banner
verbatim and were rendered as text — the user saw literal `ESC[32m…` garbage.

## Fix

Sanitize at the single choke point where child output enters the update path:
`plainProgressLine` in `runBuildScript`. CR redraws keep the segment after the
last `\r`, CSI and OSC sequences are dropped, and any leftover C0 control byte
(except tab) is removed. The `build.sh failed: %s` error benefits too. No
frontend change — the banner correctly renders whatever text it is given.

## Tests

- `TestPlainProgressLineStripsTerminalControls` — table over SGR, CR redraw, OSC
  (BEL and ST terminated), control-only lines, UTF-8, tabs.
- `TestRunBuildScriptReportsSanitizedProgress` — stub `build.sh` emitting ANSI;
  asserts no escape byte reaches the progress callback or the error.

Spec: `docs/product-specs/253-strip-ansi-escapes-from-update-progress.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)