### PR TITLE
chore: mark #253 done after QA pass

### DIFF
--- a/docs/exec-plans/completed/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/exec-plans/completed/253-strip-ansi-escapes-from-update-progress.md
@@ -4,7 +4,7 @@
 - **Issue:** —
 - **PR:** #296
 - **Branch:** feature/253-strip-ansi-escapes-from-update-progress
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -71,3 +71,14 @@ None.
 ## PR convergence ledger
 
 - **2026-08-30 iter 1** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 05bec86.
+
+## QA verdict
+
+- **2026-08-30** — verdict: PASS; checks: 5 passed / 0 failed / 0 followups; followups: none; one-line: sanitizer covered end-to-end through `runBuildScript`; build, vet and the full Go suite green on merged main.
+  - 2026-08-30 dimensions:
+    - build/lint/test — PASS — `go build ./...`, `go vet ./...`, `go test ./...` (after `scripts/ci-bootstrap.sh`) all clean; CI green on #296 across Linux/macOS/Windows.
+    - acceptance — PASS — every success criterion has a named subtest: no `\x1b` reaches progress or the error, `50%\r80%\r100%` → `100%`, control-only lines skipped, UTF-8 preserved.
+    - non-goals — PASS — diff is Go + docs only; no frontend change, no colour rendering, no general ANSI parser (`internal/session/vt.go` untouched).
+    - regression — PASS — `plainProgressLine` is unexported with a single caller; pre-existing `runBuildScript` tests still pass unchanged.
+    - doc accuracy — PASS — `.changesets/253-update-progress-ansi.md` describes the user-visible fix.
+  - Note: the live `latest`-channel banner was not exercised manually in this QA run; coverage is at the `runBuildScript` choke point, which is where the escape bytes entered.

--- a/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
@@ -5,8 +5,9 @@
 - **Complexity:** S
 - **Priority:** P2
 - **PR:** #296
-- **Stage:** QA
-- **Exec plan:** [docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md](../exec-plans/active/253-strip-ansi-escapes-from-update-progress.md)
+- **Shipped:** 2026-08-30
+- **Stage:** DONE
+- **Exec plan:** [docs/exec-plans/completed/253-strip-ansi-escapes-from-update-progress.md](../exec-plans/completed/253-strip-ansi-escapes-from-update-progress.md)
 
 ## Problem
 

--- a/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
+++ b/docs/product-specs/253-strip-ansi-escapes-from-update-progress.md
@@ -5,7 +5,7 @@
 - **Complexity:** S
 - **Priority:** P2
 - **PR:** #296
-- **Stage:** REVIEW
+- **Stage:** QA
 - **Exec plan:** [docs/exec-plans/active/253-strip-ansi-escapes-from-update-progress.md](../exec-plans/active/253-strip-ansi-escapes-from-update-progress.md)
 
 ## Problem


### PR DESCRIPTION
Post-merge bookkeeping for #253 (PR #296, merged).

- Spec stage `QA` → `DONE`, `Shipped:` recorded, exec-plan link retargeted to `completed/`.
- Exec plan moved to `docs/exec-plans/completed/`, `Status: completed`, `## QA verdict` block appended.

QA verdict: PASS — `go build`/`vet`/`test ./...` clean on merged main, all four spec success criteria covered by named subtests, no non-goal bleed, changeset present. Docs only; no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)