### PR TITLE
refactor(gui): phase 3 — render launcher + settings from React

### DIFF
--- a/.changesets/react-rewrite-phase3-modals.md
+++ b/.changesets/react-rewrite-phase3-modals.md
@@ -1,6 +1,7 @@
 ---
 type: changed
 bump: patch
+pr: 319
 ---
 
 Settings now shows its confirm and cancel key hints (`[esc]` / `[enter]`) in the dialog footer, like every other overlay.

--- a/.changesets/react-rewrite-phase3-modals.md
+++ b/.changesets/react-rewrite-phase3-modals.md
@@ -1,0 +1,6 @@
+---
+type: changed
+bump: patch
+---
+
+Settings now shows its confirm and cancel key hints (`[esc]` / `[enter]`) in the dialog footer, like every other overlay.

--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -107,6 +107,12 @@
          title="Drag to resize (← / → to adjust, ⇧ for larger steps)"></div>
   </aside>
   <div id="launcher" class="hidden" role="menu"></div>
+  <!-- The settings dialog's root. Empty: components/modals/Settings.tsx
+       renders the panel into it. The attributes are the ones ui/dialog.ts
+       stamps on a dialog root, and they live here so the React root has
+       something to mount on before the modal is ever opened. -->
+  <div id="settings" class="hv-dialog hidden" role="dialog" aria-modal="true"
+       aria-labelledby="settings-title"></div>
   <div id="command-palette" class="hidden" role="dialog" aria-label="Command palette">
     <input id="command-palette-input" type="text" placeholder="Search actions, shortcuts…" aria-label="Search commands" autocomplete="off"/>
     <div id="command-palette-list" role="listbox"></div>

--- a/cmd/hivegui/frontend/src/app/modals/launcher.ts
+++ b/cmd/hivegui/frontend/src/app/modals/launcher.ts
@@ -1,40 +1,36 @@
-// ---------- agent launcher ----------
+// ---------- agent launcher: the non-React half ----------
 //
-// Moved verbatim from main.js. Focus-pipeline callbacks are injected
-// via initLauncher(deps) — the launcher must never import the focus
-// pipeline directly (main.ts owns that wiring).
+// The launcher renders from components/modals/Launcher.tsx (Phase 3).
+// What stays here is everything that is not rendering:
+//
+//   * openLauncher / closeLauncher, the store actions every caller
+//     (keyboard.ts, events.ts, main.ts, Sidebar.tsx, EmptyState.tsx)
+//     already imports from this path,
+//   * the launch-count table the agent list is ordered by,
+//   * the three session actions that never open the launcher at all
+//     (duplicate, restart) or that open it with a request built from
+//     the active session.
+//
+// Focus-pipeline callbacks are injected via initLauncher(deps) — this
+// module must never import the focus pipeline directly (main.ts owns
+// that wiring).
 
-import {
-  CreateSession,
-  DuplicateSession,
-  RestartSession,
-  ListAgents,
-  IsGitRepo,
-} from '../../bridge.js';
+import { flushSync } from 'react-dom';
+import { DuplicateSession, RestartSession } from '../../bridge.js';
 import { state } from '../state.js';
 import { flashStatus, reportFailure } from '../dom.js';
 import { activeProjectId, resolveSessionCwd } from '../selectors.js';
 import { registerModal } from './registry.js';
 import { releaseFocus } from './focus-trap.js';
 import { pageEl } from '../el.js';
-import { cmdOrCtrl } from '../../lib/platform.js';
-import { kbd } from '../../ui/kbd.js';
+import { closeModal, isModalOpen, openModal } from '../../store/store.js';
 import type { SessionInfo } from '../state.js';
-// Type-only, so the generated module is erased before Vite resolves it.
-import type { main } from '../../../wailsjs/go/models';
 
 // Narrow on purpose: this modal needs exactly two callbacks off the
 // focus pipeline, so it names those two rather than the whole module.
 export interface LauncherDeps {
   setFocusedTile: (id: string | null) => void;
   refocusActiveTerm: () => void;
-}
-
-// One rendered agent row, paired with the element that draws it so
-// highlightLauncherSelection can toggle data-selected without re-querying.
-interface LauncherItem {
-  agent: main.AgentInfo;
-  el: HTMLElement;
 }
 
 export interface LauncherOpts {
@@ -57,88 +53,18 @@ let deps: LauncherDeps = {
 
 export const launcherEl = pageEl('launcher');
 
-// The three children openLauncher builds inside #launcher, in order:
-// the filter box, the worktree row, and the list of agent rows. Only
-// the list is rebuilt as the user types — recreating the input would
-// drop focus and the caret on every keystroke.
-//
-// All three are recreated per open (openLauncher clears #launcher), so
-// a query never leaks from one opening to the next. They are null
-// before the first open and after a close, which is reachable: the
-// ListAgents rejection path closes a launcher whose children were
-// never filled in.
-let searchEl: HTMLInputElement | null = null;
-let listEl: HTMLElement | null = null;
-// The branch-name box, when the worktree toggle is on. Module-level for
-// the same reason searchEl is: the mousedown and keydown handlers below
-// are installed once at init and have to recognise it.
-let branchEl: HTMLInputElement | null = null;
-// Bumped on every open. A ListAgents promise captures the value it was
-// issued under and bails if it no longer matches, so a slow response
-// can't land in a launcher that has since been reopened.
-//
-// This used to be implicit: the old .then began by wiping #launcher, so
-// a late resolve just rebuilt everything. The wipe had to go (it would
-// destroy the focused filter box), which turned "harmlessly redundant"
-// into "inserts a second worktree row" — the `hidden` check alone
-// doesn't catch a reopen, because the launcher is visible again by then.
-let openGeneration = 0;
-// The usage-ordered agent list ListAgents returned, kept so filtering
-// re-renders from memory instead of refetching. Reset per open, not
-// just per close: a ⌘T over an already-open launcher would otherwise
-// filter the previous opening's list until the new response lands.
-let allAgents: main.AgentInfo[] = [];
-// True from the moment a request is issued until it settles. Without
-// it, an empty allAgents is indistinguishable from "the query excluded
-// everything", and the first character typed during the round trip
-// would replace the loading row with "No agents match".
-let agentsLoading = false;
-export const launcherState: {
-  items: LauncherItem[];
-  selected: number;
-  projectId: string | null;
-  useWorktree: boolean;
-  branch: string;
-  worktreePath: string;
-  continueConversation: boolean;
-  duplicateFrom: SessionInfo | null;
-  duplicateCwd: string;
-} = {
-  items: [],
-  selected: 0,
-  projectId: null,
-  // branch names the worktree to create. Empty lets the daemon
-  // generate an adjective-noun, which is the long-standing default.
-  branch: '',
-  // worktreePath, when set, runs the session in an EXISTING worktree
-  // instead of creating one.
-  worktreePath: '',
-  // Only ever true for one opening, set by the worktree browser's
-  // "Continue previous" action.
-  continueConversation: false,
-  // useWorktree is sticky across launcher opens, persisted in
-  // localStorage. ⌃⌘N opens the launcher with this forced to true
-  // for the duration of that opening.
-  useWorktree: localStorage.getItem('hive.worktree') === '1',
-  // duplicateFrom, when set, switches the launcher into "duplicate
-  // session" mode: cwd is fixed to duplicateCwd, the worktree toggle is
-  // hidden, and selecting an agent calls DuplicateSession instead of
-  // CreateSession.
-  duplicateFrom: null,
-  duplicateCwd: '',
-};
-
 // Agent id → launch count, persisted in localStorage. Read back as
 // unknown JSON, so every lookup is `|| 0`.
-type AgentUsage = Record<string, number>;
+export type AgentUsage = Record<string, number>;
 
-function loadAgentUsage(): AgentUsage {
+export function loadAgentUsage(): AgentUsage {
   try {
     return JSON.parse(localStorage.getItem('hive.agentUsage') || '{}') || {};
   } catch {
     return {};
   }
 }
+
 export function bumpAgentUsage(id: string | undefined) {
   if (!id) return;
   const u = loadAgentUsage();
@@ -148,384 +74,59 @@ export function bumpAgentUsage(id: string | undefined) {
   } catch {}
 }
 
-function highlightLauncherSelection() {
-  launcherState.items.forEach((it, i) => {
-    it.el.toggleAttribute('data-selected', i === launcherState.selected);
-    if (i === launcherState.selected)
-      it.el.scrollIntoView({ block: 'nearest' });
-  });
-}
-
-function moveLauncherSelection(delta: number) {
-  const n = launcherState.items.length;
-  if (n === 0) return;
-  launcherState.selected = (launcherState.selected + delta + n) % n;
-  highlightLauncherSelection();
-}
-
-// launchSelected runs the create/duplicate-session sequence shared by
-// the keyboard-select path (activateLauncherSelection) and the
-// per-item click handler in openLauncher: bump usage, flash status,
-// call the daemon, close the launcher.
-function launchSelected(agentId: string) {
-  bumpAgentUsage(agentId);
-  flashStatus('creating session…');
-  // Anchor the new session under the one it came from (duplicate) or
-  // under the active one, so it lands next to its context instead of at
-  // the bottom of the sidebar.
-  const anchor = launcherState.duplicateFrom?.id || state.activeId || '';
-  if (launcherState.duplicateFrom) {
-    DuplicateSession(
-      agentId,
-      launcherState.projectId || '',
-      launcherState.duplicateCwd,
-      anchor,
-    ).catch(reportFailure('duplicate session'));
-  } else {
-    CreateSession(
-      agentId,
-      launcherState.projectId || activeProjectId(),
-      '',
-      '',
-      0,
-      0,
-      !!launcherState.useWorktree,
-      anchor,
-      launcherState.branch,
-      launcherState.worktreePath,
-      launcherState.continueConversation,
-    ).catch(reportFailure('new session'));
-  }
-  closeLauncher();
-}
-
-function activateLauncherSelection() {
-  const it = launcherState.items[launcherState.selected];
-  if (!it) return;
-  launchSelected(it.agent.id);
-}
-
-// Rebuild the agent rows from allAgents, narrowed to those whose name
-// contains the query. Same substring match the command palette uses
-// (modals/command-palette.ts) — deliberately not fuzzy.
-//
-// The query is read off searchEl every call rather than cached:
-// ListAgents can resolve after the user has already started typing,
-// and a cached query would be stale by the time this runs for the
-// first filled-in render.
-function renderLauncherList() {
-  if (!listEl) return;
-  // Two readings of the same box, on purpose. `raw` decides whether the
-  // user is typing — it must agree with the digit handler, which also
-  // tests the raw value, or a lone space would show [n] hints that no
-  // longer fire. `q` decides what matches, where surrounding whitespace
-  // is just noise.
-  const raw = searchEl?.value ?? '';
-  const q = raw.trim().toLowerCase();
-  listEl.innerHTML = '';
-  launcherState.items = [];
-  const matches = q
-    ? allAgents.filter((a) => a.name.toLowerCase().includes(q))
-    : allAgents;
-  if (matches.length === 0) {
-    const none = document.createElement('div');
-    // Three different facts, and conflating any two of them misreads as
-    // a broken agent list: the request is still in flight, the daemon
-    // returned nothing, or the query excluded everything.
-    if (agentsLoading) {
-      none.className = 'launcher-loading';
-      none.textContent = 'Loading agents…';
-    } else {
-      none.className = 'launcher-empty';
-      none.textContent = q ? 'No agents match' : 'No agents found';
-    }
-    listEl.appendChild(none);
-  }
-  matches.forEach((a, idx) => {
-    const item = document.createElement('div');
-    item.className = 'launcher-item';
-    if (!a.available) item.dataset.available = 'false';
-    item.style.setProperty('--agent-color', a.color);
-    const num = document.createElement('span');
-    num.className = 'agent-num';
-    // Number keys 1–9 select that row directly; 10+ rows show no
-    // number (no digit shortcut). While a query is active the digits
-    // type into it instead of selecting, so the hints come off — a
-    // visible [n] that does nothing is worse than none (AGENTS.md,
-    // Key Discoverability). kbd() is the only way a key hint renders
-    // (patterns.md > Keyboard hints).
-    if (!raw && idx < 9) num.append(kbd(`[${idx + 1}]`));
-    const dot = document.createElement('span');
-    dot.className = 'agent-dot';
-    const name = document.createElement('span');
-    name.className = 'agent-name';
-    name.textContent = a.name;
-    item.append(num, dot, name);
-    if (!a.available && a.installCmd && a.installCmd.length) {
-      const tag = document.createElement('span');
-      tag.className = 'install-tag';
-      tag.title = a.installCmd.join(' ');
-      tag.textContent = 'install?';
-      item.appendChild(tag);
-    }
-    item.addEventListener('click', () => launchSelected(a.id));
-    item.addEventListener('mouseenter', () => {
-      launcherState.selected = idx;
-      highlightLauncherSelection();
-    });
-    listEl?.appendChild(item);
-    launcherState.items.push({ agent: a, el: item });
-  });
-  // Narrowing the list invalidates the old index — the row that was
-  // selected may not even be rendered any more. Always land on the
-  // top match so Enter means "the obvious one".
-  launcherState.selected = 0;
-  highlightLauncherSelection();
-}
-
 // projectId is optional, not just nullable: main.ts, keyboard.ts and
 // view.ts all call openLauncher() bare and let the `|| activeProjectId()`
-// fallback below pick the project. Wave 5a typed it as required because
-// every one of those callers was still unchecked JS.
+// fallback below pick the project.
 export function openLauncher(projectId?: string | null, opts?: LauncherOpts) {
-  launcherState.projectId = projectId || activeProjectId();
   // Re-read the sticky pref each open so a one-shot forceWorktree from a
-  // previous opening doesn't leak into the next regular open. forceWorktree
-  // overrides for this opening only and is intentionally not persisted.
-  launcherState.useWorktree =
-    opts && typeof opts.forceWorktree === 'boolean'
-      ? opts.forceWorktree
-      : localStorage.getItem('hive.worktree') === '1';
-  // duplicateFrom: when present, the launcher is forking an existing
-  // session into the same cwd — never a new worktree.
-  launcherState.duplicateFrom = opts?.duplicateFrom || null;
-  launcherState.duplicateCwd = opts?.duplicateCwd || '';
-  // Reset per open: a branch typed for one session must never leak
-  // into the next one, which would silently reuse (or collide with)
-  // the previous name.
-  launcherState.branch = '';
-  launcherState.worktreePath = opts?.worktreePath || '';
-  launcherState.continueConversation = !!opts?.continueConversation;
-  if (launcherState.duplicateFrom || launcherState.worktreePath) {
-    launcherState.useWorktree = false;
-  }
-  // Open the shell synchronously with a loading row so the popup
-  // appears the instant the user asks for it; the agent list fills in
-  // when ListAgents resolves. Kills the old open-blank-then-populate
-  // flash (and the launcher not appearing at all if the list is slow).
-  launcherEl.innerHTML = '';
-  branchEl = null;
-  launcherState.items = [];
-  // Anchor under the resolved project's card header so the user
-  // can see which project the new session lands in. The header, not
-  // its + button: the card's actions are `display: none` until the
-  // header is hovered (components/ProjectCard.tsx), and a display:none anchor
-  // measures as a zero rect at the origin. Falls back to the global
-  // new-project button if the project's card isn't currently in the
-  // DOM (e.g. the project is minimized), and to a fixed spot over the
-  // sidebar if neither anchor exists — a missing anchor must not throw
-  // and leave the launcher unopened (the throw used to vanish into
-  // this chain's empty catch).
-  const anchorEl =
-    document.querySelector(
-      `.hv-project-card[data-pid="${launcherState.projectId}"] .hv-project-card__header`,
-    ) ?? document.getElementById('new-project-btn');
-  if (anchorEl) {
-    const r = anchorEl.getBoundingClientRect();
-    launcherEl.style.left = `${r.left}px`;
-    launcherEl.style.top = `${r.bottom + 4}px`;
-  } else {
-    launcherEl.style.left = '16px';
-    launcherEl.style.top = '64px';
-  }
-  // Filter box first, then the list the rows render into. Both are
-  // built fresh here (the innerHTML wipe above dropped the previous
-  // pair), which is what guarantees every opening starts with an empty
-  // query — including ⌘T on an already-open launcher and the ⇧⌘P
-  // duplicate flow. Don't "optimize" this into reusing the old input.
-  searchEl = document.createElement('input');
-  searchEl.type = 'text';
-  searchEl.className = 'launcher-search';
-  searchEl.placeholder = 'Filter agents…';
-  searchEl.setAttribute('aria-label', 'Filter agents');
-  searchEl.autocomplete = 'off';
-  searchEl.addEventListener('input', renderLauncherList);
-  listEl = document.createElement('div');
-  listEl.className = 'launcher-list';
-  launcherEl.append(searchEl, listEl);
-  // Reset before the first render so neither the previous opening's
-  // agents nor its loading state leak into this one.
-  allAgents = [];
-  agentsLoading = true;
-  // Draws the loading row through the same path every keystroke uses,
-  // so typing during the round trip can't render something the initial
-  // paint wouldn't have.
-  renderLauncherList();
-  launcherEl.classList.remove('hidden');
-  // Drop the active tile's visual focus — modal owns the keyboard.
-  deps.setFocusedTile(null);
-  // The launcher's keys are handled by its own listener (initLauncher),
-  // which only sees them while focus is inside #launcher.
-  searchEl.focus();
-
-  const gen = ++openGeneration;
-  ListAgents()
-    .then((agents) => {
-      // The user may have dismissed the launcher while the list was in
-      // flight — don't resurrect it.
-      if (launcherEl.classList.contains('hidden')) return;
-      // ...or reopened it, in which case this response belongs to a
-      // launcher that no longer exists and a newer request owns the DOM.
-      if (gen !== openGeneration) return;
-      agentsLoading = false;
-
-      // Worktree toggle row at the top of the menu. Disabled (and
-      // visually muted) when the active project's cwd isn't a git
-      // repo. The IsGitRepo probe is async; we render the row
-      // immediately as enabled and disable it once the probe
-      // completes — almost always before the user reaches for the
-      // checkbox.
-      const proj = state.projects.find((p) => p.id === launcherState.projectId);
-      const projCwd = proj?.cwd ?? '';
-      // In duplicate mode the cwd is fixed to the source session, so
-      // the worktree toggle is meaningless — skip the row entirely.
-      // In resume mode the worktree already exists, so neither the
-      // toggle nor the branch input has anything to decide.
-      if (!launcherState.duplicateFrom && !launcherState.worktreePath) {
-        const wtRow = document.createElement('label');
-        wtRow.className = 'launcher-worktree';
-        const wtBox = document.createElement('input');
-        wtBox.type = 'checkbox';
-        wtBox.checked = !!launcherState.useWorktree;
-        const wtLabel = document.createElement('span');
-        wtLabel.textContent = 'Create in git worktree';
-        wtRow.append(wtBox, wtLabel);
-        // Between the filter box and the list, not appended at the
-        // end — #launcher already holds both by the time this runs.
-        launcherEl.insertBefore(wtRow, listEl);
-
-        // Branch name, revealed only while the toggle is on: it is
-        // meaningless otherwise, and an always-visible field would push
-        // the agent list down on every open.
-        const branchInput = document.createElement('input');
-        branchEl = branchInput;
-        branchInput.type = 'text';
-        branchInput.className = 'launcher-branch';
-        branchInput.placeholder = 'branch name (optional)';
-        branchInput.setAttribute('aria-label', 'Worktree branch name');
-        branchInput.value = launcherState.branch;
-        const syncBranchVisibility = () => {
-          branchInput.classList.toggle('hidden', !launcherState.useWorktree);
-        };
-        syncBranchVisibility();
-        launcherEl.insertBefore(branchInput, listEl);
-        branchInput.addEventListener('input', () => {
-          launcherState.branch = branchInput.value.trim();
-        });
-        wtBox.addEventListener('change', (e) => {
-          const box = e.target as HTMLInputElement;
-          launcherState.useWorktree = box.checked;
-          localStorage.setItem('hive.worktree', box.checked ? '1' : '0');
-          syncBranchVisibility();
-          if (!box.checked) {
-            branchInput.value = '';
-            launcherState.branch = '';
-          }
-        });
-        if (projCwd) {
-          IsGitRepo(projCwd)
-            .then((ok) => {
-              // Same staleness rule as ListAgents above: without this, a
-              // late "not a git repo" answer for the project this open
-              // was anchored to could set useWorktree = false under a
-              // launcher since reopened on a git-backed project, leaving
-              // a checked box whose state says off.
-              if (gen !== openGeneration) return;
-              if (!ok) {
-                wtRow.classList.add('disabled');
-                wtBox.disabled = true;
-                wtBox.checked = false;
-                launcherState.useWorktree = false;
-                launcherState.branch = '';
-                branchInput.value = '';
-                branchInput.classList.add('hidden');
-                wtLabel.textContent = 'Worktree (project is not a git repo)';
-              }
-            })
-            .catch(() => {
-              // Intentionally silent: the probe rejects only when the
-              // bridge itself is down. Worst case the daemon later
-              // refuses worktree creation via control:error, which IS
-              // surfaced.
-            });
-        }
-      }
-      // Detection (exec.LookPath on the daemon side) is best-effort:
-      // it can miss agents installed as shell aliases, functions, or
-      // PATH that's only set up by an interactive rc file. So we list
-      // every agent as launchable and let the user try; the daemon
-      // runs the command via the user's interactive shell, and any
-      // real failure surfaces as "command not found" inside the
-      // session's terminal. The "install" hint stays visible as
-      // advisory text for the truly-not-installed case.
-      // Sort agents by recent usage (most-used first), ties preserve
-      // the agent package's display order. Usage is persisted in
-      // localStorage and incremented on activation.
-      const usage = loadAgentUsage();
-      allAgents = agents
-        .map((a, i) => ({ a, i }))
-        .sort((x, y) => {
-          const ux = usage[x.a.id] || 0,
-            uy = usage[y.a.id] || 0;
-          if (ux !== uy) return uy - ux;
-          return x.i - y.i;
-        })
-        .map((e) => e.a);
-      // Renders through the same path as every keystroke, so a query
-      // typed while this request was in flight is already applied.
-      renderLauncherList();
-    })
-    // Anything thrown in the chain above (not just a ListAgents
-    // rejection) used to land here silently — the user pressed ⌘T and
-    // nothing happened, with no trace. Close the loading shell too:
-    // an empty popup with stale "Loading agents…" would be worse.
-    .catch((err) => {
-      // Same staleness rule as the success path: a rejection from a
-      // superseded request must not close the launcher the user just
-      // reopened. Still reported — the failure was real.
-      reportFailure('launcher')(err);
-      if (gen !== openGeneration) return;
-      agentsLoading = false;
-      closeLauncher();
-    });
+  // previous opening doesn't leak into the next regular open.
+  // forceWorktree overrides for this opening only and is intentionally
+  // not persisted.
+  const forced =
+    opts && typeof opts.forceWorktree === 'boolean' ? opts.forceWorktree : null;
+  const duplicateFrom = opts?.duplicateFrom || null;
+  const worktreePath = opts?.worktreePath || '';
+  openModal({
+    id: 'launcher',
+    req: {
+      projectId: projectId || activeProjectId(),
+      // In duplicate mode the launcher is forking an existing session
+      // into the same cwd, and in resume mode the worktree already
+      // exists — never a new worktree in either.
+      useWorktree:
+        duplicateFrom || worktreePath
+          ? false
+          : (forced ?? localStorage.getItem('hive.worktree') === '1'),
+      duplicateFrom,
+      duplicateCwd: opts?.duplicateCwd || '',
+      worktreePath,
+      continueConversation: !!opts?.continueConversation,
+    },
+  });
 }
 
 export function closeLauncher() {
   // Idempotent: an outside click on a focusable element closes twice —
   // once from focusout at mousedown, once from the document click
   // handler — and running refocusActiveTerm() twice is pointless work
-  // against the terminal. Also makes the ListAgents rejection path safe
-  // when it fires against a launcher that is already closed.
-  if (launcherEl.classList.contains('hidden')) return;
+  // against the terminal.
+  if (!isModalOpen('launcher')) return;
   // Blur first: refocusActiveTerm() bails when activeElement is an
   // INPUT (lib/focus.ts), and hiding the launcher via CSS does not
   // synchronously move focus out of it in a real engine.
   //
-  // Whatever holds focus, not just searchEl. In practice the mousedown
-  // handler below keeps focus on searchEl, so those are the same thing
-  // today — this stays general so that adding one focusable control to
-  // the popup later can't quietly resurrect the bug it was written for
-  // (terminal never refocused, because activeElement was still an
-  // <input> the launcher owned).
+  // Whatever holds focus, not just the filter box — adding one focusable
+  // control to the popup later must not quietly resurrect the bug this
+  // was written for (terminal never refocused, because activeElement was
+  // still an <input> the launcher owned).
   releaseFocus(launcherEl);
-  launcherEl.classList.add('hidden');
-  searchEl = null;
-  listEl = null;
-  branchEl = null;
-  allAgents = [];
-  launcherState.items = [];
-  launcherState.duplicateFrom = null;
-  launcherState.duplicateCwd = '';
+  // flushSync, because the order matters and React would not otherwise
+  // keep it: this runs from a plain window listener, so an ordinary
+  // store write is flushed in a later microtask — the popup would still
+  // be visible (and `.hidden` still off #launcher) when
+  // refocusActiveTerm() ran, and app/focus.ts refuses to touch the
+  // terminal while a modal is open. The keyboard would land nowhere.
+  flushSync(() => closeModal('launcher'));
   deps.refocusActiveTerm();
 }
 
@@ -567,114 +168,8 @@ export function duplicateActiveSessionChooseTool() {
 
 export function initLauncher(injected: LauncherDeps) {
   deps = injected;
+  // Still registered: anyModalOpen() answers "does a modal own the
+  // keyboard?" off the `.hidden` class of every registered root, and
+  // #launcher keeps that class (toggled by the island's layout effect).
   registerModal(launcherEl);
-  // The launcher owns its keyboard while open, the way the command
-  // palette and settings do — it has to, now that the filter box holds
-  // focus and lib/focus.ts hands the keyboard to a focused <input>.
-  // keyboard.ts bails out for #launcher for the same reason.
-  launcherEl.addEventListener('keydown', (e) => {
-    const handle = (fn: () => void) => {
-      e.preventDefault();
-      e.stopPropagation();
-      fn();
-    };
-    if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey))
-      return handle(() => moveLauncherSelection(+1));
-    if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey))
-      return handle(() => moveLauncherSelection(-1));
-    if (e.key === 'Enter') return handle(activateLauncherSelection);
-    if (e.key === 'Escape') return handle(closeLauncher);
-    if (cmdOrCtrl(e) && (e.key === 'n' || e.key === 'N'))
-      return handle(closeLauncher);
-    // ⌘T / ⇧⌘T while already open re-opens (and so clears the query).
-    // keyboard.ts used to give us this for free — its launcher block
-    // fell through on unhandled keys and hit the global ⌘T binding
-    // further down. Now that it bails out for #launcher entirely, the
-    // binding has to be repeated here or it would silently stop working.
-    if (cmdOrCtrl(e) && (e.key === 't' || e.key === 'T'))
-      return handle(() => {
-        // Same two calls as the global binding in keyboard.ts — passing
-        // undefined re-resolves the active project rather than pinning
-        // the one this opening was anchored to.
-        if (e.shiftKey) openLauncher(undefined, { forceWorktree: true });
-        else openLauncher();
-      });
-    // Digit shortcut: 1–9 picks the corresponding row, but only while
-    // the filter box is empty — past that the user is typing a query
-    // and a digit is just a character. Raw .value, not trimmed: a
-    // typed space is already a query. Skipped when a modifier is held
-    // so ⌘1 and friends aren't swallowed.
-    if (
-      !e.metaKey &&
-      !e.ctrlKey &&
-      !e.altKey &&
-      /^[1-9]$/.test(e.key) &&
-      searchEl?.value === '' &&
-      // A digit typed into the branch box is part of the branch name
-      // (`fix-2`), not a row shortcut. Without this the box silently
-      // drops every number the user types.
-      e.target !== branchEl
-    ) {
-      const i = parseInt(e.key, 10) - 1;
-      if (i < launcherState.items.length) {
-        return handle(() => {
-          launcherState.selected = i;
-          activateLauncherSelection();
-        });
-      }
-    }
-  });
-  // Nothing but the filter box may take focus. Clicking anything else
-  // would blur it, and the keydown listener above only fires while
-  // focus is inside #launcher — so the search would silently stop
-  // responding to typing.
-  //
-  // preventDefault on mousedown suppresses only the focus shift and
-  // text selection: click still fires, so agent rows still launch and
-  // the worktree checkbox still toggles (a checkbox toggles on click
-  // activation, not on focus). The checkbox used to be exempt here,
-  // which meant clicking it moved focus onto it and every subsequent
-  // keystroke went to the checkbox instead of the query — the list just
-  // stopped narrowing, with nothing on screen to explain why.
-  launcherEl.addEventListener('mousedown', (e) => {
-    const target = e.target as Element | null;
-    // Both text boxes are exempt: they exist to be typed into, so they
-    // must be able to take focus from a click. Everything else stays
-    // blocked — see the checkbox rationale above. The launcher's own
-    // keydown handler covers the whole popup, so Enter/Escape/arrows
-    // still work while focus sits in either box.
-    if (target === searchEl || target === branchEl) return;
-    e.preventDefault();
-  });
-  // Focus leaving the launcher closes it. keyboard.ts now bails out for
-  // the whole window whenever #launcher is visible, and this module's
-  // own keydown listener only fires while focus is inside it — so a
-  // launcher that stays visible after focus moves away is a launcher
-  // nobody is listening for, Escape included.
-  //
-  // The .hv-project-card__actions buttons are how you get there: each one
-  // calls stopPropagation, so the outside-click handler below never sees
-  // them (its .hv-project-card__actions exemption has always been
-  // unreachable for that reason), but clicking the edit or delete button
-  // still moves focus out.
-  //
-  // relatedTarget null means focus went nowhere — that's closeLauncher's
-  // own blur, so ignore it rather than recursing.
-  launcherEl.addEventListener('focusout', (e) => {
-    if (launcherEl.classList.contains('hidden')) return;
-    const next = (e as FocusEvent).relatedTarget as Node | null;
-    if (next && !launcherEl.contains(next)) closeLauncher();
-  });
-  document.addEventListener('click', (e) => {
-    const target = e.target as Element | null;
-    // A click that OPENS the launcher must not also close it: this
-    // handler runs after the opener's own handler, on the same event.
-    // The sidebar's project actions are exempt for that reason, and
-    // any other opener opts in with data-opens-launcher (the worktree
-    // browser's "Open session" button does).
-    const inAction =
-      target?.closest('.hv-project-card__actions') ??
-      target?.closest('[data-opens-launcher]');
-    if (!launcherEl.contains(target) && !inAction) closeLauncher();
-  });
 }

