### PR TITLE
fix(gui): drop sessions where they land, size the drop placeholder (spec 305)

### DIFF
--- a/.changesets/305-sidebar-drag-reorder.md
+++ b/.changesets/305-sidebar-drag-reorder.md
@@ -1,0 +1,14 @@
+---
+issue: null
+pr: null
+type: fixed
+bump: patch
+---
+- Dragging a session in the sidebar now drops it exactly where the indicator
+  showed. The drop slot was resolved against the sibling list that still
+  contained the dragged row, so a row dragged downwards consistently landed
+  one position too low.
+- The drop indicator is now a placeholder the size of the dragged item, and
+  the dragged row leaves the layout while the drag is in flight — so the
+  sidebar's height stays fixed and content no longer jumps on drop. Project
+  cards get the same affordance as session rows.

--- a/cmd/hivegui/frontend/src/app/sidebar.ts
+++ b/cmd/hivegui/frontend/src/app/sidebar.ts
@@ -347,6 +347,13 @@ function wireProjectDrag(
   header: HTMLElement,
   p: ProjectInfo,
 ) {
+  const commit = (target: HTMLElement, above: boolean, e: DragEvent) => {
+    const pid = e.dataTransfer?.getData('text/x-hive-project');
+    const targetPID = target.dataset.pid ?? '';
+    if (!pid || !targetPID || pid === targetPID) return;
+    reorderDroppedProject(pid, targetPID, above);
+  };
+
   root.addEventListener('dragstart', (e) => {
     const t = e.target;
     if (t instanceof Element) {
@@ -366,9 +373,15 @@ function wireProjectDrag(
     if (!dt) return;
     dt.effectAllowed = 'move';
     dt.setData('text/x-hive-project', p.id);
-    beginDrag(root);
+    beginDrag(root, commit);
   });
-  root.addEventListener('dragend', endDrag);
+  root.addEventListener('dragend', (e) => {
+    if (e.target instanceof Element && e.target.closest('.hv-session-row')) {
+      // Bubbled from an inner session drag, which owns its own teardown.
+      return;
+    }
+    endDrag();
+  });
   root.addEventListener('dragover', (e) => {
     const dt = e.dataTransfer;
     if (!dt?.types.includes('text/x-hive-project')) return;
@@ -386,12 +399,10 @@ function wireProjectDrag(
     const dt = e.dataTransfer;
     if (!dt?.types.includes('text/x-hive-project')) return;
     e.preventDefault();
-    const pid = dt.getData('text/x-hive-project');
     const r = header.getBoundingClientRect();
     const above = e.clientY - r.top < r.height / 2;
     endDrag();
-    if (!pid || pid === p.id) return;
-    reorderDroppedProject(pid, p.id, above);
+    commit(root, above, e);
   });
 }
 
@@ -493,12 +504,27 @@ function killSession(s: SessionInfo) {
 // Same-project drops only; cross-project moves are not supported
 // yet (would require also updating project_id on the wire).
 function wireSessionDrag(li: HTMLLIElement, s: SessionInfo) {
+  // Shared by the row's own drop handler and the placeholder's: an "insert
+  // above" spacer sits under the cursor, so the release often lands on the
+  // spacer rather than on any row.
+  const commit = (target: HTMLElement, above: boolean, e: DragEvent) => {
+    const sid = e.dataTransfer?.getData('text/x-hive-session');
+    const targetSID = target.dataset.sid ?? '';
+    if (!sid || !targetSID || sid === targetSID) return;
+    const dragged = state.sessions.find((x) => x.id === sid);
+    const dropped = state.sessions.find((x) => x.id === targetSID);
+    if (!dragged || !dropped) return;
+    // cross-project: not supported yet (would need project_id on the wire).
+    if (readProjectId(dragged) !== readProjectId(dropped)) return;
+    reorderDroppedSession(sid, targetSID, above);
+  };
+
   li.addEventListener('dragstart', (e) => {
     const dt = e.dataTransfer;
     if (!dt) return;
     dt.effectAllowed = 'move';
     dt.setData('text/x-hive-session', s.id);
-    beginDrag(li);
+    beginDrag(li, commit);
   });
   li.addEventListener('dragend', endDrag);
   li.addEventListener('dragover', (e) => {
@@ -511,15 +537,10 @@ function wireSessionDrag(li: HTMLLIElement, s: SessionInfo) {
   });
   li.addEventListener('drop', (e) => {
     e.preventDefault();
-    const sid = e.dataTransfer?.getData('text/x-hive-session');
     const r = li.getBoundingClientRect();
     const above = e.clientY - r.top < r.height / 2;
     endDrag();
-    if (!sid || sid === s.id) return;
-    const dragged = state.sessions.find((x) => x.id === sid);
-    if (!dragged) return;
-    if (readProjectId(dragged) !== readProjectId(s)) return; // cross-project: not supported yet
-    reorderDroppedSession(sid, s.id, above);
+    commit(li, above, e);
   });
 }
 

--- a/cmd/hivegui/frontend/src/app/sidebar.ts
+++ b/cmd/hivegui/frontend/src/app/sidebar.ts
@@ -31,6 +31,12 @@ import { openWorktrees } from './modals/worktrees.js';
 import { beginInlineRename } from './inline-rename.js';
 import { readProjectId } from '../lib/wire.js';
 import { preserveFocus } from '../lib/preserve-focus.js';
+import { dropTargetIndex } from '../lib/reorder.js';
+import {
+  beginDrag,
+  moveTo as movePlaceholder,
+  endDrag,
+} from '../lib/drag-placeholder.js';
 
 // Per-module, not a shared deps union: sidebar wants refocusActiveTerm
 // where view wants focusActiveTerm, and one union type would loosen both.
@@ -360,18 +366,9 @@ function wireProjectDrag(
     if (!dt) return;
     dt.effectAllowed = 'move';
     dt.setData('text/x-hive-project', p.id);
-    root.classList.add('dragging');
+    beginDrag(root);
   });
-  root.addEventListener('dragend', () => {
-    root.classList.remove('dragging');
-    document
-      .querySelectorAll(
-        '.hv-project-card.drop-above, .hv-project-card.drop-below',
-      )
-      .forEach((el) => {
-        el.classList.remove('drop-above', 'drop-below');
-      });
-  });
+  root.addEventListener('dragend', endDrag);
   root.addEventListener('dragover', (e) => {
     const dt = e.dataTransfer;
     if (!dt?.types.includes('text/x-hive-project')) return;
@@ -379,32 +376,21 @@ function wireProjectDrag(
     dt.dropEffect = 'move';
     // Use the header's bounds (not the whole card): with sessions
     // expanded, the card is tall, the cursor is almost always above
-    // its midpoint, and the indicator would land far from the
+    // its midpoint, and the placeholder would land far from the
     // cursor. Anchoring both the hit-test and the visual to the
     // header keeps them in sync.
     const r = header.getBoundingClientRect();
-    const above = e.clientY - r.top < r.height / 2;
-    root.classList.toggle('drop-above', above);
-    root.classList.toggle('drop-below', !above);
-  });
-  root.addEventListener('dragleave', (e) => {
-    // Only clear when leaving the card entirely; dragover into a child
-    // re-fires and re-asserts the right class.
-    // `contains(null)` is false, so a relatedTarget that isn't a Node
-    // takes the same "left the card" branch it takes today.
-    if (!(e.relatedTarget instanceof Node) || !root.contains(e.relatedTarget)) {
-      root.classList.remove('drop-above', 'drop-below');
-    }
+    movePlaceholder(root, e.clientY - r.top < r.height / 2);
   });
   root.addEventListener('drop', (e) => {
     const dt = e.dataTransfer;
     if (!dt?.types.includes('text/x-hive-project')) return;
     e.preventDefault();
     const pid = dt.getData('text/x-hive-project');
-    root.classList.remove('drop-above', 'drop-below');
-    if (!pid || pid === p.id) return;
     const r = header.getBoundingClientRect();
     const above = e.clientY - r.top < r.height / 2;
+    endDrag();
+    if (!pid || pid === p.id) return;
     reorderDroppedProject(pid, p.id, above);
   });
 }
@@ -512,106 +498,44 @@ function wireSessionDrag(li: HTMLLIElement, s: SessionInfo) {
     if (!dt) return;
     dt.effectAllowed = 'move';
     dt.setData('text/x-hive-session', s.id);
-    li.classList.add('dragging');
+    beginDrag(li);
   });
-  li.addEventListener('dragend', () => {
-    li.classList.remove('dragging');
-    document
-      .querySelectorAll(
-        '.hv-session-row.drop-above, .hv-session-row.drop-below',
-      )
-      .forEach((el) => {
-        el.classList.remove('drop-above', 'drop-below');
-      });
-  });
+  li.addEventListener('dragend', endDrag);
   li.addEventListener('dragover', (e) => {
     const dt = e.dataTransfer;
     if (!dt?.types.includes('text/x-hive-session')) return;
     e.preventDefault();
     dt.dropEffect = 'move';
     const r = li.getBoundingClientRect();
-    const above = e.clientY - r.top < r.height / 2;
-    li.classList.toggle('drop-above', above);
-    li.classList.toggle('drop-below', !above);
-  });
-  li.addEventListener('dragleave', () => {
-    li.classList.remove('drop-above', 'drop-below');
+    movePlaceholder(li, e.clientY - r.top < r.height / 2);
   });
   li.addEventListener('drop', (e) => {
     e.preventDefault();
     const sid = e.dataTransfer?.getData('text/x-hive-session');
-    li.classList.remove('drop-above', 'drop-below');
+    const r = li.getBoundingClientRect();
+    const above = e.clientY - r.top < r.height / 2;
+    endDrag();
     if (!sid || sid === s.id) return;
     const dragged = state.sessions.find((x) => x.id === sid);
     if (!dragged) return;
-    const draggedPID = readProjectId(dragged);
-    const targetPID = readProjectId(s);
-    if (draggedPID !== targetPID) return; // cross-project: not supported yet
-    const r = li.getBoundingClientRect();
-    const above = e.clientY - r.top < r.height / 2;
+    if (readProjectId(dragged) !== readProjectId(s)) return; // cross-project: not supported yet
     reorderDroppedSession(sid, s.id, above);
   });
 }
 
-// reorderDroppedSession converts a drop position ("above" or "below"
-// the target row) into a global Order argument for UpdateSession.
-//
-// Kept separate from lib/reorder.ts's reorderTarget on purpose: that one
-// answers "swap with the adjacent sibling" (⇧⌘↑/↓) and can name the
-// target's own .order directly, while a drop can land between any two
-// rows and needs the shift compensation below. Both rely on the same
-// invariant — .order IS the index into the daemon's r.order — so if you
-// change that assumption, change it in both.
-// The daemon's moveLocked treats the argument as a global index into
-// r.order; we pick the global Order of whichever neighbor sits at
-// the project-relative drop slot (after pretending the dragged
-// session is gone).
+// reorderDroppedSession hands the drop to lib/reorder.ts's dropTargetIndex
+// and forwards the result. The index math lives there, next to the keyboard
+// path's reorderTarget, because both rest on the same invariant — a session's
+// .order IS its index in the daemon's r.order — and because a pure function
+// is the only way to table-test the off-by-one this used to have.
 function reorderDroppedSession(
   draggedID: string,
   targetID: string,
   above: boolean,
 ) {
-  const target = state.sessions.find((s) => s.id === targetID);
-  if (!target) return;
-  const projID = target.projectId ?? target.project_id ?? '';
-  const projSessions = state.sessions
-    .filter((s) => (s.projectId ?? s.project_id ?? '') === projID)
-    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-  const targetIdx = projSessions.findIndex((s) => s.id === targetID);
-  if (targetIdx < 0) return;
-  let projIdx = above ? targetIdx : targetIdx + 1;
-  const pretend = projSessions.filter((s) => s.id !== draggedID);
-  if (pretend.length === 0) return;
-  if (projIdx > pretend.length) projIdx = pretend.length;
-
-  // Find the global index in r.order that we want the dragged session
-  // to land at. We approximate using global Order values: pretend[i]
-  // currently has some Order value, and moveLocked accepts a global
-  // index. Easiest: walk the global ordered list of all sessions and
-  // count to the slot we want.
-  const globalOrdered = [...state.sessions].sort(
-    (a, b) => (a.order ?? 0) - (b.order ?? 0),
-  );
-  let globalTargetIdx: number;
-  if (projIdx >= pretend.length) {
-    // Drop after the last neighbor: land just past it.
-    const last = pretend[pretend.length - 1];
-    globalTargetIdx = globalOrdered.findIndex((x) => x.id === last.id) + 1;
-  } else {
-    const neighbor = pretend[projIdx];
-    globalTargetIdx = globalOrdered.findIndex((x) => x.id === neighbor.id);
-  }
-  if (globalTargetIdx < 0) return;
-  // moveLocked is "remove from current pos, then insert at newOrder"
-  // — so if dragged is currently *before* the target index, the
-  // index shifts by 1 after removal. Compensate.
-  const draggedGlobalIdx = globalOrdered.findIndex((x) => x.id === draggedID);
-  if (draggedGlobalIdx >= 0 && draggedGlobalIdx < globalTargetIdx) {
-    globalTargetIdx -= 1;
-  }
-  UpdateSession(draggedID, '', '', globalTargetIdx).catch(
-    reportFailure('reorder'),
-  );
+  const order = dropTargetIndex(state.sessions, draggedID, targetID, above);
+  if (order === null) return;
+  UpdateSession(draggedID, '', '', order).catch(reportFailure('reorder'));
 }
 
 function beginRenameSession(sess: SessionInfo, nameEl: HTMLElement) {

--- a/cmd/hivegui/frontend/src/lib/drag-placeholder.ts
+++ b/cmd/hivegui/frontend/src/lib/drag-placeholder.ts
@@ -1,0 +1,72 @@
+// Drop placeholder for the sidebar's drag-to-reorder (sessions and project
+// cards both). The dragged element leaves the layout flow and a spacer of its
+// exact margin box takes its place at the drop slot, so the list's total
+// height never changes mid-drag and nothing below the cursor shifts until the
+// drop actually commits.
+//
+// One module-level drag at a time: HTML5 drag-and-drop only ever has one.
+//
+// The spacer deliberately carries NEITHER `hv-session-row` nor
+// `hv-project-card`. app/sidebar.ts's domShape() reads the sidebar back with
+// that selector pair to decide whether an in-place update is safe; a spacer
+// wearing either class would read as a phantom row.
+
+const CLASS = 'hv-drop-placeholder';
+
+let dragged: HTMLElement | null = null;
+let spacer: HTMLElement | null = null;
+// Captured at dragstart, BEFORE the element leaves the flow.
+let box = { height: 0, marginTop: '0px', marginBottom: '0px' };
+
+// hide is what takes the element out of the flow. It must not run inside the
+// dragstart handler: the browser snapshots the drag image after that handler
+// returns, and a source element already at `display: none` cancels the drag.
+function hide(el: HTMLElement) {
+  el.classList.add('dragging');
+}
+
+export function beginDrag(el: HTMLElement) {
+  endDrag();
+  dragged = el;
+  const cs = getComputedStyle(el);
+  box = {
+    height: el.getBoundingClientRect().height,
+    marginTop: cs.marginTop,
+    marginBottom: cs.marginBottom,
+  };
+  setTimeout(() => {
+    if (dragged === el) hide(el);
+  }, 0);
+}
+
+// moveTo places the spacer immediately above or below `target`. Safe to call
+// on every dragover: it moves the one spacer rather than adding another, and
+// re-asserts the hidden state so a renderSidebar() rebuild landing mid-drag
+// (it clears projectsUL.innerHTML) only costs a frame of drag chrome.
+export function moveTo(target: Element, above: boolean) {
+  if (!dragged) return;
+  hide(dragged);
+  if (!spacer) {
+    spacer = document.createElement('li');
+    spacer.className = CLASS;
+    spacer.setAttribute('aria-hidden', 'true');
+  }
+  // Height plus the dragged element's own vertical margins: project cards
+  // carry margins, and a zero-margin spacer would not occupy the same space
+  // once adjacent-sibling margins collapse.
+  spacer.style.height = `${box.height}px`;
+  spacer.style.marginTop = box.marginTop;
+  spacer.style.marginBottom = box.marginBottom;
+  const before = above ? target : target.nextSibling;
+  if (before === spacer) return;
+  target.parentNode?.insertBefore(spacer, before);
+}
+
+// endDrag is idempotent — drop and dragend both fire, and a drag can be
+// cancelled without either landing on a target.
+export function endDrag() {
+  spacer?.remove();
+  spacer = null;
+  dragged?.classList.remove('dragging');
+  dragged = null;
+}

--- a/cmd/hivegui/frontend/src/lib/drag-placeholder.ts
+++ b/cmd/hivegui/frontend/src/lib/drag-placeholder.ts
@@ -36,7 +36,7 @@ let draggedSelector = '';
 let spacer: HTMLElement | null = null;
 let onDrop: DropHandler | null = null;
 // Captured at dragstart, BEFORE the element leaves the flow.
-let box = { height: 0, marginTop: '0px', marginBottom: '0px' };
+let box = { height: 0, margin: '0px' };
 
 function selectorFor(el: HTMLElement): string {
   const sid = el.dataset.sid;
@@ -94,12 +94,13 @@ function makeSpacer(): HTMLElement {
 function place(before: Node | null, parent: Node | null | undefined) {
   if (!parent) return;
   if (!spacer) spacer = makeSpacer();
-  // Height plus the dragged element's own vertical margins: project cards
-  // carry margins, and a zero-margin spacer would not occupy the same space
-  // once adjacent-sibling margins collapse.
+  // Height plus the dragged element's own margins — all four. Project cards
+  // carry `margin: --space-1 --space-2 --space-2`: without the vertical half
+  // a zero-margin spacer would not occupy the same space once adjacent-sibling
+  // margins collapse, and without the horizontal half the dashed outline would
+  // run the full sidebar width while the card it stands in for is inset.
   spacer.style.height = `${box.height}px`;
-  spacer.style.marginTop = box.marginTop;
-  spacer.style.marginBottom = box.marginBottom;
+  spacer.style.margin = box.margin;
   if (before === spacer) return;
   parent.insertBefore(spacer, before);
 }
@@ -117,8 +118,7 @@ export function beginDrag(el: HTMLElement, handler: DropHandler) {
   const cs = getComputedStyle(el);
   box = {
     height: el.getBoundingClientRect().height,
-    marginTop: cs.marginTop,
-    marginBottom: cs.marginBottom,
+    margin: `${cs.marginTop} ${cs.marginRight} ${cs.marginBottom} ${cs.marginLeft}`,
   };
   setTimeout(() => {
     if (dragged !== el) return;

--- a/cmd/hivegui/frontend/src/lib/drag-placeholder.ts
+++ b/cmd/hivegui/frontend/src/lib/drag-placeholder.ts
@@ -10,24 +10,110 @@
 // `hv-project-card`. app/sidebar.ts's domShape() reads the sidebar back with
 // that selector pair to decide whether an in-place update is safe; a spacer
 // wearing either class would read as a phantom row.
+//
+// The spacer is a REAL drop target, not decoration. An "insert above"
+// placeholder is inserted where the cursor already is, which pushes the target
+// row down and leaves the cursor hovering the spacer itself. If the spacer
+// were `pointer-events: none`, the hit-test would fall through to the
+// container — which has no dragover handler, so nothing calls preventDefault,
+// the browser disallows the drop, and releasing there silently does nothing.
+// So the spacer keeps the drag alive itself and resolves its own drop from
+// the neighbours it sits between.
 
 const CLASS = 'hv-drop-placeholder';
+const ROW = '.hv-session-row, .hv-project-card';
+
+// The drop event is handed back so the caller can read its own payload key
+// out of the DataTransfer — this module stays agnostic about what is being
+// dragged.
+type DropHandler = (target: HTMLElement, above: boolean, e: DragEvent) => void;
 
 let dragged: HTMLElement | null = null;
+// A selector for the dragged element, so a renderSidebar() rebuild landing
+// mid-drag (it clears projectsUL.innerHTML) can be recovered from: `dragged`
+// would otherwise point at a detached node for the rest of the gesture.
+let draggedSelector = '';
 let spacer: HTMLElement | null = null;
+let onDrop: DropHandler | null = null;
 // Captured at dragstart, BEFORE the element leaves the flow.
 let box = { height: 0, marginTop: '0px', marginBottom: '0px' };
 
-// hide is what takes the element out of the flow. It must not run inside the
-// dragstart handler: the browser snapshots the drag image after that handler
-// returns, and a source element already at `display: none` cancels the drag.
-function hide(el: HTMLElement) {
-  el.classList.add('dragging');
+function selectorFor(el: HTMLElement): string {
+  const sid = el.dataset.sid;
+  if (sid) return `.hv-session-row[data-sid="${CSS.escape(sid)}"]`;
+  const pid = el.dataset.pid;
+  if (pid) return `.hv-project-card[data-pid="${CSS.escape(pid)}"]`;
+  return '';
 }
 
-export function beginDrag(el: HTMLElement) {
+// resolve re-reads the dragged element from the DOM when the node we are
+// holding has been replaced by a rebuild.
+function resolve(): HTMLElement | null {
+  if (dragged?.isConnected) return dragged;
+  if (!draggedSelector) return dragged;
+  const fresh = document.querySelector<HTMLElement>(draggedSelector);
+  if (fresh) dragged = fresh;
+  return dragged;
+}
+
+// The slot the spacer currently represents, expressed the way the row drop
+// handlers express it: the row it would push down, or — when it sits at the
+// end of a list — the row it follows.
+function slot(): { target: HTMLElement; above: boolean } | null {
+  if (!spacer) return null;
+  let next = spacer.nextElementSibling;
+  while (next && !next.matches(ROW)) next = next.nextElementSibling;
+  if (next instanceof HTMLElement) return { target: next, above: true };
+  let prev = spacer.previousElementSibling;
+  while (prev && !prev.matches(ROW)) prev = prev.previousElementSibling;
+  if (prev instanceof HTMLElement) return { target: prev, above: false };
+  return null;
+}
+
+function makeSpacer(): HTMLElement {
+  const el = document.createElement('li');
+  el.className = CLASS;
+  el.setAttribute('aria-hidden', 'true');
+  el.addEventListener('dragover', (e) => {
+    // Keeps the drag alive over the gap. Without the preventDefault the
+    // browser treats the spacer as a non-target and refuses the drop.
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+  });
+  el.addEventListener('drop', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const at = slot();
+    const handler = onDrop;
+    endDrag();
+    if (at && handler) handler(at.target, at.above, e as DragEvent);
+  });
+  return el;
+}
+
+function place(before: Node | null, parent: Node | null | undefined) {
+  if (!parent) return;
+  if (!spacer) spacer = makeSpacer();
+  // Height plus the dragged element's own vertical margins: project cards
+  // carry margins, and a zero-margin spacer would not occupy the same space
+  // once adjacent-sibling margins collapse.
+  spacer.style.height = `${box.height}px`;
+  spacer.style.marginTop = box.marginTop;
+  spacer.style.marginBottom = box.marginBottom;
+  if (before === spacer) return;
+  parent.insertBefore(spacer, before);
+}
+
+// beginDrag must not take the element out of the flow synchronously: the
+// browser snapshots the drag image after the dragstart handler returns, and a
+// source element already at `display: none` cancels the drag. The swap —
+// spacer in, element out — happens together one tick later, so the list never
+// spends a frame a row shorter than it started.
+export function beginDrag(el: HTMLElement, handler: DropHandler) {
   endDrag();
   dragged = el;
+  draggedSelector = selectorFor(el);
+  onDrop = handler;
   const cs = getComputedStyle(el);
   box = {
     height: el.getBoundingClientRect().height,
@@ -35,31 +121,20 @@ export function beginDrag(el: HTMLElement) {
     marginBottom: cs.marginBottom,
   };
   setTimeout(() => {
-    if (dragged === el) hide(el);
+    if (dragged !== el) return;
+    place(el, el.parentNode);
+    el.classList.add('dragging');
   }, 0);
 }
 
 // moveTo places the spacer immediately above or below `target`. Safe to call
 // on every dragover: it moves the one spacer rather than adding another, and
-// re-asserts the hidden state so a renderSidebar() rebuild landing mid-drag
-// (it clears projectsUL.innerHTML) only costs a frame of drag chrome.
+// re-asserts the hidden state on whichever node currently represents the
+// dragged element.
 export function moveTo(target: Element, above: boolean) {
   if (!dragged) return;
-  hide(dragged);
-  if (!spacer) {
-    spacer = document.createElement('li');
-    spacer.className = CLASS;
-    spacer.setAttribute('aria-hidden', 'true');
-  }
-  // Height plus the dragged element's own vertical margins: project cards
-  // carry margins, and a zero-margin spacer would not occupy the same space
-  // once adjacent-sibling margins collapse.
-  spacer.style.height = `${box.height}px`;
-  spacer.style.marginTop = box.marginTop;
-  spacer.style.marginBottom = box.marginBottom;
-  const before = above ? target : target.nextSibling;
-  if (before === spacer) return;
-  target.parentNode?.insertBefore(spacer, before);
+  resolve()?.classList.add('dragging');
+  place(above ? target : target.nextSibling, target.parentNode);
 }
 
 // endDrag is idempotent — drop and dragend both fire, and a drag can be
@@ -67,6 +142,8 @@ export function moveTo(target: Element, above: boolean) {
 export function endDrag() {
   spacer?.remove();
   spacer = null;
-  dragged?.classList.remove('dragging');
+  onDrop = null;
+  resolve()?.classList.remove('dragging');
   dragged = null;
+  draggedSelector = '';
 }

--- a/cmd/hivegui/frontend/src/lib/reorder.ts
+++ b/cmd/hivegui/frontend/src/lib/reorder.ts
@@ -1,3 +1,5 @@
+import { readProjectId } from './wire.js';
+
 // reorderTarget converts "move the active session one slot up/down inside its
 // own project" into the index the daemon wants.
 //
@@ -83,10 +85,10 @@ export function dropTargetIndex(
   const target = globalOrdered.find((s) => s.id === targetID);
   if (draggedIdx < 0 || !target) return null;
 
-  const pid = target.projectId ?? target.project_id ?? '';
+  const pid = readProjectId(target);
   // Siblings WITHOUT the dragged session — the list the drop slot indexes.
   const sibs = globalOrdered.filter(
-    (s) => (s.projectId ?? s.project_id ?? '') === pid && s.id !== draggedID,
+    (s) => readProjectId(s) === pid && s.id !== draggedID,
   );
   const targetIdx = sibs.findIndex((s) => s.id === targetID);
   if (targetIdx < 0) return null;

--- a/cmd/hivegui/frontend/src/lib/reorder.ts
+++ b/cmd/hivegui/frontend/src/lib/reorder.ts
@@ -45,3 +45,63 @@ export function reorderTarget(
   if (tgt.id === activeId) return null;
   return tgt.order ?? null;
 }
+
+// dropTargetIndex converts a drag-and-drop landing — "above" or "below" a
+// target row — into the same global index reorderTarget returns, for the same
+// reason: registry.moveInOrder deletes the id then inserts at that index into
+// the daemon's ONE flat r.order list spanning every project.
+//
+// Where reorderTarget can name a sibling's `.order` directly (adjacent swap),
+// a drop can land between any two rows, so this one resolves the neighbour
+// that will sit at the drop slot and then compensates for the delete.
+//
+// The critical detail: the slot is an index into the sibling list with the
+// dragged session ALREADY REMOVED. Computing it against the list that still
+// contains the dragged row shifts every index by one whenever the dragged row
+// sits before the target, and the drop lands one slot too low — which is the
+// bug this function replaced (spec 305).
+//
+// `sessions` may be in any order; it is sorted by `.order` internally.
+// Returns null when there is nothing to do (unknown target, drop onto self, or
+// a slot the session already occupies).
+export function dropTargetIndex(
+  sessions: {
+    id: string;
+    projectId?: string;
+    project_id?: string;
+    order?: number;
+  }[],
+  draggedID: string,
+  targetID: string,
+  above: boolean,
+): number | null {
+  if (draggedID === targetID) return null;
+  const globalOrdered = [...sessions].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0),
+  );
+  const draggedIdx = globalOrdered.findIndex((s) => s.id === draggedID);
+  const target = globalOrdered.find((s) => s.id === targetID);
+  if (draggedIdx < 0 || !target) return null;
+
+  const pid = target.projectId ?? target.project_id ?? '';
+  // Siblings WITHOUT the dragged session — the list the drop slot indexes.
+  const sibs = globalOrdered.filter(
+    (s) => (s.projectId ?? s.project_id ?? '') === pid && s.id !== draggedID,
+  );
+  const targetIdx = sibs.findIndex((s) => s.id === targetID);
+  if (targetIdx < 0) return null;
+  const slot = above ? targetIdx : targetIdx + 1;
+
+  // Translate the project-relative slot into a global index: the global
+  // position of whichever sibling will be pushed down by the insert, or one
+  // past the last sibling when the drop lands at the end of the project.
+  let globalIdx =
+    slot >= sibs.length
+      ? globalOrdered.findIndex((s) => s.id === sibs[sibs.length - 1].id) + 1
+      : globalOrdered.findIndex((s) => s.id === sibs[slot].id);
+  if (globalIdx < 0) return null;
+  // moveInOrder deletes before inserting, so an index after the dragged
+  // session's current position shifts left by one.
+  if (draggedIdx < globalIdx) globalIdx -= 1;
+  return globalIdx === draggedIdx ? null : globalIdx;
+}

--- a/cmd/hivegui/frontend/src/theme/components/project-card.css
+++ b/cmd/hivegui/frontend/src/theme/components/project-card.css
@@ -117,21 +117,9 @@
   outline: none;
 }
 
-.hv-project-card.dragging { opacity: 0.45; }
-.hv-project-card.drop-above::after,
-.hv-project-card.drop-below::after {
-  content: '';
-  position: absolute;
-  left: var(--space-1);
-  right: var(--space-1);
-  height: 2px;
-  border-radius: 1px; /* ui-lint: allow */
-  background: var(--accent);
-  pointer-events: none;
-  z-index: 2;
-}
-.hv-project-card.drop-above::after { top: -1px; }
-.hv-project-card.drop-below::after { bottom: -1px; }
+/* Drag-to-reorder: the dragged card leaves the flow and
+   .hv-drop-placeholder (sidebar.css) reserves its box at the drop slot. */
+.hv-project-card.dragging { display: none; }
 
 .hv-project-card button:focus-visible {
   outline: 2px solid var(--accent);

--- a/cmd/hivegui/frontend/src/theme/components/session-row.css
+++ b/cmd/hivegui/frontend/src/theme/components/session-row.css
@@ -151,22 +151,11 @@
   outline: none;
 }
 
-/* Drag-to-reorder. Classes, not data attributes: they are transient
-   drag chrome, not row state. */
-.hv-session-row.dragging { opacity: 0.45; }
-.hv-session-row.drop-above::after,
-.hv-session-row.drop-below::after {
-  content: '';
-  position: absolute;
-  left: var(--space-1);
-  right: var(--space-1);
-  height: 2px;
-  border-radius: 1px; /* ui-lint: allow */
-  background: var(--accent);
-  pointer-events: none;
-}
-.hv-session-row.drop-above::after { top: -1px; }
-.hv-session-row.drop-below::after { bottom: -1px; }
+/* Drag-to-reorder. A class, not a data attribute: transient drag chrome,
+   not row state. The dragged row leaves the flow entirely and
+   .hv-drop-placeholder (sidebar.css) reserves its box at the drop slot, so
+   the list's height never changes mid-drag. */
+.hv-session-row.dragging { display: none; }
 
 .hv-session-row button:focus-visible {
   outline: 2px solid var(--accent);

--- a/cmd/hivegui/frontend/src/theme/components/sidebar.css
+++ b/cmd/hivegui/frontend/src/theme/components/sidebar.css
@@ -54,15 +54,16 @@
 /* Drop placeholder for drag-to-reorder (lib/drag-placeholder.ts). Sized in JS
    to the dragged element's exact margin box, so swapping the dragged row out
    of the flow for this leaves the list's height unchanged and nothing below
-   the cursor shifts. pointer-events: none keeps it out of the drag hit-test —
-   it must never become a dragover/dragleave target of its own. */
+   the cursor shifts. It is hit-testable on purpose: an "insert above" spacer
+   lands under the cursor, and a pointer-events: none spacer would let the
+   hit-test fall through to a container with no dragover handler — nothing
+   would call preventDefault and the drop would silently no-op. */
 .hv-drop-placeholder {
   list-style: none;
   box-sizing: border-box;
   border: 1px dashed var(--accent);
   border-radius: var(--radius-md);
   background: var(--hover);
-  pointer-events: none;
 }
 
 

--- a/cmd/hivegui/frontend/src/theme/components/sidebar.css
+++ b/cmd/hivegui/frontend/src/theme/components/sidebar.css
@@ -51,6 +51,20 @@
   overflow-x: hidden;
 }
 
+/* Drop placeholder for drag-to-reorder (lib/drag-placeholder.ts). Sized in JS
+   to the dragged element's exact margin box, so swapping the dragged row out
+   of the flow for this leaves the list's height unchanged and nothing below
+   the cursor shifts. pointer-events: none keeps it out of the drag hit-test —
+   it must never become a dragover/dragleave target of its own. */
+.hv-drop-placeholder {
+  list-style: none;
+  box-sizing: border-box;
+  border: 1px dashed var(--accent);
+  border-radius: var(--radius-md);
+  background: var(--hover);
+  pointer-events: none;
+}
+
 
 /* Keyboard-focus rings on the small controls that previously had
    none. :focus-visible only — mouse clicks stay ring-free.

--- a/cmd/hivegui/frontend/test/dom/drag-placeholder.test.ts
+++ b/cmd/hivegui/frontend/test/dom/drag-placeholder.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { beginDrag, moveTo, endDrag } from '../../src/lib/drag-placeholder';
+
+// jsdom has no layout, so getBoundingClientRect() reports 0 — that is fine
+// here. These tests own the DOM contract (where the spacer lands, that it is
+// unique, that it cleans up); the *visual* contract — that the list's height
+// really does not change — is only meaningful in a real browser and lives in
+// test/e2e/ordering.spec.ts.
+
+const list = () => document.querySelector('ul') as HTMLUListElement;
+const ids = () =>
+  Array.from(list().children).map((el) =>
+    el.classList.contains('hv-drop-placeholder') ? '·' : el.id,
+  );
+
+beforeEach(() => {
+  endDrag();
+  document.body.innerHTML =
+    '<ul>' +
+    ['a', 'b', 'c']
+      .map((id) => `<li id="${id}" class="hv-session-row"></li>`)
+      .join('') +
+    '</ul>';
+});
+
+const row = (id: string) => document.getElementById(id) as HTMLElement;
+
+describe('drag placeholder', () => {
+  it('inserts the spacer above or below the target', () => {
+    beginDrag(row('a'));
+    moveTo(row('c'), true);
+    expect(ids()).toEqual(['a', 'b', '·', 'c']);
+
+    moveTo(row('c'), false);
+    expect(ids()).toEqual(['a', 'b', 'c', '·']);
+  });
+
+  it('moves the one spacer instead of creating a second', () => {
+    beginDrag(row('a'));
+    moveTo(row('b'), true);
+    moveTo(row('c'), true);
+    expect(document.querySelectorAll('.hv-drop-placeholder')).toHaveLength(1);
+    expect(ids()).toEqual(['a', 'b', '·', 'c']);
+  });
+
+  // sidebar.ts's domShape() reads the sidebar back with this selector pair to
+  // decide whether an in-place update is safe. A spacer wearing either class
+  // would read as a phantom row and desync the shape comparison.
+  it('wears neither row class', () => {
+    beginDrag(row('a'));
+    moveTo(row('b'), true);
+    const ph = document.querySelector('.hv-drop-placeholder') as HTMLElement;
+    expect(ph.classList.contains('hv-session-row')).toBe(false);
+    expect(ph.classList.contains('hv-project-card')).toBe(false);
+    expect(ph.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('takes the dragged element out of the flow, but not before the drag image is snapshotted', () => {
+    vi.useFakeTimers();
+    try {
+      beginDrag(row('a'));
+      // Hiding the source inside the dragstart handler cancels the drag.
+      expect(row('a').classList.contains('dragging')).toBe(false);
+      vi.runAllTimers();
+      expect(row('a').classList.contains('dragging')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores the element and removes the spacer on endDrag', () => {
+    beginDrag(row('a'));
+    moveTo(row('c'), true);
+    endDrag();
+    expect(ids()).toEqual(['a', 'b', 'c']);
+    expect(row('a').classList.contains('dragging')).toBe(false);
+  });
+
+  it('is idempotent — drop and dragend both fire', () => {
+    beginDrag(row('a'));
+    moveTo(row('b'), true);
+    endDrag();
+    expect(() => endDrag()).not.toThrow();
+    expect(ids()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('ignores moveTo outside a drag', () => {
+    moveTo(row('b'), true);
+    expect(document.querySelector('.hv-drop-placeholder')).toBeNull();
+  });
+
+  // renderSidebar() clears projectsUL.innerHTML wholesale; a poll landing
+  // mid-drag would otherwise leave the drag chrome lost for the rest of the
+  // gesture.
+  it('re-asserts the hidden state on every move', () => {
+    beginDrag(row('a'));
+    row('a').classList.remove('dragging');
+    moveTo(row('b'), true);
+    expect(row('a').classList.contains('dragging')).toBe(true);
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/drag-placeholder.test.ts
+++ b/cmd/hivegui/frontend/test/dom/drag-placeholder.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { beginDrag, moveTo, endDrag } from '../../src/lib/drag-placeholder';
 
+const noop = () => {};
+const dropEvent = () =>
+  new Event('drop', { bubbles: true, cancelable: true }) as DragEvent;
+
 // jsdom has no layout, so getBoundingClientRect() reports 0 — that is fine
 // here. These tests own the DOM contract (where the spacer lands, that it is
 // unique, that it cleans up); the *visual* contract — that the list's height
@@ -18,7 +22,9 @@ beforeEach(() => {
   document.body.innerHTML =
     '<ul>' +
     ['a', 'b', 'c']
-      .map((id) => `<li id="${id}" class="hv-session-row"></li>`)
+      .map(
+        (id) => `<li id="${id}" data-sid="${id}" class="hv-session-row"></li>`,
+      )
       .join('') +
     '</ul>';
 });
@@ -26,8 +32,25 @@ beforeEach(() => {
 const row = (id: string) => document.getElementById(id) as HTMLElement;
 
 describe('drag placeholder', () => {
+  it('reserves the box in the same tick it hides the row', () => {
+    vi.useFakeTimers();
+    try {
+      beginDrag(row('a'), noop);
+      // Nothing has changed yet: hiding the source inside the dragstart
+      // handler cancels the drag, so the swap is deferred a tick.
+      expect(row('a').classList.contains('dragging')).toBe(false);
+      expect(document.querySelector('.hv-drop-placeholder')).toBeNull();
+      vi.runAllTimers();
+      // Spacer in and row out together — the list never spends a frame short.
+      expect(row('a').classList.contains('dragging')).toBe(true);
+      expect(ids()).toEqual(['·', 'a', 'b', 'c']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('inserts the spacer above or below the target', () => {
-    beginDrag(row('a'));
+    beginDrag(row('a'), noop);
     moveTo(row('c'), true);
     expect(ids()).toEqual(['a', 'b', '·', 'c']);
 
@@ -36,7 +59,7 @@ describe('drag placeholder', () => {
   });
 
   it('moves the one spacer instead of creating a second', () => {
-    beginDrag(row('a'));
+    beginDrag(row('a'), noop);
     moveTo(row('b'), true);
     moveTo(row('c'), true);
     expect(document.querySelectorAll('.hv-drop-placeholder')).toHaveLength(1);
@@ -47,7 +70,7 @@ describe('drag placeholder', () => {
   // decide whether an in-place update is safe. A spacer wearing either class
   // would read as a phantom row and desync the shape comparison.
   it('wears neither row class', () => {
-    beginDrag(row('a'));
+    beginDrag(row('a'), noop);
     moveTo(row('b'), true);
     const ph = document.querySelector('.hv-drop-placeholder') as HTMLElement;
     expect(ph.classList.contains('hv-session-row')).toBe(false);
@@ -55,21 +78,8 @@ describe('drag placeholder', () => {
     expect(ph.getAttribute('aria-hidden')).toBe('true');
   });
 
-  it('takes the dragged element out of the flow, but not before the drag image is snapshotted', () => {
-    vi.useFakeTimers();
-    try {
-      beginDrag(row('a'));
-      // Hiding the source inside the dragstart handler cancels the drag.
-      expect(row('a').classList.contains('dragging')).toBe(false);
-      vi.runAllTimers();
-      expect(row('a').classList.contains('dragging')).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   it('restores the element and removes the spacer on endDrag', () => {
-    beginDrag(row('a'));
+    beginDrag(row('a'), noop);
     moveTo(row('c'), true);
     endDrag();
     expect(ids()).toEqual(['a', 'b', 'c']);
@@ -77,7 +87,7 @@ describe('drag placeholder', () => {
   });
 
   it('is idempotent — drop and dragend both fire', () => {
-    beginDrag(row('a'));
+    beginDrag(row('a'), noop);
     moveTo(row('b'), true);
     endDrag();
     expect(() => endDrag()).not.toThrow();
@@ -93,9 +103,52 @@ describe('drag placeholder', () => {
   // mid-drag would otherwise leave the drag chrome lost for the rest of the
   // gesture.
   it('re-asserts the hidden state on every move', () => {
-    beginDrag(row('a'));
+    beginDrag(row('a'), noop);
     row('a').classList.remove('dragging');
     moveTo(row('b'), true);
     expect(row('a').classList.contains('dragging')).toBe(true);
+  });
+
+  // The regression this file gained on review: an "insert above" spacer is
+  // placed where the cursor already is, so the release lands on the SPACER,
+  // not on any row. A spacer that is not itself a drop target loses the drop.
+  it('accepts the drop itself and resolves the slot it sits in', () => {
+    const drops: [string, boolean][] = [];
+    beginDrag(row('a'), (t, above) => drops.push([t.id, above]));
+    moveTo(row('c'), true);
+    const ph = document.querySelector('.hv-drop-placeholder') as HTMLElement;
+
+    const over = new Event('dragover', { bubbles: true, cancelable: true });
+    ph.dispatchEvent(over);
+    expect(over.defaultPrevented).toBe(true);
+
+    ph.dispatchEvent(dropEvent());
+    expect(drops).toEqual([['c', true]]);
+    expect(document.querySelector('.hv-drop-placeholder')).toBeNull();
+  });
+
+  it('resolves a trailing slot against the row it follows', () => {
+    const drops: [string, boolean][] = [];
+    beginDrag(row('a'), (t, above) => drops.push([t.id, above]));
+    moveTo(row('c'), false);
+    const ph = document.querySelector('.hv-drop-placeholder') as HTMLElement;
+    ph.dispatchEvent(dropEvent());
+    expect(drops).toEqual([['c', false]]);
+  });
+
+  // renderSidebar() clears projectsUL.innerHTML wholesale. Holding the
+  // original node would leave us re-hiding a detached element for the rest of
+  // the gesture, so the module re-reads the row by its data-sid.
+  it('recovers the dragged row after a mid-drag rebuild', () => {
+    beginDrag(row('a'), noop);
+    moveTo(row('b'), true);
+    const html = list().innerHTML;
+    list().innerHTML = html.replace(
+      /<li class="hv-drop-placeholder"[^>]*><\/li>/,
+      '',
+    );
+    moveTo(row('c'), true);
+    expect(row('a').classList.contains('dragging')).toBe(true);
+    expect(document.querySelectorAll('.hv-drop-placeholder')).toHaveLength(1);
   });
 });

--- a/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
@@ -285,6 +285,163 @@ test.describe('keybinding regressions', () => {
     expect(await sidebarIds(page)).toEqual(before);
   });
 
+  // Drag-to-reorder. The regression (spec 305): the drop slot was resolved
+  // against the sibling list that still CONTAINED the dragged row, so a row
+  // dragged downwards landed one position below where it was dropped.
+  //
+  // The drag is driven by dispatched DragEvents sharing one DataTransfer
+  // rather than by locator.dragTo(): headless Chromium does not synthesise
+  // native HTML5 drag from mouse input here (verified — no dragstart fires),
+  // and the app's handlers are what these tests are about. Everything past
+  // the event dispatch is real: real layout, real CSS, real reorder call.
+  // What this cannot cover is the browser's own decision to *begin* a drag —
+  // notably that hiding the source element must be deferred a tick or the
+  // drag is cancelled. That one needs a human in the built app.
+  async function dragStart(page: Page, sid: string) {
+    await page.evaluate((id) => {
+      const w = window as unknown as { __dt?: DataTransfer };
+      w.__dt = new DataTransfer();
+      const row = document.querySelector<HTMLElement>(
+        `li.hv-session-row[data-sid="${id}"]`,
+      );
+      if (!row) throw new Error(`no row ${id}`);
+      row.dispatchEvent(
+        new DragEvent('dragstart', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: w.__dt,
+        }),
+      );
+    }, sid);
+    // beginDrag defers taking the row out of the flow by one tick.
+    await page.waitForFunction(
+      (id) =>
+        document
+          .querySelector(`li.hv-session-row[data-sid="${id}"]`)
+          ?.classList.contains('dragging') ?? false,
+      sid,
+    );
+  }
+
+  // Both dragover and drop carry the cursor's y, which is what decides the
+  // above/below half; the two must agree or the drop lands somewhere the
+  // placeholder never showed.
+  async function dragEvent(
+    page: Page,
+    type: 'dragover' | 'drop',
+    sid: string,
+    above: boolean,
+  ) {
+    await page.evaluate(
+      ({ kind, id, top }) => {
+        const w = window as unknown as { __dt?: DataTransfer };
+        const row = document.querySelector<HTMLElement>(
+          `li.hv-session-row[data-sid="${id}"]`,
+        );
+        if (!row) throw new Error(`no row ${id}`);
+        const r = row.getBoundingClientRect();
+        row.dispatchEvent(
+          new DragEvent(kind, {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: w.__dt,
+            clientY: top ? r.top + 2 : r.bottom - 2,
+          }),
+        );
+      },
+      { kind: type, id: sid, top: above },
+    );
+  }
+
+  test('a dragged session lands exactly where it was dropped', async ({
+    page,
+  }) => {
+    await boot(page, 4);
+    const before = await sidebarIds(page);
+
+    await dragStart(page, before[0]);
+    await dragEvent(page, 'dragover', before[2], true);
+    await expect(page.locator('.hv-drop-placeholder')).toHaveCount(1);
+    await dragEvent(page, 'drop', before[2], true);
+
+    // Above the target, not below it. Pre-fix this produced
+    // [1, 2, 0, 3] — one slot too low.
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([before[1], before[0], before[2], before[3]]);
+  });
+
+  test('a session dropped on a lower half lands below that row', async ({
+    page,
+  }) => {
+    await boot(page, 4);
+    const before = await sidebarIds(page);
+
+    await dragStart(page, before[0]);
+    await dragEvent(page, 'dragover', before[2], false);
+    await dragEvent(page, 'drop', before[2], false);
+
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([before[1], before[2], before[0], before[3]]);
+  });
+
+  test('dragging a session upwards lands it above the target', async ({
+    page,
+  }) => {
+    await boot(page, 4);
+    const before = await sidebarIds(page);
+
+    await dragStart(page, before[3]);
+    await dragEvent(page, 'dragover', before[1], true);
+    await dragEvent(page, 'drop', before[1], true);
+
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([before[0], before[3], before[1], before[2]]);
+  });
+
+  // vitest is CSS-blind, so the "content does not jump" half of the fix can
+  // only be asserted here: the dragged row leaves the flow and the
+  // placeholder takes over its exact box, which keeps the list's total
+  // height — and everything above the insertion point — pinned for the whole
+  // gesture.
+  test('the drag placeholder keeps the sidebar height stable', async ({
+    page,
+  }) => {
+    await boot(page, 4);
+    const ids = await sidebarIds(page);
+    const listHeight = () =>
+      page.evaluate(
+        () => document.querySelector('#projects')?.scrollHeight ?? 0,
+      );
+    const topOf = (sid: string) =>
+      page.evaluate(
+        (id) =>
+          document
+            .querySelector(`li.hv-session-row[data-sid="${id}"]`)
+            ?.getBoundingClientRect().top ?? 0,
+        sid,
+      );
+
+    const heightBefore = await listHeight();
+    const firstRowBefore = await topOf(ids[0]);
+
+    await dragStart(page, ids[3]);
+    await dragEvent(page, 'dragover', ids[2], true);
+    await expect(page.locator('.hv-drop-placeholder')).toHaveCount(1);
+
+    // The dragged row is out of the flow and the placeholder occupies its
+    // box, so the list is exactly as tall as it was.
+    expect(await listHeight()).toBe(heightBefore);
+    // Rows before the insertion point do not move at all.
+    expect(await topOf(ids[0])).toBe(firstRowBefore);
+
+    await dragEvent(page, 'drop', ids[2], true);
+    await expect(page.locator('.hv-drop-placeholder')).toHaveCount(0);
+    await expect.poll(listHeight).toBe(heightBefore);
+  });
+
   test('⌘G with a single session does not enter grid mode', async ({
     page,
   }) => {

--- a/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/ordering.spec.ts
@@ -401,6 +401,53 @@ test.describe('keybinding regressions', () => {
       .toEqual([before[0], before[3], before[1], before[2]]);
   });
 
+  // The review regression: an "insert above" placeholder is inserted where the
+  // cursor already is, so the row it displaces moves down and the release
+  // lands on the PLACEHOLDER, not on a row. A placeholder that is not itself
+  // a drop target loses the drop silently.
+  test('a drop released on the placeholder still reorders', async ({
+    page,
+  }) => {
+    await boot(page, 4);
+    const before = await sidebarIds(page);
+
+    await dragStart(page, before[0]);
+    await dragEvent(page, 'dragover', before[2], true);
+    const ph = page.locator('.hv-drop-placeholder');
+    await expect(ph).toHaveCount(1);
+
+    // The placeholder must keep the drag alive on its own …
+    const allowed = await page.evaluate(() => {
+      const w = window as unknown as { __dt?: DataTransfer };
+      const el = document.querySelector('.hv-drop-placeholder') as HTMLElement;
+      const e = new DragEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: w.__dt,
+      });
+      el.dispatchEvent(e);
+      return e.defaultPrevented;
+    });
+    expect(allowed).toBe(true);
+
+    // … and resolve its own slot when the drop lands on it.
+    await page.evaluate(() => {
+      const w = window as unknown as { __dt?: DataTransfer };
+      const el = document.querySelector('.hv-drop-placeholder') as HTMLElement;
+      el.dispatchEvent(
+        new DragEvent('drop', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: w.__dt,
+        }),
+      );
+    });
+
+    await expect
+      .poll(() => sidebarIds(page))
+      .toEqual([before[1], before[0], before[2], before[3]]);
+  });
+
   // vitest is CSS-blind, so the "content does not jump" half of the fix can
   // only be asserted here: the dragged row leaves the flow and the
   // placeholder takes over its exact box, which keeps the list's total

--- a/cmd/hivegui/frontend/test/unit/reorder.test.ts
+++ b/cmd/hivegui/frontend/test/unit/reorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { reorderTarget } from '../../src/lib/reorder.js';
+import { dropTargetIndex, reorderTarget } from '../../src/lib/reorder.js';
 
 // `order` is the session's index in the daemon's r.order — the value
 // reorderTarget must return. The fixtures below deliberately separate
@@ -131,6 +131,106 @@ describe('reorderTarget', () => {
       const target = reorderTarget(display, 's3', +1) as number;
       const after = moveInOrder(raw, 's3', target);
       expect(inProject(after, 'A')).toEqual(['s3', 's1', 's2']);
+      expect(inProject(after, 'B')).toEqual(['t1', 't2']);
+    });
+  });
+});
+
+// dropTargetIndex — the drag-and-drop half of the same conversion.
+//
+// Every case runs the returned index through moveInOrder and asserts the
+// RESULTING order. Asserting the bare index would just re-encode whatever the
+// implementation does; the bug this suite exists for (spec 305) produced a
+// perfectly plausible-looking index that landed the row one slot too low.
+describe('dropTargetIndex', () => {
+  // One project, so r.order index == display position.
+  const flat = ['a', 'b', 'c', 'd'];
+  const sessions = flat.map((id, i) => ({ id, projectId: 'P', order: i }));
+  const drop = (dragged: string, target: string, above: boolean) => {
+    const idx = dropTargetIndex(sessions, dragged, target, above);
+    return idx === null ? flat : moveInOrder(flat, dragged, idx);
+  };
+
+  it('drops above a target further down the list', () => {
+    // The regression: this used to land [b, c, a, d] — one slot too low.
+    expect(drop('a', 'c', true)).toEqual(['b', 'a', 'c', 'd']);
+  });
+
+  it('drops below a target further down the list', () => {
+    expect(drop('a', 'c', false)).toEqual(['b', 'c', 'a', 'd']);
+  });
+
+  it('drops above a target further up the list', () => {
+    expect(drop('d', 'b', true)).toEqual(['a', 'd', 'b', 'c']);
+  });
+
+  it('drops below a target further up the list', () => {
+    expect(drop('d', 'b', false)).toEqual(['a', 'b', 'd', 'c']);
+  });
+
+  it('drops at the head of the list', () => {
+    expect(drop('c', 'a', true)).toEqual(['c', 'a', 'b', 'd']);
+  });
+
+  it('drops past the last row', () => {
+    expect(drop('a', 'd', false)).toEqual(['b', 'c', 'd', 'a']);
+  });
+
+  it('is a no-op when the slot is the one the session already holds', () => {
+    expect(dropTargetIndex(sessions, 'a', 'a', true)).toBeNull();
+    expect(dropTargetIndex(sessions, 'a', 'b', true)).toBeNull();
+    expect(dropTargetIndex(sessions, 'b', 'a', false)).toBeNull();
+  });
+
+  it('returns null for an unknown dragged or target session', () => {
+    expect(dropTargetIndex(sessions, 'nope', 'b', true)).toBeNull();
+    expect(dropTargetIndex(sessions, 'a', 'nope', true)).toBeNull();
+  });
+
+  it('reads both projectId and project_id spellings', () => {
+    const snake = [
+      { id: 'a', project_id: 'P', order: 0 },
+      { id: 'b', project_id: 'P', order: 1 },
+      { id: 'c', project_id: 'P', order: 2 },
+    ];
+    const idx = dropTargetIndex(snake, 'c', 'b', true) as number;
+    expect(moveInOrder(['a', 'b', 'c'], 'c', idx)).toEqual(['a', 'c', 'b']);
+  });
+
+  // Same trap as reorderTarget's: r.order is one flat list across projects,
+  // so a project-relative slot must be translated through a sibling's global
+  // index, and the other project must come out untouched.
+  describe('when projects interleave in the daemon order', () => {
+    const raw = ['s1', 't1', 's2', 't2', 's3'];
+    const proj: Record<string, string> = {
+      s1: 'A',
+      t1: 'B',
+      s2: 'A',
+      t2: 'B',
+      s3: 'A',
+    };
+    const all = raw.map((id, i) => ({ id, projectId: proj[id], order: i }));
+    const inProject = (order: string[], pid: string) =>
+      order.filter((id) => proj[id] === pid);
+
+    it('drops above a sibling that is not adjacent in r.order', () => {
+      const idx = dropTargetIndex(all, 's3', 's2', true) as number;
+      const after = moveInOrder(raw, 's3', idx);
+      expect(inProject(after, 'A')).toEqual(['s1', 's3', 's2']);
+      expect(inProject(after, 'B')).toEqual(['t1', 't2']);
+    });
+
+    it('drops below a sibling further down the project', () => {
+      const idx = dropTargetIndex(all, 's1', 's2', false) as number;
+      const after = moveInOrder(raw, 's1', idx);
+      expect(inProject(after, 'A')).toEqual(['s2', 's1', 's3']);
+      expect(inProject(after, 'B')).toEqual(['t1', 't2']);
+    });
+
+    it('drops past the last sibling without swallowing the other project', () => {
+      const idx = dropTargetIndex(all, 's1', 's3', false) as number;
+      const after = moveInOrder(raw, 's1', idx);
+      expect(inProject(after, 'A')).toEqual(['s2', 's3', 's1']);
       expect(inProject(after, 'B')).toEqual(['t1', 't2']);
     });
   });

--- a/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
+++ b/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
@@ -1,0 +1,145 @@
+# Fix sidebar drag-and-drop ordering and drop placeholder
+
+- **Spec:** [docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md](../../product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md)
+- **Issue:** —
+- **Status:** active
+
+## Summary
+
+Two independent sidebar drag defects. The session reorder math resolves the drop
+slot against the wrong list and lands the row one position too low; the drop
+affordance is a zero-height line that reserves no space, so the list reflows all
+at once on drop. Fix the math as a pure, unit-tested function and replace the
+line with a real placeholder that occupies the dragged element's box.
+
+## Research
+
+Authored via plan-first mode. Code touched:
+
+- `cmd/hivegui/frontend/src/app/sidebar.ts:569-613` — `reorderDroppedSession`.
+  `targetIdx`/`projIdx` are computed against `projSessions` (includes the
+  dragged row) and then used to index `pretend` (dragged row filtered out).
+  When the dragged row sits before the target, every `pretend` index is shifted
+  left by one, so the resolved neighbour is one row too far down.
+  Trace `[A,B,C,D]`, drag A above C: `pretend[2]` = D (should be C), global
+  index 3 → compensated to 2 → daemon splices `[B,C,A,D]`. A lands below C.
+- `cmd/hivegui/frontend/src/app/sidebar.ts:416-432` — `reorderDroppedProject`
+  indexes one consistent list and is **not** affected.
+- `internal/registry/registry.go:1040-1060` — `moveInOrder` is
+  delete-then-insert at a global index into `r.order`; `reindexLocked` keeps
+  `Order` equal to that index. Both frontend reorder paths depend on it.
+- `cmd/hivegui/frontend/src/lib/reorder.ts` — `reorderTarget` (keyboard
+  ⇧⌘↑/↓ path) already documents the same invariant and cross-references the
+  drag path. Natural home for the extracted drag math.
+- `cmd/hivegui/frontend/src/theme/components/session-row.css:155-169` and
+  `project-card.css:118-134` — `.dragging { opacity: 0.45 }` plus an
+  absolutely-positioned 2px `::after`; neither reserves layout space.
+- `cmd/hivegui/frontend/src/app/sidebar.ts:96-125` — `sidebarShape()` /
+  `domShape()` select `.hv-project-card, .hv-session-row`; a placeholder must
+  carry neither class or the in-place-update path mistakes it for a row.
+- `renderSidebar()` (`sidebar.ts:76`) clears `projectsUL.innerHTML`, so a poll
+  landing mid-drag wipes drag chrome. The placeholder module re-asserts state
+  on every `dragover` to stay self-healing.
+
+## Approach
+
+Split the two defects.
+
+**Ordering** — extract the index computation into a pure
+`dropTargetIndex(sessions, draggedID, targetID, above)` in `lib/reorder.ts`,
+with the slot derived from `pretend` instead of `projSessions`. Chosen over an
+in-place one-line patch in `sidebar.ts` because the function is untestable where
+it currently lives (module-private, calls `UpdateSession` directly), and this
+class of off-by-one is exactly what a table test catches. It also puts both
+order-index conversions in one file under the shared `.order === r.order index`
+invariant comment.
+
+**Placeholder** — one shared `lib/drag-placeholder.ts` used by both
+`wireSessionDrag` and `wireProjectDrag`: measure the dragged element, take it
+out of flow, insert a spacer of the same margin box at the drop slot. Shared
+rather than duplicated because the two wiring functions already mirror each
+other and the measure/hide/insert/cleanup mechanics are identical.
+
+Two mechanics the implementation must get right:
+
+1. Setting `display: none` on the drag source *inside* `dragstart` aborts the
+   drag (the drag image snapshot is taken after the handler returns). Defer the
+   hidden state by one tick with `setTimeout(…, 0)`.
+2. The spacer must reproduce the full margin box. Project cards carry
+   `margin: var(--space-1) var(--space-2) var(--space-2)`; adjacent-sibling
+   margin collapsing in the `<ul>` means a zero-margin spacer would not occupy
+   the same space. Copy the computed vertical margins onto the spacer alongside
+   the measured content height.
+
+### Files to change
+
+- `cmd/hivegui/frontend/src/lib/reorder.ts` — add `dropTargetIndex(...)`
+  returning the global index for `UpdateSession`, or `null` for a no-op.
+  Extend the header comment to cover the third caller.
+- `cmd/hivegui/frontend/src/app/sidebar.ts` — `reorderDroppedSession` reduces
+  to `dropTargetIndex(...)` + `UpdateSession`. `wireSessionDrag` /
+  `wireProjectDrag`: `dragstart` → `beginDrag`, `dragover` → `moveTo`,
+  `dragend`/`drop` → `endDrag`. The `.drop-above`/`.drop-below` class toggles
+  and both `querySelectorAll` sweeps collapse into `endDrag()`. Project drag
+  keeps its header-rect hit test and `dragleave` `contains()` guard.
+- `cmd/hivegui/frontend/src/theme/components/session-row.css` — drop the
+  `.drop-above/.drop-below::after` rules; `.dragging` → `display: none`.
+- `cmd/hivegui/frontend/src/theme/components/project-card.css` — same.
+- `cmd/hivegui/frontend/src/theme/components/sidebar.css` — add
+  `.hv-drop-placeholder` (dashed token-coloured outline, `--radius-md`,
+  `list-style: none`, `box-sizing: border-box`, `pointer-events: none`).
+  Tokens only; `scripts/ui-lint.sh` rejects colour literals.
+
+### New files
+
+- `cmd/hivegui/frontend/src/lib/drag-placeholder.ts` — `beginDrag(el)` records
+  the element, its `getBoundingClientRect().height` and computed vertical
+  margins, and defers the hidden state one tick; `moveTo(target, above)`
+  lazily creates/sizes the spacer, re-asserts the hidden state and inserts it
+  before `target` or `target.nextSibling`; `endDrag()` removes the spacer,
+  unhides and clears state (idempotent).
+
+### Tests
+
+- `cmd/hivegui/frontend/test/unit/reorder.test.ts` (extend) — `dropTargetIndex`
+  table test: drag-down-above-target, drag-down-below-target, drag-up-above,
+  drag-up-below, drop onto self (`null`), drop at head, drop past the last row,
+  and the interleaved multi-project case. Each case asserts the
+  post-`moveInOrder` array, not the raw index — a bare index assertion just
+  re-encodes the bug.
+- `cmd/hivegui/frontend/test/dom/drag-placeholder.test.ts` (new) — `moveTo`
+  inserts `.hv-drop-placeholder` at the right sibling position carrying neither
+  row class; `endDrag` removes it and restores the element; a second `moveTo`
+  moves the single spacer rather than creating a second one.
+- `cmd/hivegui/frontend/test/e2e/ordering.spec.ts` (extend) — drag a session
+  onto the top half of another against the Wails mock and assert the row order
+  lands exactly at the drop point; must fail against pre-fix `main`. Also
+  capture `boundingBox().y` of the row below the drop target before and during
+  the drag and assert it is unchanged (vitest is CSS-blind; layout stability is
+  only meaningful in the browser).
+
+## Decision log
+
+- **2026-09-01** — Extract the drag index math into `lib/reorder.ts` rather than
+  patching in place. Why: the private function is untestable where it lives, and
+  the invariant it depends on is already documented next to `reorderTarget`.
+- **2026-09-01** — One placeholder module for both session rows and project
+  cards. Why: identical mechanics, and the user asked for the affordance in both
+  places.
+- **2026-09-01** — Placeholder replaces the 2px line rather than joining it, and
+  the dragged element leaves the flow. Why: only a net-zero height change keeps
+  surrounding content from shifting during the drag.
+
+## Progress
+
+- **2026-09-01** — Plan-first scaffold; stage = IMPLEMENT (set in spec frontmatter).
+
+## Open questions
+
+- Cross-project drags stay unsupported; the placeholder will render over a
+  foreign project's rows and snap back on drop. Acceptable, worth a follow-up.
+- If the deferred `display: none` still cancels the drag in WKWebView, fall back
+  to `visibility: hidden; height: 0` on the source. The e2e test catches it.
+- The spacer is `pointer-events: none`, which should prevent a spurious
+  `dragleave` on the project card when the cursor crosses it — verify in the
+  browser, not by reasoning.

--- a/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
+++ b/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
@@ -89,8 +89,10 @@ Two mechanics the implementation must get right:
 - `cmd/hivegui/frontend/src/theme/components/project-card.css` — same.
 - `cmd/hivegui/frontend/src/theme/components/sidebar.css` — add
   `.hv-drop-placeholder` (dashed token-coloured outline, `--radius-md`,
-  `list-style: none`, `box-sizing: border-box`, `pointer-events: none`).
-  Tokens only; `scripts/ui-lint.sh` rejects colour literals.
+  `list-style: none`, `box-sizing: border-box`). Tokens only;
+  `scripts/ui-lint.sh` rejects colour literals. It is deliberately
+  hit-testable — see the decision log entry that reversed the original
+  `pointer-events: none`.
 
 ### New files
 
@@ -142,6 +144,11 @@ Two mechanics the implementation must get right:
   placeholder half (drop target lost under the cursor, overclaimed mid-rebuild
   self-healing, one-frame height jump at drag start). All three verified and
   fixed on the branch; suite now 797 unit/dom + 246 e2e.
+- **2026-09-01** — Review iteration 2: APPROVE, no BLOCKING or IMPORTANT
+  findings, zero unresolved threads. Its three MINOR nits were cleared anyway
+  (spacer now copies all four margins, `dropTargetIndex` uses `readProjectId`,
+  this plan's Files-to-change no longer contradicts its own decision log).
+  Loop converged; stage = GATE.
 
 ## Decision log (cont.)
 
@@ -170,6 +177,7 @@ Two mechanics the implementation must get right:
 <Append-only. One line per /hs-review-loop iteration.>
 
 - **2026-09-01 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: d5dbc6d8b95e2678; threads_open: 0; action: escalated:risky fix needs human decision; head_sha: 770ed58.
+- **2026-09-01 iter 2** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 639c3e8.
 
 ## Open questions
 

--- a/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
+++ b/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md](../../product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md)
 - **Issue:** —
+- **PR:** #315
+- **Branch:** quick-moon
 - **Status:** active
 
 ## Summary
@@ -133,6 +135,9 @@ Two mechanics the implementation must get right:
 ## Progress
 
 - **2026-09-01** — Plan-first scaffold; stage = IMPLEMENT (set in spec frontmatter).
+- **2026-09-01** — Implemented, all checks green (794 unit/dom, 15 e2e, Go suite,
+  biome ci, tsc, ui-lint). The four new ordering assertions were confirmed to
+  fail against the pre-fix math. PR #315 opened; stage = REVIEW.
 
 ## Open questions
 
@@ -140,6 +145,15 @@ Two mechanics the implementation must get right:
   foreign project's rows and snap back on drop. Acceptable, worth a follow-up.
 - If the deferred `display: none` still cancels the drag in WKWebView, fall back
   to `visibility: hidden; height: 0` on the source. The e2e test catches it.
-- The spacer is `pointer-events: none`, which should prevent a spurious
-  `dragleave` on the project card when the cursor crosses it — verify in the
-  browser, not by reasoning.
+- Resolved during implementation: the project card's `dragleave` handler was
+  removed outright rather than made spacer-safe. A single shared spacer follows
+  the cursor, so there is no stale per-card indicator left behind to clear, and
+  a `dragleave`-driven `endDrag()` would have torn down the whole drag session
+  on the way to the next card.
+- **Open.** Headless Chromium does not synthesise native HTML5 drag against
+  this app's page (no `dragstart`; it works on a bare page — `draggable` is
+  set, `mousedown` is not `preventDefault`ed, the row is not re-rendered
+  mid-gesture; cause not found). The e2e specs dispatch `DragEvent`s instead,
+  so drag *initiation* — the thing the deferred `display: none` depends on —
+  is unverified. Needs one manual drag in the built app. Fallback if it does
+  cancel: `visibility: hidden; height: 0` on the source.

--- a/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
+++ b/docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
@@ -138,6 +138,38 @@ Two mechanics the implementation must get right:
 - **2026-09-01** — Implemented, all checks green (794 unit/dom, 15 e2e, Go suite,
   biome ci, tsc, ui-lint). The four new ordering assertions were confirmed to
   fail against the pre-fix math. PR #315 opened; stage = REVIEW.
+- **2026-09-01** — Review iteration 1 returned three findings against the
+  placeholder half (drop target lost under the cursor, overclaimed mid-rebuild
+  self-healing, one-frame height jump at drag start). All three verified and
+  fixed on the branch; suite now 797 unit/dom + 246 e2e.
+
+## Decision log (cont.)
+
+- **2026-09-01** — The placeholder is a real drop target, not decoration.
+  Review iter 1 caught that an "insert above" spacer is inserted where the
+  cursor already is: it pushes the target row down and the cursor ends up over
+  the spacer. With `pointer-events: none` the hit-test fell through to a
+  container with no `dragover` handler, so nothing called `preventDefault`, the
+  browser disallowed the drop, and releasing there silently no-opped. The
+  "below" branch still worked, which would have read as intermittent. The
+  spacer now handles its own `dragover`/`drop` and resolves its slot from the
+  rows it sits between. Rejected the alternative (container-level handlers on
+  `#projects` and each card body) as more listeners for the same result.
+- **2026-09-01** — Both drop paths read the payload out of the `DataTransfer`
+  rather than module state. A module-level "currently dragged id" was the first
+  shape; it broke `test/dom/minimize-project.test.ts`, which synthesises a drop
+  with `getData()` and no `dragstart` — and that test was right: `getData()` is
+  the canonical source during `drop`, available on the placeholder's drop too.
+- **2026-09-01** — The spacer goes in during `beginDrag`'s deferred tick, at
+  the dragged element's own position, in the same tick that hides it. Review
+  iter 1 caught that inserting it only on the first `dragover` left a window
+  where the list was one row shorter.
+
+## PR convergence ledger
+
+<Append-only. One line per /hs-review-loop iteration.>
+
+- **2026-09-01 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: d5dbc6d8b95e2678; threads_open: 0; action: escalated:risky fix needs human decision; head_sha: 770ed58.
 
 ## Open questions
 

--- a/docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
+++ b/docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
@@ -1,0 +1,55 @@
+---
+issue: null
+title: "Fix sidebar drag-and-drop ordering and drop placeholder"
+type: bug
+complexity: S
+priority: P2
+stage: IMPLEMENT
+---
+
+# Fix sidebar drag-and-drop ordering and drop placeholder
+
+- **Issue:** —
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md](../exec-plans/active/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md)
+
+## Problem
+
+Dragging a session row in the sidebar does not land it where it was dropped —
+it consistently ends up one slot *below* the drop point. The drop affordance is
+also only a 2px accent line while the dragged row keeps occupying its original
+space at 45% opacity, so nothing previews the final layout and every row below
+the drag jumps at the moment of the drop.
+
+## Desired behavior
+
+A dropped session lands exactly at the position the drop indicator showed. While
+a drag is in flight the sidebar reserves a placeholder the same size as the
+dragged item, and the dragged item itself is out of the flow — so the list's
+total height is unchanged and no surrounding content shifts until the drop
+commits. Project cards get the same affordance as session rows.
+
+## Success criteria
+
+- Dragging a session onto the top half of a target row places it immediately
+  above that row; onto the bottom half, immediately below it. Verified in both
+  drag directions and with projects interleaved in the daemon's global order.
+- A placeholder matching the dragged element's full margin box appears at the
+  drop slot, for both session rows and project cards.
+- The dragged element is removed from the layout flow while dragging, so the
+  y-position of rows below the drop target does not change during the drag.
+- A regression test exists that fails against the pre-fix ordering math.
+
+## Non-goals
+
+- Cross-project session drags (still an early return in `wireSessionDrag`).
+- Any change to the daemon's `moveInOrder` / `reindexLocked` semantics.
+- Animated placeholder transitions or drag auto-scroll.
+
+## Notes
+
+Root cause: `reorderDroppedSession` indexes `pretend` (dragged row removed)
+with an index computed against `projSessions` (dragged row present).
+`reorderDroppedProject` does not share the bug.

--- a/docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
+++ b/docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
@@ -4,7 +4,7 @@ title: "Fix sidebar drag-and-drop ordering and drop placeholder"
 type: bug
 complexity: S
 priority: P2
-stage: REVIEW
+stage: GATE
 pr: 315
 ---
 

--- a/docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
+++ b/docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md
@@ -4,7 +4,8 @@ title: "Fix sidebar drag-and-drop ordering and drop placeholder"
 type: bug
 complexity: S
 priority: P2
-stage: IMPLEMENT
+stage: REVIEW
+pr: 315
 ---
 
 # Fix sidebar drag-and-drop ordering and drop placeholder


### PR DESCRIPTION
Two sidebar drag-and-drop defects, reported together.

## 1. A dragged session landed one slot too low

`reorderDroppedSession` resolved the drop slot as an index into the project's
row list **including** the dragged row, then used that index against the list
with the dragged row **removed**. Whenever the dragged row sat before the
target, every index shifted left by one.

Trace `[A,B,C,D]`, drag `A` and drop **above** `C`:

| step | value |
|---|---|
| `targetIdx` (C, list *with* A) | 2 |
| `pretend` (list *without* A) | `[B,C,D]` |
| `pretend[2]` | **D** — should be C |
| daemon `moveInOrder` | `[B,C,A,D]` |

A lands *below* C. `reorderDroppedProject` indexes one consistent list and was
never affected.

The math moves to `lib/reorder.ts` as the pure `dropTargetIndex()`, next to
`reorderTarget()`. Both rest on the same invariant — a session's `.order` IS
its index in the daemon's `r.order` — and a pure function is the only way to
table-test this class of off-by-one.

## 2. The drop indicator reserved no space

The affordance was a 2px absolutely-positioned line while the dragged row
stayed in the flow at 45% opacity, so the whole list reflowed at the instant
of the drop. The dragged element now leaves the flow and
`lib/drag-placeholder.ts` inserts a spacer of its exact margin box at the drop
slot — net zero height change, so the list's total height and everything above
the insertion point stay pinned for the whole gesture. Session rows and project
cards share the module.

Two mechanics worth flagging for review:

- Hiding the drag source is deferred one tick. A source already at
  `display: none` when the `dragstart` handler returns cancels the drag.
- The spacer copies the dragged element's computed vertical margins, not just
  its height: project cards carry margins and a zero-margin spacer would not
  occupy the same space once adjacent-sibling margins collapse.

The spacer deliberately wears neither `hv-session-row` nor `hv-project-card`,
because `domShape()` reads the sidebar back with that selector pair.

## Tests

- `test/unit/reorder.test.ts` — `dropTargetIndex` table test. Every case
  asserts the array **after** `moveInOrder`, not the raw index; asserting the
  index would just re-encode whatever the implementation does.
- `test/dom/drag-placeholder.test.ts` — the placeholder's DOM contract
  (position, uniqueness, deferred hide, idempotent cleanup, no row classes).
- `test/e2e/ordering.spec.ts` — landing slot in both drag directions plus the
  layout-stability assertion (`#projects` `scrollHeight` and the first row's
  `top` unchanged mid-drag). vitest is CSS-blind; that half is only meaningful
  in a browser.

The four ordering assertions were confirmed to fail against the pre-fix math.

## Known gap

Headless Chromium does not synthesise native HTML5 drag against this app's
page — no `dragstart` fires, though it does on a bare page (probed: `draggable`
is set, `mousedown` is not `preventDefault`ed, the row is not re-rendered
mid-gesture; cause not found). The e2e specs therefore dispatch `DragEvent`s
sharing one `DataTransfer`. Everything downstream is real — real layout, real
CSS, real reorder call — but the browser's own decision to *begin* a drag is
not covered, which is exactly what the deferred hide depends on. Wants one
manual drag in the built app.

Verified: 794 unit/dom · 15 e2e · full Go suite · `biome ci` · `tsc --noEmit` ·
`ui-lint.sh`.

Spec: `docs/product-specs/305-fix-sidebar-drag-and-drop-ordering-and-placeholder.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)