### PR TITLE
fix(build): fail fast when wails CLI drifts from the pin

### DIFF
--- a/.changesets/305-wails-version-check.md
+++ b/.changesets/305-wails-version-check.md
@@ -1,0 +1,12 @@
+---
+issue: null
+pr: 305
+type: fixed
+bump: patch
+---
+- `build.sh` now fails with install instructions when the `wails` CLI on
+  `PATH` does not match the version pinned in `scripts/ci-bootstrap.sh`,
+  instead of silently building against a stale toolchain after a Wails
+  bump.
+- Added `scripts/check-changeset.sh`, a local mirror of the changesets CI
+  gate that can be installed as a `pre-push` hook.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,8 @@ See [DESIGN.md](DESIGN.md) for a full description of every package and how they 
    it is regenerated on `main` from `.changesets/`, and a PR that touches it fails CI unless
    labelled `regen-override`. A docs- or CI-only PR can skip the changeset with the
    `no-changeset` label. To catch a missing changeset before you push, install the local
-   gate as a `pre-push` hook:
-   `ln -sf ../../scripts/check-changeset.sh "$(git rev-parse --git-common-dir)/hooks/pre-push"`.
+   gate as a `pre-push` hook — once per clone, shared by every worktree:
+   `cp scripts/hooks/pre-push "$(git rev-parse --git-common-dir)/hooks/pre-push"`.
 5. **Update `DESIGN.md`** if your change adds or removes packages, alters a major interface, or otherwise changes the high-level structure described there.
 6. Update any relevant files in `docs/` if the subsystem they describe has changed.
 7. Open a pull request with a clear description of the problem and solution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,9 @@ See [DESIGN.md](DESIGN.md) for a full description of every package and how they 
    body. See `.changesets/README.md` for the schema. **Do not edit `CHANGELOG.md` directly** —
    it is regenerated on `main` from `.changesets/`, and a PR that touches it fails CI unless
    labelled `regen-override`. A docs- or CI-only PR can skip the changeset with the
-   `no-changeset` label.
+   `no-changeset` label. To catch a missing changeset before you push, install the local
+   gate as a `pre-push` hook:
+   `ln -sf ../../scripts/check-changeset.sh "$(git rev-parse --git-common-dir)/hooks/pre-push"`.
 5. **Update `DESIGN.md`** if your change adds or removes packages, alters a major interface, or otherwise changes the high-level structure described there.
 6. Update any relevant files in `docs/` if the subsystem they describe has changed.
 7. Open a pull request with a clear description of the problem and solution.

--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,20 @@ if ! command -v wails >/dev/null 2>&1; then
   fi
 fi
 
+# The CLI on PATH is whatever was installed last, which drifts from the pin
+# after a dependency bump. scripts/ci-bootstrap.sh is the single source of
+# truth for the version; compare against it rather than duplicating it here.
+expected_wails="$(sed -n 's/^WAILS_VERSION=//p' scripts/ci-bootstrap.sh)"
+actual_wails="$(wails version 2>/dev/null | grep -o 'v[0-9][0-9.]*' | head -1)"
+if [[ -n "$expected_wails" && "$actual_wails" != "$expected_wails" ]]; then
+  echo "error: wails CLI is ${actual_wails:-unknown}, expected ${expected_wails}." >&2
+  echo "  Install the pinned version and regenerate bindings with:" >&2
+  echo "    scripts/ci-bootstrap.sh" >&2
+  echo "  If that doesn't help, a stale wails is shadowing it on PATH:" >&2
+  echo "    which wails   # should be \$(go env GOPATH)/bin/wails" >&2
+  exit 1
+fi
+
 # Frontend deps. Wails skips `npm install` when frontend/package.json
 # matches a cached MD5, which can leave node_modules stale after a
 # pull that adds a dep. Force a clean install when package.json is

--- a/scripts/check-changeset.sh
+++ b/scripts/check-changeset.sh
@@ -4,13 +4,9 @@
 # Fails when the current branch adds no `.changesets/*.md` entry relative
 # to main, so you find out before pushing instead of from a red check.
 #
-# Install as a pre-push hook (works from any worktree; --git-common-dir
-# resolves to the shared hooks directory, so the graphify post-* hooks
-# living there are left alone — do NOT set core.hooksPath, that would
-# disable them):
+# Install once per clone; the shared hooks dir covers every worktree:
 #
-#   ln -sf ../../scripts/check-changeset.sh \
-#     "$(git rev-parse --git-common-dir)/hooks/pre-push"
+#   cp scripts/hooks/pre-push "$(git rev-parse --git-common-dir)/hooks/pre-push"
 #
 # Bypass a single push with `git push --no-verify` — CI still requires
 # either a changeset or the `no-changeset` label.