--- a/cmd/hivegui/frontend/src/app/modals/settings.ts
+++ b/cmd/hivegui/frontend/src/app/modals/settings.ts
@@ -1,67 +1,23 @@
-// ---------- settings (appearance + custom agents + updates) ----------
+// ---------- settings: the non-React half ----------
 //
-// The panel is built here rather than declared in index.html: it is the
-// only way the dialog and field primitives can own the markup, and the
-// Appearance section's controls are data-driven off PRESETS anyway.
-// The ids the keyboard pipeline and the e2e specs key off are set
-// explicitly and are part of this module's contract.
+// The panel renders from components/modals/Settings.tsx (Phase 3). What
+// stays here is the open/close pair every caller already imports from
+// this path (keyboard.ts, events.ts, main.ts, the command palette), the
+// argv splitter Go's validator mirrors, and the OS theme watch — which
+// is not part of the modal at all: it runs whether or not Settings has
+// ever been opened.
 //
-// The agent list is edited as a local draft and written in one
-// SaveCustomAgents call. Go owns validation and ID assignment — new
-// rows are saved with an empty id and come back slugged. IDs are
-// deliberately not editable: registry entries persist only the agent
-// id, so changing one would break revive for every session already
-// created with that agent.
-//
-// Appearance is NOT part of that draft. It is a local preference with
-// no round-trip and nothing to validate, so it applies and persists on
-// change — you cannot choose a theme you are not allowed to look at.
-// Cancel therefore does not revert it, and the section says so.
+// Focus-pipeline callbacks are injected via initSettings(deps) — this
+// module must never import the focus pipeline directly (main.ts owns
+// that wiring).
 
-import {
-  EventsOn,
-  GetUpdateSettings,
-  ListCustomAgents,
-  PickDirectory,
-  SaveCustomAgents,
-  SaveUpdateSettings,
-  SourceRepoStatusFor,
-  StartUpdate,
-  UpdateStatus,
-} from '../../bridge.js';
-import { isMac } from '../../lib/platform.js';
-import {
-  CHANNEL_LATEST,
-  CHANNEL_RELEASE,
-  updateButtonState,
-} from '../../lib/update-state.js';
-import {
-  applyOverrides,
-  applyTheme,
-  PRESETS,
-  readOverrides,
-  readTheme,
-  sanitizeOverrides,
-  THEME_KEY,
-  type ThemeName,
-  writeOverrides,
-} from '../../theme/theme.js';
-import { button } from '../../ui/button.js';
-import { dialog } from '../../ui/dialog.js';
-import {
-  colorInput,
-  errorSlot,
-  field,
-  selectInput,
-  textareaInput,
-  textInput,
-} from '../../ui/field.js';
-import { iconButton } from '../../ui/icon-button.js';
-import { applyUpdateAndRestart } from '../banners.js';
-import { releaseFocus } from './focus-trap.js';
+import { flushSync } from 'react-dom';
+import { applyTheme, readTheme } from '../../theme/theme.js';
 import { applyXtermTheme } from '../session-term.js';
-// Type-only, so the generated module is erased before Vite resolves it.
-import type { main } from '../../../wailsjs/go/models';
+import { closeModal, isModalOpen, openModal } from '../../store/store.js';
+import { pageEl } from '../el.js';
+import { registerModal } from './registry.js';
+import { releaseFocus } from './focus-trap.js';
 
 // Narrow on purpose: this modal needs exactly two callbacks off the
 // focus pipeline, so it names those two rather than the whole module.
@@ -75,281 +31,9 @@ let deps: SettingsDeps = {
   refocusActiveTerm: () => {},
 };
 
-const DEFAULT_COLOR = '#64748b';
-
-function hintPara(text: string): HTMLParagraphElement {
-  const p = document.createElement('p');
-  p.className = 'settings-hint';
-  p.textContent = text;
-  return p;
-}
-
-function heading(text: string): HTMLElement {
-  const h = document.createElement('h4');
-  h.textContent = text;
-  return h;
-}
-
-// ---------- appearance ----------
-
-const themeError = errorSlot('settings-overrides-error');
-
-const themeSelect = selectInput({
-  id: 'settings-theme',
-  ariaLabel: 'Theme',
-  options: PRESETS.map((p) => ({
-    value: p.id,
-    label: p.label,
-    group: p.group,
-  })),
-  onChange: (value) => selectPreset(value as ThemeName),
-});
-
-const overridesInput = textareaInput({
-  id: 'settings-overrides',
-  ariaLabel: 'Custom tokens',
-  rows: 4,
-  placeholder: '--accent: #7aa2f7;',
-  onInput: (value) => queueUserOverrides(value),
-});
-// Programmatic link to the slot this box writes its rejections into,
-// mirroring the source-repo field below: without it a screen reader
-// never hears why a line was ignored.
-overridesInput.setAttribute('aria-describedby', 'settings-overrides-error');
-
-// Applying is not free: a style invalidation, then a getComputedStyle
-// and a palette rebuild on EVERY live terminal, then a synchronous
-// localStorage write. applyXtermTheme's own comment says "not per
-// frame"; a keystroke is the per-frame case, so the work trails the
-// typing by one short pause instead of riding every character.
-let overridesTimer: ReturnType<typeof setTimeout> | null = null;
-const OVERRIDES_DEBOUNCE_MS = 150;
-
-function queueUserOverrides(raw: string): void {
-  if (overridesTimer) clearTimeout(overridesTimer);
-  overridesTimer = setTimeout(() => {
-    overridesTimer = null;
-    applyUserOverrides(raw);
-  }, OVERRIDES_DEBOUNCE_MS);
-}
-
-// One place stamps the theme, so the three things that must happen
-// together cannot drift apart: the attribute, the terminals (xterm
-// caches its palette; a CSS change alone leaves every open session on
-// the old colours), and the store.
-function selectPreset(name: ThemeName): void {
-  applyTheme(name);
-  applyXtermTheme();
-  try {
-    localStorage.setItem(THEME_KEY, name);
-  } catch {
-    // Denied storage: applied for this session, not remembered.
-  }
-}
-
-// 'system' resolves prefers-color-scheme at the moment it is applied,
-// and since phase 6 it is the default for every new install — so without
-// a listener, flipping the OS to dark leaves Hive light until it is
-// restarted. Re-applies only when the stored choice is still 'system':
-// an explicit preset is a decision the OS does not get to override.
-// Same trio as selectPreset minus the store write, because the stored
-// value ('system') is exactly what has not changed.
-export function initThemeWatch(): void {
-  const mq = window.matchMedia?.('(prefers-color-scheme: dark)');
-  // jsdom has no matchMedia, and older webviews expose the legacy
-  // addListener only; neither is worth a shim for a live-preview nicety.
-  if (!mq?.addEventListener) return;
-  mq.addEventListener('change', () => {
-    if (readTheme() !== 'system') return;
-    applyTheme('system');
-    applyXtermTheme();
-  });
-}
-
-// applyUserOverrides runs on every keystroke, which is what makes the
-// box usable — but it must never leave a half-typed line showing as an
-// error while the user is still typing it. Rejected lines are reported;
-// accepted ones apply. Typing "--acc" reports one rejected line and
-// changes nothing, which is the honest answer.
-function applyUserOverrides(raw: string): void {
-  const { css, rejected } = sanitizeOverrides(raw);
-  applyOverrides(css);
-  applyXtermTheme();
-  writeOverrides(css);
-  themeError.show(
-    rejected.length === 0
-      ? ''
-      : `Ignored ${rejected.length} line(s) — only "--token: value;" declarations are allowed: ${rejected.join(' / ')}`,
-  );
-}
-
-function appearanceSection(): Node[] {
-  return [
-    heading('Appearance'),
-    hintPara(
-      'Applies as you change it, and is remembered. Cancel does not undo it.',
-    ),
-    field('Theme', themeSelect),
-    hintPara(
-      'Override any design token, one declaration per line. Fonts must already be installed on this machine.',
-    ),
-    field('Custom tokens', overridesInput),
-    themeError.el,
-  ];
-}
-
-// ---------- custom agents ----------
-
-const listEl = document.createElement('div');
-listEl.id = 'settings-agents-list';
-
-const agentsError = errorSlot('settings-error');
-// The e2e and DOM specs assert on `.settings-error`; the primitive's
-// own class carries the styling.
-agentsError.el.classList.add('settings-error');
-
-const addBtn = button({
-  label: 'Add agent',
-  icon: 'plus',
-  onClick: () => addAgentRow(),
-});
-addBtn.id = 'settings-agent-add';
-
-function agentsSection(): Node[] {
-  return [
-    heading('Custom agents'),
-    hintPara(
-      'Define your own tools — a command and its arguments. They appear in the new-session menu alongside the built-ins.',
-    ),
-    listEl,
-    addBtn,
-    agentsError.el,
-  ];
-}
-
-// ---------- updates ----------
-
-const channelEl = selectInput({
-  id: 'settings-update-channel',
-  ariaLabel: 'Update channel',
-  options: [
-    { value: CHANNEL_RELEASE, label: 'Release — tagged versions' },
-    { value: CHANNEL_LATEST, label: 'Latest — tip of your checkout' },
-  ],
-});
-
-const sourceRepoEl = textInput({
-  id: 'settings-source-repo',
-  ariaLabel: 'Source repo',
-  placeholder: 'Detected automatically',
-});
-sourceRepoEl.setAttribute('aria-describedby', 'settings-source-repo-hint');
-
-const sourceRepoBrowse = button({
-  label: 'Browse…',
-  onClick: () => browseSourceRepo(),
-});
-sourceRepoBrowse.id = 'settings-source-repo-browse';
-
-// The row is a container, not a field: it holds the labelled input and
-// the Browse button on one line, and is hidden wholesale on the release
-// channel (the e2e spec toggles on #settings-source-repo-row).
-const sourceRepoRow = document.createElement('div');
-sourceRepoRow.id = 'settings-source-repo-row';
-sourceRepoRow.className = 'settings-field';
-sourceRepoRow.append(field('Source repo', sourceRepoEl), sourceRepoBrowse);
-
-const sourceRepoHint = hintPara('');
-sourceRepoHint.id = 'settings-source-repo-hint';
-
-const updateActionEl = button({ label: 'Update', onClick: () => runUpdate() });
-updateActionEl.id = 'settings-update-action';
-const updateActionLabel = updateActionEl.querySelector(
-  '.hv-button__label',
-) as HTMLElement;
-
-const updateStatusEl = document.createElement('span');
-updateStatusEl.id = 'settings-update-status';
-updateStatusEl.className = 'settings-hint';
-updateStatusEl.setAttribute('role', 'status');
-
-// Updates sits outside the scrolling part of the body, at its natural
-// height: a dozen custom agents must never push the channel picker
-// below the fold (test/e2e/settings.spec.ts).
-function updatesSection(): HTMLElement {
-  const actionRow = document.createElement('div');
-  actionRow.className = 'settings-field';
-  actionRow.append(updateActionEl, updateStatusEl);
-  const section = document.createElement('section');
-  section.id = 'settings-updates';
-  section.append(
-    heading('Updates'),
-    hintPara(
-      'Hive checks for updates in the background. Nothing is downloaded or built until you press Update.',
-    ),
-    field('Channel', channelEl),
-    sourceRepoRow,
-    sourceRepoHint,
-    actionRow,
-  );
-  return section;
-}
-
-// Everything above Updates scrolls together. Agents first: it is the
-// section people open Settings to edit, and it is the only one that
-// grows — putting Appearance above it pushed the list off-screen on
-// open for anyone with more than a couple of agents.
-function scrollSection(): HTMLElement {
-  const el = document.createElement('div');
-  el.id = 'settings-scroll';
-  el.append(...agentsSection(), ...appearanceSection());
-  return el;
-}
-
-// ---------- the dialog ----------
-
-const saveBtn = button({
-  label: 'Save',
-  kind: 'primary',
-  onClick: () => saveSettings(),
-});
-saveBtn.id = 'settings-save';
-const cancelBtn = button({ label: 'Cancel', onClick: () => closeSettings() });
-cancelBtn.id = 'settings-cancel';
-
-const dlg = dialog({
-  id: 'settings',
-  title: 'Settings',
-  size: 'md',
-  body: [scrollSection(), updatesSection()],
-  actions: [cancelBtn, saveBtn],
-  onClose: () => closeSettings(),
-});
-// keyboard.ts and the tests import this; it must stay the root element.
-export const settingsEl = dlg.el;
-// The primitive's panel and close button keep the ids the e2e specs use.
-dlg.panel.id = 'settings-panel';
-dlg.el.querySelector('.hv-dialog__close')?.setAttribute('id', 'settings-close');
-
-// draft is the in-progress edit; discarded on cancel. Rows are plain
-// objects, not main.CustomAgent instances — the generated class is a
-// data shape and Go re-slugs the ids on save.
-let draft: main.CustomAgent[] = [];
-
-// loading distinguishes "still fetching" from "genuinely empty" so the
-// empty state never renders over a list that is about to arrive.
-let loading = false;
-
-// loadFailed blocks Save after a failed read. Go cannot tell a
-// deliberate "delete every agent" from a draft that is empty only
-// because agents.json would not parse, so the refusal has to live
-// here, where that distinction is still known.
-let loadFailed = false;
-
-// openToken invalidates an in-flight load when the modal is closed and
-// reopened before it resolves, so a stale response cannot overwrite a
-// newer draft.
-let openToken = 0;
+// keyboard.ts and the tests key off this element; it is the dialog root
+// declared in index.html.
+export const settingsEl = pageEl('settings');
 
 /** Splits a command line into argv on whitespace.
  *
@@ -370,357 +54,60 @@ export function splitCommand(line: string | null): string[] {
     .filter(Boolean);
 }
 
-function showError(msg: string) {
-  agentsError.show(msg);
-  // The slot lives in the scrolling region, so a save rejected after
-  // the user scrolled down would otherwise land off-screen and read as
-  // "the button did nothing".
-  // Optional call: jsdom has no layout and no scrollIntoView, and this
-  // runs inside promise handlers — an unguarded throw there escapes as
-  // an unhandled rejection, which exits vitest 1 while every test still
-  // reports as passing.
-  if (msg) agentsError.el.scrollIntoView?.({ block: 'nearest' });
-}
-
-function addAgentRow() {
-  draft.push({ id: '', name: '', cmd: [], color: DEFAULT_COLOR });
-  showError('');
-  render();
-  listEl
-    .querySelector<HTMLElement>(
-      '.settings-agent-row:last-child .settings-agent-name',
-    )
-    ?.focus();
-}
-
-function deleteAgentRow(i: number) {
-  draft.splice(i, 1);
-  showError('');
-  render();
-  // render() destroyed the button that had focus, dropping it to
-  // <body> — from there the Tab trap has no boundary to wrap and the
-  // next Tab walks behind the backdrop. Put focus back on the row that
-  // took this one's place, or on "Add agent".
-  const dels = listEl.querySelectorAll<HTMLElement>('.settings-agent-delete');
-  (dels[Math.min(i, dels.length - 1)] ?? addBtn).focus();
-}
-
-function render() {
-  listEl.replaceChildren();
-  if (loading) {
-    listEl.append(hintPara('Loading…'));
-    return;
-  }
-  if (draft.length === 0) {
-    listEl.append(hintPara('No custom agents yet.'));
-    return;
-  }
-
-  draft.forEach((a, i) => {
-    const row = document.createElement('div');
-    row.className = 'settings-agent-row';
-
-    const color = colorInput({
-      value: a.color || DEFAULT_COLOR,
-      ariaLabel: 'Agent color',
-      onInput: (v) => {
-        draft[i].color = v;
-      },
-    });
-    const name = textInput({
-      className: 'settings-agent-name',
-      placeholder: 'Name (e.g. Claude Lite)',
-      ariaLabel: 'Agent name',
-      value: a.name || '',
-      onInput: (v) => {
-        draft[i].name = v;
-      },
-    });
-    const cmd = textInput({
-      className: 'settings-agent-cmd',
-      placeholder: 'Command (e.g. claude --model haiku)',
-      ariaLabel: 'Agent command',
-      value: (a.cmd || []).join(' '),
-      onInput: (v) => {
-        draft[i].cmd = splitCommand(v);
-      },
-    });
-    const del = iconButton({
-      icon: 'x',
-      label: `Delete ${a.name || 'agent'}`,
-      className: 'settings-agent-delete',
-      onClick: () => deleteAgentRow(i),
-    });
-
-    row.append(color.el, name, cmd, del);
-    listEl.append(row);
-  });
-}
-
 export function openSettings() {
-  // Re-entry must not discard an in-progress draft. This is reachable
-  // on macOS: the native File ▸ Settings… accelerator consumes ⌘,
-  // before the webview's keydown listener sees it (same precedence
-  // that makes the '?' branch in keyboard.ts dead on darwin, per
-  // menu_darwin.go), so pressing ⌘, with the modal already open
-  // arrives here as menu:settings rather than as the toggle-to-close
-  // in the keydown gate. Without this guard the `draft = []` below
-  // silently wipes the user's unsaved edits.
-  if (dlg.isOpen()) return;
-  // Seeded from the store, not from the last open: the theme can change
-  // elsewhere (the `system` preset follows the OS).
-  themeSelect.value = readTheme();
-  overridesInput.value = readOverrides().replace(/\n\s*/g, '\n');
-  themeError.clear();
-  showError('');
-  draft = [];
-  loading = true;
-  loadFailed = false;
-  const token = ++openToken;
-  setEditingEnabled(false);
-  render();
-  dlg.show();
-  // Drop the active tile's visual focus and pull focus into the
-  // dialog — same discipline as the help overlay. Without this, focus
-  // stays on the terminal and keystrokes leak behind the backdrop.
+  // Re-entry must not discard an in-progress draft. This is reachable on
+  // macOS: the native File ▸ Settings… accelerator consumes ⌘, before the
+  // webview's keydown listener sees it (same precedence that makes the
+  // '?' branch in keyboard.ts dead on darwin, per menu_darwin.go), so
+  // pressing ⌘, with the modal already open arrives here as
+  // menu:settings rather than as the toggle-to-close in the keydown
+  // gate. Without this guard the modal would remount and silently wipe
+  // the user's unsaved edits.
+  if (isModalOpen('settings')) return;
+  // Drop the active tile's visual focus — the dialog owns the keyboard,
+  // and the component pulls focus onto its close button on mount.
   deps.setFocusedTile(null);
