### PR TITLE
fix(tooling): accept GATE as a valid spec stage

### DIFF
--- a/scripts/regen-generated.py
+++ b/scripts/regen-generated.py
@@ -36,8 +36,8 @@ SPECS_INDEX = SPECS_DIR / "index.md"
 TECH_DEBT_TRACKER = REPO_ROOT / "docs" / "exec-plans" / "tech-debt-tracker.md"
 
 CHANGESET_TYPES = ["added", "changed", "fixed", "removed", "deprecated", "security"]
-STAGES = ["TRIAGE", "RESEARCH", "PLAN", "IMPLEMENT", "REVIEW", "QA", "DONE", "REJECTED"]
-ACTIVE_STAGES = {"TRIAGE", "RESEARCH", "PLAN", "IMPLEMENT", "REVIEW", "QA"}
+STAGES = ["TRIAGE", "RESEARCH", "PLAN", "IMPLEMENT", "REVIEW", "QA", "GATE", "DONE", "REJECTED"]
+ACTIVE_STAGES = {"TRIAGE", "RESEARCH", "PLAN", "IMPLEMENT", "REVIEW", "QA", "GATE"}
 PRIORITY_ORDER = {"P1": 1, "P2": 2, "P3": 3}
 
 DRY_RUN = False  # set by --check; suppresses all writes in _write_if_changed


### PR DESCRIPTION
`verify-generated` is failing on **every** PR against `main`, including unrelated ones.

## Root cause

`scripts/regen-generated.py:39` validates spec frontmatter `stage:` against a fixed list that has no `GATE`:

```
255-minimized-project-chips-fill-the-tray.md: invalid stage 'GATE'.
Must be one of: TRIAGE, RESEARCH, PLAN, IMPLEMENT, REVIEW, QA, DONE, REJECTED
```

Spec 255 landed on `main` in #300 carrying `stage: GATE`, so the regenerator now aborts on any run — and `verify-generated` runs it against every PR's merge ref.

`GATE` is a real pipeline stage: `/hs-review-loop` writes it on convergence while the PR is still open, and `/hs-merge-gate` consumes it and then writes `DONE`. The validator's list simply never learned about it.

## Fix

- `STAGES`: added `GATE` between `QA` and `DONE`.
- `ACTIVE_STAGES`: added `GATE` too — a gated feature is still in flight (PR open, not yet shipped), so it belongs in the index's Active table rather than vanishing from both tables.

## Verification

`scripts/regen-generated.sh` now exits 0 against the real spec tree, and produces the two changes that were blocked while it aborted:

- `docs/product-specs/index.md` — spec 255 appears in Active with stage `GATE`
- `CHANGELOG.md` — the `.changesets/255-*` entry folds into `[Unreleased]`

Those regenerated files are **deliberately not committed**: `block-generated-edits` rejects PRs that touch them, and the push-to-main `regenerate-generated` job rewrites them on merge.

Needs the `no-changeset` label — this is CI/tooling-only with no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)