### PR TITLE
feat(session): reopen a closed session (undo close)

### DIFF
--- a/.changesets/304-reopen-closed-session.md
+++ b/.changesets/304-reopen-closed-session.md
@@ -1,0 +1,16 @@
+---
+issue: 304
+pr: null
+type: added
+bump: minor
+---
+- Undo for an accidental session close. Closing a session now leaves a
+  record behind, so it can be reopened — with its name, colour, project,
+  worktree and (for agents that support resume) its conversation. An
+  **Undo** banner appears the moment you close something, and **⌘Z** /
+  **File ▸ Reopen Closed Session** reopens the most recent close at any
+  time, including after a restart. Reopening is honest about what it
+  cannot bring back: scrollback is always gone, and the banner says so
+  along with anything else that was lost. Closing a session and deleting
+  its worktree now saves a recovery patch of the uncommitted changes
+  first, so even that path is no longer a dead end.

--- a/.changesets/304-reopen-closed-session.md
+++ b/.changesets/304-reopen-closed-session.md
@@ -1,6 +1,6 @@
 ---
 issue: 304
-pr: null
+pr: 306
 type: added
 bump: minor
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Undo for an accidental session close. Closing a session now leaves a
+  record behind, so it can be reopened — with its name, colour, project,
+  worktree and (for agents that support resume) its conversation. An
+  **Undo** banner appears the moment you close something, and **⌘Z** /
+  **File ▸ Reopen Closed Session** reopens the most recent close at any
+  time, including after a restart. Reopening is honest about what it
+  cannot bring back: scrollback is always gone, and the banner says so
+  along with anything else that was lost. Closing a session and deleting
+  its worktree now saves a recovery patch of the uncommitted changes
+  first, so even that path is no longer a dead end.
 - In-app updates. Settings now carries an update channel: **Release**
   follows tagged versions, **Latest** follows the tip of your source
   checkout (auto-detected when Hive is running from one, or pointed at a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Undo for an accidental session close. Closing a session now leaves a
-  record behind, so it can be reopened — with its name, colour, project,
-  worktree and (for agents that support resume) its conversation. An
-  **Undo** banner appears the moment you close something, and **⌘Z** /
-  **File ▸ Reopen Closed Session** reopens the most recent close at any
-  time, including after a restart. Reopening is honest about what it
-  cannot bring back: scrollback is always gone, and the banner says so
-  along with anything else that was lost. Closing a session and deleting
-  its worktree now saves a recovery patch of the uncommitted changes
-  first, so even that path is no longer a dead end.
 - In-app updates. Settings now carries an update channel: **Release**
   follows tagged versions, **Latest** follows the tip of your source
   checkout (auto-detected when Hive is running from one, or pointed at a

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -43,7 +43,7 @@ hived process  ⇄  hivegui process       (Unix socket; daemon survives GUI clos
 ## Cross-cutting concerns
 
 - **IPC** — single channel: `internal/wire/`. Every cross-process call (GUI ⇄ daemon, future remote clients) is a wire frame. No side-channel files, no shared sqlite.
-- **Persistence** — owned by `internal/registry/`. The daemon main loop never writes session state directly. State location is resolved by `registry.StateDir()` — see `internal/registry/paths.go` for platform-specific paths. Writes are atomic (temp + rename).
+- **Persistence** — owned by `internal/registry/`. The daemon main loop never writes session state directly. State location is resolved by `registry.StateDir()` — see `internal/registry/paths.go` for platform-specific paths. Writes are atomic (temp + rename). Alongside `sessions/` and `projects/`, the registry owns `closed/`: one tombstone per recently closed session (plus, for a close that deleted a worktree, a recovery patch of its uncommitted state), written before the teardown so a close can be undone. Bounded to the last 20 closes and 7 days.
 - **Build & version** — `internal/buildinfo/` is the single source for version/commit; `cmd/version.go` and the GUI menu both read it.
 - **Notifications** — `internal/notify/` is the only entry point for desktop notifications. Platform splits (`notify_darwin.go`, `notify_linux.go`, `notify_windows.go`, `notify_darwin.m`) live behind one Go interface.
 - **Logging** — stdlib `log`. Daemon logs to a file under the platform state dir; GUI logs to stdout in dev, file in production.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ build.sh           # macOS universal build
 | ⌘N | New project |
 | ⇧⌘N | New window |
 | ⌘W | Kill active session |
+| ⌘Z | Reopen the last closed session |
 | ⇧⌘W | Close this window |
 | ⌘G / ⇧⌘G | Per-project grid / all-sessions grid |
 | ⌘↑ / ⌘↓ | Previous / next session (focused) / move between tiles vertically (grid) |

--- a/cmd/hived-ws-bridge/main.go
+++ b/cmd/hived-ws-bridge/main.go
@@ -253,6 +253,20 @@ func (s *session) dispatch(req rpcReq) {
 			return
 		}
 		s.respond(req.ID, "", s.controlWriteJSON(wire.FrameKillSession, p))
+	case "RestoreSession":
+		var p wire.RestoreSessionReq
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
+		s.respond(req.ID, "", s.controlWriteJSON(wire.FrameRestoreSession, p))
+	case "ListClosedSessions":
+		var p wire.ListClosedReq
+		if err := parseParams(req.Params, &p); err != nil {
+			s.respond(req.ID, nil, err)
+			return
+		}
+		s.respond(req.ID, "", s.controlWriteJSON(wire.FrameListClosed, p))
 	case "ListWorktrees":
 		var p wire.ListWorktreesReq
 		if err := parseParams(req.Params, &p); err != nil {

--- a/cmd/hivegui/app_calls.go
+++ b/cmd/hivegui/app_calls.go
@@ -355,6 +355,33 @@ func (a *App) KillSessionAndWorktree(id string) error {
 	})
 }
 
+// RestoreSession reopens a session closed earlier, rebuilding it from
+// the tombstone the close left in the daemon's state dir. An empty id
+// means "the most recently closed one" — resolved daemon-side so the
+// client cannot race a retention prune between listing and restoring.
+//
+// The restored entry arrives on the ordinary session event stream; a
+// "session:restored" event follows with whatever could not be brought
+// back (scrollback never can be).
+func (a *App) RestoreSession(id string) error {
+	cs, err := a.requireControl()
+	if err != nil {
+		return err
+	}
+	return cs.WriteJSON(wire.FrameRestoreSession, wire.RestoreSessionReq{SessionID: id})
+}
+
+// ListClosedSessions asks for the sessions that can still be reopened,
+// most recently closed first. The daemon answers with a "closed:list"
+// event rather than a return value, like every other control query.
+func (a *App) ListClosedSessions() error {
+	cs, err := a.requireControl()
+	if err != nil {
+		return err
+	}
+	return cs.WriteJSON(wire.FrameListClosed, wire.ListClosedReq{})
+}
+
 // RestartSession asks the daemon to recycle the agent process for
 // the given session in place. The session entry (name/color/order/
 // worktree) is preserved; the new process uses the agent's resume

--- a/cmd/hivegui/app_calls_test.go
+++ b/cmd/hivegui/app_calls_test.go
@@ -127,6 +127,8 @@ func TestRPCsRequireAControlConnection(t *testing.T) {
 		"RemoveWorktree":         func() error { return a.RemoveWorktree("p", "/tmp/wt", false, false, false) },
 		"RenameWorktree":         func() error { return a.RenameWorktree("p", "/tmp/wt", "b2") },
 		"DeleteBranch":           func() error { return a.DeleteBranch("p", "b", false, false) },
+		"RestoreSession":         func() error { return a.RestoreSession("s") },
+		"ListClosedSessions":     func() error { return a.ListClosedSessions() },
 	}
 	for name, call := range calls {
 		t.Run(name, func(t *testing.T) {
@@ -134,5 +136,53 @@ func TestRPCsRequireAControlConnection(t *testing.T) {
 				t.Errorf("%s with no control connection returned nil, want an error", name)
 			}
 		})
+	}
+}
+
+// TestRestoreSessionCall pins the payload the reopen affordances send.
+// The empty-id form is the one ⌘Z uses, and it must stay empty on the
+// wire: the daemon resolves "the last one" so the client cannot race a
+// retention prune between listing and restoring.
+func TestRestoreSessionCall(t *testing.T) {
+	for _, tc := range []struct{ name, id string }{
+		{"explicit id", "sess-1"},
+		{"reopen last", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, next := appWithControl(t)
+			done := make(chan error, 1)
+			go func() { done <- a.RestoreSession(tc.id) }()
+
+			ft, payload := next(t)
+			if ft != wire.FrameRestoreSession {
+				t.Fatalf("frame = %#x, want FrameRestoreSession", byte(ft))
+			}
+			var req wire.RestoreSessionReq
+			if err := json.Unmarshal(payload, &req); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if req.SessionID != tc.id {
+				t.Errorf("SessionID = %q, want %q", req.SessionID, tc.id)
+			}
+			if err := <-done; err != nil {
+				t.Fatalf("RestoreSession: %v", err)
+			}
+		})
+	}
+}
+
+// TestListClosedSessionsCall: the reopen list is a plain query, so the
+// only thing worth pinning is that it reaches the wire as LIST_CLOSED.
+func TestListClosedSessionsCall(t *testing.T) {
+	a, next := appWithControl(t)
+	done := make(chan error, 1)
+	go func() { done <- a.ListClosedSessions() }()
+
+	ft, _ := next(t)
+	if ft != wire.FrameListClosed {
+		t.Fatalf("frame = %#x, want FrameListClosed", byte(ft))
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("ListClosedSessions: %v", err)
 	}
 }

--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -12,6 +12,11 @@ import {
   ConnectControl,
   LogFrontend,
 } from '../bridge.js';
+import {
+  noteLocalClose,
+  onSessionRemoved,
+  onSessionRestored,
+} from './undo-close.js';
 import { state, saveCollapsed, saveMinimizedProjects } from './state.js';
 import type { SessionInfo, ProjectInfo } from './state.js';
 import { setStatus, flashStatus, reportFailure, setBootState } from './dom.js';
@@ -400,6 +405,20 @@ export function wireDaemonEvents(injected: EventsDeps) {
     }
   });
 