-  document.getElementById('settings-close')?.focus();
-
-  loadUpdateSection(token);
-
-  ListCustomAgents()
-    .then((list) => {
-      if (token !== openToken) return; // closed and reopened; stale
-      loading = false;
-      setEditingEnabled(true);
-      draft = (list || []).map((a) => ({
-        id: a.id || '',
-        name: a.name || '',
-        cmd: a.cmd || [],
-        color: a.color || DEFAULT_COLOR,
-      }));
-      render();
-    })
-    .catch((err) => {
-      if (token !== openToken) return;
-      loading = false;
-      // Editing stays disabled: the draft is empty only because the
-      // read failed, and saving it would destroy agents.json.
-      loadFailed = true;
-      render();
-      showError(
-        `Could not read agents.json — fix or move the file, then reopen Settings. (${String(err?.message || err)})`,
-      );
-    });
-}
-
-// ---------- updates section ----------
-//
-// The channel and source-repo inputs join the modal's draft/save cycle
-// (Cancel discards them). The Update button deliberately does NOT: it
-// starts real work in Go, and losing a running download because the
-// user closed the dialog would be surprising. Its state is read back
-// from Go rather than tracked here, which is also what keeps it in
-// agreement with the banner.
-
-// updateDraft mirrors the two saved fields while the modal is open.
-let updateDraft = { channel: CHANNEL_RELEASE, sourceRepo: '' };
-
-// SourceRepoStatusFor stats its way up a directory tree, so firing it
-// per keystroke is both wasteful and unordered — a slow answer for
-// "/Use" could land after the fast one for "/Users/me/hive" and
-// overwrite it with a stale error. Debounce, and stamp each request so
-// only the newest reply is allowed to render.
-let sourceRepoProbe: ReturnType<typeof setTimeout> | null = null;
-let sourceRepoToken = 0;
-const SOURCE_REPO_DEBOUNCE_MS = 250;
-
-function renderSourceRepoRow() {
-  const isLatest = updateDraft.channel === CHANNEL_LATEST;
-  sourceRepoRow.classList.toggle('hidden', !isLatest);
-  if (sourceRepoProbe) {
-    clearTimeout(sourceRepoProbe);
-    sourceRepoProbe = null;
-  }
-  const token = ++sourceRepoToken;
-  if (!isLatest) {
-    sourceRepoHint.textContent = '';
-    return;
-  }
-  const path = updateDraft.sourceRepo;
-  sourceRepoProbe = setTimeout(() => {
-    sourceRepoProbe = null;
-    SourceRepoStatusFor(path)
-      .then((st) => {
-        if (token !== sourceRepoToken || !st) return;
-        if (st.error) {
-          sourceRepoHint.textContent = st.error;
-          return;
-        }
-        sourceRepoHint.textContent = st.detected
-          ? `Detected ${st.path}`
-          : `Using ${st.path}`;
-      })
-      .catch((err) => {
-        if (token !== sourceRepoToken) return;
-        sourceRepoHint.textContent = String(err?.message || err);
-      });
-  }, SOURCE_REPO_DEBOUNCE_MS);
-}
-
-function browseSourceRepo() {
-  PickDirectory(updateDraft.sourceRepo)
-    .then((dir) => {
-      if (!dir) return; // cancelled
-      updateDraft.sourceRepo = dir;
-      sourceRepoEl.value = dir;
-      renderSourceRepoRow();
-    })
-    .catch((err) => showError(String(err?.message || err)));
-}
-
-function runUpdate() {
-  const action = updateActionEl.dataset.action;
-  if (action === 'restart') {
-    // Shared with the banner: confirm overlay + re-entrancy guard +
-    // the daemon-restart flag live there, and applying is exactly as
-    // destructive from here as it is from the banner.
-    void applyUpdateAndRestart(updateActionEl.dataset.version || '');
-    return;
-  }
-  if (action === 'start') {
-    updateActionEl.disabled = true;
-    // A synchronous refusal from StartUpdate emits no update:progress
-    // event, so re-enable the button here rather than leaving it dead.
-    StartUpdate().catch((err) => {
-      updateActionEl.disabled = false;
-      showError(String(err?.message || err));
-    });
-  }
-}
-
-function renderUpdateAction(info: main.UpdateInfo | null) {
-  const btn = updateButtonState(info, isMac);
-  updateStatusEl.textContent = btn.status;
-  updateActionEl.style.display = btn.label ? '' : 'none';
-  updateActionLabel.textContent = btn.label;
-  updateActionEl.disabled = btn.disabled;
-  updateActionEl.dataset.action = btn.action;
-  updateActionEl.dataset.version = info?.latest || '';
-}
-
-function refreshUpdateAction() {
-  UpdateStatus()
-    .then(renderUpdateAction)
-    .catch(() => renderUpdateAction(null));
-}
-
-function loadUpdateSection(token: number) {
-  GetUpdateSettings()
-    .then((s) => {
-      // Same staleness guard the agent list uses: closed and reopened
-      // before this resolved means a newer draft is on screen, and this
-      // response would overwrite it.
-      if (token !== openToken) return;
-      updateDraft = {
-        channel:
-          s?.channel === CHANNEL_LATEST ? CHANNEL_LATEST : CHANNEL_RELEASE,
-        sourceRepo: s?.source_repo || '',
-      };
-      channelEl.value = updateDraft.channel;
-      sourceRepoEl.value = updateDraft.sourceRepo;
-      renderSourceRepoRow();
-    })
-    // A corrupt update.json must not be silently replaced by defaults on
-    // the next save, so surface it the way a bad agents.json is.
-    .catch((err) => {
-      if (token !== openToken) return;
-      showError(String(err?.message || err));
-    });
-  refreshUpdateAction();
+  openModal({ id: 'settings' });
 }
 
 export function closeSettings() {
-  openToken += 1; // invalidate any in-flight load
-  // Same staleness class as openToken: a pending debounce would fire
-  // after the close with the text as it was, and on a reopen inside the
-  // window it writes that back over what the box now shows.
-  if (overridesTimer) {
-    clearTimeout(overridesTimer);
-    overridesTimer = null;
-  }
-  loading = false;
-  loadFailed = false;
+  // Blur before hiding, then hand focus back: refocusActiveTerm() bails
+  // when activeElement is an INPUT (lib/focus.ts), and unmounting the
+  // dialog does not synchronously move focus out of it in every engine.
+  // The order is why this lives here and not in a component effect.
   releaseFocus(settingsEl);
-  dlg.hide();
-  agentsError.clear();
-  draft = [];
-  updateDraft = { channel: CHANNEL_RELEASE, sourceRepo: '' };
+  // flushSync for the same reason closeLauncher uses it: this is called
+  // from plain listeners (keyboard.ts's window handler, the shell's
+  // Escape), so an ordinary store write lands a microtask later and
+  // refocusActiveTerm() would run while #settings is still visible —
+  // app/focus.ts refuses to touch the terminal while a modal is open.
+  flushSync(() => closeModal('settings'));
   deps.refocusActiveTerm();
 }
 
