### PR TITLE
fix(ui): make minimized project chips fill the sidebar tray

### DIFF
--- a/.changesets/255-minimized-project-chip-layout.md
+++ b/.changesets/255-minimized-project-chip-layout.md
@@ -1,5 +1,6 @@
 ---
 issue: null
+pr: 300
 type: fixed
 bump: patch
 ---

--- a/.changesets/255-minimized-project-chip-layout.md
+++ b/.changesets/255-minimized-project-chip-layout.md
@@ -1,0 +1,9 @@
+---
+issue: null
+type: fixed
+bump: patch
+---
+- Fixed the layout of minimized projects in the sidebar. A minimized
+  project now spans the full width of its tray with the restore `+`
+  pinned to the right edge, and clicking anywhere on the row restores
+  the project instead of only the project name.

--- a/cmd/hivegui/frontend/src/style.css
+++ b/cmd/hivegui/frontend/src/style.css
@@ -157,6 +157,13 @@ body.resizing-sidebar #app { transition: none; }
 }
 #minimized-projects.hidden { display: none; }
 
+/* Project chips are a full-width vertical list, not a wrapped tray row:
+   drop the chip's 240px cap so long names use the sidebar width, let the
+   label area take the slack so the restore + lands on the right edge, and
+   make the whole chip one restore target. */
+#minimized-projects .hv-chip { max-width: none; }
+#minimized-projects .hv-chip__open { flex: 1; text-align: left; }
+
 .hints {
   padding: 6px 10px;
   border-top: 1px solid var(--border);

--- a/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
@@ -126,3 +126,39 @@ test('both chip controls are clickable and keyboard-reachable', async ({
     expect(focused, `${sel} cannot take keyboard focus`).toBe(true);
   }
 });
+
+// The tray is a full-width vertical list, not a wrapped row of pills: the
+// chip spans the tray, the restore + hugs the right edge, and clicking the
+// dead space next to a short name restores instead of doing nothing.
+test('a project chip spans the tray, right-aligns +, and restores on any click', async ({
+  page,
+}) => {
+  await boot(page);
+  const listed = page.locator('#projects > li.hv-project-card');
+  const before = await listed.count();
+  const first = listed.first();
+  const pid = await first.getAttribute('data-pid');
+  await first.locator('.hv-project-card__header').hover();
+  await first
+    .locator('.hv-project-card__header [data-action="minimize"]')
+    .click();
+
+  const chip = page.locator(`#minimized-projects .hv-chip[data-pid="${pid}"]`);
+  await expect(chip).toBeVisible();
+
+  const tray = page.locator('#minimized-projects');
+  const trayBox = (await tray.boundingBox())!;
+  const chipBox = (await chip.boundingBox())!;
+  const restoreBox = (await chip.locator('.hv-chip__restore').boundingBox())!;
+
+  // No 240px cap: the chip fills the tray's content box.
+  expect(chipBox.width).toBeGreaterThan(trayBox.width - 16);
+  // + sits at the right edge, not next to the label.
+  expect(restoreBox.x + restoreBox.width).toBeGreaterThan(
+    chipBox.x + chipBox.width - 12,
+  );
+
+  // Click the slack between the label and the +.
+  await page.mouse.click(restoreBox.x - 12, chipBox.y + chipBox.height / 2);
+  await expect(listed).toHaveCount(before);
+});

--- a/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
@@ -146,19 +146,38 @@ test('a project chip spans the tray, right-aligns +, and restores on any click',
   const chip = page.locator(`#minimized-projects .hv-chip[data-pid="${pid}"]`);
   await expect(chip).toBeVisible();
 
-  const tray = page.locator('#minimized-projects');
-  const trayBox = (await tray.boundingBox())!;
+  // Measure against the tray's own content box rather than a fixed
+  // tolerance: clientWidth excludes the scrollbar the tray grows once
+  // enough projects are minimized, and reading the padding off the
+  // computed style keeps the assertion honest if the tray is restyled.
+  const trayInner = await page.locator('#minimized-projects').evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return (
+      el.clientWidth -
+      Number.parseFloat(cs.paddingLeft) -
+      Number.parseFloat(cs.paddingRight)
+    );
+  });
   const chipBox = (await chip.boundingBox())!;
   const restoreBox = (await chip.locator('.hv-chip__restore').boundingBox())!;
 
   // No 240px cap: the chip fills the tray's content box.
-  expect(chipBox.width).toBeGreaterThan(trayBox.width - 16);
+  expect(chipBox.width).toBeCloseTo(trayInner, 0);
   // + sits at the right edge, not next to the label.
   expect(restoreBox.x + restoreBox.width).toBeGreaterThan(
     chipBox.x + chipBox.width - 12,
   );
 