--- a/scripts/check-changeset.sh
+++ b/scripts/check-changeset.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# check-changeset.sh — local mirror of the `changesets` CI gate.
+#
+# Fails when the current branch adds no `.changesets/*.md` entry relative
+# to main, so you find out before pushing instead of from a red check.
+#
+# Install as a pre-push hook (works from any worktree; --git-common-dir
+# resolves to the shared hooks directory, so the graphify post-* hooks
+# living there are left alone — do NOT set core.hooksPath, that would
+# disable them):
+#
+#   ln -sf ../../scripts/check-changeset.sh \
+#     "$(git rev-parse --git-common-dir)/hooks/pre-push"
+#
+# Bypass a single push with `git push --no-verify` — CI still requires
+# either a changeset or the `no-changeset` label.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+base="$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || true)"
+# Detached from any main, or nothing new on this branch: nothing to gate.
+if [[ -z "$base" || "$base" == "$(git rev-parse HEAD)" ]]; then
+  exit 0
+fi
+
+# Same glob and exclusions as .github/workflows/changesets.yml.
+if git diff --name-only "$base"...HEAD -- ':(glob).changesets/*.md' \
+  | grep -vE '^\.changesets/(README\.md|\.gitkeep)$' | grep -q .; then
+  exit 0
+fi
+
+echo "error: this branch has no .changesets/*.md entry." >&2
+echo "  Add one (see CONTRIBUTING.md for the schema), e.g.:" >&2
+echo "    .changesets/<pr-or-slug>.md" >&2
+echo "  Docs/CI-only change? Push with --no-verify and apply the" >&2
+echo "  'no-changeset' label on the PR." >&2
+exit 1

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# pre-push — run the repo's changeset gate for whichever worktree is pushing.
+#
+# Lives in the shared hooks dir (.git/hooks), which every worktree of this
+# repo uses, so installing it once covers them all. core.hooksPath is
+# deliberately left unset — setting it would relocate hook lookup and
+# disable the graphify post-checkout / post-commit hooks sitting here.
+#
+# Not a symlink into one worktree: the gate must come from the tree being
+# pushed, and branches that predate it are skipped rather than broken.
+set -euo pipefail
+
+gate="$(git rev-parse --show-toplevel)/scripts/check-changeset.sh"
+[[ -f "$gate" ]] || exit 0
+exec bash "$gate"


### PR DESCRIPTION
Two related gaps that only surface after a push (or on another machine).

## 1. wails version drift

`build.sh` only checked that a `wails` binary existed, so a machine with a stale CLI (e.g. v2.12.x after the v2.15.0 bump in #302) built silently against the wrong toolchain.

It now compares `wails version` against `WAILS_VERSION` in `scripts/ci-bootstrap.sh` — the existing single source of truth, not duplicated here — and on mismatch prints the bootstrap command plus the PATH-shadowing check:

```
error: wails CLI is v2.12.2, expected v2.15.0.
  Install the pinned version and regenerate bindings with:
    scripts/ci-bootstrap.sh
  If that does not help, a stale wails is shadowing it on PATH:
    which wails   # should be $(go env GOPATH)/bin/wails
```

No CI-side check added — `ci-bootstrap.sh` installs the pin there, so it cannot drift.

## 2. Pre-push changeset gate

This PR originally shipped without a changeset; the `changesets` job only says so after the push. `scripts/check-changeset.sh` mirrors that gate locally (same glob and exclusions as `.github/workflows/changesets.yml`).

`scripts/hooks/pre-push` is the installable shim — one copy per clone, shared by every worktree:

```
cp scripts/hooks/pre-push "$(git rev-parse --git-common-dir)/hooks/pre-push"
```

The shim resolves `scripts/check-changeset.sh` from the toplevel of whichever worktree is pushing (a symlink would have pinned it to one tree, and dangles on branches that predate the script; the shim exits 0 there instead). `core.hooksPath` is deliberately left unset — setting it would relocate hook lookup and disable the graphify `post-checkout` / `post-commit` hooks already in `.git/hooks`. Bypass a push with `--no-verify`; CI still requires a changeset or the `no-changeset` label. CONTRIBUTING.md step 4 documents the install.

## Verification

- Matching wails version passes silently; a stub `wails` printing `v2.12.2` produces the error above.
- Changeset gate failed on this branch before the changeset was committed, passes after.
- Hook installed locally and exercised from two worktrees: this one (gate runs) and one on a branch without the script (exits 0). The last push went through it; graphify hooks still fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)