-// setEditingEnabled gates the controls that can mutate agents.json.
-// They stay disabled while a load is in flight or after one failed.
-function setEditingEnabled(on: boolean) {
-  saveBtn.disabled = !on;
-  addBtn.disabled = !on;
-}
-
-function saveSettings() {
-  // A draft that is empty because the file would not parse must never
-  // be written back over it.
-  if (loading || loadFailed) return;
-  // Drop fully-blank rows so an accidental "+ Add agent" doesn't
-  // block the save with a validation error.
-  const payload = draft.filter((a) => a.name.trim() || a.cmd.length);
-  // Both writes are validated Go-side and either can be rejected, so one
-  // of them is going to be the "partial save" on failure. Agents go
-  // first because that is the recoverable order: a rejected channel
-  // leaves the modal open on the row that caused it, with the agent
-  // edits already durable. The reverse strands a saved channel behind a
-  // Cancel that no longer discards it.
-  SaveCustomAgents(payload)
-    .then(() =>
-      SaveUpdateSettings({
-        channel: updateDraft.channel,
-        source_repo: updateDraft.sourceRepo,
-      } as main.UpdateSettings),
-    )
-    .then(closeSettings)
-    // Go returns one joined error naming every rejected entry; show it
-    // verbatim rather than paraphrasing it into something vaguer.
-    .catch((err) => showError(String(err?.message || err)));
+// 'system' resolves prefers-color-scheme at the moment it is applied,
+// and since phase 6 it is the default for every new install — so without
+// a listener, flipping the OS to dark leaves Hive light until it is
+// restarted. Re-applies only when the stored choice is still 'system':
+// an explicit preset is a decision the OS does not get to override.
+// Same trio as the component's theme picker minus the store write,
+// because the stored value ('system') is exactly what has not changed.
+export function initThemeWatch(): void {
+  const mq = window.matchMedia?.('(prefers-color-scheme: dark)');
+  // jsdom has no matchMedia, and older webviews expose the legacy
+  // addListener only; neither is worth a shim for a live-preview nicety.
+  if (!mq?.addEventListener) return;
+  mq.addEventListener('change', () => {
+    if (readTheme() !== 'system') return;
+    applyTheme('system');
+    applyXtermTheme();
+  });
 }
 
 export function initSettings(injected: SettingsDeps) {
   deps = injected;
-  document.getElementById('app')?.append(settingsEl);
-  channelEl.addEventListener('change', () => {
-    updateDraft.channel =
-      channelEl.value === CHANNEL_LATEST ? CHANNEL_LATEST : CHANNEL_RELEASE;
-    renderSourceRepoRow();
-  });
-  sourceRepoEl.addEventListener('input', () => {
-    updateDraft.sourceRepo = sourceRepoEl.value;
-    renderSourceRepoRow();
-  });
-  // Staging runs in Go and outlives this modal, so the button follows
-  // the same progress events the banner does rather than any local state.
-  EventsOn('update:progress', (info: main.UpdateInfo | null) =>
-    renderUpdateAction(info),
-  );
-  // Enter in a text field saves, as before. Escape and the backdrop are
-  // the dialog primitive's. The Appearance textarea is excluded by the
-  // type check: Enter there is a newline, and this listener would
-  // otherwise turn "next line of overrides" into "save and close".
-  settingsEl.addEventListener('keydown', (e) => {
-    if (
-      e.key === 'Enter' &&
-      e.target instanceof HTMLInputElement &&
-      e.target.type === 'text'
-    ) {
-      e.preventDefault();
-      saveSettings();
-    }
-  });
+  // Still registered: anyModalOpen() answers "does a modal own the
+  // keyboard?" off the `.hidden` class of every registered root, and
+  // #settings keeps that class (toggled by the island's layout effect).
+  registerModal(settingsEl);
 }

--- a/cmd/hivegui/frontend/src/components/IconButton.tsx
+++ b/cmd/hivegui/frontend/src/components/IconButton.tsx
@@ -7,6 +7,7 @@ import { Icon, type IconName } from './Icon.js';
 export interface IconButtonProps {
   icon: IconName;
   label: string;
+  id?: string;
   onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
   size?: 22 | 24;
   className?: string;
@@ -17,6 +18,7 @@ export interface IconButtonProps {
 export function IconButton({
   icon,
   label,
+  id,
   onClick,
   size = 24,
   className,
@@ -28,6 +30,7 @@ export function IconButton({
   return (
     <button
       type="button"
+      id={id}
       className={className ? `hv-icon-btn ${className}` : 'hv-icon-btn'}
       aria-label={label}
       title={label}

--- a/cmd/hivegui/frontend/src/components/modals/Launcher.tsx
+++ b/cmd/hivegui/frontend/src/components/modals/Launcher.tsx
@@ -1,0 +1,504 @@
+// ---------- agent launcher ----------
+//
+// React port of src/app/modals/launcher.ts. The island mounts on
+// #launcher, which keeps its id, its `role="menu"` and its `.hidden`
+// class — the class is the open/closed signal every keyboard gate and
+// e2e assertion reads, so it is applied from a layout effect the same
+// way Phase 2's chrome islands apply theirs.
+//
+// The launcher's own listeners (keydown, mousedown, focusout, and the
+// document-level outside click) stay on the root element rather than on
+// a React wrapper: #launcher's children are styled as direct children,
+// so an extra <div> would change the layout, and keyboard.ts bails out
+// for the whole window while #launcher is visible — these listeners are
+// the only thing handling keys while it is up.
+//
+// Per-open state (query, selection, the fetched agent list) is the body
+// component's own state and is reset by remounting it on every open:
+// `key={req.seq}`. That is what guarantees a reopen — ⌘T over an already
+// open launcher — starts with an empty query, which the imperative
+// version got by wiping #launcher.
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  CreateSession,
+  DuplicateSession,
+  IsGitRepo,
+  ListAgents,
+} from '../../bridge.js';
+import { flashStatus, reportFailure } from '../../app/dom.js';
+import { activeProjectId } from '../../app/selectors.js';
+import { state } from '../../app/state.js';
+import { cmdOrCtrl } from '../../lib/platform.js';
+import {
+  bumpAgentUsage,
+  closeLauncher,
+  loadAgentUsage,
+  openLauncher,
+} from '../../app/modals/launcher.js';
+import { useAppStore, type LauncherRequest } from '../../store/store.js';
+import { Kbd } from '../Kbd.js';
+// Type-only, so the generated module is erased before Vite resolves it.
+import type { main } from '../../../wailsjs/go/models';
+
+export interface LauncherProps {
+  root: HTMLElement | null;
+  /** Drops the active tile's visual focus — the modal owns the keyboard. */
+  setFocusedTile: (id: string | null) => void;
+}
+
+export function Launcher({ root, setFocusedTile }: LauncherProps): ReactNode {
+  const entry = useAppStore((s) => s.modals.find((m) => m.id === 'launcher'));
+  const open = !!entry;
+
+  // #launcher sits outside React's tree, so its open/closed class is
+  // applied here — as a layout effect, so the popup is visible in the
+  // same frame its contents first paint.
+  useLayoutEffect(() => {
+    root?.classList.toggle('hidden', !open);
+  }, [root, open]);
+
+  // Attached once and live even while the launcher is closed, exactly as
+  // initLauncher() attached it: a click that OPENS the launcher must not
+  // also close it, and this listener runs after the opener's own handler
+  // on the same event.
+  const openRef = useRef(open);
+  openRef.current = open;
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (!openRef.current || !root) return;
+      const target = e.target as Element | null;
+      // The sidebar's project actions are exempt because their buttons
+      // open the launcher; any other opener opts in with
+      // data-opens-launcher (the worktree browser's "Open session" does).
+      const inAction =
+        target?.closest('.hv-project-card__actions') ??
+        target?.closest('[data-opens-launcher]');
+      if (!root.contains(target) && !inAction) closeLauncher();
+    }
+    document.addEventListener('click', onDocClick);
+    return () => document.removeEventListener('click', onDocClick);
+  }, [root]);
+
+  if (!entry || !root) return null;
+  return (
+    <LauncherBody
+      key={entry.seq}
+      req={entry.req}
+      root={root}
+      setFocusedTile={setFocusedTile}
+    />
+  );
+}
+
+function LauncherBody({
+  req,
+  root,
+  setFocusedTile,
+}: {
+  req: LauncherRequest;
+  root: HTMLElement;
+  setFocusedTile: (id: string | null) => void;
+}): ReactNode {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState(0);
+  // The usage-ordered list ListAgents returned, kept so filtering
+  // re-renders from memory instead of refetching.
+  const [agents, setAgents] = useState<main.AgentInfo[]>([]);
+  // True until the request settles. Without it an empty list is
+  // indistinguishable from "the query excluded everything", and the
+  // first character typed during the round trip would replace the
+  // loading row with "No agents match".
+  const [loading, setLoading] = useState(true);
+  const [useWorktree, setUseWorktree] = useState(req.useWorktree);
+  const [branch, setBranch] = useState('');
+  // Null until the IsGitRepo probe answers; false disables the worktree
+  // row. The row renders enabled meanwhile — the probe almost always
+  // beats the user to the checkbox.
+  const [isGit, setIsGit] = useState<boolean | null>(null);
+
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const branchRef = useRef<HTMLInputElement | null>(null);
+  const selectedRef = useRef<HTMLDivElement | null>(null);
+
+  // In duplicate mode the cwd is fixed to the source session, so the
+  // worktree toggle is meaningless. In resume mode the worktree already
+  // exists, so neither the toggle nor the branch box has anything to
+  // decide.
+  const canWorktree = !req.duplicateFrom && !req.worktreePath;
+  const worktreeOff = canWorktree && isGit === false;
+
+  // Two readings of the same box, on purpose. `query` decides whether
+  // the user is typing — the digit handler tests the same raw value, or
+  // a lone space would show [n] hints that no longer fire. `q` decides
+  // what matches, where surrounding whitespace is just noise.
+  const q = query.trim().toLowerCase();
+  const matches = q
+    ? agents.filter((a) => a.name.toLowerCase().includes(q))
+    : agents;
+
+  // Position and focus, before the first paint: the popup is anchored
+  // under the resolved project's card header so the user can see which
+  // project the new session lands in. The header, not its + button: the
+  // card's actions are `display: none` until the header is hovered
+  // (components/ProjectCard.tsx), and a display:none anchor measures as a
+  // zero rect at the origin. Falls back to the global new-project button
+  // if the project's card isn't in the DOM (a minimized project), and to
+  // a fixed spot over the sidebar if neither anchor exists.
+  // Mount-only: one opening, one anchor. A re-anchor mid-open would move
+  // the popup out from under the pointer.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  useLayoutEffect(() => {
+    const anchorEl =
+      document.querySelector(
+        `.hv-project-card[data-pid="${req.projectId}"] .hv-project-card__header`,
+      ) ?? document.getElementById('new-project-btn');
+    if (anchorEl) {
+      const r = anchorEl.getBoundingClientRect();
+      root.style.left = `${r.left}px`;
+      root.style.top = `${r.bottom + 4}px`;
+    } else {
+      root.style.left = '16px';
+      root.style.top = '64px';
+    }
+    setFocusedTile(null);
+  }, []);
+
+  // Focus is a PASSIVE effect, deliberately. Layout effects run
+  // child-first, so at that point #launcher is still `.hidden` — and
+  // focus() on a display:none element is a silent no-op, which is
+  // exactly how it shipped broken to the browser while jsdom (no CSS)
+  // stayed green. Passive effects run after the island's layout effect
+  // has revealed the popup.
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  // The agent list, and the git probe that decides whether a worktree is
+  // even possible. Both are per-open (this body is remounted per open),
+  // so the "did the launcher get reopened under me?" generation check the
+  // imperative version needed is now just the unmount guard.
+  useEffect(() => {
+    let live = true;
+    ListAgents()
+      .then((list) => {
+        if (!live) return;
+        setLoading(false);
+        // Sort by recent usage (most-used first); ties preserve the
+        // agent package's display order. Usage is persisted in
+        // localStorage and incremented on activation.
+        const usage = loadAgentUsage();
+        setAgents(
+          (list || [])
+            .map((a, i) => ({ a, i }))
+            .sort((x, y) => {
+              const ux = usage[x.a.id] || 0,
+                uy = usage[y.a.id] || 0;
+              if (ux !== uy) return uy - ux;
+              return x.i - y.i;
+            })
+            .map((e) => e.a),
+        );
+      })
+      // Anything thrown in the chain above used to land here silently —
+      // the user pressed ⌘T and nothing happened, with no trace. Close
+      // the loading shell too: an empty popup with a stale "Loading
+      // agents…" would be worse.
+      .catch((err) => {
+        reportFailure('launcher')(err);
+        if (!live) return;
+        setLoading(false);
+        closeLauncher();
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  const projCwd = state.projects.find((p) => p.id === req.projectId)?.cwd ?? '';
+  useEffect(() => {
+    if (!canWorktree || !projCwd) return;
+    let live = true;
+    IsGitRepo(projCwd)
+      .then((ok) => {
+        if (!live) return;
+        setIsGit(!!ok);
+        if (!ok) {
+          setUseWorktree(false);
+          setBranch('');
+        }
+      })
+      .catch(() => {
+        // Intentionally silent: the probe rejects only when the bridge
+        // itself is down. Worst case the daemon later refuses worktree
+        // creation via control:error, which IS surfaced.
+      });
+    return () => {
+      live = false;
+    };
+  }, [canWorktree, projCwd]);
+
+  // Narrowing the list invalidates the old index — the row that was
+  // selected may not even be rendered any more. Always land on the top
+  // match so Enter means "the obvious one". The deps ARE the trigger
+  // here; the body reads neither, which is what the rule objects to.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  useEffect(() => {
+    setSelected(0);
+  }, [query, agents]);
+
+  // Same shape: `selected` is the trigger, the ref is how the row is
+  // reached.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [selected]);
+
+  // launchSelected runs the create/duplicate-session sequence shared by
+  // the keyboard-select path and the per-row click handler: bump usage,
+  // flash status, call the daemon, close the launcher.
+  function launchSelected(agentId: string) {
+    bumpAgentUsage(agentId);
+    flashStatus('creating session…');
+    // Anchor the new session under the one it came from (duplicate) or
+    // under the active one, so it lands next to its context instead of
+    // at the bottom of the sidebar.
+    const anchor = req.duplicateFrom?.id || state.activeId || '';
+    if (req.duplicateFrom) {
+      DuplicateSession(
+        agentId,
+        req.projectId || '',
+        req.duplicateCwd,
+        anchor,
+      ).catch(reportFailure('duplicate session'));
+    } else {
+      CreateSession(
+        agentId,
+        req.projectId || activeProjectId(),
+        '',
+        '',
+        0,
+        0,
+        !!useWorktree,
+        anchor,
+        // Trimmed here rather than on every keystroke so the box stays
+        // typable; a blank name means "let the daemon generate one".
+        branch.trim(),
+        req.worktreePath,
+        req.continueConversation,
+      ).catch(reportFailure('new session'));
+    }
+    closeLauncher();
+  }
+
+  function activateAt(i: number) {
+    const a = matches[i];
+    if (a) launchSelected(a.id);
+  }
+
+  function moveSelection(delta: number) {
+    const n = matches.length;
+    if (n === 0) return;
+    setSelected((cur) => (cur + delta + n) % n);
+  }
+
+  // ---------- the listeners that live on #launcher ----------
+  //
+  // Re-attached on every render so they always close over the current
+  // query and match list; removal is exact, so nothing accumulates.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const handle = (fn: () => void) => {
+        e.preventDefault();
+        e.stopPropagation();
+        fn();
+      };
+      if (e.key === 'ArrowDown' || (e.key === 'Tab' && !e.shiftKey))
+        return handle(() => moveSelection(+1));
+      if (e.key === 'ArrowUp' || (e.key === 'Tab' && e.shiftKey))
+        return handle(() => moveSelection(-1));
+      if (e.key === 'Enter') return handle(() => activateAt(selected));
+      if (e.key === 'Escape') return handle(closeLauncher);
+      if (cmdOrCtrl(e) && (e.key === 'n' || e.key === 'N'))
+        return handle(closeLauncher);
+      // ⌘T / ⇧⌘T while already open re-opens (and so clears the query).
+      // keyboard.ts bails out for #launcher entirely, so the binding has
+      // to be repeated here or it would silently stop working.
+      if (cmdOrCtrl(e) && (e.key === 't' || e.key === 'T'))
+        return handle(() => {
+          // Passing undefined re-resolves the active project rather than
+          // pinning the one this opening was anchored to.
+          if (e.shiftKey) openLauncher(undefined, { forceWorktree: true });
+          else openLauncher();
+        });
+      // Digit shortcut: 1–9 picks the corresponding row, but only while
+      // the filter box is empty — past that the user is typing a query
+      // and a digit is just a character. Raw value, not trimmed: a typed
+      // space is already a query. Skipped when a modifier is held so ⌘1
+      // and friends aren't swallowed, and inside the branch box, where a
+      // digit is part of the branch name (`fix-2`).
+      if (
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        /^[1-9]$/.test(e.key) &&
+        query === '' &&
+        e.target !== branchRef.current
+      ) {
+        const i = parseInt(e.key, 10) - 1;
+        if (i < matches.length) {
+          return handle(() => {
+            setSelected(i);
+            activateAt(i);
+          });
+        }
+      }
+    }
+    // Nothing but the two text boxes may take focus. Clicking anything
+    // else would blur them, and the keydown listener above only fires
+    // while focus is inside #launcher — so the search would silently
+    // stop responding to typing. preventDefault on mousedown suppresses
+    // only the focus shift and text selection: click still fires, so
+    // agent rows still launch and the worktree checkbox still toggles.
+    function onMouseDown(e: MouseEvent) {
+      const target = e.target as Element | null;
+      if (target === searchRef.current || target === branchRef.current) return;
+      e.preventDefault();
+    }
+    // Focus leaving the launcher closes it: keyboard.ts bails out for the
+    // whole window while #launcher is visible and this module's keydown
+    // listener only fires while focus is inside it, so a launcher that
+    // stays visible after focus moves away is one nobody is listening
+    // for, Escape included. relatedTarget null means focus went nowhere —
+    // that's closeLauncher's own blur, so ignore it rather than recursing.
+    function onFocusOut(e: FocusEvent) {
+      const next = e.relatedTarget as Node | null;
+      if (next && !root.contains(next)) closeLauncher();
+    }
+    root.addEventListener('keydown', onKeyDown);
+    root.addEventListener('mousedown', onMouseDown);
+    root.addEventListener('focusout', onFocusOut);
+    return () => {
+      root.removeEventListener('keydown', onKeyDown);
+      root.removeEventListener('mousedown', onMouseDown);
+      root.removeEventListener('focusout', onFocusOut);
+    };
+  });
+
+  return (
+    <>
+      <input
+        ref={searchRef}
+        type="text"
+        className="launcher-search"
+        placeholder="Filter agents…"
+        aria-label="Filter agents"
+        autoComplete="off"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      {/* Between the filter box and the list, and only once the agent
+          list has landed — the same order and timing the imperative
+          version inserted it with. */}
+      {canWorktree && !loading ? (
+        <>
+          <label
+            className={
+              worktreeOff ? 'launcher-worktree disabled' : 'launcher-worktree'
+            }
+          >
+            <input
+              type="checkbox"
+              checked={useWorktree}
+              disabled={worktreeOff}
+              onChange={(e) => {
+                const on = e.target.checked;
+                setUseWorktree(on);
+                try {
+                  localStorage.setItem('hive.worktree', on ? '1' : '0');
+                } catch {}
+                if (!on) setBranch('');
+              }}
+            />
+            <span>
+              {worktreeOff
+                ? 'Worktree (project is not a git repo)'
+                : 'Create in git worktree'}
+            </span>
+          </label>
+          {/* Revealed only while the toggle is on: it is meaningless
+              otherwise, and an always-visible field would push the agent
+              list down on every open. */}
+          <input
+            ref={branchRef}
+            type="text"
+            className={
+              useWorktree ? 'launcher-branch' : 'launcher-branch hidden'
+            }
+            placeholder="branch name (optional)"
+            aria-label="Worktree branch name"
+            value={branch}
+            onChange={(e) => setBranch(e.target.value)}
+          />
+        </>
+      ) : null}
+      <div className="launcher-list">
+        {matches.length === 0 ? (
+          // Three different facts, and conflating any two of them
+          // misreads as a broken agent list: the request is still in
+          // flight, the daemon returned nothing, or the query excluded
+          // everything.
+          loading ? (
+            <div className="launcher-loading">Loading agents…</div>
+          ) : (
+            <div className="launcher-empty">
+              {q ? 'No agents match' : 'No agents found'}
+            </div>
+          )
+        ) : null}
+        {matches.map((a, idx) => (
+          // The rows are the launcher's keyboard path already: 1-9 pick
+          // one directly, arrows move the selection and Enter launches
+          // it (the listener on #launcher above). A role and a key
+          // handler here would put a second, undocumented way to do the
+          // same thing in the tab order — and the popup deliberately
+          // keeps focus in the filter box.
+          // biome-ignore lint/a11y/noStaticElementInteractions: see above
+          // biome-ignore lint/a11y/useKeyWithClickEvents: see above
+          <div
+            key={a.id}
+            ref={idx === selected ? selectedRef : undefined}
+            className="launcher-item"
+            data-selected={idx === selected ? '' : undefined}
+            data-available={a.available ? undefined : 'false'}
+            style={{ ['--agent-color' as string]: a.color }}
+            onClick={() => launchSelected(a.id)}
+            onMouseEnter={() => setSelected(idx)}
+          >
+            {/* Number keys 1–9 select that row directly; 10+ rows show no
+                number. While a query is active the digits type into it
+                instead of selecting, so the hints come off — a visible
+                [n] that does nothing is worse than none (AGENTS.md, Key
+                Discoverability). */}
+            <span className="agent-num">
+              {!query && idx < 9 ? <Kbd>{`[${idx + 1}]`}</Kbd> : null}
+            </span>
+            <span className="agent-dot" />
+            <span className="agent-name">{a.name}</span>
+            {!a.available && a.installCmd?.length ? (
+              <span className="install-tag" title={a.installCmd.join(' ')}>
+                install?
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/cmd/hivegui/frontend/src/components/modals/ModalShell.tsx
+++ b/cmd/hivegui/frontend/src/components/modals/ModalShell.tsx
@@ -1,0 +1,134 @@
+// ---------- modal shell ----------
+//
+// The React half of src/ui/dialog.ts: same markup, same class names,
+// same `hidden` contract. The imperative dialog() stays for the four
+// modals Phase 4 still has to port (worktrees, project editor, help
+// overlay, choice dialog); this is what a ported one renders through.
+//
+// The root element is NOT created here. It lives in index.html so the
+// React root has something to mount on before the store says the modal
+// is open, and so the id, `role` and `aria-modal` that the keyboard
+// pipeline and the e2e specs key off exist from the first paint. This
+// component owns everything inside it; the island that renders it owns
+// the root's `hidden` class, because that class has to be right in the
+// frame this component is no longer mounted in.
+//
+// What this does NOT own, for the same reasons dialog() does not:
+//   * Where focus goes on open and close. Every modal has its own
+//     answer; closing in particular must blur BEFORE the caller hands
+//     focus back to the terminal, which only the close function can
+//     order correctly (see closeSettings).
+//   * Hiding itself. `onClose` is the module's close function, which has
+//     bookkeeping — in-flight loads, drafts — that must run whichever
+//     gesture closed the dialog.
+//
+// See docs/design-docs/ui/components.md › dialog.
+
+import { useEffect, type ReactNode } from 'react';
+import { trapFocus } from '../../app/modals/focus-trap.js';
+import { IconButton } from '../IconButton.js';
+import { Kbd } from '../Kbd.js';
+
+export interface ModalHint {
+  /** Rendered as-is, so it carries its own [] or () per AGENTS.md. */
+  keys: string;
+  label: string;
+}
+
+export interface ModalShellProps {
+  id: string;
+  /** The dialog root from index.html. Mounted only while open. */
+  root: HTMLElement;
+  title: string;
+  onClose: () => void;
+  size?: 'sm' | 'md' | 'lg';
+  /** Confirm/cancel key hints. Every overlay must show them (AGENTS.md). */
+  hints?: ModalHint[];
+  actions?: ReactNode;
+  children?: ReactNode;
+}
+
+export function ModalShell({
+  id,
+  root,
+  title,
+  onClose,
+  size = 'md',
+  hints,
+  actions,
+  children,
+}: ModalShellProps): ReactNode {
+  // Acquired on mount, released on unmount: Escape, the backdrop, and
+  // Tab containment. The trap is a fallback — keyboard.ts's window
+  // listener is on the capture phase, so for a modal it knows about it
+  // runs first and this never fires. It matters for the case that one
+  // does not cover: focus already inside the dialog with the window
+  // handler having bailed out.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (trapFocus(root, e)) e.stopPropagation();
+    }
+    // Both ends of the gesture must land on the backdrop. A
+    // text-selection drag that starts inside an input and releases
+    // outside the panel dispatches its click on the nearest common
+    // ancestor — the backdrop — so testing the click alone discards the
+    // whole draft mid-edit.
+    let downOnBackdrop = false;
+    function onMouseDown(e: MouseEvent) {
+      downOnBackdrop = e.target === root;
+    }
+    function onClick(e: MouseEvent) {
+      const fire = downOnBackdrop && e.target === root;
+      downOnBackdrop = false;
+      if (fire) onClose();
+    }
+    root.addEventListener('keydown', onKeyDown);
+    root.addEventListener('mousedown', onMouseDown);
+    root.addEventListener('click', onClick);
+    return () => {
+      root.removeEventListener('keydown', onKeyDown);
+      root.removeEventListener('mousedown', onMouseDown);
+      root.removeEventListener('click', onClick);
+    };
+  }, [root, onClose]);
+
+  const hintList = hints ?? [];
+  return (
+    <div className="hv-dialog__panel" id={`${id}-panel`} data-size={size}>
+      <header className="hv-dialog__header">
+        {/* The accessible name is this one string: the root points at it
+            with aria-labelledby. */}
+        <h3 className="hv-dialog__title" id={`${id}-title`}>
+          {title}
+          <span className="hv-dialog__title-suffix" />
+        </h3>
+        <IconButton
+          icon="x"
+          label="Close"
+          className="hv-dialog__close"
+          id={`${id}-close`}
+          onClick={onClose}
+        />
+      </header>
+      <div className="hv-dialog__body">{children}</div>
+      <footer className="hv-dialog__footer">
+        {hintList.length ? (
+          <div className="hv-dialog__hints">
+            {hintList.map((h) => (
+              <span key={h.keys} className="hv-dialog__hint">
+                <Kbd>{h.keys}</Kbd> {h.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
+        {actions ? <div className="hv-dialog__actions">{actions}</div> : null}
+      </footer>
+    </div>
+  );
+}

--- a/cmd/hivegui/frontend/src/components/modals/Settings.tsx
+++ b/cmd/hivegui/frontend/src/components/modals/Settings.tsx
@@ -1,0 +1,703 @@
+// ---------- settings (appearance + custom agents + updates) ----------
+//
+// React port of src/app/modals/settings.ts. The ids the keyboard
+// pipeline and the e2e specs key off are set explicitly here and are
+// part of this component's contract.
+//
+// The agent list is edited as a local draft and written in one
+// SaveCustomAgents call. Go owns validation and ID assignment — new rows
+// are saved with an empty id and come back slugged. IDs are deliberately
+// not editable: registry entries persist only the agent id, so changing
+// one would break revive for every session already created with it.
+//
+// Appearance is NOT part of that draft. It is a local preference with no
+// round-trip and nothing to validate, so it applies and persists on
+// change — you cannot choose a theme you are not allowed to look at.
+// Cancel therefore does not revert it, and the section says so.
+//
+// Per-open state resets by construction: the body is mounted only while
+// the modal is open, so the staleness tokens the imperative version
+// needed (openToken) are now the unmount guard on each request.
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  EventsOn,
+  GetUpdateSettings,
+  ListCustomAgents,
+  PickDirectory,
+  SaveCustomAgents,
+  SaveUpdateSettings,
+  SourceRepoStatusFor,
+  StartUpdate,
+  UpdateStatus,
+} from '../../bridge.js';
+import { isMac } from '../../lib/platform.js';
+import {
+  CHANNEL_LATEST,
+  CHANNEL_RELEASE,
+  updateButtonState,
+} from '../../lib/update-state.js';
+import {
+  applyOverrides,
+  applyTheme,
+  PRESETS,
+  readOverrides,
+  readTheme,
+  sanitizeOverrides,
+  THEME_KEY,
+  writeOverrides,
+  type ThemeName,
+} from '../../theme/theme.js';
+import { applyUpdateAndRestart } from '../../app/banners.js';
+import { applyXtermTheme } from '../../app/session-term.js';
+import { closeSettings, splitCommand } from '../../app/modals/settings.js';
+import { useAppStore } from '../../store/store.js';
+import { Button } from '../Button.js';
+import { IconButton } from '../IconButton.js';
+import { ModalShell } from './ModalShell.js';
+// Type-only, so the generated module is erased before Vite resolves it.
+import type { main } from '../../../wailsjs/go/models';
+
+const DEFAULT_COLOR = '#64748b';
+
+// Applying overrides is not free: a style invalidation, then a
+// getComputedStyle and a palette rebuild on EVERY live terminal, then a
+// synchronous localStorage write. applyXtermTheme's own comment says
+// "not per frame"; a keystroke is the per-frame case, so the work trails
+// the typing by one short pause instead of riding every character.
+const OVERRIDES_DEBOUNCE_MS = 150;
+// SourceRepoStatusFor stats its way up a directory tree, so firing it per
+// keystroke is both wasteful and unordered.
+const SOURCE_REPO_DEBOUNCE_MS = 250;
+
+export function Settings({ root }: { root: HTMLElement | null }): ReactNode {
+  const entry = useAppStore((s) => s.modals.find((m) => m.id === 'settings'));
+
+  // #settings sits outside React's tree, so its open/closed class is
+  // applied here. The `hidden` class is load-bearing: registry.ts's
+  // anyModalOpen(), keyboard.ts's per-modal gate and every e2e
+  // visibility assertion read it.
+  useLayoutEffect(() => {
+    root?.classList.toggle('hidden', !entry);
+  }, [root, entry]);
+
+  if (!entry || !root) return null;
+  // Remounted per opening, which is what resets the draft, the load
+  // flags and the two debounces — the openToken the imperative version
+  // carried is now this key plus a per-request unmount guard.
+  return <SettingsDialog key={entry.seq} root={root} />;
+}
+
+function SettingsDialog({ root }: { root: HTMLElement }): ReactNode {
+  // draft is the in-progress edit; discarded on cancel (this component
+  // unmounts). Rows are plain objects, not main.CustomAgent instances —
+  // the generated class is a data shape and Go re-slugs the ids on save.
+  const [draft, setDraft] = useState<main.CustomAgent[]>([]);
+  // loading distinguishes "still fetching" from "genuinely empty" so the
+  // empty state never renders over a list that is about to arrive.
+  const [loading, setLoading] = useState(true);
+  // loadFailed blocks Save after a failed read. Go cannot tell a
+  // deliberate "delete every agent" from a draft that is empty only
+  // because agents.json would not parse, so the refusal has to live here,
+  // where that distinction is still known.
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [error, setError] = useState('');
+  const [theme, setTheme] = useState<ThemeName>(() => readTheme());
+  const [overrides, setOverrides] = useState(() =>
+    readOverrides().replace(/\n\s*/g, '\n'),
+  );
+  const [overridesError, setOverridesError] = useState('');
+  // updateDraft mirrors the two saved update fields while the modal is
+  // open; Cancel discards them like any other draft.
+  const [channel, setChannel] = useState(CHANNEL_RELEASE);
+  const [sourceRepo, setSourceRepo] = useState('');
+  const [sourceRepoHint, setSourceRepoHint] = useState('');
+  const [updateInfo, setUpdateInfo] = useState<main.UpdateInfo | null>(null);
+
+  // Staging runs in Go and outlives this modal, so the button follows
+  // the same progress events the banner does rather than any local
+  // state. The state it starts from is re-read on open (UpdateStatus
+  // below) rather than tracked while the dialog is closed.
+  useEffect(
+    () =>
+      EventsOn('update:progress', (info: main.UpdateInfo | null) =>
+        setUpdateInfo(info),
+      ),
+    [],
+  );
+
+  const errorRef = useRef<HTMLParagraphElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  // The row index whose delete button took the last click. render()
+  // destroyed the button that had focus, dropping it to <body> — from
+  // there the Tab trap has no boundary to wrap and the next Tab walks
+  // behind the backdrop. Put focus back on the row that took this one's
+  // place, or on "Add agent".
+  const refocusDelete = useRef<number | null>(null);
+  // Focus the newly added row's name box, once it exists.
+  const focusLastName = useRef(false);
+
+  const editingEnabled = !loading && !loadFailed;
+
+  // ---------- the load, and the focus it lands with ----------
+
+  // Mount-only: this effect IS the open, and re-running it would refetch
+  // under an edited draft.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  useEffect(() => {
+    let live = true;
+    // Drop the active tile's visual focus and pull focus into the
+    // dialog — same discipline as the help overlay. Without this, focus
+    // stays on the terminal and keystrokes leak behind the backdrop.
+    document.getElementById('settings-close')?.focus();
+
+    ListCustomAgents()
+      .then((list) => {
+        if (!live) return; // closed and reopened; stale
+        setLoading(false);
+        setDraft(
+          (list || []).map((a) => ({
+            id: a.id || '',
+            name: a.name || '',
+            cmd: a.cmd || [],
+            color: a.color || DEFAULT_COLOR,
+          })) as main.CustomAgent[],
+        );
+      })
+      .catch((err) => {
+        if (!live) return;
+        setLoading(false);
+        // Editing stays disabled: the draft is empty only because the
+        // read failed, and saving it would destroy agents.json.
+        setLoadFailed(true);
+        showError(
+          `Could not read agents.json — fix or move the file, then reopen Settings. (${String(err?.message || err)})`,
+        );
+      });
+
+    GetUpdateSettings()
+      .then((s) => {
+        if (!live) return;
+        setChannel(
+          s?.channel === CHANNEL_LATEST ? CHANNEL_LATEST : CHANNEL_RELEASE,
+        );
+        setSourceRepo(s?.source_repo || '');
+      })
+      // A corrupt update.json must not be silently replaced by defaults
+      // on the next save, so surface it the way a bad agents.json is.
+      .catch((err) => {
+        if (!live) return;
+        showError(String(err?.message || err));
+      });
+
+    // Read back from Go rather than tracked here, which is what keeps
+    // the button in agreement with the banner.
+    UpdateStatus()
+      .then((info) => live && setUpdateInfo(info))
+      .catch(() => live && setUpdateInfo(null));
+
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  // ---------- errors ----------
+
+  function showError(msg: string) {
+    setError(msg);
+    // The slot lives in the scrolling region, so a save rejected after
+    // the user scrolled down would otherwise land off-screen and read as
+    // "the button did nothing". Optional call: jsdom has no layout.
+    if (msg)
+      queueMicrotask(() =>
+        errorRef.current?.scrollIntoView?.({ block: 'nearest' }),
+      );
+  }
+
+  // ---------- appearance ----------
+
+  // One place stamps the theme, so the three things that must happen
+  // together cannot drift apart: the attribute, the terminals (xterm
+  // caches its palette; a CSS change alone leaves every open session on
+  // the old colours), and the stored choice.
+  function selectPreset(name: ThemeName) {
+    setTheme(name);
+    applyTheme(name);
+    applyXtermTheme();
+    try {
+      localStorage.setItem(THEME_KEY, name);
+    } catch {
+      // Denied storage: applied for this session, not remembered.
+    }
+  }
+
+  // Debounced, and cancelled on close by the cleanup: a pending timer
+  // would otherwise fire after the dialog is gone with the text as it
+  // was, and on a reopen inside the window write that back over what the
+  // box now shows.
+  const firstOverrides = useRef(true);
+  useEffect(() => {
+    if (firstOverrides.current) {
+      // The mount value is what is already applied; re-applying it would
+      // rewrite storage for a dialog the user only looked at.
+      firstOverrides.current = false;
+      return;
+    }
+    const t = setTimeout(() => {
+      // Rejected lines are reported; accepted ones apply. Typing "--acc"
+      // reports one rejected line and changes nothing, which is the
+      // honest answer.
+      const { css, rejected } = sanitizeOverrides(overrides);
+      applyOverrides(css);
+      applyXtermTheme();
+      writeOverrides(css);
+      setOverridesError(
+        rejected.length === 0
+          ? ''
+          : `Ignored ${rejected.length} line(s) — only "--token: value;" declarations are allowed: ${rejected.join(' / ')}`,
+      );
+    }, OVERRIDES_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [overrides]);
+
+  // ---------- updates ----------
+
+  const isLatest = channel === CHANNEL_LATEST;
+  useEffect(() => {
+    if (!isLatest) {
+      setSourceRepoHint('');
+      return;
+    }
+    let live = true;
+    const t = setTimeout(() => {
+      SourceRepoStatusFor(sourceRepo)
+        .then((st) => {
+          if (!live || !st) return;
+          if (st.error) {
+            setSourceRepoHint(st.error);
+            return;
+          }
+          setSourceRepoHint(
+            st.detected ? `Detected ${st.path}` : `Using ${st.path}`,
+          );
+        })
+        .catch((err) => {
+          if (!live) return;
+          setSourceRepoHint(String(err?.message || err));
+        });
+    }, SOURCE_REPO_DEBOUNCE_MS);
+    return () => {
+      live = false;
+      clearTimeout(t);
+    };
+  }, [isLatest, sourceRepo]);
+
+  function browseSourceRepo() {
+    PickDirectory(sourceRepo)
+      .then((dir) => {
+        if (!dir) return; // cancelled
+        setSourceRepo(dir);
+      })
+      .catch((err) => showError(String(err?.message || err)));
+  }
+
+  const updateBtn = updateButtonState(updateInfo, isMac);
+  const [updateBusy, setUpdateBusy] = useState(false);
+
+  function runUpdate() {
+    if (updateBtn.action === 'restart') {
+      // Shared with the banner: confirm overlay + re-entrancy guard +
+      // the daemon-restart flag live there, and applying is exactly as
+      // destructive from here as it is from the banner.
+      void applyUpdateAndRestart(updateInfo?.latest || '');
+      return;
+    }
+    if (updateBtn.action === 'start') {
+      setUpdateBusy(true);
+      // A synchronous refusal from StartUpdate emits no update:progress
+      // event, so re-enable the button here rather than leaving it dead.
+      StartUpdate().catch((err) => {
+        setUpdateBusy(false);
+        showError(String(err?.message || err));
+      });
+    }
+  }
+
+  // ---------- agents ----------
+
+  function addAgentRow() {
+    setDraft((cur) => [
+      ...cur,
+      { id: '', name: '', cmd: [], color: DEFAULT_COLOR } as main.CustomAgent,
+    ]);
+    showError('');
+    focusLastName.current = true;
+  }
+
+  function deleteAgentRow(i: number) {
+    setDraft((cur) => cur.filter((_, idx) => idx !== i));
+    showError('');
+    refocusDelete.current = i;
+  }
+
+  function patchAgent(i: number, patch: Partial<main.CustomAgent>) {
+    setDraft((cur) =>
+      cur.map((a, idx) => (idx === i ? { ...a, ...patch } : a)),
+    );
+  }
+
+  // The refs are read, never subscribed to: this effect exists to put
+  // focus back after the list re-rendered, so `draft` is the whole
+  // dependency.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  useEffect(() => {
+    if (focusLastName.current) {
+      focusLastName.current = false;
+      listRef.current
+        ?.querySelector<HTMLElement>(
+          '.settings-agent-row:last-child .settings-agent-name',
+        )
+        ?.focus();
+      return;
+    }
+    const i = refocusDelete.current;
+    if (i == null) return;
+    refocusDelete.current = null;
+    const dels =
+      listRef.current?.querySelectorAll<HTMLElement>(
+        '.settings-agent-delete',
+      ) ?? [];
+    (
+      dels[Math.min(i, dels.length - 1)] ??
+      document.getElementById('settings-agent-add')
+    )?.focus();
+  }, [draft]);
+
+  // ---------- save ----------
+
+  function saveSettings() {
+    // A draft that is empty because the file would not parse must never
+    // be written back over it.
+    if (loading || loadFailed) return;
+    // Drop fully-blank rows so an accidental "+ Add agent" doesn't block
+    // the save with a validation error.
+    const payload = draft.filter((a) => a.name.trim() || a.cmd.length);
+    // Both writes are validated Go-side and either can be rejected, so
+    // one of them is going to be the "partial save" on failure. Agents go
+    // first because that is the recoverable order: a rejected channel
+    // leaves the modal open on the row that caused it, with the agent
+    // edits already durable. The reverse strands a saved channel behind a
+    // Cancel that no longer discards it.
+    SaveCustomAgents(payload)
+      .then(() =>
+        SaveUpdateSettings({
+          channel,
+          source_repo: sourceRepo,
+        } as main.UpdateSettings),
+      )
+      .then(closeSettings)
+      // Go returns one joined error naming every rejected entry; show it
+      // verbatim rather than paraphrasing it into something vaguer.
+      .catch((err) => showError(String(err?.message || err)));
+  }
+
+  // Enter in a text field saves, as before. Escape and the backdrop are
+  // the shell's. The Appearance textarea is excluded by the type check:
+  // Enter there is a newline, and this would otherwise turn "next line of
+  // overrides" into "save and close".
+  //
+  // On the root element, not on a wrapper: #settings-scroll and
+  // #settings-updates must stay direct children of .hv-dialog__body
+  // (settings.css pins Updates below the scrolling region), so this
+  // subtree has no element of its own to hang a React handler on.
+  // Re-attached each render so it closes over the current draft.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (
+        e.key === 'Enter' &&
+        e.target instanceof HTMLInputElement &&
+        e.target.type === 'text'
+      ) {
+        e.preventDefault();
+        saveSettings();
+      }
+    }
+    root.addEventListener('keydown', onKeyDown);
+    return () => root.removeEventListener('keydown', onKeyDown);
+  });
+
+  return (
+    <ModalShell
+      id="settings"
+      root={root}
+      title="Settings"
+      size="md"
+      onClose={closeSettings}
+      hints={[
+        { keys: '[esc]', label: 'cancel' },
+        { keys: '[enter]', label: 'save' },
+      ]}
+      actions={
+        <>
+          <Button id="settings-cancel" label="Cancel" onClick={closeSettings} />
+          <Button
+            id="settings-save"
+            label="Save"
+            kind="primary"
+            disabled={!editingEnabled}
+            onClick={saveSettings}
+          />
+        </>
+      }
+    >
+      {/* Everything above Updates scrolls together. Agents first: it is
+          the section people open Settings to edit, and it is the only one
+          that grows — putting Appearance above it pushed the list
+          off-screen on open for anyone with more than a couple of
+          agents. */}
+      <div id="settings-scroll">
+        <h4>Custom agents</h4>
+        <p className="settings-hint">
+          Define your own tools — a command and its arguments. They appear in
+          the new-session menu alongside the built-ins.
+        </p>
+        <div id="settings-agents-list" ref={listRef}>
+          {loading ? (
+            <p className="settings-hint">Loading…</p>
+          ) : draft.length === 0 ? (
+            <p className="settings-hint">No custom agents yet.</p>
+          ) : (
+            draft.map((a, i) => (
+              // Index keys on purpose: a new row has no id at all until
+              // Go assigns one on save, and the position IS the identity
+              // here — every edit and the delete address a row by index.
+              // biome-ignore lint/suspicious/noArrayIndexKey: see above
+              <div className="settings-agent-row" key={i}>
+                <span
+                  className="hv-swatch"
+                  style={{ ['--swatch' as string]: a.color || DEFAULT_COLOR }}
+                >
+                  <input
+                    type="color"
+                    aria-label="Agent color"
+                    value={a.color || DEFAULT_COLOR}
+                    onChange={(e) => patchAgent(i, { color: e.target.value })}
+                  />
+                </span>
+                <input
+                  type="text"
+                  className="hv-input settings-agent-name"
+                  autoComplete="off"
+                  aria-label="Agent name"
+                  placeholder="Name (e.g. Claude Lite)"
+                  value={a.name || ''}
+                  onChange={(e) => patchAgent(i, { name: e.target.value })}
+                />
+                <input
+                  type="text"
+                  className="hv-input settings-agent-cmd"
+                  autoComplete="off"
+                  aria-label="Agent command"
+                  placeholder="Command (e.g. claude --model haiku)"
+                  value={(a.cmd || []).join(' ')}
+                  onChange={(e) =>
+                    patchAgent(i, { cmd: splitCommand(e.target.value) })
+                  }
+                />
+                <IconButton
+                  icon="x"
+                  label={`Delete ${a.name || 'agent'}`}
+                  className="settings-agent-delete"
+                  onClick={() => deleteAgentRow(i)}
+                />
+              </div>
+            ))
+          )}
+        </div>
+        <Button
+          id="settings-agent-add"
+          label="Add agent"
+          icon="plus"
+          disabled={!editingEnabled}
+          onClick={addAgentRow}
+        />
+        <p
+          id="settings-error"
+          ref={errorRef}
+          role="alert"
+          className={
+            error
+              ? 'hv-field-error settings-error'
+              : 'hv-field-error settings-error hidden'
+          }
+        >
+          {error}
+        </p>
+
+        <h4>Appearance</h4>
+        <p className="settings-hint">
+          Applies as you change it, and is remembered. Cancel does not undo it.
+        </p>
+        <label className="hv-field">
+          <span className="hv-field__label">Theme</span>
+          <select
+            id="settings-theme"
+            className="hv-input"
+            aria-label="Theme"
+            value={theme}
+            onChange={(e) => selectPreset(e.target.value as ThemeName)}
+          >
+            {groupPresets().map((g) =>
+              g.group ? (
+                <optgroup key={g.group} label={g.group}>
+                  {g.options.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.label}
+                    </option>
+                  ))}
+                </optgroup>
+              ) : (
+                g.options.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.label}
+                  </option>
+                ))
+              ),
+            )}
+          </select>
+        </label>
+        <p className="settings-hint">
+          Override any design token, one declaration per line. Fonts must
+          already be installed on this machine.
+        </p>
+        <label className="hv-field">
+          <span className="hv-field__label">Custom tokens</span>
+          <textarea
+            id="settings-overrides"
+            className="hv-input hv-input--mono"
+            aria-label="Custom tokens"
+            // Programmatic link to the slot this box writes its
+            // rejections into: without it a screen reader never hears why
+            // a line was ignored.
+            aria-describedby="settings-overrides-error"
+            rows={4}
+            spellCheck={false}
+            placeholder="--accent: #7aa2f7;"
+            value={overrides}
+            onChange={(e) => setOverrides(e.target.value)}
+          />
+        </label>
+        <p
+          id="settings-overrides-error"
+          role="alert"
+          className={
+            overridesError ? 'hv-field-error' : 'hv-field-error hidden'
+          }
+        >
+          {overridesError}
+        </p>
+      </div>
+
+      {/* Updates sits outside the scrolling part of the body, at its
+          natural height: a dozen custom agents must never push the
+          channel picker below the fold (test/e2e/settings.spec.ts). */}
+      <section id="settings-updates">
+        <h4>Updates</h4>
+        <p className="settings-hint">
+          Hive checks for updates in the background. Nothing is downloaded or
+          built until you press Update.
+        </p>
+        <label className="hv-field">
+          <span className="hv-field__label">Channel</span>
+          <select
+            id="settings-update-channel"
+            className="hv-input"
+            aria-label="Update channel"
+            value={channel}
+            onChange={(e) =>
+              setChannel(
+                e.target.value === CHANNEL_LATEST
+                  ? CHANNEL_LATEST
+                  : CHANNEL_RELEASE,
+              )
+            }
+          >
+            <option value={CHANNEL_RELEASE}>Release — tagged versions</option>
+            <option value={CHANNEL_LATEST}>
+              Latest — tip of your checkout
+            </option>
+          </select>
+        </label>
+        {/* A container, not a field: it holds the labelled input and the
+            Browse button on one line, and is hidden wholesale on the
+            release channel. */}
+        <div
+          id="settings-source-repo-row"
+          className={isLatest ? 'settings-field' : 'settings-field hidden'}
+        >
+          <label className="hv-field">
+            <span className="hv-field__label">Source repo</span>
+            <input
+              id="settings-source-repo"
+              type="text"
+              className="hv-input"
+              autoComplete="off"
+              aria-label="Source repo"
+              aria-describedby="settings-source-repo-hint"
+              placeholder="Detected automatically"
+              value={sourceRepo}
+              onChange={(e) => setSourceRepo(e.target.value)}
+            />
+          </label>
+          <Button
+            id="settings-source-repo-browse"
+            label="Browse…"
+            onClick={browseSourceRepo}
+          />
+        </div>
+        <p id="settings-source-repo-hint" className="settings-hint">
+          {sourceRepoHint}
+        </p>
+        <div className="settings-field">
+          <Button
+            id="settings-update-action"
+            label={updateBtn.label}
+            hidden={!updateBtn.label}
+            disabled={updateBtn.disabled || updateBusy}
+            onClick={runUpdate}
+            extra={{
+              'data-action': updateBtn.action,
+              'data-version': updateInfo?.latest || '',
+            }}
+          />
+          <span
+            id="settings-update-status"
+            className="settings-hint"
+            role="status"
+          >
+            {updateBtn.status}
+          </span>
+        </div>
+      </section>
+    </ModalShell>
+  );
+}
+
+// Consecutive presets sharing a group land in one <optgroup>, per-run
+// rather than per-name so the array order is the rendered order.
+function groupPresets(): { group: string | null; options: typeof PRESETS }[] {
+  const runs: { group: string | null; options: (typeof PRESETS)[number][] }[] =
+    [];
+  for (const p of PRESETS) {
+    const last = runs[runs.length - 1];
+    if (last && last.group === (p.group ?? null)) last.options.push(p);
+    else runs.push({ group: p.group ?? null, options: [p] });
+  }
+  return runs;
+}

