### PR TITLE
chore(deps): bump Wails v2.12.0 -> v2.15.0

### DIFF
--- a/docs/analysis/2026-08-24-improvements.md
+++ b/docs/analysis/2026-08-24-improvements.md
@@ -39,7 +39,7 @@ otherwise. Numbers are measured before/after, not estimated.
 | 3 | God-files | **Go half done, frontend half deliberately not.** `app.go` 1101 → 192 + four domain files (largest 416). `registry.go`'s `kill` 164 → 128 by lifting `disposeWorktree` out. `session-term.ts` and `style.css` left alone — see "Not done, and why" below. |
 | 4 | Long functions | **Done.** `serveControl` 274 → 144, with the 14-case dispatch now `handleControlFrame(...) bool` behind a `controlOps` value, and twelve identical decode prologues collapsed into `decodeReq[T]`. The seam paid for itself: the handlers are now unit-tested without a socket. |
 | 5 | Go static analysis | **Done.** `staticcheck` (pinned 2025.1.1) and `govulncheck` run on the Linux CI leg. Baseline was one real finding (an unused assignment `go vet` misses); both are clean now. `govulncheck` is clean on the Go 1.25.x that setup-go resolves from go.mod — a local 1.26.4 toolchain reports four stdlib advisories, which is the toolchain's age, not this repo's. |
-| 6 | Dependencies | **Partly.** Go module graph refreshed (`go-pty` 0.2.3 + indirects). Wails held at v2.12.0 and xterm held at 5.5 — both explained below. |
+| 6 | Dependencies | **Partly.** Go module graph refreshed (`go-pty` 0.2.3 + indirects). Wails held at v2.12.0 (bumped to v2.15.0 on 2026-08-30, see below) and xterm still held at 5.5 — both explained below. |
 | 7 | Plan-lifecycle drift | **Done.** 247 moved to `completed/`; 142's stub corrected (PR #160 was closed unmerged, the bug is still real, and `in-house-vt-emulator.md` is the route to it). `scripts/check-plan-lifecycle.sh` asks `gh` about every PR referenced from `active/` so this stops recurring. |
 | 8 | Housekeeping | **Done.** Stray root `node_modules/` removed (a vitest cache, accidentally committed in #255) and gitignored. The `frontend/dist` seeding is already handled by `scripts/ci-bootstrap.sh`, so no change was needed there. |
 
@@ -56,10 +56,15 @@ regression there reproduces only with a full 5000-line buffer, in a real
 WebView, which no CI leg here runs. Worth doing, worth doing alone, and worth
 watching a real terminal while you do it.
 
-**Wails v2.12.0 → v2.15.0.** Held. `scripts/ci-bootstrap.sh` pins the Wails
-*CLI* to the same version, and the CLI generates the bindings and drives the
-build. Bumping the library alone invites skew; bumping both is a real upgrade
-that deserves its own commit and a native build to validate.
+**Wails v2.12.0 → v2.15.0.** Done 2026-08-30. Library and the
+`scripts/ci-bootstrap.sh` CLI pin bumped together, so the bindings generator and
+the build stay on one version. v2.13/v2.14/v2.15 carry no v2 breaking changes
+— the release notes are two nil-pointer fixes, a `wake` build-runner fix, and
+a v3-side dev-proxy fix; `go.sum` moved but no indirect did. Validated:
+`go vet ./...` and `go test ./...` clean, `wails generate module` produced
+byte-identical bindings, native `wails build` (darwin/arm64) succeeded, and the
+packaged app was launched against a sandboxed `HIVE_SOCKET`/`HIVE_STATE_DIR`
+— control channel connected and the frontend heartbeat ran with no errors.
 
 **Splitting `session-term.ts` (1638) and `style.css` (1984).** Not done, and I
 would argue against doing it now. Unlike `app.go` (a 50-method binding surface

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
-	github.com/wailsapp/wails/v2 v2.12.0
+	github.com/wailsapp/wails/v2 v2.15.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/wailsapp/go-webview2 v1.0.23 h1:jmv8qhz1lHibCc79bMM/a/FqOnnzOGEisLav+
 github.com/wailsapp/go-webview2 v1.0.23/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.12.0 h1:BHO/kLNWFHYjCzucxbzAYZWUjub1Tvb4cSguQozHn5c=
-github.com/wailsapp/wails/v2 v2.12.0/go.mod h1:mo1bzK1DEJrobt7YrBjgxvb5Sihb1mhAY09hppbibQg=
+github.com/wailsapp/wails/v2 v2.15.0 h1:u7cHK+UesZOlYxyJxfYLteaCPhws6UsZoDdqUejuX6Q=
+github.com/wailsapp/wails/v2 v2.15.0/go.mod h1:scxrgwfsv6yR6fE6cCF+Flfl+JeU+SR87T9x4kILJ6M=
 golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
 golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=

--- a/scripts/ci-bootstrap.sh
+++ b/scripts/ci-bootstrap.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-WAILS_VERSION=v2.12.0
+WAILS_VERSION=v2.15.0
 
 mkdir -p cmd/hivegui/frontend/dist
 echo placeholder > cmd/hivegui/frontend/dist/.placeholder


### PR DESCRIPTION
Picks up the first of the four items the 2026-08-24 improvement plan left as "yours to call".

## What

- `go.mod`: `github.com/wailsapp/wails/v2` v2.12.0 → v2.15.0
- `scripts/ci-bootstrap.sh`: `WAILS_VERSION` pin bumped in lockstep

The CLI pin has to move with the library — the CLI generates `frontend/wailsjs` and drives the build, so bumping one alone invites skew. That coupling is exactly why the plan held this bump for its own PR.

## Risk

Low. v2.13/v2.14/v2.15 carry no v2 breaking changes — the release notes are two nil-pointer fixes (`application.Quit` before `Run`, the WebView2 bootstrapper download), a `wake` build-runner fix, and a v3-side dev-proxy fix. `go.sum` moved; no indirect dependency did.

## Validation

- `go vet ./...` — clean
- `go test ./...` — exit 0
- `wails generate module` — bindings byte-identical (no diff under the gitignored `cmd/hivegui/frontend/wailsjs`)
- `wails build` darwin/arm64 — succeeded
- Packaged app launched against a sandboxed `HIVE_SOCKET` / `HIVE_STATE_DIR`: control channel connected, frontend heartbeat steady (`hb alive vis=1 focus=1`), no errors

No screenshot: this machine denies Screen Recording to the shell, so `screencapture` can't grab the window. Log evidence only.

## Not in this PR

xterm 5.5 → 6.0 stays held — 6.0 rewrote the viewport/scrollbar surface that ~87 call sites in `src/` depend on, and that's the surface with the longest bug history here. Its own PR, with a real terminal watched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)