+  // What a restore could NOT bring back. Its own event rather than a
+  // field on the session, because it describes the transition, not the
+  // session — a tile that has been open for an hour should not still
+  // be advertising that its worktree was rebuilt.
+  EventsOn('session:restored', (jsonStr: string) => {
+    try {
+      onSessionRestored(JSON.parse(jsonStr));
+    } catch {
+      // A malformed payload costs the user the "what was lost" line,
+      // not the restored session — the tile already arrived on the
+      // ordinary session event stream.
+    }
+  });
+
   EventsOn('session:event', (jsonStr: string) => {
     const ev = JSON.parse(jsonStr) as SessionEvent;
     const i = state.sessions.findIndex((s) => s.id === ev.session.id);
@@ -435,6 +454,8 @@ export function wireDaemonEvents(injected: EventsDeps) {
       }
     }
     if (ev.kind === 'removed') {
+      // Offers undo, but only for a close this client issued.
+      onSessionRemoved(ev.session.id);
       state.aliveById.delete(ev.session.id);
       state.phaseById.delete(ev.session.id);
       state.dismissedDead.delete(ev.session.id);
@@ -686,7 +707,12 @@ export function wireDaemonEvents(injected: EventsDeps) {
       // before issuing a second kill that would just produce a confusing
       // "no_such_session" control error.
       if (!state.sessions.find((s) => s.id === e.session_id)) return;
+      const sessName = sess?.name ?? 'Session';
       if (answer === 'close-and-clean') {
+        // Deleting the worktree is the one close that destroys work,
+        // so the banner it raises says so rather than offering a plain
+        // "Undo" the restore cannot honour in full.
+        noteLocalClose(e.session_id, sessName, true);
         // One daemon-side operation: the worktree is occupied until
         // this session is gone, so closing and then asking to remove it
         // would race its own teardown and be refused as in-use.
@@ -695,6 +721,7 @@ export function wireDaemonEvents(injected: EventsDeps) {
         );
         return;
       }
+      noteLocalClose(e.session_id, sessName);
       KillSession(e.session_id, true).catch(reportFailure('force kill'));
       return;
     }

--- a/cmd/hivegui/frontend/src/app/keyboard.ts
+++ b/cmd/hivegui/frontend/src/app/keyboard.ts
@@ -6,7 +6,6 @@
 
 import {
   EventsOn,
-  KillSession,
   KillProject,
   Confirm,
   UpdateSession,
@@ -16,6 +15,7 @@ import {
   SetClipboardText,
   Notify,
 } from '../bridge.js';
+import { closeActiveSession, reopenLastClosedSession } from './undo-close.js';
 import { state } from './state.js';
 import { flashStatus, reportFailure } from './dom.js';
 import {
@@ -354,7 +354,14 @@ window.addEventListener(
         // force=false: lets the daemon refuse with worktree_dirty if
         // the worktree has uncommitted changes; the control:error
         // handler then shows a confirm dialog and retries with force.
-        KillSession(state.activeId, false).catch(reportFailure('close'));
+        closeActiveSession();
+      }
+    } else if (e.key === 'z' || e.key === 'Z') {
+      // ⌘Z — undo the close you just made. ⇧⌘Z is left unbound: it
+      // reads as redo, which this has no counterpart for.
+      if (!e.shiftKey) {
+        swallow();
+        reopenLastClosedSession();
       }
     } else if (/^[1-9]$/.test(e.key)) {
       const idx = parseInt(e.key, 10) - 1;
@@ -661,10 +668,8 @@ const menuActions = {
   'menu:command-palette': () => openCommandPalette(),
   'menu:settings': () => openSettings(),
   'menu:worktrees': () => openWorktreesForActiveProject(),
-  'menu:close-session': () => {
-    if (state.activeId)
-      KillSession(state.activeId, false).catch(reportFailure('close'));
-  },
+  'menu:close-session': () => closeActiveSession(),
+  'menu:reopen-closed-session': () => reopenLastClosedSession(),
   'menu:zoom-in': () => deps.bumpFontSize(+1),
   'menu:zoom-out': () => deps.bumpFontSize(-1),
   'menu:zoom-reset': () => deps.resetFontSize(),

--- a/cmd/hivegui/frontend/src/app/sidebar.ts
+++ b/cmd/hivegui/frontend/src/app/sidebar.ts
@@ -12,6 +12,7 @@ import {
   KillSession,
   Confirm,
 } from '../bridge.js';
+import { noteLocalClose } from './undo-close.js';
 import {
   state,
   saveCollapsed,
@@ -429,7 +430,9 @@ function killSession(s: SessionInfo) {
     `Kill ${s.name ?? 'this session'}? Its scrollback is lost.`,
   )
     .then((ok) => {
-      if (ok) KillSession(s.id, false).catch(reportFailure('kill session'));
+      if (!ok) return;
+      noteLocalClose(s.id, s.name ?? 'Session');
+      KillSession(s.id, false).catch(reportFailure('kill session'));
     })
     .catch(reportFailure('kill session'));
 }

--- a/cmd/hivegui/frontend/src/app/undo-close.ts
+++ b/cmd/hivegui/frontend/src/app/undo-close.ts
@@ -163,12 +163,23 @@ export function onSessionRestored(ev: RestoredEvent) {
   const patch = ev.patch_path ?? ev.patchPath;
   if (patch) losses.push(`uncommitted changes were saved to ${patch}`);
 
+  // Name the session that actually came back. ⌘Z sends an empty id and
+  // the daemon resolves "the last closed one", so the session restored
+  // is not necessarily the one the banner was offering undo for —
+  // reporting an unqualified "Session reopened" would then describe the
+  // wrong session. The event carries the id precisely so this message
+  // can be specific; falling back to the generic noun is fine when the
+  // added event has not landed yet.
+  const id = ev.session_id ?? ev.sessionId ?? '';
+  const name = state.sessions.find((s) => s.id === id)?.name;
+  const subject = name ? `“${name}” reopened` : 'Session reopened';
+
   // Scrollback is unconditional: there is no disk-backed scrollback to
   // replay from, so every restore starts with an empty terminal. Said
   // once, plainly, rather than per-restore.
   const text = losses.length
-    ? `Session reopened — scrollback is gone, and ${losses.join('; ')}.`
-    : 'Session reopened. Scrollback is gone; everything else came back.';
+    ? `${subject} — scrollback is gone, and ${losses.join('; ')}.`
+    : `${subject}. Scrollback is gone; everything else came back.`;
 
   undoBanner.setText(text);
   undoBanner.action('undo').hidden = true;

--- a/cmd/hivegui/frontend/src/app/undo-close.ts
+++ b/cmd/hivegui/frontend/src/app/undo-close.ts
@@ -1,0 +1,213 @@
+// Undo for an accidental session close.
+//
+// A close leaves a tombstone in the daemon's state dir, so reopening
+// is a real operation rather than a held-back teardown. Two ways in:
+// the banner this module raises the moment a close lands, and ⌘Z /
+// File ▸ Reopen Closed Session for anything older than that.
+//
+// The banner is deliberately honest. Scrollback never comes back, and
+// a restore can also lose the worktree or the agent conversation — so
+// the follow-up message reports what was actually degraded instead of
+// saying "restored" and letting the user discover the gap themselves.
+import { KillSession, RestoreSession } from '../bridge.js';
+import { state } from './state.js';
+import { reportFailure } from './dom.js';
+import { banner, type Banner } from '../ui/banner.js';
+
+/** How long the undo offer stays on screen. The tombstone outlives it. */
+const BANNER_MS = 15_000;
+
+/** Shape of the daemon's session:restored payload (snake_case on the wire). */
+interface RestoredEvent {
+  session_id?: string;
+  sessionId?: string;
+  project_reassigned?: boolean;
+  projectReassigned?: boolean;
+  worktree_recreated?: boolean;
+  worktreeRecreated?: boolean;
+  worktree_lost?: boolean;
+  worktreeLost?: boolean;
+  conversation_lost?: boolean;
+  conversationLost?: boolean;
+  agent_fell_back?: boolean;
+  agentFellBack?: boolean;
+  patch_path?: string;
+  patchPath?: string;
+  patch_skipped?: boolean;
+  patchSkipped?: boolean;
+}
+
+/** One close this client issued, remembered until its event lands. */
+interface PendingClose {
+  name: string;
+  /** The close also asked for the worktree to be deleted. */
+  deletedWorktree: boolean;
+}
+
+// Closes THIS client issued, by session id. Undo belongs to whoever
+// pressed close: a session removed by another window (or by a project
+// kill) must not raise a banner here, so the removed event alone is
+// not enough to act on.
+const pending = new Map<string, PendingClose>();
+
+let undoBanner: Banner | null = null;
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Record that this client is closing `id`. Called at the close call
+ * site, before the request goes out — the removed event carries no
+ * hint of who asked for it.
+ */
+export function noteLocalClose(
+  id: string,
+  name: string,
+  deletedWorktree = false,
+) {
+  if (!id) return;
+  pending.set(id, { name: name || 'Session', deletedWorktree });
+}
+
+/**
+ * Handle a session:event(removed). Raises the undo banner when this
+ * client issued the close, and does nothing otherwise.
+ */
+export function onSessionRemoved(id: string) {
+  const p = pending.get(id);
+  if (!p) return;
+  pending.delete(id);
+  showUndo(id, p);
+}
+
+function showUndo(id: string, p: PendingClose) {
+  if (!undoBanner) return;
+  undoBanner.setText(
+    p.deletedWorktree
+      ? `Closed “${p.name}” and deleted its worktree.`
+      : `Closed “${p.name}”.`,
+  );
+  const action = undoBanner.action('undo');
+  action.textContent = p.deletedWorktree ? 'Reopen session' : 'Undo';
+  action.hidden = false;
+  undoBanner.el.dataset.sessionId = id;
+  undoBanner.show();
+  restartHideTimer();
+}
+
+function restartHideTimer() {
+  if (hideTimer) clearTimeout(hideTimer);
+  hideTimer = setTimeout(() => undoBanner?.hide(), BANNER_MS);
+}
+
+/**
+ * Close the active session, remembering that this client asked for it.
+ *
+ * The single close entry point for ⌘W, the File menu and the command
+ * palette — it exists so noteLocalClose can never be forgotten at one
+ * of them. Without the note the removed event is indistinguishable
+ * from a close another window issued, and the undo banner silently
+ * does not appear.
+ *
+ * force=false, like every other live-session close: the daemon refuses
+ * with worktree_dirty when there are uncommitted changes, and
+ * events.ts asks the real three-way question.
+ */
+export function closeActiveSession() {
+  const id = state.activeId;
+  if (!id) return;
+  const s = state.sessions.find((x) => x.id === id);
+  noteLocalClose(id, s?.name ?? 'Session');
+  KillSession(id, false).catch(reportFailure('close'));
+}
+
+/**
+ * Reopen a closed session. An empty id means "the most recently
+ * closed one" — resolved daemon-side so ⌘Z cannot race a retention
+ * prune between listing and restoring.
+ */
+export function reopenClosedSession(id = '') {
+  RestoreSession(id).catch(reportFailure('reopen session'));
+}
+
+/** ⌘Z / File ▸ Reopen Closed Session. */
+export function reopenLastClosedSession() {
+  reopenClosedSession('');
+}
+
+/**
+ * Report the outcome of a restore. Replaces the banner text rather
+ * than dismissing it: a restore that silently dropped the worktree or
+ * the conversation would otherwise look like a clean undo.
+ */
+export function onSessionRestored(ev: RestoredEvent) {
+  if (!undoBanner) return;
+  const losses: string[] = [];
+  if (ev.worktree_lost ?? ev.worktreeLost) {
+    losses.push('its worktree could not be restored');
+  } else if (ev.worktree_recreated ?? ev.worktreeRecreated) {
+    losses.push(
+      'the worktree was rebuilt from its branch, without uncommitted changes',
+    );
+  }
+  if (ev.conversation_lost ?? ev.conversationLost) {
+    losses.push('the agent started a new conversation');
+  }
+  if (ev.agent_fell_back ?? ev.agentFellBack) {
+    losses.push('its agent is gone, so it came back as a shell');
+  }
+  if (ev.project_reassigned ?? ev.projectReassigned) {
+    losses.push('its project was deleted, so it moved to the default one');
+  }
+  if (ev.patch_skipped ?? ev.patchSkipped) {
+    losses.push('the uncommitted changes were too large to save');
+  }
+  const patch = ev.patch_path ?? ev.patchPath;
+  if (patch) losses.push(`uncommitted changes were saved to ${patch}`);
+
+  // Scrollback is unconditional: there is no disk-backed scrollback to
+  // replay from, so every restore starts with an empty terminal. Said
+  // once, plainly, rather than per-restore.
+  const text = losses.length
+    ? `Session reopened — scrollback is gone, and ${losses.join('; ')}.`
+    : 'Session reopened. Scrollback is gone; everything else came back.';
+
+  undoBanner.setText(text);
+  undoBanner.action('undo').hidden = true;
+  undoBanner.show();
+  restartHideTimer();
+}
+
+/**
+ * Build and mount the banner. Lazy, like the daemon and update
+ * banners: jsdom tests import this module without ever closing a
+ * session, and a mount on import would inject markup into scaffolds
+ * that do not expect it.
+ */
+export function initUndoClose() {
+  if (undoBanner) return;
+  undoBanner = banner({
+    kind: 'info',
+    actions: [
+      {
+        id: 'undo',
+        label: 'Undo',
+        onClick: () => {
+          const id = undoBanner?.el.dataset.sessionId || '';
+          undoBanner?.hide();
+          reopenClosedSession(id);
+        },
+      },
+    ],
+    onDismiss: () => undoBanner?.hide(),
+  });
+  undoBanner.el.dataset.slot = 'undo-close';
+  document.getElementById('app')?.prepend(undoBanner.el);
+}
+
+/** Test seam: drop all state between cases. */
+export function resetUndoCloseForTest() {
+  pending.clear();
+  if (hideTimer) clearTimeout(hideTimer);
+  hideTimer = null;
+  undoBanner?.el.remove();
+  undoBanner = null;
+}

--- a/cmd/hivegui/frontend/src/bridge.ts
+++ b/cmd/hivegui/frontend/src/bridge.ts
@@ -23,6 +23,8 @@ export {
   KillSession,
   KillSessionAndWorktree,
   RestartSession,
+  RestoreSession,
+  ListClosedSessions,
   UpdateSession,
   ListAgents,
   ListCustomAgents,

--- a/cmd/hivegui/frontend/src/lib/shortcuts.ts
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.ts
@@ -109,6 +109,7 @@ export function shortcutGroups({ isMac }: { isMac: boolean }): ShortcutGroup[] {
           label: 'Duplicate session (choose tool)',
         },
         { keys: m('W'), label: 'Close session' },
+        { keys: m('Z'), label: 'Reopen closed session' },
         { keys: `${m('1')}–${m('9')}`, label: 'Switch to session 1–9' },
         {
           keys: `${isMac ? '⌘' : 'Ctrl+'}${vArrows}`,

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -9,7 +9,6 @@ import '@xterm/xterm/css/xterm.css';
 
 import {
   ConnectControl,
-  KillSession,
   OpenNewWindow,
   CloseWindow,
   OpenTerminalAt,
@@ -46,6 +45,11 @@ import { openHelpOverlay, initHelpOverlay } from './app/modals/help-overlay.js';
 import { initSidebar } from './app/sidebar.js';
 import { wireDaemonEvents, reconnectControl } from './app/events.js';
 import { isDaemonRestarting, initBanners, restartHive } from './app/banners.js';
+import {
+  initUndoClose,
+  closeActiveSession,
+  reopenLastClosedSession,
+} from './app/undo-close.js';
 import { initVersionFooter } from './app/version-footer.js';
 import {
   switchTo,
@@ -130,9 +134,13 @@ const paletteCommands = [
     id: 'close-session',
     name: 'Close Session',
     run: () => {
-      if (state.activeId)
-        KillSession(state.activeId, false).catch(reportFailure('close'));
+      if (state.activeId) closeActiveSession();
     },
+  },
+  {
+    id: 'reopen-closed-session',
+    name: 'Reopen Closed Session',
+    run: () => reopenLastClosedSession(),
   },
   {
     id: 'new-window',
@@ -239,6 +247,7 @@ initSidebar({
   refocusActiveTerm,
 });
 initBanners();
+initUndoClose();
 initView({ ensureTerm, setActive, focusActiveTerm, scrollTrace });
 // Seed the status bar's hint slot. setModeHint is otherwise reached only
 // from switchTo() and setView(), and a boot with zero sessions calls

--- a/cmd/hivegui/frontend/test/dom/undo-close.test.ts
+++ b/cmd/hivegui/frontend/test/dom/undo-close.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+//
+// Undo for an accidental session close (src/app/undo-close.ts).
+//
+// Two things this file exists to pin. First: the banner belongs to
+// whoever pressed close — reacting to every `removed` event would pop
+// an undo offer in a window that did not ask for one, for a session it
+// may not even have been showing. Second: the follow-up message has to
+// report what the restore actually lost. A restore that silently drops
+// the worktree or the agent conversation while the banner says
+// "reopened" is worse than no undo at all, because the user stops
+// looking.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock factories are hoisted above every top-level binding, so the
+// spies have to be created inside them and read back afterwards.
+vi.mock('../../src/bridge.js', () => ({
+  KillSession: vi.fn(() => Promise.resolve()),
+  RestoreSession: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../../src/app/dom.js', () => ({
+  reportFailure: () => () => {},
+}));
+
+import { KillSession, RestoreSession } from '../../src/bridge.js';
+
+import {
+  initUndoClose,
+  noteLocalClose,
+  onSessionRemoved,
+  onSessionRestored,
+  closeActiveSession,
+  reopenLastClosedSession,
+  resetUndoCloseForTest,
+} from '../../src/app/undo-close.js';
+import { state } from '../../src/app/state.js';
+
+function bannerEl(): HTMLElement | null {
+  return document.querySelector('[data-slot="undo-close"]');
+}
+function bannerText(): string {
+  return bannerEl()?.querySelector('.hv-banner__text')?.textContent ?? '';
+}
+function undoButton(): HTMLButtonElement | null {
+  return bannerEl()?.querySelector('[data-action-id="undo"]') ?? null;
+}
+function visible(): boolean {
+  const el = bannerEl();
+  return !!el && !el.hidden;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetUndoCloseForTest();
+  document.body.innerHTML = '<div id="app"></div>';
+  state.activeId = null;
+  state.sessions = [];
+  initUndoClose();
+});
+
+describe('undo banner', () => {
+  it('shows an undo banner after a locally initiated close', () => {
+    expect(visible()).toBe(false);
+    noteLocalClose('s1', 'api-refactor');
+    onSessionRemoved('s1');
+
+    expect(visible()).toBe(true);
+    expect(bannerText()).toContain('api-refactor');
+    expect(undoButton()?.hidden).toBe(false);
+    expect(undoButton()?.textContent).toBe('Undo');
+  });
+
+  it('does not show a banner for a close initiated elsewhere', () => {
+    // No noteLocalClose: another window (or a project kill) removed it.
+    onSessionRemoved('s-remote');
+    expect(visible()).toBe(false);
+  });
+
+  it('offers undo only once per close', () => {
+    noteLocalClose('s1', 'one');
+    onSessionRemoved('s1');
+    bannerEl()!.hidden = true;
+
+    // A duplicate removed event must not re-raise the offer: the
+    // tombstone it referred to is already being acted on.
+    onSessionRemoved('s1');
+    expect(visible()).toBe(false);
+  });
+
+  it('labels a close-and-delete-worktree undo as unrecoverable', () => {
+    noteLocalClose('s1', 'api-refactor', true);
+    onSessionRemoved('s1');
+
+    expect(bannerText()).toContain('deleted its worktree');
+    // Not the word "Undo": the worktree's uncommitted state does not
+    // come back, so the button must not promise that it does.
+    expect(undoButton()?.textContent).toBe('Reopen session');
+  });
+
+  it('restores the session the banner is about, not the last one closed', () => {
+    noteLocalClose('s1', 'first');
+    onSessionRemoved('s1');
+    undoButton()!.click();
+
+    expect(RestoreSession).toHaveBeenCalledWith('s1');
+  });
+});
+
+describe('closeActiveSession', () => {
+  it('notes the close so the banner can appear', () => {
+    state.activeId = 's1';
+    state.sessions = [{ id: 's1', name: 'api-refactor' } as never];
+
+    closeActiveSession();
+
+    expect(KillSession).toHaveBeenCalledWith('s1', false);
+    onSessionRemoved('s1');
+    expect(visible()).toBe(true);
+    expect(bannerText()).toContain('api-refactor');
+  });
+
+  it('does nothing with no active session', () => {
+    state.activeId = null;
+    closeActiveSession();
+    expect(KillSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('reopen last closed', () => {
+  it('sends an empty id so the daemon picks the newest', () => {
+    // Resolving "the last one" client-side would race the retention
+    // prune between listing and restoring.
+    reopenLastClosedSession();
+    expect(RestoreSession).toHaveBeenCalledWith('');
+  });
+});
+
+describe('restore outcome', () => {
+  it('reports a clean undo without claiming scrollback came back', () => {
+    onSessionRestored({ session_id: 's1' });
+
+    expect(bannerText()).toContain('Scrollback is gone');
+    expect(undoButton()?.hidden).toBe(true);
+  });
+
+  it('reports degradation instead of a bare success', () => {
+    onSessionRestored({
+      session_id: 's1',
+      worktree_lost: true,
+      conversation_lost: true,
+    });
+
+    const text = bannerText();
+    expect(text).toContain('worktree could not be restored');
+    expect(text).toContain('new conversation');
+  });
+
+  it('surfaces the recovery patch path when the worktree was deleted', () => {
+    onSessionRestored({
+      session_id: 's1',
+      worktree_recreated: true,
+      patch_path: '/state/closed/s1.patch',
+    });
+
+    const text = bannerText();
+    expect(text).toContain('/state/closed/s1.patch');
+    expect(text).toContain('rebuilt from its branch');
+  });
+
+  it('distinguishes a skipped patch from no patch at all', () => {
+    // Empty patch_path plus patch_skipped means work WAS at stake and
+    // could not be saved — the opposite of "nothing to save".
+    onSessionRestored({ session_id: 's1', patch_skipped: true });
+    expect(bannerText()).toContain('too large to save');
+  });
+
+  it('reads camelCase payloads too', () => {
+    // Wire JSON is snake_case, but the boundary reads both.
+    onSessionRestored({ session_id: 's1', worktreeLost: true });
+    expect(bannerText()).toContain('worktree could not be restored');
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/undo-close.test.ts
+++ b/cmd/hivegui/frontend/test/dom/undo-close.test.ts
@@ -144,6 +144,27 @@ describe('restore outcome', () => {
     expect(undoButton()?.hidden).toBe(true);
   });
 
+  it('names the session that actually came back', () => {
+    // ⌘Z restores whatever the daemon says was closed last, which is
+    // not necessarily the session the banner offered undo for — so the
+    // report has to name the one that returned, not the one we asked
+    // about.
+    state.sessions = [{ id: 's2', name: 'other-branch' } as never];
+    noteLocalClose('s1', 'api-refactor');
+    onSessionRemoved('s1');
+
+    onSessionRestored({ session_id: 's2' });
+
+    expect(bannerText()).toContain('other-branch');
+    expect(bannerText()).not.toContain('api-refactor');
+  });
+
+  it('falls back to a generic subject when the session is not in state yet', () => {
+    state.sessions = [];
+    onSessionRestored({ session_id: 'not-here-yet' });
+    expect(bannerText()).toContain('Session reopened');
+  });
+
   it('reports degradation instead of a bare success', () => {
     onSessionRestored({
       session_id: 's1',

--- a/cmd/hivegui/frontend/test/e2e-real/undo-close.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/undo-close.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { bridgeCalls, registerSessionCleanup } from './bridge-sessions.js';
+
+// Layer B cover for undo-close: a real close writes a real tombstone
+// under the daemon's state dir, and a real restore rebuilds the entry
+// from it and spawns a fresh PTY.
+//
+// The mock suite can only prove the wiring, because it invents the
+// tombstone itself. What only the real daemon can prove is that the
+// record survives the teardown it is written in front of, and that the
+// restored session comes back with a live process attached — the two
+// things the whole design rests on.
+
+const WS_URL = process.env.WS_BRIDGE_URL;
+
+// Module scope: registerSessionCleanup installs an afterAll hook.
+const createdSessionIds = new Set<string>();
+registerSessionCleanup(createdSessionIds);
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((url) => {
+    window.__WS_BRIDGE_URL = url;
+  }, WS_URL);
+});
+
+test('a closed session can be reopened through the real daemon', async ({
+  page,
+}) => {
+  test.skip(!WS_URL, 'WS_BRIDGE_URL not set — globalSetup did not run');
+
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li.hv-session-row').length >= 1,
+    null,
+    { timeout: 10000 },
+  );
+
+  // Work on a session of our own rather than the bootstrap one: this
+  // spec closes it, and the suite shares a single daemon across every
+  // file, so removing "main" would leak into whatever runs next.
+  const beforeCount = await page.evaluate(
+    () => document.querySelectorAll('#projects li.hv-session-row').length,
+  );
+  await bridgeCalls([
+    [
+      'CreateSession',
+      { name: 'undo-me', shell: '/bin/bash', cols: 80, rows: 24 },
+    ],
+  ]);
+  await page.waitForFunction(
+    (n) => document.querySelectorAll('#projects li.hv-session-row').length > n,
+    beforeCount,
+    { timeout: 10000 },
+  );
+
+  const id = await page.evaluate(
+    () =>
+      (window.__hive_state?.sessions ?? []).find((s) => s.name === 'undo-me')
+        ?.id ?? '',
+  );
+  expect(id).not.toBe('');
+  createdSessionIds.add(id);
+
+  await bridgeCalls([['KillSession', { session_id: id, force: true }]]);
+  await page.waitForFunction(
+    (sid) => !(window.__hive_state?.sessions ?? []).some((s) => s.id === sid),
+    id,
+    { timeout: 10000 },
+  );
+
+  // The tombstone the close wrote — before its own teardown — is what
+  // makes the next line possible at all.
+  await bridgeCalls([['RestoreSession', { session_id: id }]]);
+  await page.waitForFunction(
+    (sid) => (window.__hive_state?.sessions ?? []).some((s) => s.id === sid),
+    id,
+    { timeout: 15000 },
+  );
+
+  const restored = await page.evaluate((sid) => {
+    const s = (window.__hive_state?.sessions ?? []).find((x) => x.id === sid);
+    return s ? { name: s.name, alive: s.alive } : null;
+  }, id);
+  // Same id, same name — and a live process, not a dead tile: the
+  // restore has to spawn, not merely re-add a row.
+  expect(restored?.name).toBe('undo-me');
+  expect(restored?.alive).not.toBe(false);
+});
+
+test('restoring a session that was never closed is refused, not invented', async ({
+  page,
+}) => {
+  test.skip(!WS_URL, 'WS_BRIDGE_URL not set — globalSetup did not run');
+
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li.hv-session-row').length >= 1,
+    null,
+    { timeout: 10000 },
+  );
+
+  const before = await page.evaluate(
+    () => (window.__hive_state?.sessions ?? []).length,
+  );
+
+  await bridgeCalls([['RestoreSession', { session_id: 'no-such-session' }]]);
+  await page.waitForTimeout(1000);
+
+  expect(
+    await page.evaluate(() => (window.__hive_state?.sessions ?? []).length),
+  ).toBe(before);
+});

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
@@ -234,6 +234,12 @@ export async function KillSessionAndWorktree(id: string) {
     remove_worktree: true,
   });
 }
+export async function RestoreSession(id: string) {
+  return call('RestoreSession', { session_id: id });
+}
+export async function ListClosedSessions() {
+  return call('ListClosedSessions', {});
+}
 export async function RestartSession(_id: string) {
   return '';
 }

--- a/cmd/hivegui/frontend/test/e2e/undo-close.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/undo-close.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// E2E for undo-close against the Wails mock. The DOM suite already
+// covers the banner's copy in isolation; what only a real click path
+// can prove is the wiring — that ⌘W actually routes through
+// closeActiveSession (and therefore notes the close), that the banner
+// mounts into the live layout, and that ⌘Z reaches the daemon call.
+//
+// The ⌘Z leg matters most: ⇧⌘T was the obvious binding and turned out
+// to be New Session in Worktree. A spec that presses the chord and
+// asserts a session came back is what stops that from recurring.
+
+const mod = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+async function boot(page: Page) {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li').length > 0,
+  );
+}
+
+// Closing the last session leaves document.activeElement on <body>,
+// and Chromium then delivers no keydown at all for a ⌘-chord. A real
+// window always has something focused; clicking the app restores that
+// precondition so the chord under test is actually dispatched.
+async function focusApp(page: Page) {
+  await page.locator('#app').click({ position: { x: 4, y: 4 } });
+}
+
+const banner = (page: Page) => page.locator('[data-slot="undo-close"]');
+
+test('closing a session offers an undo banner', async ({ page }) => {
+  await boot(page);
+  await expect(banner(page)).toBeHidden();
+
+  const name = await page.evaluate(
+    () => window.__hive.state?.sessions[0]?.name ?? '',
+  );
+  await page.keyboard.press(`${mod}+w`);
+
+  await expect(banner(page)).toBeVisible();
+  await expect(banner(page)).toContainText(name);
+  await expect(banner(page).locator('[data-action-id="undo"]')).toHaveText(
+    'Undo',
+  );
+});
+
+test('the undo button brings the session back', async ({ page }) => {
+  await boot(page);
+  const before = await page.evaluate(
+    () => window.__hive.state?.sessions.length ?? 0,
+  );
+
+  await page.keyboard.press(`${mod}+w`);
+  await page.waitForFunction(
+    (n) => (window.__hive.state?.sessions.length ?? 0) === n - 1,
+    before,
+  );
+
+  await banner(page).locator('[data-action-id="undo"]').click();
+
+  await page.waitForFunction(
+    (n) => (window.__hive.state?.sessions.length ?? 0) === n,
+    before,
+  );
+  // The banner switches from an offer to a report of what was lost —
+  // it must not simply vanish and imply a clean undo.
+  await expect(banner(page)).toContainText('Scrollback is gone');
+});
+
+test('⌘Z reopens the last closed session', async ({ page }) => {
+  await boot(page);
+  const before = await page.evaluate(
+    () => window.__hive.state?.sessions.length ?? 0,
+  );
+
+  await page.keyboard.press(`${mod}+w`);
+  await page.waitForFunction(
+    (n) => (window.__hive.state?.sessions.length ?? 0) === n - 1,
+    before,
+  );
+
+  await focusApp(page);
+  await page.keyboard.press(`${mod}+z`);
+
+  await page.waitForFunction(
+    (n) => (window.__hive.state?.sessions.length ?? 0) === n,
+    before,
+  );
+});
+
+test('⌘Z does not open a new session in a worktree', async ({ page }) => {
+  // The regression this whole binding audit came out of: ⇧⌘T was the
+  // first choice for reopen and is already New Session in Worktree.
+  // With nothing closed, ⌘Z must do nothing at all — certainly not
+  // create anything.
+  await boot(page);
+  const before = await page.evaluate(
+    () => window.__hive.state?.sessions.length ?? 0,
+  );
+
+  await page.keyboard.press(`${mod}+z`);
+  await page.waitForTimeout(200);
+
+  expect(
+    await page.evaluate(() => window.__hive.state?.sessions.length ?? 0),
+  ).toBe(before);
+});

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -135,6 +135,13 @@ export type MockBranch = {
   merged?: boolean;
 };
 
+/** One closed session the mock can still reopen. */
+export type MockClosed = {
+  session: MockSession;
+  closedAt: string;
+  degraded: Record<string, boolean>;
+};
+
 const state: {
   projects: MockProject[];
   sessions: MockSession[];
@@ -142,6 +149,10 @@ const state: {
   orphanBranches: MockBranch[];
   // Branch names the GUI asked to delete on the remote.
   deletedRemotes: string[];
+  // Tombstones left by closes, oldest last — the mock's stand-in for
+  // <stateDir>/closed/. `degraded` is what the daemon would report on
+  // SESSION_RESTORED for this particular close.
+  closed: MockClosed[];
 } = {
   projects: [
     {
@@ -173,6 +184,7 @@ const state: {
   worktrees: [],
   orphanBranches: [],
   deletedRemotes: [],
+  closed: [],
 };
 
 function broadcast() {
@@ -380,14 +392,18 @@ export async function KillSessionAndWorktree(id: string) {
   maybeFail('KillSessionAndWorktree');
   const s = state.sessions.find((x) => x.id === id);
   const path = s?.worktree_path;
-  await KillSession(id, true);
+  await KillSession(id, true, true);
   if (path) {
     const i = state.worktrees.findIndex((w) => w.path === path);
     if (i >= 0) state.worktrees.splice(i, 1);
   }
   return '';
 }
-export async function KillSession(id: string, force?: boolean) {
+export async function KillSession(
+  id: string,
+  force?: boolean,
+  removeWorktree = false,
+) {
   maybeFail('KillSession');
   const i = state.sessions.findIndex((s) => s.id === id);
   if (i < 0) return '';
@@ -418,6 +434,13 @@ export async function KillSession(id: string, force?: boolean) {
     const j = state.sessions.findIndex((s) => s.id === id);
     if (j < 0) return;
     const [removed] = state.sessions.splice(j, 1);
+    // Every close leaves a tombstone, exactly as the daemon writes one
+    // before the teardown.
+    state.closed.push({
+      session: { ...removed, phase: 'ready' },
+      closedAt: new Date().toISOString(),
+      degraded: removeWorktree ? { worktree_lost: true } : {},
+    });
     // A kill shifts every later session down a slot, so the daemon
     // recompacts .order and broadcasts the survivors (registry.Kill).
     // Leaving holes here would model a bug the daemon no longer has —
@@ -431,6 +454,56 @@ export async function KillSession(id: string, force?: boolean) {
     emitUpdatedExcept(removed.id);
   });
   return '';
+}
+// Undo close. The mock keeps its own tombstone list so a spec can
+// drive the full close → banner → reopen loop; the real daemon keeps
+// these on disk under the state dir.
+export async function RestoreSession(id: string) {
+  maybeFail('RestoreSession');
+  const i = id
+    ? state.closed.findIndex((t: MockClosed) => t.session.id === id)
+    : state.closed.length - 1;
+  if (i < 0) {
+    emit(
+      'control:error',
+      JSON.stringify({
+        code: id ? 'no_such_closed_session' : 'no_closed_sessions',
+        message: 'nothing to reopen',
+      }),
+    );
+    return '';
+  }
+  const [tomb] = state.closed.splice(i, 1);
+  // Appended, like the registry: every sibling's order shifted when
+  // this one was removed, so the remembered slot no longer means what
+  // it meant.
+  state.sessions.push(tomb.session);
+  renumber();
+  emit(
+    'session:event',
+    JSON.stringify({ kind: 'added', session: tomb.session }),
+  );
+  emit(
+    'session:restored',
+    JSON.stringify({ session_id: tomb.session.id, ...tomb.degraded }),
+  );
+  emit('closed:list', JSON.stringify({ closed: closedList() }));
+  return '';
+}
+export async function ListClosedSessions() {
+  maybeFail('ListClosedSessions');
+  emit('closed:list', JSON.stringify({ closed: closedList() }));
+  return '';
+}
+function closedList() {
+  return state.closed
+    .slice()
+    .reverse()
+    .map((t: MockClosed) => ({
+      session_id: t.session.id,
+      name: t.session.name,
+      closed_at: t.closedAt,
+    }));
 }
 export async function RestartSession(_id: string) {
   maybeFail('RestartSession');

--- a/cmd/hivegui/menu_darwin.go
+++ b/cmd/hivegui/menu_darwin.go
@@ -53,6 +53,13 @@ func buildAppMenu(a *App) *menu.Menu {
 	file.AddText("Close Window",
 		keys.Combo("w", keys.ShiftKey, keys.CmdOrCtrlKey),
 		func(_ *menu.CallbackData) { a.CloseWindow() })
+	// ⌘Z, the reflex after an accidental ⌘W. Hive has no Edit menu, so
+	// there is no stock Undo item to collide with, and ⌘ is not a
+	// terminal modifier — xterm.js never received this chord, so
+	// binding it takes nothing away from the focused agent.
+	file.AddText("Reopen Closed Session",
+		keys.CmdOrCtrl("z"),
+		emit("menu:reopen-closed-session"))
 	file.AddSeparator()
 	file.AddText("Delete Project…",
 		keys.Combo("backspace", keys.ShiftKey, keys.CmdOrCtrlKey),

--- a/cmd/hivegui/menu_darwin_test.go
+++ b/cmd/hivegui/menu_darwin_test.go
@@ -149,3 +149,52 @@ func TestMenuHasNoArrowLeftRightAccelerators(t *testing.T) {
 		t.Error("walkAccelerators found no 'down' binding; the walker is broken")
 	}
 }
+
+// TestReopenClosedSessionAccelerator pins ⌘Z to Reopen Closed Session
+// and, more importantly, proves nothing else claims it. ⇧⌘T was the
+// obvious choice for this action and is already New Session in
+// Worktree; this test is what stops the next binding from repeating
+// that.
+func TestReopenClosedSessionAccelerator(t *testing.T) {
+	m := buildAppMenu(&App{})
+	accels := map[string]*keys.Accelerator{}
+	walkAccelerators(m.Items, accels)
+
+	got, ok := accels["Reopen Closed Session"]
+	if !ok || got == nil {
+		t.Fatal("Reopen Closed Session has no accelerator")
+	}
+	if got.Key != "z" {
+		t.Errorf("Reopen Closed Session bound to %q, want \"z\"", got.Key)
+	}
+	var cmd, shift bool
+	for _, mod := range got.Modifiers {
+		switch mod {
+		case keys.CmdOrCtrlKey:
+			cmd = true
+		case keys.ShiftKey:
+			shift = true
+		}
+	}
+	if !cmd {
+		t.Error("Reopen Closed Session missing CmdOrCtrl modifier")
+	}
+	if shift {
+		t.Error("Reopen Closed Session is ⇧⌘Z; that is conventionally redo")
+	}
+
+	for label, a := range accels {
+		if label == "Reopen Closed Session" || a == nil || a.Key != "z" {
+			continue
+		}
+		hasShift := false
+		for _, mod := range a.Modifiers {
+			if mod == keys.ShiftKey {
+				hasShift = true
+			}
+		}
+		if !hasShift {
+			t.Errorf("%q also claims ⌘Z", label)
+		}
+	}
+}

--- a/docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md
+++ b/docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md
@@ -345,6 +345,11 @@ TDD per `AGENTS.md` — every behaviour ships with its test.
   dispatch, GUI bindings, `undo-close.ts` with the banner and ⌘Z. Go suite,
   frontend unit/dom/e2e, tsc, biome and ui-lint all green.
 
+## PR convergence ledger
+
+- **2026-08-31 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: c6de5a00…; threads_open: 0; action: stop; head_sha: d8e652b.
+- **2026-08-31 post-loop** — 3 IMPORTANT findings applied by hand rather than left for the gate (boil-the-lake): wire-id path guard, ErrExists + traversal coverage, restored-session naming.
+
 ## Open questions
 
 None. All five open decisions were resolved during plan review.

--- a/docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md
+++ b/docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/304-reopen-a-closed-session-undo-close.md](../../product-specs/304-reopen-a-closed-session-undo-close.md)
 - **Issue:** #304
+- **PR:** #306
+- **Branch:** feature/304-reopen-closed-session
 - **Status:** active
 
 ## Summary
@@ -337,6 +339,7 @@ TDD per `AGENTS.md` — every behaviour ships with its test.
 - **2026-08-31** — Plan-first scaffold; stage = IMPLEMENT (set in spec
   frontmatter). Design approved via the plan-html review loop; irreversibility
   audit and all five open decisions resolved before scaffolding.
+- **2026-08-31** — PR #306 opened; stage = REVIEW.
 - **2026-08-31** — Implemented on `feature/304-reopen-closed-session`. Registry
   tombstones + `Restore`, `worktree.DumpPatch`, three new wire frames, daemon
   dispatch, GUI bindings, `undo-close.ts` with the banner and ⌘Z. Go suite,

--- a/docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md
+++ b/docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md
@@ -1,0 +1,347 @@
+# Reopen a closed session (undo close)
+
+- **Spec:** [docs/product-specs/304-reopen-a-closed-session-undo-close.md](../../product-specs/304-reopen-a-closed-session-undo-close.md)
+- **Issue:** #304
+- **Status:** active
+
+## Summary
+
+Make a session close recoverable. `registry.kill()` writes a small tombstone to
+`<stateDir>/closed/<id>.json` immediately before the teardown; a new
+`RESTORE_SESSION` wire frame rebuilds the entry from it and revives the agent by
+its pinned `agent_session_id`. The GUI offers an undo banner at the moment of
+the close and `⌘Z` / File ▸ Reopen Closed Session for later recall. Restore
+reports what it could not bring back instead of claiming a clean undo.
+
+## Research
+
+Authored via plan-first mode; findings below come from reading the close path
+end to end during plan iteration.
+
+**Relevant code**
+
+- `internal/registry/registry.go:772` — `kill(id, force, removeWorktree)`. The
+  ordering is deliberate and documented in place: dirty pre-flight → delete
+  entry + reindex + persist index → `sess.Close()` (PTY dies) →
+  `disposeWorktree()` → `os.RemoveAll(<stateDir>/sessions/<id>)` → broadcast
+  `session:removed` plus refreshed survivors. The tombstone write goes in front
+  of all of it.
+- `internal/registry/registry.go:900` — `disposeWorktree()`. Every branch is a
+  refusal except two: an explicit remove request, and a worktree holding
+  nothing. Notably it refuses to delete anything not `worktree.IsManaged()`.
+- `internal/registry/persist.go:11` — `MetaFile` is the whole persisted entry:
+  id, name, color, order, created, agent, project_id, worktree_path,
+  worktree_branch, `agent_session_id`. Small enough to copy verbatim into a
+  tombstone.
+- `internal/registry/registry.go:532` — `Revive()`. Re-resolves the agent
+  command (so a moved binary is picked up), prefers the worktree path as cwd,
+  self-heals a vanished worktree, and resumes by `agent_session_id`. **This is
+  why the feature is feasible at all** — restore is mostly "rebuild the entry,
+  then call Revive".
+- `internal/worktree/worktree.go:193` — `Cleanup()` removes the directory and
+  prunes git admin state but **never deletes the branch**. A pruned worktree is
+  therefore recreatable via `git worktree add <path> <branch>`; committed work
+  survives a close, uncommitted work does not.
+- `internal/registry/projects.go:142` — `ReclaimOrphanWorktrees()` deletes
+  pristine *unclaimed* worktrees at boot. A tombstoned worktree is unclaimed by
+  definition; see the edge case below.
+- `internal/registry/create.go:341` — `insertEntry()`. Restore reuses this
+  shape rather than growing a parallel ordering/persist/broadcast path.
+- `cmd/hivegui/frontend/src/ui/banner.ts` — the banner primitive already takes
+  labelled actions and a dismiss; `src/app/banners.ts:425` owns the notice row.
+- `cmd/hivegui/frontend/src/app/events.ts:660` — the three-way dirty-worktree
+  dialog (Cancel / Close session / Close and delete worktree).
+
+**Audit: does closing a dirty worktree already prompt?** Yes, for every live
+session, across all five close call sites:
+
+| Call site | force | Prompts? |
+|---|---|---|
+| `keyboard.ts:357` — ⌘W | false | yes |
+| `keyboard.ts:666` — File ▸ Close Session | false | yes |
+| `main.ts:134` — command palette | false | yes |
+| `sidebar.ts:432` — sidebar kill, live branch | false | yes (after its own `Confirm`) |
+| `sidebar.ts:424` / `session-term.ts:1623` — *dead* session | true | no prompt |
+
+The two `force=true` sites are dead sessions only — no process left to guard.
+They skip the dirty *check*, but still call `kill(…, removeWorktree=false)`, and
+`disposeWorktree` independently refuses to delete a non-pristine worktree
+(`registry.go:915`). So a dirty worktree survives even there and reappears in
+the worktree browser. **No close path can destroy uncommitted work without the
+user explicitly picking the danger choice.** That floor stays; this change does
+not touch it.
+
+**Consequence for framing:** the accidental close — the case this feature
+exists for — is by construction the non-destructive one, because deleting a
+worktree takes a deliberate second click. The common undo is a clean undo.
+
+**What is irreversible**
+
+| Destroyed at close | Comes back? | Why |
+|---|---|---|
+| PTY child process | new one | Restore spawns a fresh process, not the same pid. |
+| Terminal scrollback | **no** | In-memory ring plus the session dir are both gone; disk-backed scrollback does not exist. |
+| Agent conversation | usually | Replayed by the agent's own resume when `agent_session_id` is set. A plain shell comes back blank. |
+| In-flight agent state never written to its rollout file | **no** | It only lived in the killed process. |
+| Worktree uncommitted changes, via *Close and delete worktree* | via patch | Was unrecoverable; the capped patch dump below changes that. Still requires the explicit danger choice. |
+| Worktree unpushed commits | yes | The branch survives `Cleanup`; only the checkout dir went away. |
+| Pristine worktree directory | yes | Recreatable from the branch. |
+| Name / colour / project / agent binding | yes | All in the tombstone. |
+
+## Approach
+
+**Tombstone-on-kill, not deferred teardown.** The obvious cheap design is to
+hold the teardown for ~15s behind a banner. Rejected: it keeps alive a process
+the user asked to end, blocks worktree cleanup for the delay, has nothing to
+offer after a daemon restart, and turns every close into a latency question.
+
+Instead, immediately before the teardown, `kill()` writes:
+
+```go
+type Tombstone struct {
+    Meta            MetaFile  `json:"meta"`
+    ClosedAt        time.Time `json:"closed_at"`
+    // The close ASKED to delete the worktree; disposeWorktree can
+    // still refuse. Restore probes the filesystem rather than trusting
+    // this, so it is a diagnostic, not a decision input.
+    WorktreeRemoveRequested bool   `json:"worktree_remove_requested,omitempty"`
+    WorktreeShared          bool   `json:"worktree_shared,omitempty"`
+    PatchPath               string `json:"patch_path,omitempty"`
+    PatchSkipped            bool   `json:"patch_skipped,omitempty"`
+}
+```
+
+Written through the same atomic temp+rename helper as every other registry
+write; the registry stays the only writer under `StateDir()`. Pruned on each
+write by **both** bounds — last 20 records and 7 days, whichever prunes first.
+Metadata only, under 1 KB each. It survives daemon restarts, costs the close
+path one small file write, needs no timers, and gives "reopen the thing I closed
+ten minutes ago" for free.
+
+**Recovery patch.** On the destructive branch only (`removeWorktree=true`),
+before `worktree.Cleanup` runs, dump the worktree's uncommitted state to
+`<stateDir>/closed/<id>.patch`: `git diff HEAD` plus untracked files
+(`git ls-files -o --exclude-standard` fed through `git diff --no-index /dev/null`).
+Capped at 10 MiB; above the cap, skip and set `patch_skipped` so restore says so
+rather than implying a patch exists. Best-effort — a failure logs and never
+blocks the close the user asked for.
+
+Deliberately **not** `git stash`: the stash stack is shared by every worktree of
+the repo, and silently pushing onto a user's stack is a surprising side effect
+that another tool (or another Hive session) can pop. A file under the state dir
+is inert.
+
+Restore does **not** auto-apply the patch. It recreates the worktree from the
+branch and reports the patch path, leaving `git apply` to the user — auto-applying
+into a checkout whose HEAD may have moved turns one bad close into a merge
+conflict.
+
+**Restore flow.** `registry.Restore(id, opts) (*Entry, RestoreResult, error)` — `opts` is the same `session.Options` the daemon hands `Revive` on boot. The
+result carries what was degraded so the GUI can say so:
+
+1. Read the tombstone. Missing → `ErrNotFound`.
+2. Id already live → `ErrExists` (defensive; ids are unique).
+3. **Project** gone → restore into the default project, flag `ProjectReassigned`.
+4. **Worktree**, under `gitMu`:
+   - path on disk and hive-managed → adopt as-is. Claimed by a sibling is fine
+     and expected — duplicate sessions (⌘P) legitimately share one worktree.
+   - path gone, branch exists → `git worktree add <path> <branch>`, flag
+     `WorktreeRecreated`. Uncommitted work is *not* back.
+   - path gone, branch gone → no worktree, cwd = project cwd, flag `WorktreeLost`.
+   - path exists but is *not* hive-managed → adopt read-only as cwd, never
+     recreate. Same paranoia as `disposeWorktree`.
+5. **Recovery patch**: if the tombstone names one, surface `PatchPath`, or flag
+   `PatchSkipped` when it exceeded the cap. Never auto-applied.
+6. **Agent** unresolvable (a custom agent since deleted) → `Revive` already
+   falls back to a shell; flag `AgentFellBack`.
+7. Insert the entry at the **end** of the order, reindex, persist index.
+   Appending never surprises; restoring into the original slot was considered
+   and dropped.
+8. `Revive(id, opts)` — resumes by `agent_session_id` when present, flag
+   `ConversationLost` when not.
+9. Delete the tombstone, broadcast `session:added` plus refreshed survivors
+   (same stale-snapshot reasoning as `kill`'s tail).
+
+**UI.** Two affordances, no new modal.
+
+*Undo banner* — a third `banner()` instance driven from a new
+`src/app/undo-close.ts`. Shown on `session:removed` **only when this client
+initiated the close**, which means tracking locally-issued close ids at call
+time rather than reacting to every removal event. Auto-hides after 15s; the
+tombstone outlives it. Copy is outcome-specific: `Closed "api-refactor". [Undo]`
+for the ordinary path, `Closed "api-refactor" and deleted its worktree. [Reopen]
+— changes recoverable from a saved patch` for the destructive one. After restore
+returns, the text is replaced with what was actually degraded rather than a
+silent success.
+
+*Reopen last closed* — **`⌘Z`**. `⇧⌘T` was the first choice and is taken (New
+Session in Worktree, `menu_darwin.go:38`). The keymap was audited: `⌘Z` is
+unbound in both `keyboard.ts` and `menu_darwin.go`, Hive has no Edit menu so
+there is no stock Undo item, and `⌘` is not a terminal modifier — xterm.js was
+never going to deliver it to the agent, so nothing is taken away. An accidental
+close is exactly the moment a hand reaches for `⌘Z`. Alternatives considered:
+`⇧⌘Z` (conventionally redo), `⌘U` (weak mnemonic), `⌘R` (better saved for
+Restart Session, which has no accelerator today), and no global key at all
+(cheapest, but fails the "closed it ten minutes ago" case).
+
+No "recently closed" browser UI in this change — the wire call returns a list,
+so one can be added later without another protocol change.
+
+**Edge cases**
+
+1. **Daemon restart between close and undo.** Tombstones are on disk, so `⌘Z`
+   still works; only the banner is lost. Main reason deferred kill was rejected.
+2. **Boot orphan-reclaim races the undo window.** `ReclaimOrphanWorktrees`
+   deletes pristine, unclaimed worktrees at startup, and a tombstoned worktree is
+   exactly "unclaimed". Narrow (a pristine worktree is normally already removed
+   by the kill that wrote the tombstone), but if a kill was interrupted between
+   steps, boot would silently delete something the user could still undo into.
+   Fix: `worktreeClaimed()` also consults live tombstones. Three lines, closes a
+   silent-data-loss path.
+3. **Double undo.** The tombstone is read-and-deleted under the lock; a second
+   call gets `ErrNotFound` and the banner just hides.
+4. **Restore while a sibling occupies the worktree.** Adopt, do not refuse —
+   that is the existing duplicate-session semantic.
+5. **Project close** (`KillProject` with `killSessions`) writes N tombstones for
+   free. Undoing a whole project as one unit is a non-goal.
+6. **Force kill from a dead tile** (`session-term.ts:1623`) tombstones like any
+   other close.
+7. **State-dir growth.** Bounded ring, sub-KB records. The patch dump is the only
+   thing that could get large, hence its cap.
+8. **e2e isolation.** `<stateDir>/closed/` is under `HIVE_STATE_DIR`, so the
+   real-e2e harness is already isolated. No new escape hatch.
+9. **Agent binary moved** (nvm switch). `Revive` re-resolves the agent command by
+   design; nothing extra needed.
+
+### Files to change
+
+- `internal/registry/registry.go` — `kill()` writes the tombstone before the
+  teardown; `disposeWorktree` reports whether it removed the dir and triggers
+  the patch dump on the destructive branch.
+- `internal/registry/paths.go` — `ClosedDir(stateDir)`.
+- `internal/registry/projects.go` — `worktreeClaimed()` consults tombstones.
+- `internal/worktree/worktree.go` — `DumpPatch(root, path, out string, cap int64)`,
+  beside `Cleanup` and `Inspect` where the other git shell-outs live.
+- `internal/wire/control.go` — `RestoreSessionReq`, `ListClosedReq`,
+  `ClosedResp`, `ClosedSessionInfo`, all with `json:"snake_case"` tags.
+- `internal/wire/frame.go` — `FrameRestoreSession`, `FrameListClosed`,
+  `FrameClosed`.
+- `internal/daemon/daemon.go` — dispatch both request frames alongside
+  `FrameKillSession`.
+- `cmd/hivegui/app_calls.go` — `RestoreSession(id)`, `ListClosedSessions()`.
+- `cmd/hived-ws-bridge/main.go` and `internal/wire/testclient` — the lock-step
+  clients the wire-change pattern in `AGENTS.md` requires.
+- `cmd/hivegui/frontend/src/bridge.ts` — export the two calls.
+- `cmd/hivegui/frontend/src/app/events.ts` — hand `session:removed` off to
+  `undo-close.ts`; reword the "cannot be undone" note now that a patch is saved
+  (accurately, not reassuringly).
+- `cmd/hivegui/frontend/src/lib/keymap.ts`, `src/app/keyboard.ts`,
+  `cmd/hivegui/menu_darwin.go` (File ▸ Reopen Closed Session, `⌘Z`), the help
+  overlay and the status-bar hints — the five surfaces the Keybindings Policy
+  names.
+- `cmd/hivegui/frontend/src/main.ts` — command-palette entry.
+- `CHANGELOG.md` — `[Unreleased]` entry (user-visible).
+- `DESIGN.md` — one line: the registry also owns `closed/`.
+
+JS readers of the new payload use `snake_case ?? camelCase` at the boundary, per
+the hard rule.
+
+### New files
+
+- `internal/registry/closed.go` — `Tombstone`, write/read/list/prune, `Restore`,
+  `RestoreResult`, and the capped recovery-patch dump.
+- `internal/registry/closed_test.go`
+- `cmd/hivegui/frontend/src/app/undo-close.ts` — banner + `⌘Z` handler.
+- `cmd/hivegui/frontend/test/dom/undo-close.test.ts`
+
+### Tests
+
+TDD per `AGENTS.md` — every behaviour ships with its test.
+
+**Go — `internal/registry/closed_test.go`**
+
+- `TestKillWritesTombstone` — record exists, fields match the entry.
+- `TestRestoreRebuildsEntry` — name, colour, agent, project, agent_session_id.
+- `TestRestoreReattachesSurvivingWorktree`
+- `TestRestoreRecreatesWorktreeFromBranch` — dir gone, branch present, commits
+  back, uncommitted not.
+- `TestRestoreWithoutWorktreeWhenBranchGone` — flags `WorktreeLost`, cwd falls
+  back to project.
+- `TestRestoreRefusesNonHiveManagedRecreate`
+- `TestRestoreMissingTombstoneNotFound` / `TestRestoreTwiceSecondFails`
+- `TestRestoreIntoDefaultProjectWhenProjectGone`
+- `TestRestoreAppendsToEndOfOrder`
+- `TestTombstonePruneKeepsLastNAndSevenDays` — both bounds, whichever first.
+- `TestKillDumpsPatchBeforeWorktreeDelete` / `TestPatchSkippedAboveCap` /
+  `TestPatchDumpFailureDoesNotBlockClose`
+- `TestOrphanReclaimSkipsTombstonedWorktree` — the silent-data-loss guard.
+
+**Go — daemon / GUI**
+
+- `cmd/hivegui/menu_darwin_test.go`: assert `⌘Z` is bound once and to Reopen
+  Closed Session (the file already walks accelerators for exactly this kind of
+  collision check).
+- `internal/daemon/control_frame_test.go`: `TestRestoreSessionFrame`,
+  `TestRestoreSessionUnknownIDSendsError`, `TestListClosedFrame`.
+- `cmd/hivegui/app_calls_test.go`: `TestRestoreSessionCall`,
+  `TestListClosedSessionsCall`.
+
+**DOM — `test/dom/undo-close.test.ts`**
+
+- `shows an undo banner after a locally initiated close`
+- `labels a close-and-delete-worktree undo as unrecoverable`
+- `reports degradation returned by restore instead of a bare success`
+- `does not show a banner for a close initiated elsewhere`
+- `surfaces the recovery patch path when the worktree was deleted`
+
+**e2e-real**
+
+- Close a session, press `⌘Z`, assert the tile returns with the same name and a
+  live PTY. Isolated via `HIVE_SOCKET` + `HIVE_STATE_DIR` like the rest of the
+  suite.
+
+## Decision log
+
+- **2026-08-31** — Tombstone-on-kill over deferred teardown. Why: survives
+  daemon restarts, keeps no process the user asked to end, no timers, and
+  enables later recall for free.
+- **2026-08-31** — Write a capped 10 MiB recovery patch before the destructive
+  worktree delete. Why: it is the only genuinely unrecoverable case, and ~30
+  lines converts it. Not `git stash` — the stash stack is shared across every
+  worktree of the repo and polluting it is a surprising side effect.
+- **2026-08-31** — Restore never auto-applies the patch. Why: applying into a
+  checkout whose HEAD may have moved turns one bad close into a merge conflict.
+- **2026-08-31** — Restore appends to the end of the session order rather than
+  the original slot. Why: simpler, and never surprises.
+- **2026-08-31** — Tombstone retention bounded by both count (20) and age (7
+  days), whichever prunes first.
+- **2026-08-31** — Undo banner only for closes this client initiated. Why: undo
+  belongs to whoever pressed close.
+- **2026-08-31** — Keybinding is `⌘Z`, not `⇧⌘T` (taken by New Session in
+  Worktree). Why: unbound at both the app and terminal layers, and it is the
+  reflex reached for after an accidental close.
+- **2026-08-31** — `RESTORE_SESSION` with an empty id means "the most recently
+  closed one", resolved daemon-side. Why: a client that lists and then restores
+  can race the retention prune between the two calls.
+- **2026-08-31** — The undo banner tracks locally-issued close ids in a new
+  `closeActiveSession()` helper rather than reacting to `session:removed`. Why:
+  a single entry point is the only way ⌘W, the File menu and the palette cannot
+  drift into forgetting the note.
+- **2026-08-31** — Dropped a speculative branch letting ⌘Z through the launcher
+  guard. Why: it was written for a case that turned out not to occur (closing
+  the last session does not auto-open the launcher), and unreachable code is
+  not a safety net.
+
+## Progress
+
+- **2026-08-31** — Plan-first scaffold; stage = IMPLEMENT (set in spec
+  frontmatter). Design approved via the plan-html review loop; irreversibility
+  audit and all five open decisions resolved before scaffolding.
+- **2026-08-31** — Implemented on `feature/304-reopen-closed-session`. Registry
+  tombstones + `Restore`, `worktree.DumpPatch`, three new wire frames, daemon
+  dispatch, GUI bindings, `undo-close.ts` with the banner and ⌘Z. Go suite,
+  frontend unit/dom/e2e, tsc, biome and ui-lint all green.
+
+## Open questions
+
+None. All five open decisions were resolved during plan review.

--- a/docs/exec-plans/completed/304-reopen-a-closed-session-undo-close.md
+++ b/docs/exec-plans/completed/304-reopen-a-closed-session-undo-close.md
@@ -4,7 +4,7 @@
 - **Issue:** #304
 - **PR:** #306
 - **Branch:** feature/304-reopen-closed-session
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -344,6 +344,14 @@ TDD per `AGENTS.md` — every behaviour ships with its test.
   tombstones + `Restore`, `worktree.DumpPatch`, three new wire frames, daemon
   dispatch, GUI bindings, `undo-close.ts` with the banner and ⌘Z. Go suite,
   frontend unit/dom/e2e, tsc, biome and ui-lint all green.
+
+## QA verdict
+
+- **2026-08-31** — verdict: PASS; checks: 3 dimensions / 8 acceptance criteria / 5 non-goals passed, 0 failed, 0 followups; followups: none; one-line: undo-close delivers every success criterion, bleeds into no non-goal, and leaves every close confirmation byte-identical to main.
+  - 2026-08-31 dimensions:
+    - acceptance — PASS — all 8 criteria demonstrated by passing tests, not asserted from source; tombstone-before-teardown confirmed by ordering at registry.go:854.
+    - non-goals — PASS — `kill()` dirty pre-flight and `disposeWorktree`'s Pristine()-gated branch byte-identical to main; no `git apply` exec anywhere; `KillProject` untouched.
+    - doc accuracy — PASS — changeset, README keybinds row, help overlay, command palette and DESIGN.md persistence section all updated for ⌘Z and `closed/`.
 
 ## PR convergence ledger
 

--- a/docs/product-specs/304-reopen-a-closed-session-undo-close.md
+++ b/docs/product-specs/304-reopen-a-closed-session-undo-close.md
@@ -4,16 +4,18 @@ title: "Reopen a closed session (undo close)"
 type: enhancement
 complexity: M
 priority: P2
-stage: IMPLEMENT
+stage: REVIEW
+pr: 306
 ---
 
 # Reopen a closed session (undo close)
 
 - **Issue:** #304
+- **PR:** #306
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** P2
-- **Stage:** IMPLEMENT
+- **Stage:** REVIEW
 - **Exec plan:** [docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md](../exec-plans/active/304-reopen-a-closed-session-undo-close.md)
 
 ## Problem

--- a/docs/product-specs/304-reopen-a-closed-session-undo-close.md
+++ b/docs/product-specs/304-reopen-a-closed-session-undo-close.md
@@ -4,8 +4,9 @@ title: "Reopen a closed session (undo close)"
 type: enhancement
 complexity: M
 priority: P2
-stage: GATE
+stage: DONE
 pr: 306
+shipped: 2026-08-31
 ---
 
 # Reopen a closed session (undo close)
@@ -15,8 +16,8 @@ pr: 306
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** P2
-- **Stage:** GATE
-- **Exec plan:** [docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md](../exec-plans/active/304-reopen-a-closed-session-undo-close.md)
+- **Stage:** DONE
+- **Exec plan:** [docs/exec-plans/completed/304-reopen-a-closed-session-undo-close.md](../exec-plans/completed/304-reopen-a-closed-session-undo-close.md)
 
 ## Problem
 

--- a/docs/product-specs/304-reopen-a-closed-session-undo-close.md
+++ b/docs/product-specs/304-reopen-a-closed-session-undo-close.md
@@ -4,7 +4,7 @@ title: "Reopen a closed session (undo close)"
 type: enhancement
 complexity: M
 priority: P2
-stage: REVIEW
+stage: GATE
 pr: 306
 ---
 
@@ -15,7 +15,7 @@ pr: 306
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** P2
-- **Stage:** REVIEW
+- **Stage:** GATE
 - **Exec plan:** [docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md](../exec-plans/active/304-reopen-a-closed-session-undo-close.md)
 
 ## Problem

--- a/docs/product-specs/304-reopen-a-closed-session-undo-close.md
+++ b/docs/product-specs/304-reopen-a-closed-session-undo-close.md
@@ -1,0 +1,88 @@
+---
+issue: 304
+title: "Reopen a closed session (undo close)"
+type: enhancement
+complexity: M
+priority: P2
+stage: IMPLEMENT
+---
+
+# Reopen a closed session (undo close)
+
+- **Issue:** #304
+- **Type:** enhancement
+- **Complexity:** M
+- **Priority:** P2
+- **Stage:** IMPLEMENT
+- **Exec plan:** [docs/exec-plans/active/304-reopen-a-closed-session-undo-close.md](../exec-plans/active/304-reopen-a-closed-session-undo-close.md)
+
+## Problem
+
+Closing a session is a one-way teardown. `registry.kill()` deletes the entry,
+kills the PTY child, disposes of the worktree, and removes
+`<stateDir>/sessions/<id>/` — with nothing written down first. An accidental
+`⌘W` on the wrong tile, or a confirm dialog dismissed too fast, has no recovery
+path at all: the session, its name, its project and worktree binding, and its
+agent conversation are simply gone.
+
+The entry's persisted state is small and fully described by
+`registry.MetaFile`, and `Revive()` already resumes agent conversations by the
+pinned `agent_session_id`. Everything needed to bring a session back already
+exists; nothing captures it before the teardown runs.
+
+## Desired behavior
+
+Closing a session leaves a recoverable trace. Immediately after a close, an
+undo affordance is offered inline; later, the most recently closed session can
+be reopened from a keybinding or the File menu. A reopened session comes back
+with its name, colour, project, agent binding and worktree, and — for agents
+that support per-id resume — its conversation.
+
+Undo is honest about what it cannot restore. Terminal scrollback and any
+in-flight agent state that was never written to the agent's rollout file do not
+come back, and the UI says so rather than reporting a silent success.
+
+Closing remains exactly as protected as it is today: every live-session close
+still prompts before a dirty worktree can be touched, and destroying
+uncommitted work still requires explicitly picking the danger choice. Undo does
+not make close less careful.
+
+## Success criteria
+
+- Closing a session writes a tombstone under `<stateDir>/closed/<id>.json`
+  before any teardown step runs, and the tombstone survives a daemon restart.
+- A `RESTORE_SESSION` wire frame rebuilds the entry: name, colour, project,
+  agent, worktree binding and `agent_session_id` all return, and the session is
+  revived with its conversation when the agent supports per-id resume.
+- Restore reports what was degraded (worktree lost or recreated, conversation
+  lost, agent fell back to a shell, recovery patch skipped) rather than a bare
+  success, and the UI surfaces it.
+- A worktree that still exists on disk is re-adopted; one that was pruned is
+  recreated from its surviving branch; one whose branch is also gone restores
+  without a worktree instead of failing.
+- An undo banner appears after a close initiated by this client, and `⌘Z` /
+  File ▸ Reopen Closed Session / the command palette reopen the most recently
+  closed session.
+- Before the destructive `Close and delete worktree` path deletes anything, a
+  capped recovery patch of the uncommitted state is written next to the
+  tombstone, and its path is surfaced on restore.
+- Boot-time orphan-worktree reclaim no longer deletes a worktree that a live
+  tombstone still refers to.
+- Every existing close confirmation still fires; no close path becomes quieter.
+
+## Non-goals
+
+- Restoring terminal scrollback. That needs disk-backed scrollback, which does
+  not exist yet.
+- Auto-applying the recovery patch during restore. The patch is written and its
+  path surfaced; running `git apply` stays the user's call.
+- Undoing a project close as a single unit. Sessions closed by a project kill
+  are individually reopenable, but there is no one-shot project undo.
+- A full "recently closed" browser UI. The wire call returns a list so one can
+  be added later without another protocol change.
+- Loosening any close confirmation.
+
+## Notes
+
+Scaffolded via plan-first mode; the approved design, the irreversibility audit
+and the resolved decisions live in the exec plan.

--- a/internal/daemon/control_frame_test.go
+++ b/internal/daemon/control_frame_test.go
@@ -151,3 +151,159 @@ func TestDecodeReqEmptyPayload(t *testing.T) {
 		t.Fatalf("round trip failed: ok=%v req=%+v errs=%v", ok, req, got)
 	}
 }
+
+// --- undo close ---
+
+// TestControlFrameRestoreBadPayload extends the bad_payload contract
+// to the restore frame. Kept out of the table above because that test
+// asserts the registry is untouched via `mutated`, which the restore
+// path does not use.
+func TestControlFrameRestoreBadPayload(t *testing.T) {
+	d := newFrameTestDaemon(t)
+	rec := &recordOps{}
+	if done := d.handleControlFrame(context.Background(), rec.ops(),
+		wire.FrameRestoreSession, []byte(`["not","an","object"]`)); done {
+		t.Fatal("a bad payload closed the connection")
+	}
+	if len(rec.errs) != 1 || rec.errs[0].Code != "bad_payload" {
+		t.Fatalf("got %+v, want exactly one bad_payload error", rec.errs)
+	}
+}
+
+// TestControlFrameListClosedAnswersInPlace: LIST_CLOSED needs no
+// payload and answers synchronously, like the other list frames.
+func TestControlFrameListClosedAnswersInPlace(t *testing.T) {
+	d := newFrameTestDaemon(t)
+	rec := &recordOps{}
+	if done := d.handleControlFrame(context.Background(), rec.ops(), wire.FrameListClosed, nil); done {
+		t.Fatal("LIST_CLOSED closed the connection")
+	}
+	if len(rec.frames) != 1 || rec.frames[0] != wire.FrameClosed {
+		t.Errorf("got frames %v, want [CLOSED]", rec.frames)
+	}
+}
+
+// TestControlFrameRestoreUnknownIDSendsError: asking to reopen a
+// session with no tombstone is a refusal the user can act on, not a
+// generic failure — the GUI shows different copy for each.
+func TestControlFrameRestoreUnknownIDSendsError(t *testing.T) {
+	d := newFrameTestDaemon(t)
+	rec := &recordOps{}
+	payload, _ := json.Marshal(wire.RestoreSessionReq{SessionID: "no-such-session"})
+	d.handleControlFrame(context.Background(), rec.ops(), wire.FrameRestoreSession, payload)
+	d.ops.Wait()
+
+	if len(rec.errs) != 1 || rec.errs[0].Code != "no_such_closed_session" {
+		t.Fatalf("got %+v, want one no_such_closed_session error", rec.errs)
+	}
+	// A refused restore still refreshes the reopen list: a pruned or
+	// already-restored tombstone is exactly why it failed.
+	if len(rec.frames) != 1 || rec.frames[0] != wire.FrameClosed {
+		t.Errorf("got frames %v, want [CLOSED] after a refusal", rec.frames)
+	}
+}
+
+// TestControlFrameRestoreEmptyIDWithNothingClosed: the reopen-last
+// affordance sends an empty id. With no tombstones at all that must
+// say so rather than fall through to "not found" for a session the
+// user never named.
+func TestControlFrameRestoreEmptyIDWithNothingClosed(t *testing.T) {
+	d := newFrameTestDaemon(t)
+	rec := &recordOps{}
+	payload, _ := json.Marshal(wire.RestoreSessionReq{})
+	d.handleControlFrame(context.Background(), rec.ops(), wire.FrameRestoreSession, payload)
+	d.ops.Wait()
+
+	if len(rec.errs) != 1 || rec.errs[0].Code != "no_closed_sessions" {
+		t.Fatalf("got %+v, want one no_closed_sessions error", rec.errs)
+	}
+}
+
+// TestControlFrameRestoreRoundTrip drives a real close and reopen
+// through the frame layer: the session comes back and the daemon
+// reports what it could not restore.
+func TestControlFrameRestoreRoundTrip(t *testing.T) {
+	d := newFrameTestDaemon(t)
+	reg := d.Registry()
+	if _, err := reg.EnsureDefaultProject(t.TempDir()); err != nil {
+		t.Fatalf("EnsureDefaultProject: %v", err)
+	}
+	e, err := reg.Create(context.Background(), wire.CreateSpec{Shell: "/bin/bash"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := e.ID
+	if err := reg.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	rec := &recordOps{}
+	payload, _ := json.Marshal(wire.RestoreSessionReq{SessionID: id})
+	d.handleControlFrame(context.Background(), rec.ops(), wire.FrameRestoreSession, payload)
+	d.ops.Wait()
+	defer reg.Kill(id, true)
+
+	if len(rec.errs) != 0 {
+		t.Fatalf("restore errored: %+v", rec.errs)
+	}
+	if reg.Get(id) == nil {
+		t.Fatal("session did not come back")
+	}
+	// SESSION_RESTORED (what was degraded) then CLOSED (the refreshed
+	// reopen list), in that order.
+	want := []wire.FrameType{wire.FrameSessionRestored, wire.FrameClosed}
+	if len(rec.frames) != len(want) {
+		t.Fatalf("got frames %v, want %v", rec.frames, want)
+	}
+	for i, w := range want {
+		if rec.frames[i] != w {
+			t.Errorf("frame %d = %#x, want %#x", i, byte(rec.frames[i]), byte(w))
+		}
+	}
+}
+
+// TestControlFrameRestoreAlreadyOpen: reopening a session that is
+// already open must be its own refusal, not a silent duplicate.
+func TestControlFrameRestoreAlreadyOpen(t *testing.T) {
+	d := newFrameTestDaemon(t)
+	reg := d.Registry()
+	if _, err := reg.EnsureDefaultProject(t.TempDir()); err != nil {
+		t.Fatalf("EnsureDefaultProject: %v", err)
+	}
+	e, err := reg.Create(context.Background(), wire.CreateSpec{Shell: "/bin/bash"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := e.ID
+	if err := reg.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if _, _, err := reg.Restore(id, session.Options{Shell: "/bin/bash", Cols: 80, Rows: 24}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer reg.Kill(id, true)
+
+	// The tombstone is gone after a successful restore, so the frame
+	// path reports "no longer restorable" — which is the honest answer
+	// and, importantly, is not a second copy of the session.
+	rec := &recordOps{}
+	payload, _ := json.Marshal(wire.RestoreSessionReq{SessionID: id})
+	d.handleControlFrame(context.Background(), rec.ops(), wire.FrameRestoreSession, payload)
+	d.ops.Wait()
+
+	if len(rec.errs) != 1 {
+		t.Fatalf("got %+v, want exactly one refusal", rec.errs)
+	}
+	if c := rec.errs[0].Code; c != "no_such_closed_session" && c != "session_already_open" {
+		t.Errorf("refusal code = %q, want no_such_closed_session or session_already_open", c)
+	}
+	copies := 0
+	for _, info := range reg.List() {
+		if info.ID == id {
+			copies++
+		}
+	}
+	if copies != 1 {
+		t.Errorf("registry holds %d copies of %s, want 1 — a second restore duplicated it", copies, id)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -685,6 +685,60 @@ func (d *Daemon) handleControlFrame(ctx context.Context, ops controlOps, ft wire
 				}
 			}
 		})
+	case wire.FrameListClosed:
+		_ = ops.writeJSON(wire.FrameClosed, wire.ClosedResp{Closed: d.reg.ListClosed()})
+	case wire.FrameRestoreSession:
+		req, ok := decodeReq[wire.RestoreSessionReq](payload, ops.sendError)
+		if !ok {
+			return false
+		}
+		// Off the read loop like every other lifecycle op: a restore
+		// can recreate a worktree, which shells out to git and takes
+		// seconds on a large repo.
+		d.runOp(func() {
+			id := req.SessionID
+			if id == "" {
+				// "Reopen the last one." Resolved daemon-side so the
+				// client cannot race a prune between LIST_CLOSED and
+				// the restore it based on that list.
+				closed := d.reg.ListClosed()
+				if len(closed) == 0 {
+					ops.sendError("no_closed_sessions", "no recently closed session to reopen")
+					return
+				}
+				id = closed[0].SessionID
+			}
+			_, res, err := d.reg.Restore(id, d.cfg.BootstrapSession)
+			if err != nil {
+				switch {
+				case errors.Is(err, registry.ErrNotFound):
+					ops.sendError("no_such_closed_session", "that session is no longer restorable")
+				case errors.Is(err, registry.ErrExists):
+					ops.sendError("session_already_open", "that session is already open")
+				default:
+					ops.sendError("restore_failed", err.Error())
+				}
+				// The reopen list is stale either way — a pruned or
+				// already-restored tombstone is exactly why this
+				// failed, so send it before the client acts again.
+				_ = ops.writeJSON(wire.FrameClosed, wire.ClosedResp{Closed: d.reg.ListClosed()})
+				return
+			}
+			// The entry's own "added" event has already gone out to
+			// every listener via the registry broadcast. This reports
+			// only what the restore could not bring back.
+			_ = ops.writeJSON(wire.FrameSessionRestored, wire.RestoredResp{
+				SessionID:         id,
+				ProjectReassigned: res.ProjectReassigned,
+				WorktreeRecreated: res.WorktreeRecreated,
+				WorktreeLost:      res.WorktreeLost,
+				ConversationLost:  res.ConversationLost,
+				AgentFellBack:     res.AgentFellBack,
+				PatchPath:         res.PatchPath,
+				PatchSkipped:      res.PatchSkipped,
+			})
+			_ = ops.writeJSON(wire.FrameClosed, wire.ClosedResp{Closed: d.reg.ListClosed()})
+		})
 	case wire.FrameRestartSession:
 		req, ok := decodeReq[wire.RestartSessionReq](payload, ops.sendError)
 		if !ok {

--- a/internal/registry/closed.go
+++ b/internal/registry/closed.go
@@ -1,0 +1,421 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/lucascaro/hive/internal/agent"
+	"github.com/lucascaro/hive/internal/session"
+	"github.com/lucascaro/hive/internal/wire"
+	"github.com/lucascaro/hive/internal/worktree"
+)
+
+// ErrExists is returned by Restore when the id it was asked to bring
+// back is already live. Defensive: session ids are unique, so this
+// only fires if something upstream reused one.
+var ErrExists = errors.New("registry: session already exists")
+
+// Tombstone retention. Both bounds apply and whichever prunes first
+// wins: the count keeps the state dir from growing without limit on a
+// heavy day, the age keeps a week-old close from surfacing as "the
+// last thing you closed" long after the context is gone.
+const (
+	maxTombstones   = 20
+	maxTombstoneAge = 7 * 24 * time.Hour
+)
+
+// maxPatchBytes caps the recovery patch written before a worktree is
+// deleted. Above this the patch is skipped and the fact recorded, so
+// the UI can say "too large to save" instead of implying a recovery
+// that does not exist.
+const maxPatchBytes = 10 << 20
+
+// Tombstone is what a close leaves behind: enough to rebuild the
+// registry entry, plus what the close itself did to the worktree.
+//
+// Metadata only — well under 1 KB. Scrollback is deliberately not
+// captured here; it lives in the session's in-memory ring and there is
+// no disk-backed scrollback to copy from.
+type Tombstone struct {
+	Meta     MetaFile  `json:"meta"`
+	ClosedAt time.Time `json:"closed_at"`
+	// WorktreeRemoveRequested records that the close asked for the
+	// worktree to be deleted, not that the deletion succeeded —
+	// disposeWorktree can still refuse (an unmanaged path). Restore
+	// probes the filesystem rather than trusting this, so it is a
+	// diagnostic, not a decision input.
+	WorktreeRemoveRequested bool `json:"worktree_remove_requested,omitempty"`
+	// WorktreeShared records that a sibling session still lived in the
+	// worktree at close time, so this close never touched it.
+	WorktreeShared bool `json:"worktree_shared,omitempty"`
+	// PatchPath is the recovery patch written before a requested
+	// worktree deletion; "" when none was written (nothing uncommitted,
+	// no deletion requested, or the dump failed).
+	PatchPath string `json:"patch_path,omitempty"`
+	// PatchSkipped is true when there WAS uncommitted work but the
+	// patch exceeded maxPatchBytes. The distinction matters: "" plus
+	// false means nothing was at stake, "" plus true means something
+	// was and we could not save it.
+	PatchSkipped bool `json:"patch_skipped,omitempty"`
+}
+
+// RestoreResult reports everything a restore could NOT bring back
+// cleanly. Every field is a degradation, so the zero value is a clean
+// undo and the GUI can render "restored" versus "restored, but…"
+// without a second round trip.
+type RestoreResult struct {
+	ProjectReassigned bool
+	WorktreeRecreated bool
+	WorktreeLost      bool
+	ConversationLost  bool
+	AgentFellBack     bool
+	PatchPath         string
+	PatchSkipped      bool
+}
+
+// Clean reports whether the restore lost nothing worth telling the
+// user about.
+func (rr RestoreResult) Clean() bool {
+	return !rr.ProjectReassigned && !rr.WorktreeRecreated && !rr.WorktreeLost &&
+		!rr.ConversationLost && !rr.AgentFellBack && !rr.PatchSkipped
+}
+
+// ClosedDir is the directory holding one tombstone (and any recovery
+// patch) per recently closed session.
+func ClosedDir(stateDir string) string {
+	return filepath.Join(stateDir, "closed")
+}
+
+func (r *Registry) tombstonePath(id string) string {
+	return filepath.Join(ClosedDir(r.stateDir), id+".json")
+}
+
+func (r *Registry) patchPath(id string) string {
+	return filepath.Join(ClosedDir(r.stateDir), id+".patch")
+}
+
+// writeTombstoneLocked records the entry as closed. Called under r.mu
+// immediately before kill removes it from the map, so the record is on
+// disk before anything — in memory or on disk — is destroyed.
+//
+// Failure is logged, never returned: a close the user asked for must
+// not be blocked because undo bookkeeping failed.
+func (r *Registry) writeTombstoneLocked(e *Entry, t Tombstone) {
+	t.Meta = MetaFile{
+		ID: e.ID, Name: e.Name, Color: e.Color,
+		Order: e.Order, Created: e.Created, Agent: e.Agent,
+		ProjectID:      e.ProjectID,
+		WorktreePath:   e.WorktreePath,
+		WorktreeBranch: e.WorktreeBranch,
+		AgentSessionID: e.AgentSessionID,
+	}
+	t.ClosedAt = time.Now().UTC()
+	if err := writeJSON(r.tombstonePath(e.ID), t); err != nil {
+		log.Printf("registry: kill %s: could not record tombstone (undo unavailable for this close): %v", e.ID, err)
+	}
+}
+
+// dumpRecoveryPatch captures the uncommitted state of a worktree that
+// this close has been told to delete. Runs before the tombstone write
+// and outside r.mu — it shells out to git several times.
+//
+// Best-effort by design: every failure path returns a Tombstone with
+// no patch rather than an error, because the user asked to close the
+// session and a failed backup must not veto that.
+func (r *Registry) dumpRecoveryPatch(id, wtPath string) (patchPath string, skipped bool) {
+	r.gitMu.Lock()
+	defer r.gitMu.Unlock()
+	out := r.patchPath(id)
+	err := worktree.DumpPatch(wtPath, out, maxPatchBytes)
+	switch {
+	case errors.Is(err, worktree.ErrPatchTooLarge):
+		log.Printf("registry: kill %s: uncommitted work in %s exceeds the %d-byte recovery-patch cap; not saved",
+			id, wtPath, maxPatchBytes)
+		return "", true
+	case err != nil:
+		log.Printf("registry: kill %s: could not save a recovery patch for %s: %v", id, wtPath, err)
+		return "", false
+	}
+	// DumpPatch writes nothing when there is nothing uncommitted.
+	if _, statErr := os.Stat(out); statErr != nil {
+		return "", false
+	}
+	return out, false
+}
+
+// readTombstone loads one record. A malformed file is treated as
+// missing — an unreadable tombstone is not something the user can act
+// on, and failing the restore with a JSON error helps nobody.
+func (r *Registry) readTombstone(id string) (Tombstone, error) {
+	var t Tombstone
+	if err := readJSON(r.tombstonePath(id), &t); err != nil {
+		return t, ErrNotFound
+	}
+	if t.Meta.ID == "" {
+		return t, ErrNotFound
+	}
+	return t, nil
+}
+
+// listTombstones returns every readable tombstone, newest close first.
+func (r *Registry) listTombstones() []Tombstone {
+	ents, err := os.ReadDir(ClosedDir(r.stateDir))
+	if err != nil {
+		return nil
+	}
+	var out []Tombstone
+	for _, de := range ents {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+		var t Tombstone
+		if err := readJSON(filepath.Join(ClosedDir(r.stateDir), de.Name()), &t); err != nil {
+			continue
+		}
+		if t.Meta.ID == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ClosedAt.After(out[j].ClosedAt) })
+	return out
+}
+
+// ListClosed returns the recently closed sessions, newest first, for
+// the "reopen last closed" affordance.
+func (r *Registry) ListClosed() []wire.ClosedSessionInfo {
+	ts := r.listTombstones()
+	out := make([]wire.ClosedSessionInfo, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, wire.ClosedSessionInfo{
+			SessionID:      t.Meta.ID,
+			Name:           t.Meta.Name,
+			Color:          t.Meta.Color,
+			Agent:          t.Meta.Agent,
+			ProjectID:      t.Meta.ProjectID,
+			WorktreeBranch: t.Meta.WorktreeBranch,
+			ClosedAt:       t.ClosedAt.UTC().Format(time.RFC3339),
+			HasPatch:       t.PatchPath != "",
+		})
+	}
+	return out
+}
+
+// pruneTombstones enforces both retention bounds. Called after each
+// write, outside every lock.
+func (r *Registry) pruneTombstones() {
+	ts := r.listTombstones() // newest first
+	cutoff := time.Now().UTC().Add(-maxTombstoneAge)
+	for i, t := range ts {
+		if i < maxTombstones && t.ClosedAt.After(cutoff) {
+			continue
+		}
+		r.discardTombstone(t.Meta.ID)
+	}
+}
+
+// discardTombstone removes a record and any recovery patch beside it.
+func (r *Registry) discardTombstone(id string) {
+	if err := os.Remove(r.tombstonePath(id)); err != nil && !os.IsNotExist(err) {
+		log.Printf("registry: could not remove tombstone %s: %v", id, err)
+	}
+	if err := os.Remove(r.patchPath(id)); err != nil && !os.IsNotExist(err) {
+		log.Printf("registry: could not remove recovery patch %s: %v", id, err)
+	}
+}
+
+// tombstoneClaimsWorktree reports whether a live tombstone still
+// refers to this worktree path.
+//
+// Boot-time orphan reclaim deletes pristine worktrees that no session
+// claims — and a tombstoned worktree is unclaimed by definition. The
+// window is narrow (a pristine worktree is normally removed by the
+// same kill that wrote the tombstone) but it is a silent delete of
+// something the user can still undo into, at boot, with no confirm.
+// Cheap to close, so close it.
+func (r *Registry) tombstoneClaimsWorktree(path string) bool {
+	if path == "" {
+		return false
+	}
+	for _, t := range r.listTombstones() {
+		if t.Meta.WorktreePath == path {
+			return true
+		}
+	}
+	return false
+}
+
+// Restore brings back a session closed earlier in this state dir,
+// rebuilding its entry from the tombstone and reviving the agent.
+//
+// The returned RestoreResult names everything that could not be
+// restored cleanly. It is not an error channel: a restore that comes
+// back without its worktree still succeeded — the tile, the name, the
+// project and (usually) the conversation are back, and the caller's
+// job is to say what was lost, not to treat it as a failure.
+//
+// Never auto-applies the recovery patch. Applying a patch into a
+// checkout whose HEAD may have moved since the close turns one bad
+// close into a merge conflict; the path is surfaced and `git apply`
+// stays the user's decision.
+func (r *Registry) Restore(id string, opts session.Options) (*Entry, RestoreResult, error) {
+	var res RestoreResult
+
+	t, err := r.readTombstone(id)
+	if err != nil {
+		return nil, res, err
+	}
+	res.PatchPath = t.PatchPath
+	res.PatchSkipped = t.PatchSkipped
+
+	r.mu.Lock()
+	if _, live := r.entries[id]; live {
+		r.mu.Unlock()
+		return nil, res, ErrExists
+	}
+	// Resolve the project now: it may have been killed since the close.
+	projectID := t.Meta.ProjectID
+	if _, ok := r.projects[projectID]; !ok {
+		projectID = r.defaultProjectIDLocked()
+		res.ProjectReassigned = projectID != t.Meta.ProjectID
+	}
+	projectCwd := ""
+	if p, ok := r.projects[projectID]; ok {
+		projectCwd = p.Cwd
+	}
+	r.mu.Unlock()
+
+	// Worktree resolution runs outside r.mu (it shells out to git) and
+	// under gitMu, the same discipline create and kill follow.
+	wtPath, wtBranch := r.resolveRestoreWorktree(id, projectCwd, t, &res)
+
+	if t.Meta.Agent != "" {
+		if _, ok := agent.Get(agent.ID(t.Meta.Agent)); !ok {
+			// A custom agent deleted since the close. Revive already
+			// falls back to a generic shell; flag it so the UI can say
+			// the session came back as a shell rather than as the tool
+			// the user remembers.
+			res.AgentFellBack = true
+		}
+		res.ConversationLost = t.Meta.AgentSessionID == ""
+	}
+
+	e := &Entry{
+		ID: t.Meta.ID, Name: t.Meta.Name, Color: t.Meta.Color,
+		Created:        t.Meta.Created,
+		Agent:          t.Meta.Agent,
+		ProjectID:      projectID,
+		WorktreePath:   wtPath,
+		WorktreeBranch: wtBranch,
+		AgentSessionID: t.Meta.AgentSessionID,
+	}
+
+	r.mu.Lock()
+	// Re-check liveness: the worktree work above ran unlocked and can
+	// take seconds, easily long enough for a second undo to land.
+	if _, live := r.entries[id]; live {
+		r.mu.Unlock()
+		return nil, res, ErrExists
+	}
+	r.entries[id] = e
+	// Append rather than splice back into the original slot. Every
+	// sibling's Order shifted down when this entry was removed, so the
+	// remembered index no longer means what it meant; appending is
+	// both simpler and never lands the tile somewhere surprising.
+	r.order = append(r.order, id)
+	r.reindexLocked()
+	if perr := r.persistEntryLocked(e); perr != nil {
+		delete(r.entries, id)
+		r.order = slices.Delete(r.order, len(r.order)-1, len(r.order))
+		r.reindexLocked()
+		r.mu.Unlock()
+		return nil, res, fmt.Errorf("restore %s: persist entry: %w", id, perr)
+	}
+	r.persistIndexLoggedLocked("restore")
+	info := e.Info()
+	r.mu.Unlock()
+
+	// The entry exists and is visible before the PTY forks, so a client
+	// sees the tile come back immediately rather than after the spawn.
+	r.broadcast(wire.SessionEventAdded, info)
+
+	// The tombstone has done its job. Drop it before the revive so a
+	// spawn failure can't leave a record that would restore a second
+	// copy of a session that is already in the map.
+	r.discardTombstone(id)
+
+	if rerr := r.Revive(id, opts); rerr != nil {
+		// The entry stays: a session whose agent failed to spawn is an
+		// ordinary dead tile the user can restart, which is strictly
+		// better than silently undoing the undo.
+		log.Printf("registry: restore %s: revive failed: %v", id, rerr)
+	}
+
+	r.mu.Lock()
+	e = r.entries[id]
+	r.mu.Unlock()
+	return e, res, nil
+}
+
+// resolveRestoreWorktree decides what worktree, if any, the restored
+// entry gets. Returns the path and branch to bind, both "" when the
+// session comes back without one.
+//
+// Mirrors disposeWorktree's paranoia in reverse: it will re-adopt a
+// directory that is still there, and it will recreate one from its
+// surviving branch, but it never creates a worktree at a path outside
+// hive's managed directory.
+func (r *Registry) resolveRestoreWorktree(id, projectCwd string, t Tombstone, res *RestoreResult) (string, string) {
+	wtPath, wtBranch := t.Meta.WorktreePath, t.Meta.WorktreeBranch
+	if wtPath == "" {
+		return "", ""
+	}
+
+	// Still on disk — whether because the close kept it (dirty, or
+	// shared with a sibling) or because the delete was refused. Adopt
+	// it as-is. A sibling already living there is fine and expected:
+	// duplicated sessions legitimately share one worktree.
+	if _, err := os.Stat(wtPath); err == nil {
+		return wtPath, wtBranch
+	}
+
+	r.gitMu.Lock()
+	defer r.gitMu.Unlock()
+
+	root, err := worktree.Root(projectCwd)
+	if err != nil {
+		log.Printf("registry: restore %s: project cwd %q is not a git repo; restoring without a worktree", id, projectCwd)
+		res.WorktreeLost = true
+		return "", ""
+	}
+	// Never materialize a directory outside the managed namespace. The
+	// path came off disk and this is the last guard before a mkdir.
+	if !worktree.IsManaged(root, wtPath) {
+		log.Printf("registry: restore %s: %s is not a hive-managed worktree of %s; restoring without a worktree", id, wtPath, root)
+		res.WorktreeLost = true
+		return "", ""
+	}
+	if wtBranch == "" || !worktree.BranchExists(root, wtBranch) {
+		log.Printf("registry: restore %s: branch %q is gone; restoring without a worktree", id, wtBranch)
+		res.WorktreeLost = true
+		return "", ""
+	}
+	if err := worktree.CreateWorktree(context.Background(), root, wtBranch, wtPath); err != nil {
+		log.Printf("registry: restore %s: could not recreate worktree %s on %s: %v", id, wtPath, wtBranch, err)
+		res.WorktreeLost = true
+		return "", ""
+	}
+	worktree.LinkAgentConfig(root, wtPath)
+	// Committed work is back; anything uncommitted at close time is
+	// not, and only the recovery patch (if one fit) can return it.
+	res.WorktreeRecreated = true
+	return wtPath, wtBranch
+}

--- a/internal/registry/closed.go
+++ b/internal/registry/closed.go
@@ -156,13 +156,49 @@ func (r *Registry) dumpRecoveryPatch(id, wtPath string) (patchPath string, skipp
 // on, and failing the restore with a JSON error helps nobody.
 func (r *Registry) readTombstone(id string) (Tombstone, error) {
 	var t Tombstone
+	// The id arrives off the wire and is about to be joined into a
+	// path that discardTombstone will later os.Remove. Kill() is
+	// protected incidentally — it looks its id up in r.entries first,
+	// so only known ids ever reach a path — but Restore builds the
+	// path from the raw string, so the guard has to be explicit here.
+	// The socket is local and user-owned, which bounds the impact; it
+	// does not make an unvalidated path join at a trust boundary OK.
+	if !validSessionID(id) {
+		return t, ErrNotFound
+	}
 	if err := readJSON(r.tombstonePath(id), &t); err != nil {
 		return t, ErrNotFound
 	}
 	if t.Meta.ID == "" {
 		return t, ErrNotFound
 	}
+	// The file's own id must match the one we were asked for. A
+	// mismatch means the store is inconsistent, and restoring under
+	// the wrong id would then delete the wrong tombstone.
+	if t.Meta.ID != id {
+		return t, ErrNotFound
+	}
 	return t, nil
+}
+
+// validSessionID reports whether id is safe to use as a path segment.
+// Session ids are generated UUIDs, so this is deliberately stricter
+// than "no separators": anything outside the UUID alphabet is rejected
+// rather than escaped, because there is no legitimate caller that
+// needs it.
+func validSessionID(id string) bool {
+	if id == "" || len(id) > 128 {
+		return false
+	}
+	for _, c := range id {
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9', c == '-', c == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // listTombstones returns every readable tombstone, newest close first.
@@ -223,7 +259,14 @@ func (r *Registry) pruneTombstones() {
 }
 
 // discardTombstone removes a record and any recovery patch beside it.
+// Callers reach this only after readTombstone or listTombstones has
+// vouched for the id, but it re-checks: this is the function that
+// removes files, and it is one line to make that independent of who
+// calls it.
 func (r *Registry) discardTombstone(id string) {
+	if !validSessionID(id) {
+		return
+	}
 	if err := os.Remove(r.tombstonePath(id)); err != nil && !os.IsNotExist(err) {
 		log.Printf("registry: could not remove tombstone %s: %v", id, err)
 	}

--- a/internal/registry/closed_test.go
+++ b/internal/registry/closed_test.go
@@ -132,9 +132,67 @@ func TestRestoreTwiceSecondFails(t *testing.T) {
 	}
 	defer r.Kill(id, true)
 
+	// Specifically ErrNotFound, not "either error": a successful
+	// restore deletes the tombstone, and Restore reads the tombstone
+	// before it checks the live map, so ErrNotFound is the only
+	// reachable outcome here. Accepting ErrExists too would let this
+	// test pass while the ordering silently changed.
 	_, _, err := r.Restore(id, shellOpts())
-	if !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrExists) {
-		t.Errorf("second Restore err = %v, want ErrNotFound or ErrExists", err)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("second Restore err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestRestoreRefusesWhenIdIsLive covers the ErrExists branch, which no
+// ordinary sequence reaches: a successful restore removes the
+// tombstone, so the live-map check only fires when a tombstone and a
+// live entry exist for the same id at once. Hand-build that state —
+// otherwise the guard is dead code that nothing proves works.
+func TestRestoreRefusesWhenIdIsLive(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	e := createShell(t, r)
+	id := e.ID
+	defer r.Kill(id, true)
+
+	writeTestTombstone(t, r, id, time.Now().UTC())
+
+	_, _, err := r.Restore(id, shellOpts())
+	if !errors.Is(err, ErrExists) {
+		t.Fatalf("Restore of a live id = %v, want ErrExists", err)
+	}
+	// The refusal must not have taken the tombstone with it: this
+	// close is still undoable once the live session goes away.
+	if _, rerr := r.readTombstone(id); rerr != nil {
+		t.Errorf("a refused restore discarded the tombstone: %v", rerr)
+	}
+}
+
+// TestRestoreRejectsTraversalIds pins the path guard. The id is joined
+// into a filename that a successful restore later removes, so a
+// separator or a `..` must never reach the filesystem.
+func TestRestoreRejectsTraversalIds(t *testing.T) {
+	r := freshRegistry(t)
+	// A real tombstone the traversal ids must not be able to reach.
+	writeTestTombstone(t, r, "victim", time.Now().UTC())
+
+	for _, id := range []string{
+		"../victim",
+		"../../etc/passwd",
+		"a/b",
+		`a\b`,
+		"..",
+		"",
+	} {
+		t.Run(id, func(t *testing.T) {
+			if _, _, err := r.Restore(id, shellOpts()); !errors.Is(err, ErrNotFound) {
+				t.Errorf("Restore(%q) = %v, want ErrNotFound", id, err)
+			}
+		})
+	}
+	// Nothing above may have deleted the real record.
+	if _, err := r.readTombstone("victim"); err != nil {
+		t.Errorf("a traversal id removed an unrelated tombstone: %v", err)
 	}
 }
 

--- a/internal/registry/closed_test.go
+++ b/internal/registry/closed_test.go
@@ -1,0 +1,623 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lucascaro/hive/internal/session"
+	"github.com/lucascaro/hive/internal/wire"
+	"github.com/lucascaro/hive/internal/worktree"
+)
+
+// shellOpts is the spawn config every test here reuses. Restore takes
+// the same session.Options the daemon hands Revive on boot.
+func shellOpts() session.Options {
+	return session.Options{Shell: "/bin/bash", Cols: 80, Rows: 24}
+}
+
+// createShell makes a plain session in the default project.
+func createShell(t *testing.T, r *Registry) *Entry {
+	t.Helper()
+	if _, err := r.EnsureDefaultProject(t.TempDir()); err != nil {
+		t.Fatalf("EnsureDefaultProject: %v", err)
+	}
+	e, err := r.Create(context.Background(), wire.CreateSpec{Shell: "/bin/bash"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	return e
+}
+
+func TestKillWritesTombstone(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	e := createShell(t, r)
+	id, name, color := e.ID, e.Name, e.Color
+
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	tomb, err := r.readTombstone(id)
+	if err != nil {
+		t.Fatalf("readTombstone after Kill: %v", err)
+	}
+	if tomb.Meta.ID != id || tomb.Meta.Name != name || tomb.Meta.Color != color {
+		t.Errorf("tombstone meta = %+v, want id/name/color %q/%q/%q", tomb.Meta, id, name, color)
+	}
+	if tomb.ClosedAt.IsZero() {
+		t.Error("tombstone ClosedAt is zero")
+	}
+}
+
+func TestRestoreRebuildsEntry(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	e := createShell(t, r)
+	id, name, color, created := e.ID, e.Name, e.Color, e.Created
+
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if r.Get(id) != nil {
+		t.Fatal("entry still present after Kill")
+	}
+
+	got, res, err := r.Restore(id, shellOpts())
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	if got == nil {
+		t.Fatal("Restore returned a nil entry")
+	}
+	if got.ID != id || got.Name != name || got.Color != color {
+		t.Errorf("restored entry = %q/%q/%q, want %q/%q/%q", got.ID, got.Name, got.Color, id, name, color)
+	}
+	if !got.Created.Equal(created) {
+		t.Errorf("Created = %v, want %v (the original creation time, not the restore time)", got.Created, created)
+	}
+	// A plain shell has no agent conversation, so nothing is degraded.
+	if !res.Clean() {
+		t.Errorf("restoring a plain shell should be a clean undo, got %+v", res)
+	}
+	// It must be back in the list, not merely in the map.
+	var found bool
+	for _, info := range r.List() {
+		if info.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("restored session missing from List()")
+	}
+}
+
+func TestRestoreDropsTheTombstone(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	e := createShell(t, r)
+	id := e.ID
+
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if _, _, err := r.Restore(id, shellOpts()); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	if _, err := r.readTombstone(id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("tombstone survived a successful restore (err=%v); a second undo would duplicate the session", err)
+	}
+}
+
+func TestRestoreTwiceSecondFails(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	e := createShell(t, r)
+	id := e.ID
+
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if _, _, err := r.Restore(id, shellOpts()); err != nil {
+		t.Fatalf("first Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	_, _, err := r.Restore(id, shellOpts())
+	if !errors.Is(err, ErrNotFound) && !errors.Is(err, ErrExists) {
+		t.Errorf("second Restore err = %v, want ErrNotFound or ErrExists", err)
+	}
+}
+
+func TestRestoreMissingTombstoneNotFound(t *testing.T) {
+	r := freshRegistry(t)
+	if _, _, err := r.Restore("nope", shellOpts()); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Restore of unknown id = %v, want ErrNotFound", err)
+	}
+}
+
+func TestRestoreAppendsToEndOfOrder(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	first := createShell(t, r)
+	second := createShell(t, r)
+	third := createShell(t, r)
+	defer r.Kill(second.ID, true)
+	defer r.Kill(third.ID, true)
+
+	// Close the FIRST one, so a restore that used the remembered Order
+	// would splice it back to the head.
+	if err := r.Kill(first.ID, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if _, _, err := r.Restore(first.ID, shellOpts()); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(first.ID, true)
+
+	list := r.List()
+	if len(list) != 3 {
+		t.Fatalf("List has %d sessions, want 3", len(list))
+	}
+	if list[len(list)-1].ID != first.ID {
+		t.Errorf("restored session is at position %v, want last; order = %v", list, listIDs(list))
+	}
+	// Order values must be a dense 0..n-1 after the reindex.
+	for i, info := range list {
+		if info.Order != i {
+			t.Errorf("session %d has Order %d, want %d (reindex did not run)", i, info.Order, i)
+		}
+	}
+}
+
+func listIDs(infos []wire.SessionInfo) []string {
+	out := make([]string, 0, len(infos))
+	for _, i := range infos {
+		out = append(out, i.ID)
+	}
+	return out
+}
+
+func TestRestoreIntoDefaultProjectWhenProjectGone(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	if _, err := r.EnsureDefaultProject(t.TempDir()); err != nil {
+		t.Fatalf("EnsureDefaultProject: %v", err)
+	}
+	doomed, err := r.CreateProject(wire.CreateProjectReq{Name: "doomed", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	e, err := r.Create(context.Background(), wire.CreateSpec{ProjectID: doomed.ID, Shell: "/bin/bash"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := e.ID
+
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if err := r.KillProject(doomed.ID, true); err != nil {
+		t.Fatalf("KillProject: %v", err)
+	}
+
+	got, res, err := r.Restore(id, shellOpts())
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	if got.ProjectID == doomed.ID {
+		t.Error("restored into the deleted project; that is a dangling reference")
+	}
+	if !res.ProjectReassigned {
+		t.Error("ProjectReassigned not reported; the UI would claim a clean undo")
+	}
+}
+
+func TestRestoreReattachesSurvivingWorktree(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	e, err := r.Create(context.Background(), wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id, wtPath, wtBranch := e.ID, e.WorktreePath, e.WorktreeBranch
+	if wtPath == "" {
+		t.Skip("worktree creation unavailable in this environment")
+	}
+	// Dirty it, so the ordinary close keeps the directory.
+	mustWriteFile(t, filepath.Join(wtPath, "scratch.txt"), "work in progress\n")
+
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if _, statErr := os.Stat(wtPath); statErr != nil {
+		t.Fatalf("closing a session with a dirty worktree deleted it: %v", statErr)
+	}
+
+	got, res, err := r.Restore(id, shellOpts())
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	if got.WorktreePath != wtPath || got.WorktreeBranch != wtBranch {
+		t.Errorf("worktree binding = %q/%q, want %q/%q", got.WorktreePath, got.WorktreeBranch, wtPath, wtBranch)
+	}
+	if res.WorktreeRecreated || res.WorktreeLost {
+		t.Errorf("an intact worktree should be adopted as-is, got %+v", res)
+	}
+	// The uncommitted file is still there — nothing deleted it.
+	if _, err := os.Stat(filepath.Join(wtPath, "scratch.txt")); err != nil {
+		t.Errorf("uncommitted work vanished across close+restore: %v", err)
+	}
+}
+
+func TestRestoreRecreatesWorktreeFromBranch(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	e, err := r.Create(context.Background(), wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id, wtPath, wtBranch := e.ID, e.WorktreePath, e.WorktreeBranch
+	if wtPath == "" {
+		t.Skip("worktree creation unavailable in this environment")
+	}
+	// Commit something so there is work to prove came back.
+	mustWriteFile(t, filepath.Join(wtPath, "committed.txt"), "kept\n")
+	runGit(t, wtPath, "add", "committed.txt")
+	runGit(t, wtPath, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "work")
+
+	// Explicitly destructive close: deletes the worktree directory.
+	if err := r.KillAndRemoveWorktree(id, true); err != nil {
+		t.Fatalf("KillAndRemoveWorktree: %v", err)
+	}
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		t.Fatal("worktree still on disk after an explicit delete")
+	}
+
+	got, res, err := r.Restore(id, shellOpts())
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	if got.WorktreePath != wtPath {
+		t.Fatalf("worktree not recreated at %q, got %q", wtPath, got.WorktreePath)
+	}
+	if !res.WorktreeRecreated {
+		t.Error("WorktreeRecreated not reported; the UI would not warn about lost uncommitted work")
+	}
+	if got.WorktreeBranch != wtBranch {
+		t.Errorf("branch = %q, want %q", got.WorktreeBranch, wtBranch)
+	}
+	// Committed work is back; that is the whole point of recreating
+	// from the branch rather than starting fresh.
+	if _, err := os.Stat(filepath.Join(wtPath, "committed.txt")); err != nil {
+		t.Errorf("committed work did not come back: %v", err)
+	}
+}
+
+func TestRestoreWithoutWorktreeWhenBranchGone(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	e, err := r.Create(context.Background(), wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id, wtPath, wtBranch := e.ID, e.WorktreePath, e.WorktreeBranch
+	if wtPath == "" {
+		t.Skip("worktree creation unavailable in this environment")
+	}
+	if err := r.KillAndRemoveWorktree(id, true); err != nil {
+		t.Fatalf("KillAndRemoveWorktree: %v", err)
+	}
+	runGit(t, p.Cwd, "branch", "-D", wtBranch)
+
+	got, res, err := r.Restore(id, shellOpts())
+	if err != nil {
+		t.Fatalf("Restore should degrade, not fail: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	if got.WorktreePath != "" {
+		t.Errorf("WorktreePath = %q, want empty when the branch is gone", got.WorktreePath)
+	}
+	if !res.WorktreeLost {
+		t.Error("WorktreeLost not reported")
+	}
+}
+
+func TestRestoreRefusesUnmanagedWorktreePath(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+	e := createShellIn(t, r, p)
+	id := e.ID
+
+	// Point the tombstone at a path outside hive's managed directory
+	// that does not exist. Restore must never materialize a directory
+	// there — the path came off disk and is not trusted.
+	outside := filepath.Join(t.TempDir(), "not-hive-managed")
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	tomb, err := r.readTombstone(id)
+	if err != nil {
+		t.Fatalf("readTombstone: %v", err)
+	}
+	tomb.Meta.WorktreePath = outside
+	tomb.Meta.WorktreeBranch = "main"
+	if err := writeJSON(r.tombstonePath(id), tomb); err != nil {
+		t.Fatalf("rewrite tombstone: %v", err)
+	}
+
+	got, res, err := r.Restore(id, shellOpts())
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+
+	if got.WorktreePath != "" {
+		t.Errorf("adopted an unmanaged path %q", got.WorktreePath)
+	}
+	if _, statErr := os.Stat(outside); statErr == nil {
+		t.Errorf("restore created a directory outside the managed namespace at %q", outside)
+	}
+	if !res.WorktreeLost {
+		t.Error("WorktreeLost not reported")
+	}
+}
+
+// createShellIn makes a plain (worktree-less) session in project p.
+func createShellIn(t *testing.T, r *Registry, p *Project) *Entry {
+	t.Helper()
+	e, err := r.Create(context.Background(), wire.CreateSpec{ProjectID: p.ID, Shell: "/bin/bash"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	return e
+}
+
+func TestKillDumpsPatchBeforeWorktreeDelete(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	e, err := r.Create(context.Background(), wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id, wtPath := e.ID, e.WorktreePath
+	if wtPath == "" {
+		t.Skip("worktree creation unavailable in this environment")
+	}
+	// One tracked modification and one untracked file — the patch has
+	// to carry both or it is not a recovery.
+	runGit(t, wtPath, "-c", "user.email=t@t", "-c", "user.name=t",
+		"commit", "--allow-empty", "-q", "-m", "base")
+	mustWriteFile(t, filepath.Join(wtPath, "tracked.txt"), "v1\n")
+	runGit(t, wtPath, "add", "tracked.txt")
+	runGit(t, wtPath, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "add tracked")
+	mustWriteFile(t, filepath.Join(wtPath, "tracked.txt"), "v2-uncommitted\n")
+	mustWriteFile(t, filepath.Join(wtPath, "untracked.txt"), "brand new\n")
+
+	if err := r.KillAndRemoveWorktree(id, true); err != nil {
+		t.Fatalf("KillAndRemoveWorktree: %v", err)
+	}
+
+	tomb, err := r.readTombstone(id)
+	if err != nil {
+		t.Fatalf("readTombstone: %v", err)
+	}
+	if tomb.PatchPath == "" {
+		t.Fatal("no recovery patch recorded; deleting a dirty worktree lost work with no trace")
+	}
+	body, err := os.ReadFile(tomb.PatchPath)
+	if err != nil {
+		t.Fatalf("read recovery patch: %v", err)
+	}
+	if !strings.Contains(string(body), "v2-uncommitted") {
+		t.Error("patch is missing the tracked modification")
+	}
+	if !strings.Contains(string(body), "untracked.txt") {
+		t.Error("patch is missing the untracked file")
+	}
+
+	// And the restore surfaces it rather than making the user hunt.
+	_, res, err := r.Restore(id, shellOpts())
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	defer r.Kill(id, true)
+	if res.PatchPath != tomb.PatchPath {
+		t.Errorf("RestoreResult.PatchPath = %q, want %q", res.PatchPath, tomb.PatchPath)
+	}
+}
+
+func TestKillWritesNoPatchWhenWorktreeIsClean(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	e, err := r.Create(context.Background(), wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id := e.ID
+	if e.WorktreePath == "" {
+		t.Skip("worktree creation unavailable in this environment")
+	}
+
+	if err := r.KillAndRemoveWorktree(id, true); err != nil {
+		t.Fatalf("KillAndRemoveWorktree: %v", err)
+	}
+	tomb, err := r.readTombstone(id)
+	if err != nil {
+		t.Fatalf("readTombstone: %v", err)
+	}
+	if tomb.PatchPath != "" {
+		t.Errorf("wrote a recovery patch for a clean worktree (%q); it would recover nothing", tomb.PatchPath)
+	}
+	if tomb.PatchSkipped {
+		t.Error("PatchSkipped set for a clean worktree; that claims work was at stake")
+	}
+}
+
+func TestPatchSkippedAboveCap(t *testing.T) {
+	skipNonPosix(t)
+	repo := initGitRepo(t)
+	// Two files whose combined diff comfortably exceeds a 1 KiB cap.
+	mustWriteFile(t, filepath.Join(repo, "big.txt"), strings.Repeat("padding line\n", 500))
+	out := filepath.Join(t.TempDir(), "recovery.patch")
+
+	err := worktree.DumpPatch(repo, out, 1024)
+	if !errors.Is(err, worktree.ErrPatchTooLarge) {
+		t.Fatalf("DumpPatch err = %v, want ErrPatchTooLarge", err)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("an over-cap dump still wrote a file; a truncated patch is worse than none")
+	}
+}
+
+func TestPatchDumpFailureDoesNotBlockClose(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	if _, err := r.EnsureDefaultProject(t.TempDir()); err != nil {
+		t.Fatalf("EnsureDefaultProject: %v", err)
+	}
+	// A non-git project: the entry gets no worktree, so the dump path
+	// is skipped entirely and the close must still complete.
+	e := createShell(t, r)
+	id := e.ID
+	if err := r.KillAndRemoveWorktree(id, true); err != nil {
+		t.Fatalf("close failed when no patch could be taken: %v", err)
+	}
+	if _, err := r.readTombstone(id); err != nil {
+		t.Errorf("no tombstone written: %v", err)
+	}
+}
+
+func TestTombstonePruneKeepsLastNAndSevenDays(t *testing.T) {
+	r := freshRegistry(t)
+
+	// One more than the count bound, all recent.
+	for i := range maxTombstones + 5 {
+		id := "recent-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		writeTestTombstone(t, r, id, time.Now().UTC().Add(-time.Duration(i)*time.Minute))
+	}
+	// One well inside the count bound but older than the age bound.
+	writeTestTombstone(t, r, "ancient", time.Now().UTC().Add(-8*24*time.Hour))
+
+	r.pruneTombstones()
+
+	got := r.listTombstones()
+	if len(got) > maxTombstones {
+		t.Errorf("prune left %d tombstones, want at most %d", len(got), maxTombstones)
+	}
+	for _, tomb := range got {
+		if tomb.Meta.ID == "ancient" {
+			t.Error("prune kept a tombstone older than the age bound")
+		}
+	}
+	// Newest survives — pruning must not evict the one thing undo needs.
+	if len(got) == 0 || got[0].Meta.ID != "recent-aa" {
+		t.Errorf("newest tombstone did not survive the prune; got %v", got)
+	}
+}
+
+func TestPruneRemovesTheRecoveryPatchToo(t *testing.T) {
+	r := freshRegistry(t)
+	writeTestTombstone(t, r, "old", time.Now().UTC().Add(-8*24*time.Hour))
+	patch := r.patchPath("old")
+	if err := os.WriteFile(patch, []byte("diff --git a/x b/x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r.pruneTombstones()
+
+	if _, err := os.Stat(patch); err == nil {
+		t.Error("prune dropped the tombstone but left its recovery patch behind, leaking disk forever")
+	}
+}
+
+func writeTestTombstone(t *testing.T, r *Registry, id string, closedAt time.Time) {
+	t.Helper()
+	tomb := Tombstone{Meta: MetaFile{ID: id, Name: id}, ClosedAt: closedAt}
+	if err := writeJSON(r.tombstonePath(id), tomb); err != nil {
+		t.Fatalf("write tombstone %s: %v", id, err)
+	}
+}
+
+func TestOrphanReclaimSkipsTombstonedWorktree(t *testing.T) {
+	skipNonPosix(t)
+	r, p := freshRegistryWithProject(t)
+
+	e, err := r.Create(context.Background(), wire.CreateSpec{
+		ProjectID: p.ID, Shell: "/bin/bash", UseWorktree: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	id, wtPath := e.ID, e.WorktreePath
+	if wtPath == "" {
+		t.Skip("worktree creation unavailable in this environment")
+	}
+	// Dirty it so the ordinary close keeps the directory, leaving
+	// exactly the shape boot-time reclaim would find: a worktree on
+	// disk that no live session claims.
+	mustWriteFile(t, filepath.Join(wtPath, "wip.txt"), "unfinished\n")
+	if err := r.Kill(id, true); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	if !r.worktreeClaimed(wtPath) {
+		t.Fatal("a tombstoned worktree reads as unclaimed; boot reclaim would delete what the user can still undo into")
+	}
+
+	// And the full scan+reclaim leaves it alone.
+	r.ReclaimOrphanWorktrees(context.Background(), r.ScanOrphanWorktrees())
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Errorf("orphan reclaim deleted a tombstoned worktree: %v", err)
+	}
+}
+
+func TestListClosedIsNewestFirst(t *testing.T) {
+	r := freshRegistry(t)
+	now := time.Now().UTC()
+	writeTestTombstone(t, r, "older", now.Add(-time.Hour))
+	writeTestTombstone(t, r, "newest", now)
+	writeTestTombstone(t, r, "middle", now.Add(-time.Minute))
+
+	got := r.ListClosed()
+	if len(got) != 3 {
+		t.Fatalf("ListClosed returned %d, want 3", len(got))
+	}
+	want := []string{"newest", "middle", "older"}
+	for i, w := range want {
+		if got[i].SessionID != w {
+			t.Errorf("position %d = %q, want %q (reopen-last would pick the wrong session)", i, got[i].SessionID, w)
+		}
+	}
+}

--- a/internal/registry/projects.go
+++ b/internal/registry/projects.go
@@ -210,16 +210,25 @@ func (r *Registry) reclaimOne(root, path string) {
 }
 
 // worktreeClaimed reports whether any registry entry currently owns
-// the worktree directory at path.
+// the worktree directory at path — or whether a recently closed
+// session can still be restored into it.
+//
+// The tombstone half matters because boot-time orphan reclaim deletes
+// pristine *unclaimed* worktrees, and a tombstoned worktree is
+// unclaimed by definition. Without this, a worktree the user could
+// still undo into would be deleted at startup: silently, with no
+// confirm, before they ever saw the window.
 func (r *Registry) worktreeClaimed(path string) bool {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	for _, e := range r.entries {
 		if e.WorktreePath == path {
+			r.mu.Unlock()
 			return true
 		}
 	}
-	return false
+	r.mu.Unlock()
+	// Reads the closed/ directory, so deliberately outside r.mu.
+	return r.tombstoneClaimsWorktree(path)
 }
 
 // MigrateOrphanSessions assigns any session without a ProjectID to

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -818,6 +818,21 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 			return ErrWorktreeDirty
 		}
 	}
+	// Past the pre-flight, so this close is really happening. Capture
+	// the uncommitted state of a worktree we have been told to delete
+	// BEFORE anything is torn down — this is the one close path that
+	// destroys work, and the patch is the only way back from it.
+	//
+	// Outside r.mu: it shells out to git several times. Best-effort by
+	// construction; a failed backup never vetoes the close.
+	tomb := Tombstone{
+		WorktreeRemoveRequested: removeWorktree,
+		WorktreeShared:          worktreeShared,
+	}
+	if removeWorktree && wtPath != "" && !worktreeShared {
+		tomb.PatchPath, tomb.PatchSkipped = r.dumpRecoveryPatch(id, wtPath)
+	}
+
 	// Announce the teardown while the entry still exists: after the
 	// delete below there is nothing left for List() to return, so a
 	// client connecting mid-kill would otherwise see nothing at all.
@@ -831,6 +846,12 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 		r.mu.Unlock()
 		return ErrNotFound
 	}
+	// Record the close before anything is destroyed — in memory or on
+	// disk — so a crash anywhere below still leaves an undoable trace.
+	// Under r.mu, alongside the index persist a few lines down: it is
+	// one small atomic write, and the entry it describes must not
+	// change between reading it and writing it.
+	r.writeTombstoneLocked(e, tomb)
 	delete(r.entries, id)
 	for i, sid := range r.order {
 		if sid == id {
@@ -884,6 +905,10 @@ func (r *Registry) kill(id string, force, removeWorktree bool) error {
 	for _, info := range r.List() {
 		r.broadcast(wire.SessionEventUpdated, info)
 	}
+	// Last, and outside every lock: enforce the tombstone retention
+	// bounds. Doing it after the broadcast keeps the close's visible
+	// latency independent of how many old records need sweeping.
+	r.pruneTombstones()
 	return nil
 }
 

--- a/internal/wire/client.go
+++ b/internal/wire/client.go
@@ -115,6 +115,9 @@ var controlEvents = map[FrameType]string{
 	FrameProjectEvent: "project:event",
 	FrameWorktrees:    "worktree:list",
 	FrameError:        "control:error",
+
+	FrameClosed:          "closed:list",
+	FrameSessionRestored: "session:restored",
 }
 
 var attachEvents = map[FrameType]string{

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -184,6 +184,72 @@ type KillSessionReq struct {
 	RemoveWorktree bool `json:"remove_worktree,omitempty"`
 }
 
+// RestoreSessionReq is the RESTORE_SESSION payload. SessionID is the
+// id of a session closed earlier; empty means "the most recently
+// closed one", which is what the reopen-last affordance sends so the
+// client does not have to LIST_CLOSED first and then race a prune.
+type RestoreSessionReq struct {
+	SessionID string `json:"session_id,omitempty"`
+}
+
+// ListClosedReq is the LIST_CLOSED payload.
+type ListClosedReq struct{}
+
+// ClosedResp is the CLOSED payload: the sessions that can still be
+// reopened, most recently closed first.
+type ClosedResp struct {
+	Closed []ClosedSessionInfo `json:"closed"`
+}
+
+// ClosedSessionInfo describes one restorable session. Deliberately
+// thinner than SessionInfo — nothing here is live, so there is no
+// phase, no alive flag and no title to report.
+type ClosedSessionInfo struct {
+	SessionID      string `json:"session_id"`
+	Name           string `json:"name"`
+	Color          string `json:"color,omitempty"`
+	Agent          string `json:"agent,omitempty"`
+	ProjectID      string `json:"project_id,omitempty"`
+	WorktreeBranch string `json:"worktree_branch,omitempty"`
+	ClosedAt       string `json:"closed_at"`
+	// HasPatch reports that a recovery patch of the worktree's
+	// uncommitted state was saved when this session was closed.
+	HasPatch bool `json:"has_patch,omitempty"`
+}
+
+// RestoredResp is the SESSION_RESTORED payload: what the restore could
+// NOT bring back. Sent after the session's "added" event so a client
+// can render the tile first and then explain the gaps.
+//
+// Every field is a degradation, so an all-false payload means a clean
+// undo. Scrollback is absent from this list because it is never
+// restorable — the UI says so unconditionally rather than per-restore.
+type RestoredResp struct {
+	SessionID string `json:"session_id"`
+	// ProjectReassigned: the original project was deleted, so the
+	// session came back in the default project.
+	ProjectReassigned bool `json:"project_reassigned,omitempty"`
+	// WorktreeRecreated: the directory was gone and was rebuilt from
+	// the surviving branch. Committed work is back; uncommitted is not.
+	WorktreeRecreated bool `json:"worktree_recreated,omitempty"`
+	// WorktreeLost: no worktree could be restored; the session runs in
+	// the project directory instead.
+	WorktreeLost bool `json:"worktree_lost,omitempty"`
+	// ConversationLost: the agent had no pinned conversation id, so it
+	// came back as a fresh conversation.
+	ConversationLost bool `json:"conversation_lost,omitempty"`
+	// AgentFellBack: the session's agent is no longer in the catalog
+	// (a custom agent deleted since), so it came back as a shell.
+	AgentFellBack bool `json:"agent_fell_back,omitempty"`
+	// PatchPath is where the recovery patch for a deleted worktree was
+	// saved, "" when there is none.
+	PatchPath string `json:"patch_path,omitempty"`
+	// PatchSkipped: there WAS uncommitted work at close time but it
+	// exceeded the patch cap and was not saved. Distinct from an empty
+	// PatchPath, which means nothing was at stake.
+	PatchSkipped bool `json:"patch_skipped,omitempty"`
+}
+
 // RestartSessionReq is the RESTART_SESSION payload. The daemon
 // terminates the agent process in place (preserving the session
 // entry, its name/color/order/worktree) and respawns it using the

--- a/internal/wire/frame.go
+++ b/internal/wire/frame.go
@@ -97,6 +97,18 @@ const (
 	// still has a worktree goes through REMOVE_WORKTREE instead, so the
 	// directory and the ref never get out of step.
 	FrameDeleteBranch FrameType = 0x1b // C → S, JSON, control
+
+	// Undo-close. A kill leaves a tombstone in the daemon's state dir;
+	// RESTORE_SESSION rebuilds the entry from it and revives the agent,
+	// and LIST_CLOSED reports what is still restorable. The daemon
+	// answers LIST_CLOSED with FrameClosed, and answers a restore with
+	// the ordinary SESSION_EVENT stream (the restored entry arrives as
+	// an "added" event like any other) plus FrameClosed so the client's
+	// reopen list is current without a second request.
+	FrameRestoreSession  FrameType = 0x1c // C → S, JSON, control
+	FrameListClosed      FrameType = 0x1d // C → S, JSON, control
+	FrameClosed          FrameType = 0x1e // S → C, JSON, control
+	FrameSessionRestored FrameType = 0x1f // S → C, JSON, control
 )
 
 func (t FrameType) String() string {
@@ -155,6 +167,14 @@ func (t FrameType) String() string {
 		return "RENAME_WORKTREE"
 	case FrameDeleteBranch:
 		return "DELETE_BRANCH"
+	case FrameRestoreSession:
+		return "RESTORE_SESSION"
+	case FrameListClosed:
+		return "LIST_CLOSED"
+	case FrameClosed:
+		return "CLOSED"
+	case FrameSessionRestored:
+		return "SESSION_RESTORED"
 	default:
 		return fmt.Sprintf("UNKNOWN(0x%02x)", byte(t))
 	}

--- a/internal/wire/testclient/client.go
+++ b/internal/wire/testclient/client.go
@@ -114,6 +114,64 @@ func (c *Client) ListSessions() error {
 	return c.cli.WriteJSON(wire.FrameListSessions, wire.ListSessionsReq{})
 }
 
+// KillSession sends KILL_SESSION.
+func (c *Client) KillSession(req wire.KillSessionReq) error {
+	return c.cli.WriteJSON(wire.FrameKillSession, req)
+}
+
+// RestoreSession sends RESTORE_SESSION. An empty id asks the daemon
+// for the most recently closed session. Use AwaitSessionRestored to
+// consume the degradation report, or AwaitControlError for a refusal.
+func (c *Client) RestoreSession(req wire.RestoreSessionReq) error {
+	return c.cli.WriteJSON(wire.FrameRestoreSession, req)
+}
+
+// ListClosedSessions sends LIST_CLOSED. Use AwaitClosed to consume
+// the response.
+func (c *Client) ListClosedSessions() error {
+	return c.cli.WriteJSON(wire.FrameListClosed, wire.ListClosedReq{})
+}
+
+// AwaitClosed consumes the next CLOSED snapshot.
+func (c *Client) AwaitClosed(timeout time.Duration) (wire.ClosedResp, error) {
+	var resp wire.ClosedResp
+	err := c.awaitSnapshot(wire.FrameClosed, "CLOSED", timeout, &resp)
+	return resp, err
+}
+
+// AwaitSessionRestored consumes the next SESSION_RESTORED frame — the
+// report of what a restore could not bring back.
+func (c *Client) AwaitSessionRestored(timeout time.Duration) (wire.RestoredResp, error) {
+	var resp wire.RestoredResp
+	err := c.awaitSnapshot(wire.FrameSessionRestored, "SESSION_RESTORED", timeout, &resp)
+	return resp, err
+}
+
+// awaitSnapshot drains the snapshot channel until the wanted frame
+// type arrives and unmarshals it into out. Control mode interleaves
+// several unsolicited snapshots (PROJECTS, SESSIONS, CLOSED), so
+// every await has to skip past the ones it did not ask for.
+func (c *Client) awaitSnapshot(want wire.FrameType, name string, timeout time.Duration, out any) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("testclient: timeout waiting for %s", name)
+		}
+		select {
+		case msg := <-c.snaps:
+			if msg.t != want {
+				continue
+			}
+			return json.Unmarshal(msg.payload, out)
+		case err := <-c.errs:
+			return err
+		case <-time.After(remaining):
+			return fmt.Errorf("testclient: timeout waiting for %s", name)
+		}
+	}
+}
+
 // ListWorktrees sends LIST_WORKTREES. Use AwaitWorktrees to consume
 // the response.
 func (c *Client) ListWorktrees(projectID string) error {

--- a/internal/worktree/patch.go
+++ b/internal/worktree/patch.go
@@ -1,0 +1,132 @@
+package worktree
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ErrPatchTooLarge is returned by DumpPatch when the recovery patch
+// would exceed the caller's cap. The output file is not written.
+var ErrPatchTooLarge = errors.New("worktree: recovery patch exceeds cap")
+
+// BranchExists reports whether refs/heads/<branch> exists in repoDir.
+// Exported wrapper over the internal probe so the registry can decide
+// whether a deleted worktree is recreatable from its branch.
+func BranchExists(repoDir, branch string) bool {
+	if repoDir == "" || branch == "" {
+		return false
+	}
+	return branchExists(context.Background(), repoDir, branch)
+}
+
+// DumpPatch writes a `git apply`-able patch of everything uncommitted
+// in worktreePath to outPath: tracked modifications (`git diff HEAD`)
+// plus every untracked, non-ignored file rendered as an addition.
+//
+// It exists for exactly one caller: the close path that deletes a
+// worktree on the user's explicit instruction. That is the only place
+// where closing a session destroys work, and a patch under the state
+// dir is the difference between "unrecoverable" and "run git apply".
+//
+// Deliberately NOT `git stash`. The stash stack is shared by every
+// worktree of a repository, so stashing here would push an entry onto
+// a stack the user — or another Hive session, or an unrelated tool —
+// can pop, reorder or drop. A plain file is inert.
+//
+// Nothing in the worktree is mutated: no `git add`, no index writes.
+// The obvious one-subprocess trick (`git add -N .` so `git diff HEAD`
+// picks up untracked files) is avoided for that reason — the dump runs
+// before a delete that can still be refused upstream, and a read-only
+// operation must stay read-only.
+//
+// Returns ErrPatchTooLarge (and writes nothing) when the accumulated
+// patch would exceed capBytes; the caller records that fact rather
+// than implying a patch exists. Accumulation stops as soon as the cap
+// is passed, so a worktree full of large untracked blobs costs one
+// oversized buffer, not a full traversal.
+func DumpPatch(worktreePath, outPath string, capBytes int64) error {
+	if worktreePath == "" {
+		return errors.New("worktree.DumpPatch: empty worktree path")
+	}
+	var buf bytes.Buffer
+
+	// Tracked changes, staged and unstaged, against HEAD. --binary so
+	// a modified image or fixture round-trips through git apply.
+	tracked, err := git(context.Background(), readTimeout, worktreePath,
+		"diff", "--binary", "HEAD")
+	if err != nil {
+		return fmt.Errorf("git diff HEAD: %w", err)
+	}
+	buf.Write(tracked)
+	if int64(buf.Len()) > capBytes {
+		return ErrPatchTooLarge
+	}
+
+	// Untracked but not ignored. -z because a filename may contain a
+	// newline, and this path must not silently drop such a file.
+	out, err := git(context.Background(), readTimeout, worktreePath,
+		"ls-files", "-o", "--exclude-standard", "-z")
+	if err != nil {
+		return fmt.Errorf("git ls-files -o: %w", err)
+	}
+	for name := range strings.SplitSeq(string(out), "\x00") {
+		if name == "" {
+			continue
+		}
+		d, derr := diffAgainstNull(worktreePath, name)
+		if derr != nil {
+			// One unreadable untracked file must not cost the user the
+			// rest of the patch. Note it inline so the omission is
+			// visible in the file itself, not only in the daemon log.
+			fmt.Fprintf(&buf, "# hive: could not capture untracked file %q: %v\n", name, derr)
+			continue
+		}
+		buf.Write(d)
+		if int64(buf.Len()) > capBytes {
+			return ErrPatchTooLarge
+		}
+	}
+
+	if buf.Len() == 0 {
+		// Nothing uncommitted. Writing an empty patch would advertise a
+		// recovery that recovers nothing.
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o700); err != nil {
+		return err
+	}
+	tmp := outPath + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, outPath)
+}
+
+// diffAgainstNull renders one untracked file as an addition diff.
+//
+// `git diff --no-index` exits 1 when the two inputs differ, which is
+// the expected outcome for every call here — so exit 1 with output is
+// success, and only a truly failed run (no output) is an error. That
+// is also why this does not go through git(): that helper treats any
+// non-zero exit as failure.
+func diffAgainstNull(worktreePath, name string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), readTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", worktreePath,
+		"diff", "--no-index", "--binary", "--", os.DevNull, name)
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	out, err := cmd.Output()
+	if len(out) > 0 {
+		return out, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Fixes #304

Closing a session was a one-way teardown: PTY killed, registry entry deleted, session dir removed, worktree sometimes pruned. An accidental ⌘W had no recovery path at all.

## Approach

`registry.kill()` now writes a tombstone to `<stateDir>/closed/<id>.json` **immediately before the teardown** — under `r.mu`, so the record is on disk before anything, in memory or on disk, is destroyed. A new `RESTORE_SESSION` frame rebuilds the entry from it and revives the agent by its pinned `agent_session_id`, so the conversation comes back for agents that support per-id resume.

Chose tombstones over **deferring the teardown** behind a banner: deferring keeps alive a process the user asked to end, blocks worktree cleanup for the delay, offers nothing after a daemon restart, and adds latency to every close. Tombstones cost one small atomic write and need no timers.

Worktree resolution mirrors `disposeWorktree`'s paranoia in reverse — a surviving directory is re-adopted (a sibling already living there is fine; duplicated sessions legitimately share one), a pruned one is recreated from its branch (`Cleanup` never deletes branches, so committed work returns), and a path outside the managed namespace is never materialized.

## Honest about what does not come back

`RestoreResult` reports every degradation so the UI says what was lost rather than claiming a clean undo. Scrollback is **never** restorable — there is no disk-backed scrollback to replay from — and the banner says so unconditionally rather than per-restore.

| Destroyed at close | Comes back? |
|---|---|
| Terminal scrollback | no |
| In-flight agent state never written to its rollout file | no |
| Agent conversation | usually (via `agent_session_id`) |
| Worktree uncommitted changes, via *Close and delete worktree* | via recovery patch |
| Worktree unpushed commits / pristine directory | yes |
| Name, colour, project, agent binding | yes |

## Recovery patch

Closing a session **and** deleting its worktree is the one close that can destroy work. It now dumps the uncommitted state to a capped 10 MiB patch first. Deliberately **not** `git stash` — that stack is shared by every worktree of the repo, and pushing onto it silently is a side effect another tool (or another Hive session) can pop. Restore surfaces the path but never applies it: applying into a checkout whose HEAD has moved turns one bad close into a merge conflict.

## Latent bug fixed along the way

Boot-time orphan reclaim deletes pristine *unclaimed* worktrees — and a tombstoned worktree is unclaimed by definition. Narrow window, but it is a silent delete, at boot, with no confirm, of something the user could still undo into. `worktreeClaimed()` now consults tombstones. Covered by `TestOrphanReclaimSkipsTombstonedWorktree`.

## Closing stays exactly as protected

Audited all five close call sites: every live-session close passes `force=false`, so the daemon still refuses with `worktree_dirty` and the three-way dialog still fires. The two `force=true` sites are dead sessions only, and `disposeWorktree` independently refuses to delete a non-pristine worktree there. No close path became quieter.

## UI

- Undo banner, raised **only** for closes this client issued — undo belongs to whoever pressed close, so a session removed by another window raises nothing.
- `⌘Z` / File ▸ Reopen Closed Session / command palette. `⌘Z` rather than the obvious `⇧⌘T`, which is already New Session in Worktree; `⌘` is not a terminal modifier, so nothing is taken from the focused agent. `TestReopenClosedSessionAccelerator` pins it against future collisions.
- Retention bounded by both count (20) and age (7 days).

## Testing

New: 16 Go (registry / daemon frames / GUI bindings / menu accelerator), 13 DOM, 4 mock-e2e, 2 e2e-real.

Green locally: full Go suite, 709 frontend unit/dom, 218 mock-e2e, `tsc`, `biome ci`, `ui-lint`. The new `e2e-real` specs pass in isolation against a real daemon. The wider `e2e-real` suite is flaky on this machine and is being addressed separately — its failures here land in `wheel-scroll` / `worktrees` / `scroll-codex`, which this diff does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)