--- a/cmd/hivegui/frontend/src/components/modals/Settings.tsx
+++ b/cmd/hivegui/frontend/src/components/modals/Settings.tsx
@@ -419,10 +419,18 @@ function SettingsDialog({ root }: { root: HTMLElement }): ReactNode {
       .catch((err) => showError(String(err?.message || err)));
   }
 
-  // Enter in a text field saves, as before. Escape and the backdrop are
-  // the shell's. The Appearance textarea is excluded by the type check:
-  // Enter there is a newline, and this would otherwise turn "next line of
-  // overrides" into "save and close".
+  // Enter confirms the dialog — AGENTS.md lists dialog confirm/cancel
+  // (Enter / Esc) as a hard-coded, non-rebindable binding, and the
+  // footer hint says so. Two exclusions:
+  //   * the Appearance textarea, where Enter is a newline (turning
+  //     "next line of overrides" into "save and close" is the bug this
+  //     started as),
+  //   * buttons, where Enter is the button's own activation — Cancel
+  //     would otherwise close AND save on the same keystroke.
+  //
+  // Pre-Phase-3 this fired only from `input[type=text]`, which is why
+  // the hint was inaccurate the moment it was added: Enter did nothing
+  // from the selects or the panel itself.
   //
   // On the root element, not on a wrapper: #settings-scroll and
   // #settings-updates must stay direct children of .hv-dialog__body
@@ -431,14 +439,16 @@ function SettingsDialog({ root }: { root: HTMLElement }): ReactNode {
   // Re-attached each render so it closes over the current draft.
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Enter') return;
+      const target = e.target as HTMLElement | null;
       if (
-        e.key === 'Enter' &&
-        e.target instanceof HTMLInputElement &&
-        e.target.type === 'text'
+        target instanceof HTMLTextAreaElement ||
+        target instanceof HTMLButtonElement
       ) {
-        e.preventDefault();
-        saveSettings();
+        return;
       }
+      e.preventDefault();
+      saveSettings();
     }
     root.addEventListener('keydown', onKeyDown);
     return () => root.removeEventListener('keydown', onKeyDown);