-  // Click the slack between the label and the +.
-  await page.mouse.click(restoreBox.x - 12, chipBox.y + chipBox.height / 2);
+  // Click the slack between the label and the +. Assert first that the
+  // point really is dead space — with a long enough project name this
+  // would land on the label and pass without testing anything.
+  const slackX = restoreBox.x - 12;
+  const slackY = chipBox.y + chipBox.height / 2;
+  const onLabel = await page.evaluate(
+    ({ x, y }) => !!document.elementFromPoint(x, y)?.closest('.hv-chip__label'),
+    { x: slackX, y: slackY },
+  );
+  expect(onLabel, 'the click point is on the label, not the slack').toBe(false);
+  await page.mouse.click(slackX, slackY);
   await expect(listed).toHaveCount(before);
 });

--- a/docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md
+++ b/docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md
@@ -1,0 +1,76 @@
+# Minimized project chips fill the tray with a right-aligned restore
+
+- **Spec:** [docs/product-specs/255-minimized-project-chips-fill-the-tray.md](../../product-specs/255-minimized-project-chips-fill-the-tray.md)
+- **Issue:** —
+- **Status:** active
+
+## Summary
+
+Two scoped CSS overrides in the `#minimized-projects` tray so project chips
+span the sidebar, the restore `+` right-aligns, and the whole row is one
+restore target. No component or TypeScript change.
+
+## Research
+
+- `src/theme/components/chip.css` — `.hv-chip` carries `max-width: 240px`,
+  sized for the horizontal `#minimized-tray` session pills. `.hv-chip__open`
+  is content-sized (`flex: 0 1 auto`), so the restore `+` sits right after
+  the label.
+- `src/style.css:146` — `#minimized-projects` is a `flex-direction: column`
+  list; `align-items: stretch` already gives chips the full tray width up to
+  the 240px cap.
+- `src/app/sidebar.ts:104` `renderMinimizedProjects` / `renderProjectChip` —
+  already passes `onClick: () => deps.restoreProject(p.id)`. The handler
+  lives on `.hv-chip__open`, so "click anywhere restores" is a *layout* gap,
+  not a missing listener: the open button just doesn't cover the row.
+
+## Approach
+
+Override the two chip properties inside the `#minimized-projects` scope
+rather than changing `chip.css`. The chip component is shared with the
+session tray, where the 240px cap is correct — an unscoped change would
+turn that horizontal row of pills into full-width bars. The id scope also
+wins on specificity regardless of stylesheet order.
+
+Making `.hv-chip__open` `flex: 1` is what delivers the click-anywhere
+requirement: the existing restore handler already covers every pixel the
+button occupies, so growing the button to fill the row is a smaller and
+safer fix than adding a second listener on the chip root (which would have
+to reason about `stopPropagation` from both child buttons).
+
+### Files to change
+
+- `cmd/hivegui/frontend/src/style.css` — add `#minimized-projects .hv-chip { max-width: none; }`
+  and `#minimized-projects .hv-chip__open { flex: 1; text-align: left; }`.
+- `cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts` — add the layout regression test.
+
+### New files
+
+None.
+
+### Tests
+
+- `test/e2e/minimize-project.spec.ts` › `a project chip spans the tray,
+  right-aligns +, and restores on any click` — minimizes the first project,
+  then asserts (a) chip width ≈ tray content width, (b) the restore button's
+  right edge is within 12px of the chip's right edge, (c) a click 12px left
+  of the `+` restores the project. Must be e2e: jsdom applies no CSS, so a
+  unit test cannot see a `max-width` or a flex distribution.
+
+## Decision log
+
+- **2026-08-30** — Scope the overrides to `#minimized-projects` instead of
+  editing `.hv-chip`. Why: the same chip is the minimized-*sessions* pill,
+  where the 240px cap is the intended design.
+- **2026-08-30** — Deliver click-anywhere via `flex: 1` on the existing open
+  button rather than a new root listener. Why: no new event plumbing, and
+  the child restore button already calls `stopPropagation`.
+
+## Progress
+
+- **2026-08-30** — Implemented; `npm test` (676), `npx playwright test` (206),
+  `biome ci .` and `npm run typecheck` all green.
+
+## Open questions
+
+None.

--- a/docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md
+++ b/docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/255-minimized-project-chips-fill-the-tray.md](../../product-specs/255-minimized-project-chips-fill-the-tray.md)
 - **Issue:** —
+- **PR:** #300
+- **Branch:** feature/255-minimized-project-chip-layout
 - **Status:** active
 
 ## Summary
@@ -70,6 +72,12 @@ None.
 
 - **2026-08-30** — Implemented; `npm test` (676), `npx playwright test` (206),
   `biome ci .` and `npm run typecheck` all green.
+
+- **2026-08-30** — PR #300 opened; stage = REVIEW.
+
+## PR convergence ledger
+
+<Append-only. One line per /hs-review-loop iteration.>
 
 ## Open questions
 

--- a/docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md
+++ b/docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md
@@ -70,6 +70,7 @@ None.
 
 ## Progress
 
+- **2026-08-30** — Review loop converged on iteration 1 (APPROVE, 0 threads); two MINOR test-brittleness notes addressed. Stage = GATE.
 - **2026-08-30** — Implemented; `npm test` (676), `npx playwright test` (206),
   `biome ci .` and `npm run typecheck` all green.
 
@@ -78,6 +79,8 @@ None.
 ## PR convergence ledger
 
 <Append-only. One line per /hs-review-loop iteration.>
+
+- **2026-08-30 iter 1** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 25b211f.
 
 ## Open questions
 

--- a/docs/product-specs/255-minimized-project-chips-fill-the-tray.md
+++ b/docs/product-specs/255-minimized-project-chips-fill-the-tray.md
@@ -4,16 +4,18 @@ title: "Minimized project chips fill the tray with a right-aligned restore"
 type: bug
 complexity: S
 priority: P2
-stage: IMPLEMENT
+stage: REVIEW
+pr: 300
 ---
 
 # Minimized project chips fill the tray with a right-aligned restore
 
 - **Issue:** —
+- **PR:** #300
 - **Type:** bug
 - **Complexity:** S
 - **Priority:** P2
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Exec plan:** [docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md](../exec-plans/active/255-minimized-project-chips-fill-the-tray.md)
 
 ## Problem

--- a/docs/product-specs/255-minimized-project-chips-fill-the-tray.md
+++ b/docs/product-specs/255-minimized-project-chips-fill-the-tray.md
@@ -1,0 +1,50 @@
+---
+issue: null
+title: "Minimized project chips fill the tray with a right-aligned restore"
+type: bug
+complexity: S
+priority: P2
+stage: IMPLEMENT
+---
+
+# Minimized project chips fill the tray with a right-aligned restore
+
+- **Issue:** —
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P2
+- **Stage:** IMPLEMENT
+- **Exec plan:** [docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md](../exec-plans/active/255-minimized-project-chips-fill-the-tray.md)
+
+## Problem
+
+The minimized-projects tray at the bottom of the sidebar reuses the chip
+component built for the horizontal minimized-*sessions* tray, where a
+240px cap keeps pills from running away. In a vertical, full-width list
+that cap is wrong: a chip stops short of the sidebar edge, the restore
+`+` sits immediately after the project name instead of on the right edge,
+and the empty space between the name and the tray edge is dead — clicking
+it does nothing, even though putting a project away means the only reason
+to click its chip is to get it back.
+
+## Desired behavior
+
+A minimized project reads as a full-width row: the chip spans the tray,
+its restore `+` is pinned to the right edge, and a click anywhere on the
+row restores the project.
+
+## Success criteria
+
+- A project chip's width matches the tray's content width; no 240px cap.
+- The restore `+` is flush with the chip's right edge.
+- Clicking the slack between the project name and the `+` restores the project.
+- The horizontal minimized-*sessions* tray keeps its 240px chip cap.
+
+## Non-goals
+
+- Restyling the minimized-sessions tray or the chip component itself.
+- Changing what restore does, or the chip's attention/bell behavior.
+
+## Notes
+
+Follows #250, which introduced the minimized-projects tray.

--- a/docs/product-specs/255-minimized-project-chips-fill-the-tray.md
+++ b/docs/product-specs/255-minimized-project-chips-fill-the-tray.md
@@ -4,7 +4,7 @@ title: "Minimized project chips fill the tray with a right-aligned restore"
 type: bug
 complexity: S
 priority: P2
-stage: REVIEW
+stage: GATE
 pr: 300
 ---
 
@@ -15,7 +15,7 @@ pr: 300
 - **Type:** bug
 - **Complexity:** S
 - **Priority:** P2
-- **Stage:** REVIEW
+- **Stage:** GATE
 - **Exec plan:** [docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md](../exec-plans/active/255-minimized-project-chips-fill-the-tray.md)
 
 ## Problem


### PR DESCRIPTION
Spec: `docs/product-specs/255-minimized-project-chips-fill-the-tray.md`
Exec plan: `docs/exec-plans/active/255-minimized-project-chips-fill-the-tray.md`

## What

The minimized-projects tray reuses the chip component built for the horizontal
minimized-*sessions* row, where a `max-width: 240px` keeps pills from running
away. In a vertical full-width list that cap is wrong:

- the chip stopped short of the sidebar edge,
- the restore `+` sat right after the project name instead of on the right edge,
- and the gap between them was dead space — clicking it did nothing.

## How

Two overrides scoped to `#minimized-projects` (not to `.hv-chip` itself, so the
session tray keeps its cap):

```css
#minimized-projects .hv-chip { max-width: none; }
#minimized-projects .hv-chip__open { flex: 1; text-align: left; }
```

Click-anywhere needed no JS: `renderProjectChip` already wires
`onClick: () => restoreProject(p.id)` on `.hv-chip__open`. Growing that button
to fill the row is what makes the handler cover every pixel.

## Tests

New e2e case in `test/e2e/minimize-project.spec.ts` asserting chip width ≈ tray
width, the `+`'s right edge within 12px of the chip's, and a click in the slack
restoring the project. It has to be e2e — jsdom applies no CSS.

Green locally: 676 unit, 206 e2e, `biome ci .`, `npm run typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)