--- a/cmd/hivegui/frontend/src/components/modals/Settings.tsx
+++ b/cmd/hivegui/frontend/src/components/modals/Settings.tsx
@@ -119,6 +119,14 @@ function SettingsDialog({ root }: { root: HTMLElement }): ReactNode {
   const [sourceRepo, setSourceRepo] = useState('');
   const [sourceRepoHint, setSourceRepoHint] = useState('');
   const [updateInfo, setUpdateInfo] = useState<main.UpdateInfo | null>(null);
+  // Covers the gap between the click and the first progress event only.
+  // Every progress event clears it: staging succeeding turns the button
+  // into "Restart" (and an error into "Retry"), and a latch that outlived
+  // the event would leave the user staring at a greyed-out button with no
+  // way to apply the update but closing and reopening Settings. The
+  // imperative version got this for free — renderUpdateAction reassigned
+  // .disabled on every event.
+  const [updateBusy, setUpdateBusy] = useState(false);
 
   // Staging runs in Go and outlives this modal, so the button follows
   // the same progress events the banner does rather than any local
@@ -126,9 +134,10 @@ function SettingsDialog({ root }: { root: HTMLElement }): ReactNode {
   // below) rather than tracked while the dialog is closed.
   useEffect(
     () =>
-      EventsOn('update:progress', (info: main.UpdateInfo | null) =>
-        setUpdateInfo(info),
-      ),
+      EventsOn('update:progress', (info: main.UpdateInfo | null) => {
+        setUpdateInfo(info);
+        setUpdateBusy(false);
+      }),
     [],
   );
 
@@ -211,14 +220,18 @@ function SettingsDialog({ root }: { root: HTMLElement }): ReactNode {
 
   function showError(msg: string) {
     setError(msg);
-    // The slot lives in the scrolling region, so a save rejected after
-    // the user scrolled down would otherwise land off-screen and read as
-    // "the button did nothing". Optional call: jsdom has no layout.
-    if (msg)
-      queueMicrotask(() =>
-        errorRef.current?.scrollIntoView?.({ block: 'nearest' }),
-      );
   }
+
+  // The slot lives in the scrolling region, so a save rejected after the
+  // user scrolled down would otherwise land off-screen and read as "the
+  // button did nothing". It has to run AFTER the commit that un-hides the
+  // slot: `.hv-field-error.hidden` is `display: none`, and scrolling to a
+  // hidden element is a no-op — which is what a microtask scheduled from
+  // showError() got, on exactly the async-rejection path this exists for.
+  // Optional call: jsdom has no layout.
+  useLayoutEffect(() => {
+    if (error) errorRef.current?.scrollIntoView?.({ block: 'nearest' });
+  }, [error]);
 
   // ---------- appearance ----------
 
@@ -308,7 +321,6 @@ function SettingsDialog({ root }: { root: HTMLElement }): ReactNode {
   }
 
   const updateBtn = updateButtonState(updateInfo, isMac);
-  const [updateBusy, setUpdateBusy] = useState(false);
 
   function runUpdate() {
     if (updateBtn.action === 'restart') {

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -56,6 +56,8 @@ import { BootState } from './components/BootState.js';
 import { EmptyState } from './components/EmptyState.js';
 import { MinimizedTray } from './components/MinimizedTray.js';
 import { Sidebar } from './components/Sidebar.js';
+import { Launcher } from './components/modals/Launcher.js';
+import { Settings } from './components/modals/Settings.js';
 import { StatusBar } from './components/StatusBar.js';
 import { VersionFooter } from './components/VersionFooter.js';
 import { mustEl, pageEl } from './app/el.js';
@@ -310,6 +312,20 @@ mountIsland(
 // Sidebar footer: hive/hived version + build. It takes its own
 // "daemon:stale" subscription, so it fills in once the control
 // handshake lands.
+// The two ported modals. Both mount on the root their region already
+// owns and stay mounted; the store decides whether anything renders
+// inside, and the island toggles the root's `hidden` class.
+mountIsland(
+  pageEl('launcher'),
+  createElement(Launcher, {
+    root: pageEl('launcher'),
+    setFocusedTile,
+  }),
+);
+mountIsland(
+  pageEl('settings'),
+  createElement(Settings, { root: pageEl('settings') }),
+);
 mountIsland(
   pageEl('sidebar-hints'),
   createElement(VersionFooter, { root: pageEl('sidebar-hints') }),

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -309,9 +309,6 @@ mountIsland(
     restoreSession,
   }),
 );
-// Sidebar footer: hive/hived version + build. It takes its own
-// "daemon:stale" subscription, so it fills in once the control
-// handshake lands.
 // The two ported modals. Both mount on the root their region already
 // owns and stay mounted; the store decides whether anything renders
 // inside, and the island toggles the root's `hidden` class.
@@ -326,6 +323,9 @@ mountIsland(
   pageEl('settings'),
   createElement(Settings, { root: pageEl('settings') }),
 );
+// Sidebar footer: hive/hived version + build. It takes its own
+// "daemon:stale" subscription, so it fills in once the control
+// handshake lands.
 mountIsland(
   pageEl('sidebar-hints'),
   createElement(VersionFooter, { root: pageEl('sidebar-hints') }),

--- a/cmd/hivegui/frontend/src/store/store.ts
+++ b/cmd/hivegui/frontend/src/store/store.ts
@@ -782,13 +782,6 @@ export function closeModal(id: ModalId): void {
   if (next.length !== cur.length) set({ modals: next });
 }
 
-export function modalEntry<T extends ModalId>(
-  id: T,
-): Extract<ModalEntry, { id: T }> | null {
-  const found = get().modals.find((m) => m.id === id);
-  return (found as Extract<ModalEntry, { id: T }> | undefined) ?? null;
-}
-
 export function isModalOpen(id: ModalId): boolean {
   return get().modals.some((m) => m.id === id);
 }

--- a/cmd/hivegui/frontend/src/store/store.ts
+++ b/cmd/hivegui/frontend/src/store/store.ts
@@ -75,6 +75,36 @@ export interface AppData {
   modeHint: ModeHint[];
   bootState: BootStateView | null;
   banners: Record<BannerSlot, BannerData>;
+  // ---------- modals (Phase 3) ----------
+  // The open modals, innermost last. It is the RENDER signal — which
+  // React modal is mounted-visible — and nothing else. "does a modal own
+  // the keyboard?" is still answered by app/modals/registry.ts off the
+  // `.hidden` class of every registered root (the legacy modals have no
+  // entry here at all), so this stack never has to agree with it.
+  modals: ModalEntry[];
+}
+
+// A modal is its id plus whatever that opening was parameterised with.
+// The launcher carries a request because every one of its openings is
+// different (which project, duplicate-from, resume-in-worktree); the
+// settings modal has nothing to carry.
+export type ModalId = 'launcher' | 'settings';
+
+// `seq` is the opening's generation, minted by openModal. A component
+// keys its per-open state off it (`key={entry.seq}`), which is what makes
+// a re-open — ⌘T over an already-open launcher — start clean instead of
+// looking like no change at all.
+export type ModalEntry =
+  | { id: 'launcher'; seq: number; req: LauncherRequest }
+  | { id: 'settings'; seq: number };
+
+export interface LauncherRequest {
+  projectId: string | null;
+  useWorktree: boolean;
+  duplicateFrom: SessionInfo | null;
+  duplicateCwd: string;
+  worktreePath: string;
+  continueConversation: boolean;
 }
 
 export interface StatusView {
@@ -267,6 +297,7 @@ function initialData(): AppData {
       // renderUpdateAction reveals it once there is something to do.
       update: { ...EMPTY_BANNER, actions: { action: { hidden: true } } },
     },
+    modals: [],
   };
 }
 
@@ -729,6 +760,39 @@ export function resetBanner(slot: BannerSlot): void {
 
 // Reset to a freshly-loaded state, optionally seeded. Only the dom/unit
 // suites call this — the app itself boots the store exactly once.
+// ---------- modals ----------
+
+// openModal pushes, replacing an entry that is already open rather than
+// stacking a second copy of it: re-opening the launcher over itself is a
+// real gesture (⌘T while it is up) and must leave exactly one.
+let modalSeq = 0;
+export function openModal(entry: DistributiveOmit<ModalEntry, 'seq'>): void {
+  const rest = get().modals.filter((m) => m.id !== entry.id);
+  set({ modals: [...rest, { ...entry, seq: ++modalSeq } as ModalEntry] });
+}
+
+// Omit over a union distributes only if it is applied per member.
+type DistributiveOmit<T, K extends keyof T> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+export function closeModal(id: ModalId): void {
+  const cur = get().modals;
+  const next = cur.filter((m) => m.id !== id);
+  if (next.length !== cur.length) set({ modals: next });
+}
+
+export function modalEntry<T extends ModalId>(
+  id: T,
+): Extract<ModalEntry, { id: T }> | null {
+  const found = get().modals.find((m) => m.id === id);
+  return (found as Extract<ModalEntry, { id: T }> | undefined) ?? null;
+}
+
+export function isModalOpen(id: ModalId): boolean {
+  return get().modals.some((m) => m.id === id);
+}
+
 export function resetStore(seed: Partial<AppData> = {}): void {
   replace({ ...initialData(), ...seed }, true);
 }

--- a/cmd/hivegui/frontend/test/dom/launcher.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/launcher.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 //
-// Covers the agent launcher's filter box (src/app/modals/launcher.ts):
+// Covers the agent launcher's filter box
+// (src/components/modals/Launcher.tsx, opened through the
+// openLauncher/closeLauncher pair in src/app/modals/launcher.ts):
 // the substring narrowing itself, and the four things around it that
 // carry real risk —
 //   * the digit shortcuts (1–9) must keep working while the box is
@@ -13,6 +15,8 @@
 //     already-open launcher.
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { resetStore } from '../../src/store/store.js';
 // Type-only: erased, so the generated module is never resolved at runtime.
 import type { main } from '../../wailsjs/go/models';
 import { isMac } from '../../src/lib/platform.js';
@@ -98,11 +102,16 @@ vi.mock('../../src/bridge.js', () => ({
 // resolves with mustEl at import time — launcher.ts pulls dom.ts in for
 // flashStatus, so they must exist before the dynamic import below even
 // though this suite never touches them.
+//
+// #launcher is nested one level under <body>: RTL's cleanup() removes a
+// render() container whose parentNode IS document.body, which would rip
+// the element pageEl('launcher') resolved at import time out of the
+// document and turn every later lookup into a silent null.
 const MARKUP = `
   <main id="terms"></main>
   <ul id="projects"></ul>
   <div id="status"><span id="status-text"></span><span id="status-hint"></span></div>
-  <div id="launcher" class="hidden" role="menu"></div>`;
+  <div id="app"><div id="launcher" class="hidden" role="menu"></div></div>`;
 
 type LauncherModule = typeof import('../../src/app/modals/launcher.js');
 let openLauncher: LauncherModule['openLauncher'];
@@ -110,6 +119,9 @@ let closeLauncher: LauncherModule['closeLauncher'];
 let initLauncher: LauncherModule['initLauncher'];
 let refocusActiveTerm: Mock<() => void>;
 let setFocusedTile: Mock<(id: string | null) => void>;
+// Imported with the module below, for the same reason: the component
+// pulls app/dom.ts in, which resolves #terms with mustEl at load.
+let Launcher: typeof import('../../src/components/modals/Launcher.js')['Launcher'];
 
 function launcher() {
   return document.getElementById('launcher') as HTMLElement;
@@ -129,26 +141,31 @@ function selectedName() {
   return launcher().querySelector('.launcher-item[data-selected] .agent-name')
     ?.textContent;
 }
-// The launcher owns its keys via a listener on #launcher, so events
-// must be dispatched from inside it (bubbling), exactly as a real
-// keystroke into the focused filter box would.
+// The launcher owns its keys via a plain listener on #launcher, so
+// events must be dispatched from inside it (bubbling), exactly as a real
+// keystroke into the focused filter box would. That listener is not a
+// React one, so the state it sets needs act() around the dispatch.
 // Returns false when the handler called preventDefault — i.e. when the
 // launcher consumed the key rather than letting it reach the input.
 function press(key: string, init: KeyboardEventInit = {}) {
-  return searchBox().dispatchEvent(
-    new KeyboardEvent('keydown', {
-      key,
-      bubbles: true,
-      cancelable: true,
-      ...init,
-    }),
-  );
+  let delivered = true;
+  act(() => {
+    delivered = searchBox().dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ...init,
+      }),
+    );
+  });
+  return delivered;
 }
-// Typing = set the value, then fire `input`. jsdom won't do the former
-// for us from a KeyboardEvent, and the digit path is keydown-only.
+// Typing goes through fireEvent, not a hand-built input event: the box
+// is a controlled input, and React's value tracker swallows a change
+// made by assigning .value directly.
 function type(text: string) {
-  searchBox().value = text;
-  searchBox().dispatchEvent(new Event('input', { bubbles: true }));
+  fireEvent.change(searchBox(), { target: { value: text } });
 }
 // Open and let ListAgents settle.
 // A few turns of the microtask queue: the IsGitRepo probe chains off
@@ -158,11 +175,25 @@ async function flushMicrotasks() {
   await new Promise((r) => setTimeout(r, 0));
 }
 
+// Opening writes the store from outside a React event handler, and the
+// agent list lands in a promise callback — both need act() for the
+// island to have re-rendered by the time the assertions run.
+async function openWith(fn: () => void) {
+  await act(async () => {
+    fn();
+  });
+}
+async function settleAgents(list: main.AgentInfo[] = AGENTS) {
+  await act(async () => {
+    resolveAgents(list);
+    await agentsPromise;
+    await Promise.resolve();
+  });
+}
+
 async function open() {
-  openLauncher('p1');
-  resolveAgents(AGENTS);
-  await agentsPromise;
-  await Promise.resolve();
+  await openWith(() => openLauncher('p1'));
+  await settleAgents();
 }
 
 beforeAll(async () => {
@@ -172,6 +203,7 @@ beforeAll(async () => {
   Element.prototype.scrollIntoView = vi.fn();
   // Imported AFTER the markup exists: launcherEl is resolved at module
   // load via pageEl('launcher').
+  ({ Launcher } = await import('../../src/components/modals/Launcher.js'));
   const mod = await import('../../src/app/modals/launcher.js');
   openLauncher = mod.openLauncher;
   closeLauncher = mod.closeLauncher;
@@ -185,7 +217,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
   listAgents.mockImplementation(() => freshAgentsPromise());
-  closeLauncher();
+  resetStore();
+  render(<Launcher root={launcher()} setFocusedTile={setFocusedTile} />, {
+    container: launcher(),
+  });
 });
 
 describe('launcher filter box', () => {
@@ -216,17 +251,15 @@ describe('launcher filter box', () => {
   });
 
   it('distinguishes an empty agent list from an empty filter result', async () => {
-    openLauncher('p1');
-    resolveAgents([]);
-    await agentsPromise;
-    await Promise.resolve();
+    await openWith(() => openLauncher('p1'));
+    await settleAgents([]);
     expect(launcher().querySelector('.launcher-empty')?.textContent).toBe(
       'No agents found',
     );
   });
 
   it('keeps showing the loading row when the user types before agents arrive', async () => {
-    openLauncher('p1');
+    await openWith(() => openLauncher('p1'));
     expect(launcher().querySelector('.launcher-loading')).not.toBeNull();
     // The keystroke re-renders the list. While the request is in flight
     // there are no agents to filter, and an empty result must not be
@@ -236,9 +269,7 @@ describe('launcher filter box', () => {
       'Loading agents…',
     );
     expect(launcher().querySelector('.launcher-empty')).toBeNull();
-    resolveAgents(AGENTS);
-    await agentsPromise;
-    await Promise.resolve();
+    await settleAgents();
     expect(launcher().querySelector('.launcher-loading')).toBeNull();
     expect(names()).toEqual(['Claude']);
   });
@@ -247,20 +278,18 @@ describe('launcher filter box', () => {
     await open();
     // Reopen without closing: until the new response lands there is no
     // list yet, so the stale one must not be what the query filters.
-    openLauncher('p1');
+    await openWith(() => openLauncher('p1'));
     type('cla');
     expect(rows()).toHaveLength(0);
     expect(launcher().querySelector('.launcher-loading')).not.toBeNull();
   });
 
   it('honors a query typed while ListAgents is still in flight', async () => {
-    openLauncher('p1');
+    await openWith(() => openLauncher('p1'));
     // Still loading — the filter box is already on screen and focused.
     expect(launcher().querySelector('.launcher-loading')).not.toBeNull();
     type('codex');
-    resolveAgents(AGENTS);
-    await agentsPromise;
-    await Promise.resolve();
+    await settleAgents();
     expect(names()).toEqual(['Codex CLI']);
   });
 
@@ -353,9 +382,7 @@ describe('launcher keyboard', () => {
     // cmdOrCtrl() rejects the cross-platform combo outright, so the
     // modifier has to match the platform the module resolved at load.
     press('t', isMac ? { metaKey: true } : { ctrlKey: true });
-    resolveAgents(AGENTS);
-    await agentsPromise;
-    await Promise.resolve();
+    await settleAgents();
     expect(searchBox().value).toBe('');
     expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
   });
@@ -364,9 +391,8 @@ describe('launcher keyboard', () => {
     await open();
     searchBox().focus();
     const box = searchBox();
-    // Cleared AFTER opening: beforeEach calls closeLauncher(), which
-    // already ran refocusActiveTerm once, so a bare toHaveBeenCalled()
-    // here would pass even if Escape did nothing.
+    // Cleared AFTER opening, so a bare toHaveBeenCalled() here cannot
+    // pass on a refocus some earlier close already made.
     refocusActiveTerm.mockClear();
     press('Escape');
     expect(launcher().classList.contains('hidden')).toBe(true);
@@ -382,8 +408,7 @@ describe('launcher worktree row', () => {
     const wt = launcher().querySelector('.launcher-worktree');
     expect(wt).not.toBeNull();
     const box = wt?.querySelector('input[type=checkbox]') as HTMLInputElement;
-    box.checked = true;
-    box.dispatchEvent(new Event('change', { bubbles: true }));
+    fireEvent.click(box);
     expect(localStorage.getItem('hive.worktree')).toBe('1');
   });
 
@@ -408,15 +433,13 @@ describe('launcher branch name', () => {
     launcher().querySelector(
       '.launcher-worktree input[type=checkbox]',
     ) as HTMLInputElement;
+  // Controlled inputs both: a click is what flips a checkbox, and
+  // fireEvent.change is the only way past React's value tracker.
   const toggleWorktree = (on: boolean) => {
-    const box = wtBox();
-    box.checked = on;
-    box.dispatchEvent(new Event('change', { bubbles: true }));
+    if (wtBox().checked !== on) fireEvent.click(wtBox());
   };
   const typeBranch = (value: string) => {
-    const box = branchBox();
-    box.value = value;
-    box.dispatchEvent(new Event('input', { bubbles: true }));
+    fireEvent.change(branchBox(), { target: { value } });
   };
 
   // The launcher preventDefaults mousedown on everything but its text
@@ -430,7 +453,9 @@ describe('launcher branch name', () => {
       bubbles: true,
       cancelable: true,
     });
-    branchBox().dispatchEvent(ev);
+    act(() => {
+      branchBox().dispatchEvent(ev);
+    });
     expect(
       ev.defaultPrevented,
       'mousedown was preventDefaulted, so the box can never take focus',
@@ -445,7 +470,9 @@ describe('launcher branch name', () => {
       bubbles: true,
       cancelable: true,
     });
-    rowEl.dispatchEvent(ev);
+    act(() => {
+      rowEl.dispatchEvent(ev);
+    });
     expect(ev.defaultPrevented).toBe(true);
   });
 
@@ -461,7 +488,9 @@ describe('launcher branch name', () => {
       bubbles: true,
       cancelable: true,
     });
-    branchBox().dispatchEvent(ev);
+    act(() => {
+      branchBox().dispatchEvent(ev);
+    });
     expect(ev.defaultPrevented, 'digit was consumed as a row shortcut').toBe(
       false,
     );
@@ -473,9 +502,11 @@ describe('launcher branch name', () => {
     await open();
     branchBox().focus();
     typeBranch('typed-here');
-    branchBox().dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-    );
+    act(() => {
+      branchBox().dispatchEvent(
+        new window.KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+    });
     expect(createSession).toHaveBeenCalled();
     expect(createSession.mock.calls[0][8]).toBe('typed-here');
   });
@@ -484,9 +515,11 @@ describe('launcher branch name', () => {
     localStorage.setItem('hive.worktree', '1');
     await open();
     branchBox().focus();
-    branchBox().dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-    );
+    act(() => {
+      branchBox().dispatchEvent(
+        new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      );
+    });
     expect(launcher().classList.contains('hidden')).toBe(true);
   });
 
@@ -532,7 +565,7 @@ describe('launcher branch name', () => {
     localStorage.setItem('hive.worktree', '1');
     await open();
     typeBranch('first-only');
-    closeLauncher();
+    act(() => closeLauncher());
     await open();
     expect(branchBox().value).toBe('');
     press('Enter');
@@ -558,7 +591,9 @@ describe('launcher branch name', () => {
     state.projects = [{ id: 'p1', name: 'p', cwd: '/not-a-repo' }];
     try {
       await open();
-      await flushMicrotasks();
+      await act(async () => {
+        await flushMicrotasks();
+      });
       expect(branchBox().classList.contains('hidden')).toBe(true);
       expect(wtBox().checked).toBe(false);
     } finally {
@@ -569,10 +604,10 @@ describe('launcher branch name', () => {
 
 describe('launcher resume-in-worktree mode', () => {
   it('offers neither the worktree toggle nor a branch field', async () => {
-    openLauncher('p1', { worktreePath: '/repo/.worktrees/resume' });
-    resolveAgents(AGENTS);
-    await agentsPromise;
-    await Promise.resolve();
+    await openWith(() =>
+      openLauncher('p1', { worktreePath: '/repo/.worktrees/resume' }),
+    );
+    await settleAgents();
     expect(launcher().querySelector('.launcher-worktree')).toBeNull();
     expect(launcher().querySelector('.launcher-branch')).toBeNull();
   });
@@ -580,21 +615,21 @@ describe('launcher resume-in-worktree mode', () => {
   it('passes the worktree path and never asks for a new worktree', async () => {
     // Sticky preference is on; resume mode must still not create one.
     localStorage.setItem('hive.worktree', '1');
-    openLauncher('p1', { worktreePath: '/repo/.worktrees/resume' });
-    resolveAgents(AGENTS);
-    await agentsPromise;
-    await Promise.resolve();
+    await openWith(() =>
+      openLauncher('p1', { worktreePath: '/repo/.worktrees/resume' }),
+    );
+    await settleAgents();
     press('Enter');
     expect(createSession.mock.calls[0][6]).toBe(false);
     expect(createSession.mock.calls[0][9]).toBe('/repo/.worktrees/resume');
   });
 
   it('does not leak the path into the next regular opening', async () => {
-    openLauncher('p1', { worktreePath: '/repo/.worktrees/resume' });
-    resolveAgents(AGENTS);
-    await agentsPromise;
-    await Promise.resolve();
-    closeLauncher();
+    await openWith(() =>
+      openLauncher('p1', { worktreePath: '/repo/.worktrees/resume' }),
+    );
+    await settleAgents();
+    act(() => closeLauncher());
     await open();
     press('Enter');
     expect(createSession.mock.calls[0][9]).toBe('');
@@ -607,19 +642,23 @@ describe('launcher stale-response handling', () => {
     // stale one must not touch the DOM the second open now owns. The
     // `hidden` guard alone can't catch this — the launcher is visible
     // again by the time the first response lands.
-    openLauncher('p1');
+    await openWith(() => openLauncher('p1'));
     const resolveFirst = resolveAgents;
     const first = agentsPromise;
-    openLauncher('p1');
+    await openWith(() => openLauncher('p1'));
     const resolveSecond = resolveAgents;
     const second = agentsPromise;
 
-    resolveFirst(AGENTS);
-    await first;
-    await Promise.resolve();
-    resolveSecond(AGENTS);
-    await second;
-    await Promise.resolve();
+    await act(async () => {
+      resolveFirst(AGENTS);
+      await first;
+      await Promise.resolve();
+    });
+    await act(async () => {
+      resolveSecond(AGENTS);
+      await second;
+      await Promise.resolve();
+    });
 
     expect(launcher().querySelectorAll('.launcher-worktree')).toHaveLength(1);
     expect(launcher().querySelectorAll('.launcher-branch')).toHaveLength(1);
@@ -634,12 +673,14 @@ describe('launcher stale-response handling', () => {
 
   it('does not close a reopened launcher when a superseded request rejects', async () => {
     listAgents.mockImplementationOnce(() => Promise.reject(new Error('boom')));
-    openLauncher('p1');
-    openLauncher('p1');
-    resolveAgents(AGENTS);
-    await agentsPromise;
-    await Promise.resolve();
-    await Promise.resolve();
+    await openWith(() => openLauncher('p1'));
+    await openWith(() => openLauncher('p1'));
+    await act(async () => {
+      resolveAgents(AGENTS);
+      await agentsPromise;
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     expect(launcher().classList.contains('hidden')).toBe(false);
     expect(names()).toEqual(['Shell', 'Claude', 'Codex CLI']);
   });
@@ -652,9 +693,11 @@ describe('launcher teardown', () => {
 
   it('does not throw when ListAgents rejects', async () => {
     listAgents.mockImplementationOnce(() => Promise.reject(new Error('boom')));
-    openLauncher('p1');
-    await Promise.resolve();
-    await Promise.resolve();
+    await openWith(() => openLauncher('p1'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     expect(launcher().classList.contains('hidden')).toBe(true);
   });
 });

--- a/cmd/hivegui/frontend/test/dom/launcher.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/launcher.test.tsx
@@ -686,6 +686,83 @@ describe('launcher stale-response handling', () => {
   });
 });
 
+// Both close paths moved from initLauncher() into the island's effects
+// in Phase 3, and they are load-bearing in opposite directions: keyboard.ts
+// bails out for the whole window while #launcher is visible, so a launcher
+// left open with focus elsewhere has nobody listening for Escape — while a
+// close that fires on the very click that OPENED it makes the popup
+// unopenable from the sidebar at all.
+describe('launcher outside interaction', () => {
+  it('closes on a click outside itself', async () => {
+    await open();
+    act(() => {
+      document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(launcher().classList.contains('hidden')).toBe(true);
+  });
+
+  it('stays open for a click on the project actions that opened it', async () => {
+    const actions = document.createElement('div');
+    actions.className = 'hv-project-card__actions';
+    document.getElementById('app')?.appendChild(actions);
+    try {
+      await open();
+      act(() => {
+        actions.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      expect(launcher().classList.contains('hidden')).toBe(false);
+    } finally {
+      actions.remove();
+    }
+  });
+
+  it('stays open for a click on an opener that opts in with data-opens-launcher', async () => {
+    const opener = document.createElement('button');
+    opener.setAttribute('data-opens-launcher', '');
+    document.getElementById('app')?.appendChild(opener);
+    try {
+      await open();
+      act(() => {
+        opener.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      expect(launcher().classList.contains('hidden')).toBe(false);
+    } finally {
+      opener.remove();
+    }
+  });
+
+  it('closes when focus leaves it for something else', async () => {
+    const outside = document.createElement('button');
+    document.getElementById('app')?.appendChild(outside);
+    try {
+      await open();
+      act(() => {
+        searchBox().dispatchEvent(
+          new FocusEvent('focusout', {
+            bubbles: true,
+            relatedTarget: outside,
+          }),
+        );
+      });
+      expect(launcher().classList.contains('hidden')).toBe(true);
+    } finally {
+      outside.remove();
+    }
+  });
+
+  // relatedTarget null means focus went nowhere — that is closeLauncher's
+  // own blur, so it must not recurse.
+  it('ignores a focusout that goes nowhere', async () => {
+    await open();
+    act(() => {
+      searchBox().dispatchEvent(
+        new FocusEvent('focusout', { bubbles: true, relatedTarget: null }),
+      );
+    });
+    expect(launcher().classList.contains('hidden')).toBe(false);
+  });
+});
+
 describe('launcher teardown', () => {
   it('does not throw when closed before it was ever opened', () => {
     expect(() => closeLauncher()).not.toThrow();

--- a/cmd/hivegui/frontend/test/dom/modal-shell.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/modal-shell.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+//
+// The shared modal shell (src/components/modals/ModalShell.tsx): the
+// markup contract ui/dialog.ts established, and the three gestures it
+// owns — Escape, the backdrop, and Tab containment. The `hidden` class
+// is deliberately NOT here: the island that mounts the shell owns it
+// (see settings.test.tsx), because it has to be right in the frame the
+// shell is no longer mounted in.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { ModalShell } from '../../src/components/modals/ModalShell.js';
+
+let root: HTMLElement;
+// Declared with its exact signature: vitest's bare Mock won't satisfy
+// the `() => void` the shell's prop asks for.
+let onClose: Mock<() => void>;
+
+function mount(children?: React.ReactNode) {
+  return render(
+    <ModalShell
+      id="demo"
+      root={root}
+      title="Demo"
+      onClose={onClose}
+      hints={[
+        { keys: '[esc]', label: 'cancel' },
+        { keys: '[enter]', label: 'save' },
+      ]}
+      actions={
+        <button type="button" id="demo-ok">
+          OK
+        </button>
+      }
+    >
+      {children ?? <input type="text" aria-label="first" />}
+    </ModalShell>,
+    { container: root },
+  );
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="app"></div>';
+  root = document.createElement('div');
+  root.id = 'demo';
+  root.className = 'hv-dialog';
+  document.getElementById('app')?.appendChild(root);
+  onClose = vi.fn();
+});
+
+describe('modal shell markup', () => {
+  it('renders the dialog structure the primitive established', () => {
+    mount();
+    const panel = root.querySelector('#demo-panel');
+    expect(panel?.className).toBe('hv-dialog__panel');
+    expect(panel?.getAttribute('data-size')).toBe('md');
+    expect(root.querySelector('#demo-title')?.textContent).toBe('Demo');
+    expect(
+      root.querySelector('.hv-dialog__title-suffix'),
+      'the suffix slot rides inside the h3 so the accessible name stays one string',
+    ).not.toBeNull();
+    expect(root.querySelector('#demo-close')?.className).toContain(
+      'hv-dialog__close',
+    );
+    expect(root.querySelector('.hv-dialog__body input')).not.toBeNull();
+    expect(root.querySelector('.hv-dialog__actions #demo-ok')).not.toBeNull();
+  });
+
+  // AGENTS.md, Feedback on Action: every overlay must display the
+  // bindings that confirm and cancel it.
+  it('shows its confirm/cancel key hints', () => {
+    mount();
+    const hints = [...root.querySelectorAll('.hv-dialog__hints .hv-kbd')].map(
+      (k) => k.textContent,
+    );
+    expect(hints).toEqual(['[esc]', '[enter]']);
+    expect(root.querySelector('.hv-dialog__hints')?.textContent).toContain(
+      'cancel',
+    );
+  });
+
+  it('closes from the header button', () => {
+    mount();
+    fireEvent.click(root.querySelector('#demo-close') as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('modal shell gestures', () => {
+  it('closes on Escape and consumes the event', () => {
+    mount();
+    const seen = vi.fn();
+    window.addEventListener('keydown', seen);
+    const delivered = root.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    window.removeEventListener('keydown', seen);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(delivered, 'Escape must be preventDefaulted').toBe(false);
+    expect(
+      seen,
+      'a second handler must not spend the same Escape',
+    ).not.toHaveBeenCalled();
+  });
+
+  // Both ends of the gesture must land on the backdrop: a text-selection
+  // drag that starts inside an input and releases outside the panel
+  // dispatches its click on the backdrop, and closing there discards the
+  // whole draft mid-edit.
+  it('closes on a backdrop click but not on a drag that merely ends there', () => {
+    mount();
+    fireEvent.mouseDown(root);
+    fireEvent.click(root);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    onClose.mockClear();
+    fireEvent.mouseDown(root.querySelector('input') as HTMLElement);
+    fireEvent.click(root);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close on a click inside the panel', () => {
+    mount();
+    const panel = root.querySelector('#demo-panel') as HTMLElement;
+    fireEvent.mouseDown(panel);
+    fireEvent.click(panel);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // The trap is acquired while the shell is mounted and released with
+  // it: an untrapped modal's next Tab stop is a hidden terminal's
+  // textarea, so keystrokes leak into a session the user cannot see.
+  it('wraps Tab at the end of the dialog and releases the trap on unmount', () => {
+    const view = mount();
+    const last = root.querySelector('#demo-ok') as HTMLElement;
+    const close = root.querySelector('#demo-close') as HTMLElement;
+    last.focus();
+    const tab = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      bubbles: true,
+      cancelable: true,
+    });
+    root.dispatchEvent(tab);
+    expect(tab.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(close);
+
+    view.unmount();
+    const after = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      bubbles: true,
+      cancelable: true,
+    });
+    root.dispatchEvent(after);
+    expect(after.defaultPrevented).toBe(false);
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/settings-updates.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/settings-updates.test.tsx
@@ -274,6 +274,36 @@ describe('settings: update button', () => {
     expect(bridge.ApplyUpdateAndRestart).not.toHaveBeenCalled();
   });
 
+  // The click-time disable is a stopgap for the gap before the first
+  // progress event, not a latch. Once staging is ready the button is the
+  // only way to apply the update — leaving it greyed out stranded the
+  // user with nothing to do but close and reopen Settings.
+  it('re-enables the button when staging finishes after a click', async () => {
+    open();
+    await settle();
+    const action = el<HTMLButtonElement>('settings-update-action');
+    fireEvent.click(action);
+    expect(action.disabled).toBe(true);
+
+    // The same event the banner listens to, delivered through the
+    // subscription EventsOn registered on open.
+    const [, onProgress] = bridge.EventsOn.mock.calls.find(
+      ([name]) => name === 'update:progress',
+    ) as [string, (info: UpdateInfoLike) => void];
+    act(() => {
+      onProgress({
+        available: true,
+        stage: 'ready',
+        latest: '2.5.0',
+        message: 'Update ready',
+        channel: 'release',
+      });
+    });
+
+    expect(action.textContent).toBe('Restart');
+    expect(action.disabled).toBe(false);
+  });
+
   // Staging outlives the modal: closing and reopening must show the
   // work Go is still doing, not a reset button.
   it('re-reads staging state on reopen rather than tracking it locally', async () => {

--- a/cmd/hivegui/frontend/test/dom/settings-updates.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/settings-updates.test.tsx
@@ -6,6 +6,8 @@
 // Cancel must not be able to lose a running download.
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { resetStore } from '../../src/store/store.js';
 import type { UpdateInfoLike } from '../../src/lib/update-state.js';
 
 const bridge = vi.hoisted(() => ({
@@ -59,11 +61,13 @@ vi.mock('../../src/app/session-term.js', () => ({
   applyXtermTheme: vi.fn(),
 }));
 
-// settings.ts builds its own dialog now (dialog + field primitives), so
-// the fixture is only the app root it mounts into plus the singletons
-// dom.ts resolves at import time.
+// The dialog root is declared in index.html and the component renders
+// into it, so the fixture carries the same element — nested under #app,
+// because RTL's cleanup() removes a render() container whose parentNode
+// IS document.body.
 const MARKUP = `
-  <div id="app"></div>
+  <div id="app"><div id="settings" class="hv-dialog hidden" role="dialog"
+    aria-modal="true" aria-labelledby="settings-title"></div></div>
   <div id="terms"></div><ul id="projects"></ul><div id="status"><span id="status-text"></span><span id="status-hint"></span></div>`;
 
 type SettingsModule = typeof import('../../src/app/modals/settings.js');
@@ -72,6 +76,7 @@ let closeSettings: SettingsModule['closeSettings'];
 let initSettings: SettingsModule['initSettings'];
 let refocusActiveTerm: Mock<() => void>;
 let setFocusedTile: Mock<(id: string | null) => void>;
+let Settings: typeof import('../../src/components/modals/Settings.js')['Settings'];
 
 function el<T extends HTMLElement>(id: string): T {
   const found = document.getElementById(id);
@@ -79,17 +84,30 @@ function el<T extends HTMLElement>(id: string): T {
   return found as T;
 }
 
-// Lets every pending bridge promise settle before asserting on the DOM.
-const settle = () => new Promise((r) => setTimeout(r, 0));
+// Lets every pending bridge promise settle AND React re-render before
+// asserting on the DOM: the bridge callbacks write state from outside a
+// React event handler.
+const settle = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
 // The source-repo probe is debounced (it stats its way up a directory
 // tree), so its assertions have to wait past that window rather than a
 // microtask.
-const settleProbe = () => new Promise((r) => setTimeout(r, 320));
+const settleProbe = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 320));
+  });
+
+// The open/close pair writes the store from outside React.
+const open = () => act(() => openSettings());
+const close = () => act(() => closeSettings());
 
 beforeAll(async () => {
   document.body.innerHTML = MARKUP;
   const mod = await import('../../src/app/modals/settings.js');
   ({ openSettings, closeSettings, initSettings } = mod);
+  ({ Settings } = await import('../../src/components/modals/Settings.js'));
   refocusActiveTerm = vi.fn();
   setFocusedTile = vi.fn();
   initSettings({ refocusActiveTerm, setFocusedTile });
@@ -101,12 +119,13 @@ beforeEach(async () => {
     channel: 'release',
     source_repo: '',
   });
-  closeSettings();
+  resetStore();
+  render(<Settings root={el('settings')} />, { container: el('settings') });
 });
 
 describe('settings: update channel', () => {
   it('hides the source-repo row on the release channel', async () => {
-    openSettings();
+    open();
     await settle();
     expect(el<HTMLSelectElement>('settings-update-channel').value).toBe(
       'release',
@@ -117,11 +136,10 @@ describe('settings: update channel', () => {
   });
 
   it('reveals the source-repo row and its detected path on latest', async () => {
-    openSettings();
+    open();
     await settle();
     const channel = el<HTMLSelectElement>('settings-update-channel');
-    channel.value = 'latest';
-    channel.dispatchEvent(new Event('change'));
+    fireEvent.change(channel, { target: { value: 'latest' } });
     await settleProbe();
 
     expect(el('settings-source-repo-row').classList.contains('hidden')).toBe(
@@ -131,12 +149,11 @@ describe('settings: update channel', () => {
   });
 
   it('saves the channel alongside the agents', async () => {
-    openSettings();
+    open();
     await settle();
     const channel = el<HTMLSelectElement>('settings-update-channel');
-    channel.value = 'latest';
-    channel.dispatchEvent(new Event('change'));
-    el('settings-save').dispatchEvent(new MouseEvent('click'));
+    fireEvent.change(channel, { target: { value: 'latest' } });
+    fireEvent.click(el('settings-save'));
     await settle();
 
     expect(bridge.SaveUpdateSettings).toHaveBeenCalledWith(
@@ -158,9 +175,9 @@ describe('settings: update channel', () => {
     bridge.SaveUpdateSettings.mockRejectedValueOnce(
       new Error('no hive checkout found'),
     );
-    openSettings();
+    open();
     await settle();
-    el('settings-save').dispatchEvent(new MouseEvent('click'));
+    fireEvent.click(el('settings-save'));
     await settle();
 
     expect(el('settings-error').textContent).toContain('no hive checkout');
@@ -171,18 +188,16 @@ describe('settings: update channel', () => {
   // both wasteful and unordered, so a slow answer for "/Use" could
   // overwrite the fast one for "/Users/me/hive".
   it('debounces the source-repo probe across rapid typing', async () => {
-    openSettings();
+    open();
     await settle();
     const channel = el<HTMLSelectElement>('settings-update-channel');
-    channel.value = 'latest';
-    channel.dispatchEvent(new Event('change'));
+    fireEvent.change(channel, { target: { value: 'latest' } });
     await settleProbe();
     bridge.SourceRepoStatusFor.mockClear();
 
     const input = el<HTMLInputElement>('settings-source-repo');
     for (const v of ['/U', '/Us', '/User', '/Users/me/hive']) {
-      input.value = v;
-      input.dispatchEvent(new Event('input'));
+      fireEvent.change(input, { target: { value: v } });
     }
     await settleProbe();
 
@@ -191,12 +206,11 @@ describe('settings: update channel', () => {
   });
 
   it('fills the path from the directory picker', async () => {
-    openSettings();
+    open();
     await settle();
     const channel = el<HTMLSelectElement>('settings-update-channel');
-    channel.value = 'latest';
-    channel.dispatchEvent(new Event('change'));
-    el('settings-source-repo-browse').dispatchEvent(new MouseEvent('click'));
+    fireEvent.change(channel, { target: { value: 'latest' } });
+    fireEvent.click(el('settings-source-repo-browse'));
     await settleProbe();
 
     expect(el<HTMLInputElement>('settings-source-repo').value).toBe(
@@ -207,7 +221,7 @@ describe('settings: update channel', () => {
 
 describe('settings: update button', () => {
   it('offers Update when one is available', async () => {
-    openSettings();
+    open();
     await settle();
     const action = el<HTMLButtonElement>('settings-update-action');
     expect(action.textContent).toBe('Update');
@@ -216,9 +230,9 @@ describe('settings: update button', () => {
   });
 
   it('starts staging on click', async () => {
-    openSettings();
+    open();
     await settle();
-    el('settings-update-action').dispatchEvent(new MouseEvent('click'));
+    fireEvent.click(el('settings-update-action'));
     await settle();
     expect(bridge.StartUpdate).toHaveBeenCalledTimes(1);
     expect(bridge.ApplyUpdateAndRestart).not.toHaveBeenCalled();
@@ -232,11 +246,11 @@ describe('settings: update button', () => {
       message: 'Update ready',
       channel: 'release',
     });
-    openSettings();
+    open();
     await settle();
     const action = el<HTMLButtonElement>('settings-update-action');
     expect(action.textContent).toBe('Restart');
-    action.dispatchEvent(new MouseEvent('click'));
+    fireEvent.click(action);
     await settle();
     expect(bridge.Confirm).toHaveBeenCalledTimes(1);
     expect(bridge.ApplyUpdateAndRestart).toHaveBeenCalledTimes(1);
@@ -253,9 +267,9 @@ describe('settings: update button', () => {
       latest: '2.5.0',
       channel: 'release',
     });
-    openSettings();
+    open();
     await settle();
-    el('settings-update-action').dispatchEvent(new MouseEvent('click'));
+    fireEvent.click(el('settings-update-action'));
     await settle();
     expect(bridge.ApplyUpdateAndRestart).not.toHaveBeenCalled();
   });
@@ -263,16 +277,16 @@ describe('settings: update button', () => {
   // Staging outlives the modal: closing and reopening must show the
   // work Go is still doing, not a reset button.
   it('re-reads staging state on reopen rather than tracking it locally', async () => {
-    openSettings();
+    open();
     await settle();
-    closeSettings();
+    close();
     bridge.UpdateStatus.mockResolvedValueOnce({
       available: true,
       stage: 'staging',
       message: 'Downloading…',
       channel: 'release',
     });
-    openSettings();
+    open();
     await settle();
 
     const action = el<HTMLButtonElement>('settings-update-action');

--- a/cmd/hivegui/frontend/test/dom/settings.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/settings.test.tsx
@@ -138,7 +138,7 @@ const flush = () =>
 // Drives an <input> the way a user does. fireEvent, not a hand-built
 // event: these are controlled inputs, and React's value tracker swallows
 // a change made by assigning .value directly.
-function type(input: HTMLInputElement, value: string) {
+function type(input: HTMLInputElement | HTMLTextAreaElement, value: string) {
   fireEvent.change(input, { target: { value } });
 }
 
@@ -473,16 +473,36 @@ describe('appearance a11y', () => {
 });
 
 describe('appearance debounce', () => {
+  // The positive control. Without it the case below passes just as well
+  // when nothing is ever scheduled — which is what a raw `.value =`
+  // assignment does to a controlled textarea, React's value tracker
+  // swallowing the change and no debounce ever starting.
+  it('writes overrides once the debounce elapses', async () => {
+    vi.useFakeTimers();
+    try {
+      open();
+      type(el<HTMLTextAreaElement>('settings-overrides'), '--accent: red;');
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(localStorage.getItem('hive.themeOverrides')).toContain(
+        '--accent: red',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not write overrides after the dialog is closed', async () => {
     vi.useFakeTimers();
     try {
       open();
-      const box = el<HTMLTextAreaElement>('settings-overrides');
-      box.value = '--accent: red;';
-      box.dispatchEvent(new window.Event('input', { bubbles: true }));
+      type(el<HTMLTextAreaElement>('settings-overrides'), '--accent: red;');
       close();
       const before = localStorage.getItem('hive.themeOverrides');
-      vi.advanceTimersByTime(500);
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
       expect(localStorage.getItem('hive.themeOverrides')).toBe(before);
     } finally {
       vi.useRealTimers();

--- a/cmd/hivegui/frontend/test/dom/settings.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/settings.test.tsx
@@ -430,6 +430,54 @@ describe('focus containment', () => {
   });
 });
 
+// The footer advertises [enter] save, so Enter has to actually confirm
+// the dialog — AGENTS.md lists dialog confirm/cancel as a hard-coded
+// binding. The two exclusions are the ones that would break something:
+// a newline in the overrides box, and Cancel closing AND saving on one
+// keystroke.
+describe('enter confirms', () => {
+  it('saves from a text field', async () => {
+    open();
+    await flush();
+    click(el('settings-agent-add'));
+    type(cell(rows()[0], '.settings-agent-name'), 'From Enter');
+    type(cell(rows()[0], '.settings-agent-cmd'), 'entertool');
+    fireEvent.keyDown(cell(rows()[0], '.settings-agent-name'), {
+      key: 'Enter',
+    });
+    await flush();
+    expect(saveCustomAgents).toHaveBeenCalledTimes(1);
+    expect(saveCustomAgents.mock.calls[0][0][0].name).toBe('From Enter');
+  });
+
+  it('saves from a select, which the old text-input-only gate ignored', async () => {
+    open();
+    await flush();
+    fireEvent.keyDown(el('settings-update-channel'), { key: 'Enter' });
+    await flush();
+    expect(saveCustomAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves Enter alone inside the custom-tokens textarea', async () => {
+    open();
+    await flush();
+    fireEvent.keyDown(el('settings-overrides'), { key: 'Enter' });
+    await flush();
+    expect(saveCustomAgents).not.toHaveBeenCalled();
+  });
+
+  // Enter on a focused button is that button's own activation. Without
+  // the exclusion, Enter on Cancel would close the dialog and save the
+  // draft it was meant to discard.
+  it('leaves Enter alone on a button', async () => {
+    open();
+    await flush();
+    fireEvent.keyDown(el('settings-cancel'), { key: 'Enter' });
+    await flush();
+    expect(saveCustomAgents).not.toHaveBeenCalled();
+  });
+});
+
 describe('escape', () => {
   it('consumes the event so it cannot reach the window handler', async () => {
     open();

--- a/cmd/hivegui/frontend/test/dom/settings.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/settings.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 //
-// Covers the settings modal (src/app/modals/settings.ts): the
+// Covers the settings modal (src/components/modals/Settings.tsx, opened
+// through the openSettings/closeSettings pair in
+// src/app/modals/settings.ts): the
 // add/edit/delete round-trip, the exact payload handed to
 // SaveCustomAgents, and the two behaviors that carry real risk —
 // existing ids must survive a rename (registry entries persist only
@@ -8,6 +10,8 @@
 // Go must surface its error instead of closing the modal.
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { resetStore } from '../../src/store/store.js';
 // Type-only: erased, so the generated module is never resolved at runtime.
 import type { main } from '../../wailsjs/go/models';
 
@@ -63,11 +67,13 @@ vi.mock('../../src/app/session-term.js', () => ({
 // wrapper, so this file now pulls banners.ts -> dom.ts in transitively.
 // dom.ts resolves its singletons with mustEl at import time, so their
 // markup has to exist even though nothing here exercises them.
-// settings.ts builds its own dialog now (dialog + field primitives), so
-// the fixture is only the app root it mounts into plus the singletons
-// dom.ts resolves at import time.
+// The dialog root is declared in index.html and the component renders
+// into it, so the fixture carries the same element — nested under #app,
+// because RTL's cleanup() removes a render() container whose parentNode
+// IS document.body.
 const MARKUP = `
-  <div id="app"></div>
+  <div id="app"><div id="settings" class="hv-dialog hidden" role="dialog"
+    aria-modal="true" aria-labelledby="settings-title"></div></div>
   <div id="terms"></div><ul id="projects"></ul><div id="status"><span id="status-text"></span><span id="status-hint"></span></div>`;
 
 // Typed off the module itself rather than restated, so a changed export
@@ -82,12 +88,17 @@ let splitCommand: SettingsModule['splitCommand'];
 // the SettingsDeps fields initSettings expects.
 let refocusActiveTerm: Mock<() => void>;
 let setFocusedTile: Mock<(id: string | null) => void>;
+// Imported after the markup exists: the module resolves #settings with
+// pageEl at load, and the component pulls app/dom.ts in for its own
+// singletons.
+let Settings: typeof import('../../src/components/modals/Settings.js')['Settings'];
 
 beforeAll(async () => {
   document.body.innerHTML = MARKUP;
   ({ openSettings, closeSettings, initSettings, splitCommand } = await import(
     '../../src/app/modals/settings.js'
   ));
+  ({ Settings } = await import('../../src/components/modals/Settings.js'));
   refocusActiveTerm = vi.fn();
   setFocusedTile = vi.fn();
   initSettings({ setFocusedTile, refocusActiveTerm });
@@ -98,7 +109,8 @@ beforeEach(() => {
   saveCustomAgents.mockReset().mockResolvedValue(undefined);
   refocusActiveTerm.mockReset();
   setFocusedTile.mockReset();
-  el('settings').classList.add('hidden');
+  resetStore();
+  render(<Settings root={el('settings')} />, { container: el('settings') });
 });
 
 // MARKUP above is this file's contract, so a missing id is a bug in the
@@ -115,13 +127,25 @@ const cell = <T extends HTMLElement = HTMLInputElement>(
   row: Element,
   sel: string,
 ): T => row.querySelector(sel) as T;
-const flush = () => new Promise((r) => setTimeout(r, 0));
+// Lets the load promises settle AND React re-render before the
+// assertions: both the open and every bridge callback write state from
+// outside a React event handler.
+const flush = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
 
-// Drives an <input> the way a user does: set the value, fire 'input'.
+// Drives an <input> the way a user does. fireEvent, not a hand-built
+// event: these are controlled inputs, and React's value tracker swallows
+// a change made by assigning .value directly.
 function type(input: HTMLInputElement, value: string) {
-  input.value = value;
-  input.dispatchEvent(new window.Event('input', { bubbles: true }));
+  fireEvent.change(input, { target: { value } });
 }
+
+// The open/close pair writes the store from outside React.
+const open = () => act(() => openSettings());
+const close = () => act(() => closeSettings());
+const click = (target: HTMLElement) => fireEvent.click(target);
 
 describe('splitCommand', () => {
   it('splits a command line into argv on whitespace', () => {
@@ -154,7 +178,7 @@ describe('settings modal', () => {
       },
     ]);
 
-    openSettings();
+    open();
     expect(el('settings').classList.contains('hidden')).toBe(false);
     expect(setFocusedTile).toHaveBeenCalledWith(null);
     await flush();
@@ -165,21 +189,21 @@ describe('settings modal', () => {
       'claude --model haiku',
     );
 
-    closeSettings();
+    close();
     expect(el('settings').classList.contains('hidden')).toBe(true);
     expect(refocusActiveTerm).toHaveBeenCalled();
   });
 
   it('adds an agent and saves it with an empty id for Go to assign', async () => {
-    openSettings();
+    open();
     await flush();
 
-    el('settings-agent-add').click();
+    click(el('settings-agent-add'));
     expect(rows()).toHaveLength(1);
     type(cell(rows()[0], '.settings-agent-name'), 'Claude Lite');
     type(cell(rows()[0], '.settings-agent-cmd'), 'claude --model haiku');
 
-    el('settings-save').click();
+    click(el('settings-save'));
     await flush();
 
     expect(saveCustomAgents).toHaveBeenCalledWith([
@@ -205,11 +229,11 @@ describe('settings modal', () => {
         color: '#8b5cf6',
       },
     ]);
-    openSettings();
+    open();
     await flush();
 
     type(cell(rows()[0], '.settings-agent-name'), 'Claude Litest');
-    el('settings-save').click();
+    click(el('settings-save'));
     await flush();
 
     const [payload] = saveCustomAgents.mock.calls[0];
@@ -223,14 +247,14 @@ describe('settings modal', () => {
       { id: 'two', name: 'Two', cmd: ['two'], color: '#222222' },
       { id: 'three', name: 'Three', cmd: ['three'], color: '#333333' },
     ]);
-    openSettings();
+    open();
     await flush();
     expect(rows()).toHaveLength(3);
 
-    cell(rows()[1], '.settings-agent-delete').click();
+    click(cell(rows()[1], '.settings-agent-delete'));
     expect(rows()).toHaveLength(2);
 
-    el('settings-save').click();
+    click(el('settings-save'));
     await flush();
 
     const [payload] = saveCustomAgents.mock.calls[0];
@@ -238,15 +262,15 @@ describe('settings modal', () => {
   });
 
   it('drops fully-blank rows so a stray "+ Add agent" does not block the save', async () => {
-    openSettings();
+    open();
     await flush();
 
-    el('settings-agent-add').click();
+    click(el('settings-agent-add'));
     type(cell(rows()[0], '.settings-agent-name'), 'Real');
     type(cell(rows()[0], '.settings-agent-cmd'), 'realtool');
-    el('settings-agent-add').click(); // left entirely blank
+    click(el('settings-agent-add')); // left entirely blank
 
-    el('settings-save').click();
+    click(el('settings-save'));
     await flush();
 
     const [payload] = saveCustomAgents.mock.calls[0];
@@ -258,13 +282,13 @@ describe('settings modal', () => {
     saveCustomAgents.mockRejectedValue(
       new Error('"claude" is a built-in agent and cannot be redefined'),
     );
-    openSettings();
+    open();
     await flush();
 
-    el('settings-agent-add').click();
+    click(el('settings-agent-add'));
     type(cell(rows()[0], '.settings-agent-name'), 'Claude');
     type(cell(rows()[0], '.settings-agent-cmd'), 'claude');
-    el('settings-save').click();
+    click(el('settings-save'));
     await flush();
 
     expect(el('settings').classList.contains('hidden')).toBe(false);
@@ -274,7 +298,7 @@ describe('settings modal', () => {
 
   it('reports a failed load without throwing', async () => {
     listCustomAgents.mockRejectedValue(new Error('boom'));
-    openSettings();
+    open();
     await flush();
 
     expect(el('settings-error').classList.contains('hidden')).toBe(false);
@@ -285,26 +309,28 @@ describe('settings modal', () => {
     listCustomAgents.mockResolvedValue([
       { id: 'keep', name: 'Keep', cmd: ['keep'], color: '#111111' },
     ]);
-    openSettings();
+    open();
     await flush();
     type(cell(rows()[0], '.settings-agent-name'), 'Scribbled');
 
-    el('settings-cancel').click();
+    click(el('settings-cancel'));
     expect(el('settings').classList.contains('hidden')).toBe(true);
     expect(saveCustomAgents).not.toHaveBeenCalled();
 
     // Reopening re-reads from disk rather than showing the discarded draft.
-    openSettings();
+    open();
     await flush();
     expect(cell(rows()[0], '.settings-agent-name').value).toBe('Keep');
   });
 
   it('closes on Escape', async () => {
-    openSettings();
+    open();
     await flush();
-    el('settings').dispatchEvent(
-      new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-    );
+    act(() => {
+      el('settings').dispatchEvent(
+        new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+      );
+    });
     expect(el('settings').classList.contains('hidden')).toBe(true);
   });
 });
@@ -318,7 +344,7 @@ describe('failed load', () => {
     listCustomAgents.mockRejectedValue(
       new Error('parse agents.json: invalid character'),
     );
-    openSettings();
+    open();
     await flush();
 
     expect(el('settings-error').classList.contains('hidden')).toBe(false);
@@ -326,26 +352,26 @@ describe('failed load', () => {
     expect(el<HTMLButtonElement>('settings-save').disabled).toBe(true);
     expect(el<HTMLButtonElement>('settings-agent-add').disabled).toBe(true);
 
-    el('settings-save').click();
+    click(el('settings-save'));
     await flush();
     expect(saveCustomAgents).not.toHaveBeenCalled();
     // The modal stays open so the error remains visible.
     expect(el('settings').classList.contains('hidden')).toBe(false);
-    closeSettings();
+    close();
   });
 
   it('re-enables editing on a later successful open', async () => {
     listCustomAgents.mockRejectedValue(new Error('boom'));
-    openSettings();
+    open();
     await flush();
-    closeSettings();
+    close();
 
     listCustomAgents.mockResolvedValue([]);
-    openSettings();
+    open();
     await flush();
     expect(el<HTMLButtonElement>('settings-save').disabled).toBe(false);
     expect(el<HTMLButtonElement>('settings-agent-add').disabled).toBe(false);
-    closeSettings();
+    close();
   });
 });
 
@@ -357,13 +383,13 @@ describe('load race', () => {
         resolveFirst = r;
       }),
     );
-    openSettings();
+    open();
 
-    closeSettings();
+    close();
     listCustomAgents.mockResolvedValue([
       { id: 'kept', name: 'Kept', cmd: ['kept'], color: '#111111' },
     ]);
-    openSettings();
+    open();
     await flush();
 
     resolveFirst([
@@ -373,7 +399,7 @@ describe('load race', () => {
 
     expect(rows()).toHaveLength(1);
     expect(cell(rows()[0], '.settings-agent-name').value).toBe('Kept');
-    closeSettings();
+    close();
   });
 });
 
@@ -383,7 +409,7 @@ describe('focus containment', () => {
       { id: 'one', name: 'One', cmd: ['one'], color: '#111111' },
       { id: 'two', name: 'Two', cmd: ['two'], color: '#222222' },
     ]);
-    openSettings();
+    open();
     await flush();
 
     const del = cell(rows()[0], '.settings-agent-delete');
@@ -397,27 +423,29 @@ describe('focus containment', () => {
     expect(el('settings').contains(document.activeElement)).toBe(true);
 
     // Deleting the last remaining row falls back to "+ Add agent".
-    cell(rows()[0], '.settings-agent-delete').click();
+    click(cell(rows()[0], '.settings-agent-delete'));
     expect(rows()).toHaveLength(0);
     expect(document.activeElement).toBe(el('settings-agent-add'));
-    closeSettings();
+    close();
   });
 });
 
 describe('escape', () => {
   it('consumes the event so it cannot reach the window handler', async () => {
-    openSettings();
+    open();
     await flush();
 
     const seen = vi.fn();
     window.addEventListener('keydown', seen);
-    el('settings').dispatchEvent(
-      new KeyboardEvent('keydown', {
-        key: 'Escape',
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
+    act(() => {
+      el('settings').dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
     window.removeEventListener('keydown', seen);
 
     expect(el('settings').classList.contains('hidden')).toBe(true);
@@ -430,7 +458,11 @@ describe('escape', () => {
 // window writes it back over what the box now shows — including
 // writeOverrides('') when the field was cleared on the way out.
 describe('appearance a11y', () => {
-  it('links the custom-tokens box to the slot it reports into', () => {
+  it('links the custom-tokens box to the slot it reports into', async () => {
+    // The controls exist only while the dialog is open now: React
+    // renders the panel on open and unmounts it on close.
+    open();
+    await flush();
     expect(
       el<HTMLTextAreaElement>('settings-overrides').getAttribute(
         'aria-describedby',
@@ -444,11 +476,11 @@ describe('appearance debounce', () => {
   it('does not write overrides after the dialog is closed', async () => {
     vi.useFakeTimers();
     try {
-      openSettings();
+      open();
       const box = el<HTMLTextAreaElement>('settings-overrides');
       box.value = '--accent: red;';
       box.dispatchEvent(new window.Event('input', { bubbles: true }));
-      closeSettings();
+      close();
       const before = localStorage.getItem('hive.themeOverrides');
       vi.advanceTimersByTime(500);
       expect(localStorage.getItem('hive.themeOverrides')).toBe(before);

--- a/docs/exec-plans/active/react-ui-rewrite-phase3.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase3.md
@@ -128,7 +128,15 @@ they are the proof the DOM contract survived.
 0 violations; `vite build` succeeds; vitest **78 files / 848 tests** green;
 `go build ./...` + `go test ./internal/... ./cmd/hivegui/...` green; Playwright
 e2e **258 passed / 0 failed / 31 skipped**; `npm run test:e2e:real` **24 passed**.
-No flake-baseline comparison was needed: nothing failed.
+**2026-09-02 — CI.** All legs green on `a65813f` (Linux, macOS, Windows,
+`block-generated-edits`, `verify-generated`, CodeQL). The macOS leg went red once
+on `worktrees.spec.ts:247` ("the worktree glyph on a session opens the browser",
+a `focus()` → `toBeFocused()` assertion) and passed on retry — `1 flaky / 257
+passed`, which the strict setting reports as a failed leg. Not this phase:
+`worktrees.spec.ts` and the sidebar row it drives are untouched here (the
+worktree browser is Phase 4), the same file flaked on Phase 2's run
+(`worktrees.spec.ts:387`), the spec ran 120/120 locally on macOS at
+`--repeat-each=3`, and a re-run of the failed leg alone came back green.
 
 ## PR convergence ledger
 
@@ -137,3 +145,4 @@ _(opened 2026-09-02 for PR #319; `/hs-review-loop` appends one entry per iterati
 - **2026-09-02 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 54e8817e; threads_open: 0; action: fixes applied + push (3 IMPORTANT stood, so not convergence under the loop's "COMMENT with only MINOR remaining" bar); head_sha: 2e01fb5.
 - **2026-09-02 iter 2** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: converged (all three iter-1 IMPORTANTs verified fixed at source); head_sha: 2e01fb5.
 - **2026-09-02 post-loop** — two of the three remaining MINORs applied: unused `modalEntry()` export deleted, and the `[enter] save` hint made honest (see Decision log). The third — a repeated identical error message not re-scrolling — left as-is: the reviewer's own read is that the fix is worse than the bug.
+- **2026-09-02 post-loop CI** — all legs green on `a65813f` after one retry-green flake on `worktrees.spec.ts:247` (see Verification).

--- a/docs/exec-plans/active/react-ui-rewrite-phase3.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase3.md
@@ -3,6 +3,8 @@
 - **Master plan:** [react-ui-rewrite.md](react-ui-rewrite.md)
 - **Spec:** [docs/product-specs/react-ui-rewrite.md](../../product-specs/react-ui-rewrite.md)
 - **Issue:** —
+- **PR:** https://github.com/lucascaro/hive/pull/319
+- **Branch:** `feature/react-rewrite-phase3`
 - **Status:** active
 
 All paths relative to `cmd/hivegui/frontend/` unless rooted.

--- a/docs/exec-plans/active/react-ui-rewrite-phase3.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase3.md
@@ -41,3 +41,77 @@ Violating any one reintroduces a shipped bug.
 
 Per the master plan's Verification block, compared against
 `.plans/react-rewrite-flake-baseline.md`.
+
+## Decision log
+
+**2026-09-02 — `anyModalOpen()` does NOT OR two sources.** Scope called for the
+store to be a second source of "is a modal open" alongside `modals/registry.ts`.
+It isn't needed: the registry already answers off the `.hidden` class of every
+registered root, and both React modals keep their root registered and keep
+toggling that class (from the island's layout effect). So the DOM class stays
+the single source of truth for "a modal owns the keyboard", and `app/focus.ts`,
+`app/session-term.ts` and every `getElementById(...).classList` gate in
+`keyboard.ts` are untouched — the smaller diff *and* the one with no
+two-sources-of-truth to keep in agreement.
+
+**2026-09-02 — modal entries, not bare ids.** `modals: ModalEntry[]` where an
+entry is `{ id: 'launcher'; seq; req }` or `{ id: 'settings'; seq }`, rather than
+the planned `ModalId[]`. Every launcher opening is parameterised (which project,
+duplicate-from, resume-in-worktree), and `seq` — minted by `openModal` — is what
+the component keys its per-open state off (`key={entry.seq}`). That key IS the
+port of the imperative `openGeneration` / `openToken` counters: a re-open
+remounts the body, so a stale response lands on an unmounted component and the
+"did it get reopened under me?" check is just the unmount guard.
+
+**2026-09-02 — `flushSync` on both close paths.** `closeLauncher` and
+`closeSettings` run from plain window/DOM listeners, so an ordinary store write
+is flushed a microtask later — the modal would still be visible when
+`refocusActiveTerm()` ran, and `app/focus.ts` refuses to touch the terminal
+while a modal is open. Four e2e specs caught exactly that ("closing returns the
+keyboard to the terminal"). Wrapping the `closeModal` call in `flushSync` keeps
+the blur → hide → refocus order the imperative version had.
+
+**2026-09-02 — focus-on-open is a passive effect, not a layout one.** Layout
+effects run child-first, so when the body's ran, the island had not yet removed
+`.hidden` — and `focus()` on a `display: none` element is a silent no-op. jsdom
+has no CSS, so the DOM tests stayed green while the browser lost the filter box's
+focus entirely. Positioning stays in the layout effect (no flash); focus moved to
+a passive one, which runs after the island's layout effect has revealed the
+popup.
+
+**2026-09-02 — `settings.ts` and `launcher.ts` are gutted, not deleted.**
+Scope said "deleted". Both files still export the open/close pair every caller
+imports from that path, plus what is not rendering: the launch-count table, the
+three session actions (duplicate / restart / duplicate-choose-tool), the argv
+splitter Go's validator mirrors, and `initThemeWatch`, which is not part of the
+modal at all. Deleting the modules would have meant rewriting every import in
+`keyboard.ts`, `events.ts`, `main.ts`, `Sidebar.tsx` and `EmptyState.tsx` for no
+gain — the same shape as Phase 2's gutted `banners.ts`.
+
+**2026-09-02 — the dialog root moved into `index.html`.** `#settings` is now a
+static empty `div.hv-dialog.hidden` with the `role`/`aria-modal`/
+`aria-labelledby` `ui/dialog.ts` used to stamp, because a React root needs a
+mount node that exists before the modal is first opened. `#settings-scroll` and
+`#settings-updates` stay direct children of `.hv-dialog__body` — `settings.css`
+pins Updates below the scrolling region — so the Enter-to-save listener hangs off
+the root element rather than a wrapper div.
+
+## Progress
+
+**2026-09-02** — Implemented. Store (`modals` slice + `openModal`/`closeModal`/
+`isModalOpen`/`modalEntry`); new `components/modals/{ModalShell,Launcher,Settings}.tsx`;
+`app/modals/{launcher,settings}.ts` gutted to the store-backed open/close pairs;
+`index.html` gained the `#settings` root; `main.ts` mounts the two islands;
+`IconButton` gained an `id` prop (the dialog close button needs `#settings-close`).
+
+Tests: `launcher.test.ts`, `settings.test.ts` and `settings-updates.test.ts`
+rewritten to RTL `.tsx` with every case ported and counts unchanged
+(36 / 19 / 11); new `modal-shell.test.tsx` (7). The e2e specs are unmodified —
+they are the proof the DOM contract survived.
+
+**2026-09-02 — Verification.** `npm run typecheck` clean; `npx biome ci .` clean
+(8 pre-existing warnings, same set as `main`); `scripts/ui-lint.sh --strict`
+0 violations; `vite build` succeeds; vitest **78 files / 848 tests** green;
+`go build ./...` + `go test ./internal/... ./cmd/hivegui/...` green; Playwright
+e2e **258 passed / 0 failed / 31 skipped**; `npm run test:e2e:real` **24 passed**.
+No flake-baseline comparison was needed: nothing failed.

--- a/docs/exec-plans/active/react-ui-rewrite-phase3.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase3.md
@@ -117,3 +117,7 @@ they are the proof the DOM contract survived.
 `go build ./...` + `go test ./internal/... ./cmd/hivegui/...` green; Playwright
 e2e **258 passed / 0 failed / 31 skipped**; `npm run test:e2e:real` **24 passed**.
 No flake-baseline comparison was needed: nothing failed.
+
+## PR convergence ledger
+
+_(opened 2026-09-02 for PR #319; `/hs-review-loop` appends one entry per iteration)_

--- a/docs/exec-plans/active/react-ui-rewrite-phase3.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase3.md
@@ -121,3 +121,5 @@ No flake-baseline comparison was needed: nothing failed.
 ## PR convergence ledger
 
 _(opened 2026-09-02 for PR #319; `/hs-review-loop` appends one entry per iteration)_
+
+- **2026-09-02 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 54e8817e; threads_open: 0; action: fixes applied + push (3 IMPORTANT stood, so not convergence under the loop's "COMMENT with only MINOR remaining" bar); head_sha: 2e01fb5.

--- a/docs/exec-plans/active/react-ui-rewrite-phase3.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase3.md
@@ -98,6 +98,18 @@ mount node that exists before the modal is first opened. `#settings-scroll` and
 pins Updates below the scrolling region — so the Enter-to-save listener hangs off
 the root element rather than a wrapper div.
 
+**2026-09-02 — the `[enter] save` hint is new UI, so Enter now confirms the
+dialog.** Review iteration 2 corrected the record: the pre-Phase-3 `dialog({...})`
+call passed no `hints` at all, so the footer hint this phase adds (for the plan's
+"visible confirm/cancel key hints" criterion, and AGENTS.md › Feedback on Action)
+was never a preserved behaviour — and it was inaccurate the moment it landed,
+because the keydown gate fired only for `input[type=text]`. Rather than drop a
+hint the criteria ask for, Enter now saves from anywhere in the dialog except the
+Appearance textarea (Enter is a newline there) and buttons (Enter is the button's
+own activation — Cancel would otherwise close *and* save). AGENTS.md lists dialog
+confirm/cancel as a hard-coded, non-rebindable binding, so this is the behaviour
+the hint should always have described.
+
 ## Progress
 
 **2026-09-02** — Implemented. Store (`modals` slice + `openModal`/`closeModal`/
@@ -123,3 +135,5 @@ No flake-baseline comparison was needed: nothing failed.
 _(opened 2026-09-02 for PR #319; `/hs-review-loop` appends one entry per iteration)_
 
 - **2026-09-02 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 54e8817e; threads_open: 0; action: fixes applied + push (3 IMPORTANT stood, so not convergence under the loop's "COMMENT with only MINOR remaining" bar); head_sha: 2e01fb5.
+- **2026-09-02 iter 2** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: converged (all three iter-1 IMPORTANTs verified fixed at source); head_sha: 2e01fb5.
+- **2026-09-02 post-loop** — two of the three remaining MINORs applied: unused `modalEntry()` export deleted, and the `[enter] save` hint made honest (see Decision log). The third — a repeated identical error message not re-scrolling — left as-is: the reviewer's own read is that the fix is worse than the bug.

--- a/docs/exec-plans/active/react-ui-rewrite.md
+++ b/docs/exec-plans/active/react-ui-rewrite.md
@@ -109,7 +109,7 @@ implemented — the briefs deliberately do not all exist up front.
 | 0 — store + tooling | [phase0](../completed/react-ui-rewrite-phase0.md) | #311 | **merged** |
 | 1 — sidebar island | [phase1](react-ui-rewrite-phase1.md) | #317 | **merged** |
 | 2 — chrome island | [phase2](react-ui-rewrite-phase2.md) | #318 | **merged** |
-| 3 — modals A | [phase3](react-ui-rewrite-phase3.md) | — | implemented |
+| 3 — modals A | [phase3](react-ui-rewrite-phase3.md) | #319 | implemented, in review |
 | 4 — modals B + keyboard | [phase4](react-ui-rewrite-phase4.md) | — | not started |
 | 5 — grid shell | [phase5](react-ui-rewrite-phase5.md) | — | not started |
 | 6 — single root + deletion | [phase6](react-ui-rewrite-phase6.md) | — | not started |

--- a/docs/exec-plans/active/react-ui-rewrite.md
+++ b/docs/exec-plans/active/react-ui-rewrite.md
@@ -108,8 +108,8 @@ implemented — the briefs deliberately do not all exist up front.
 |---|---|---|---|
 | 0 — store + tooling | [phase0](../completed/react-ui-rewrite-phase0.md) | #311 | **merged** |
 | 1 — sidebar island | [phase1](react-ui-rewrite-phase1.md) | #317 | **merged** |
-| 2 — chrome island | [phase2](react-ui-rewrite-phase2.md) | #318 | implemented, in review |
-| 3 — modals A | [phase3](react-ui-rewrite-phase3.md) | — | not started |
+| 2 — chrome island | [phase2](react-ui-rewrite-phase2.md) | #318 | **merged** |
+| 3 — modals A | [phase3](react-ui-rewrite-phase3.md) | — | implemented |
 | 4 — modals B + keyboard | [phase4](react-ui-rewrite-phase4.md) | — | not started |
 | 5 — grid shell | [phase5](react-ui-rewrite-phase5.md) | — | not started |
 | 6 — single root + deletion | [phase6](react-ui-rewrite-phase6.md) | — | not started |
@@ -210,3 +210,73 @@ in this phase too.
 **Sanctioned spec edit.** `test/e2e/nav-history.spec.ts:100` — `MinimizedTray`
 subscribes to `minimized`, so the in-place `.add` stops rendering. Changed to
 the store action, as the master plan pre-authorised.
+
+### Phase 3 — modals A: launcher + settings (written 2026-09-02 against `main` @ fff838f)
+
+**Roots.** Two islands, same shape as Phase 2: React renders the innards, the
+container keeps its id and its container-level classes are applied from a
+`useLayoutEffect`.
+
+| Root container | Component | Container-level state kept by effect |
+|---|---|---|
+| `#launcher` (exists in `index.html`, `class="hidden" role="menu"`) | `Launcher` | `.hidden`, inline `left`/`top` |
+| `#settings` (**new in `index.html`**, `class="hv-dialog hidden"`) | `Settings` via `ModalShell` | `.hidden` |
+
+`#settings` is the one markup addition. Today `settings.ts` builds the whole
+dialog with `ui/dialog.ts` and `initSettings()` appends it to `#app`; a React
+island needs a mount node that exists before the root is created, so the root
+div moves into `index.html` with the attributes `dialog()` set on it
+(`id`, `class="hv-dialog hidden"`, `role="dialog"`, `aria-modal="true"`,
+`aria-labelledby="settings-title"`). Everything inside it is `ModalShell`'s.
+
+**Markup contract extracted from the legacy modules** (the e2e specs assert on
+all of it, unmodified):
+
+- `#launcher` › `input.launcher-search` (`aria-label="Filter agents"`,
+  `placeholder="Filter agents…"`, `autocomplete=off`) · `label.launcher-worktree`
+  (`input[type=checkbox]` + `<span>`, `.disabled` when the project is not a git
+  repo) · `input.launcher-branch` (`aria-label="Worktree branch name"`,
+  `.hidden` while the toggle is off) · `div.launcher-list` ›
+  `div.launcher-item[data-selected][data-available=false][style=--agent-color]`
+  › `span.agent-num` › `kbd.hv-kbd` · `span.agent-dot` · `span.agent-name` ·
+  `span.install-tag[title]`. Empty/loading rows are `div.launcher-empty`
+  ("No agents match" / "No agents found") and `div.launcher-loading`
+  ("Loading agents…"). **Order matters**: search, worktree row, branch box, list.
+- `#settings` › `.hv-dialog__panel#settings-panel[data-size=md]` ›
+  `header.hv-dialog__header` › `h3.hv-dialog__title#settings-title` +
+  `span.hv-dialog__title-suffix`, `button.hv-icon-btn.hv-dialog__close#settings-close`;
+  `div.hv-dialog__body` › `#settings-scroll` (agents then appearance) and
+  `section#settings-updates`; `footer.hv-dialog__footer` ›
+  `div.hv-dialog__actions` › `#settings-cancel`, `#settings-save`.
+  Inside: `#settings-agents-list` › `div.settings-agent-row` ›
+  `span.hv-swatch` › `input[type=color]`, `input.settings-agent-name`,
+  `input.settings-agent-cmd`, `button.settings-agent-delete`; `#settings-agent-add`;
+  `p#settings-error.hv-field-error.settings-error`; `#settings-theme`,
+  `#settings-overrides` + `p#settings-overrides-error`;
+  `#settings-update-channel`, `#settings-source-repo-row` (`.hidden` off the
+  latest channel) › `#settings-source-repo` + `#settings-source-repo-browse`,
+  `p#settings-source-repo-hint`, `#settings-update-action` +
+  `#settings-update-status`. Hint paragraphs are `p.settings-hint`.
+
+**Store additions** (`src/store/store.ts`): `modals: ModalId[]` with
+`openModal`/`closeModal`/`isModalOpen`. The stack is the *render* signal —
+which React modal is mounted-visible — and nothing more.
+
+**Deviation from the plan's `anyModalOpen()` line (see Decision log).** No
+OR-ing of two sources. `registry.ts` already answers `anyModalOpen()` off the
+`.hidden` class of every registered root, and both React roots keep their root
+element registered and keep toggling `.hidden` from the store. The DOM class
+stays the single source of truth for "a modal owns the keyboard", so
+`focus.ts`, `session-term.ts` and every `getElementById(...).classList` gate in
+`keyboard.ts` are untouched.
+
+**Ported behaviour that is easy to lose** (each has a test):
+open-generation token (`ListAgents` / `IsGitRepo` staleness), `openToken`
+(settings load staleness), the overrides debounce (150 ms) and the source-repo
+probe debounce (250 ms) *including their cancellation on close*, digit
+shortcuts only while the raw query is empty and not in the branch box,
+`mousedown` `preventDefault` on everything but the two text boxes, `focusout`
+close, the document-level outside-click close with its
+`.hv-project-card__actions` / `[data-opens-launcher]` exemptions, re-entrant
+`openSettings()` not wiping a draft, `loadFailed` blocking Save, and
+agents-before-update-settings save order.

--- a/docs/product-specs/react-ui-rewrite.md
+++ b/docs/product-specs/react-ui-rewrite.md
@@ -4,7 +4,7 @@ title: "Incremental React 19 rewrite of the hivegui frontend"
 type: enhancement
 complexity: L
 priority: P2
-pr: 318
+pr: 319
 stage: IMPLEMENT
 ---
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -75,12 +75,19 @@ func TestCreateListKill(t *testing.T) {
 	// Skips the lifecycle-phase `updated` events that create and kill
 	// emit on their way through (covered by TestCreatePhaseSequence /
 	// TestKillPhaseSequence); this test is about added/removed.
+	//
+	// `title` is skipped for a sharper reason: these are real /bin/bash
+	// sessions, and a shell emits its OSC window title whenever it
+	// pleases. A title event landing between `added` and `removed`
+	// failed this test on CI ("event kind: got title, want removed") —
+	// a race the assertion was never about.
 	expectEvent := func(kind string) wire.SessionEvent {
 		deadline := time.After(2 * time.Second)
 		for {
 			select {
 			case ev := <-listener:
-				if ev.Kind == wire.SessionEventUpdated && kind != wire.SessionEventUpdated {
+				if (ev.Kind == wire.SessionEventUpdated ||
+					ev.Kind == wire.SessionEventTitle) && kind != ev.Kind {
 					continue
 				}
 				if ev.Kind != kind {
@@ -106,6 +113,12 @@ func TestCreateListKill(t *testing.T) {
 	if got[0].Order != 0 || got[1].Order != 1 {
 		t.Errorf("order numbers: %+v", got)
 	}
+
+	// Deterministic stand-in for the CI race: on Linux the shell's OSC
+	// title landed here on its own and the assertion below read it as
+	// the kill event. Injecting one makes the skip above load-bearing
+	// rather than timing-dependent.
+	r.noteTitleChange(a.ID)
 
 	if err := r.Kill(a.ID, true); err != nil {
 		t.Fatalf("Kill alpha: %v", err)


### PR DESCRIPTION
Phase 3 of the incremental React rewrite ([master plan](docs/exec-plans/active/react-ui-rewrite.md), [phase plan](docs/exec-plans/active/react-ui-rewrite-phase3.md)). Ports the two biggest modals onto React islands, following the Phase 1/2 pattern: the region keeps its root element (id, role, `.hidden` class), React owns everything inside it, and the container-level class is applied from the island's layout effect.

## What's in it

- **Store**: `modals: ModalEntry[]` — a stack of typed entries (`{id:'launcher', seq, req}` / `{id:'settings', seq}`) with `openModal`/`closeModal`/`isModalOpen`/`modalEntry`. `seq` is the opening's generation; components key per-open state off it, so a reopen remounts the body and the imperative `openGeneration`/`openToken` staleness counters become the unmount guard.
- **New components**: `ModalShell.tsx` (the `ui/dialog.ts` markup contract, Escape, backdrop, Tab trap, plus the confirm/cancel key hints AGENTS.md asks every overlay for), `Launcher.tsx`, `Settings.tsx`.
- **`app/modals/{launcher,settings}.ts` gutted, not deleted**: they keep the open/close pair every caller imports plus what is not rendering (agent-usage table, duplicate/restart actions, `splitCommand`, `initThemeWatch`), so `keyboard.ts`, `events.ts`, `main.ts`, `Sidebar.tsx` and `EmptyState.tsx` compile unchanged.
- **`anyModalOpen()` unchanged**: `modals/registry.ts` still answers off the `.hidden` class of every registered root, and both islands keep toggling it. No second source of truth.
- **`index.html`** gains an empty `#settings` dialog root (a React root needs a mount node before the modal is first opened).

## Two browser-only bugs the jsdom suite could not see

Both were caught by the unmodified e2e specs:

1. **Close paths need `flushSync`.** They run from plain window listeners, so an ordinary store write flushes a microtask later — the modal was still visible when `refocusActiveTerm()` ran, and `app/focus.ts` refuses to touch the terminal while a modal is open.
2. **Focus-on-open must be a passive effect.** Layout effects run child-first, so `.hidden` was still on the island and `focus()` on a `display: none` element is a silent no-op.

## Deviations from the phase plan's Scope

All logged in the plan's Decision log: no `anyModalOpen()` OR-ing, modal *entries* rather than bare ids, modules gutted rather than deleted, and the dialog root moved into `index.html`.

## Verification

`npm run typecheck` clean · `npx biome ci .` clean (8 pre-existing warnings, same set as `main`) · `scripts/ui-lint.sh --strict` 0 violations · `vite build` succeeds · vitest **78 files / 848 tests** · `go build ./...` + `go test ./internal/... ./cmd/hivegui/...` green · Playwright e2e **258 passed / 0 failed** (run twice) · `npm run test:e2e:real` **24 passed**. The e2e specs are unmodified — they are the proof the DOM contract survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)