### PR TITLE
refactor(gui): phase 5 — grid shell renders from the store

### DIFF
--- a/cmd/hivegui/frontend/index.html
+++ b/cmd/hivegui/frontend/index.html
@@ -141,6 +141,12 @@
        hv-dialog — the palette is its own popup. -->
   <div id="command-palette" class="hidden" role="dialog" aria-label="Command palette"></div>
   <main id="terms" aria-label="Terminals"></main>
+  <!-- Mount point for components/GridView.tsx, which renders no DOM: the
+       terminal tiles inside #terms are SessionTerm hosts and React must
+       never own them. `hidden` is display:none, so this is not an #app
+       grid item and every region's explicit row placement is unchanged.
+       Phase 6 of the React rewrite removes it with the island array. -->
+  <div id="grid-root" hidden></div>
   <div id="empty-state" class="hidden"></div>
   <!-- Visible from the first paint: the daemon may take seconds to come
        up on a cold, busy machine, and a black pane with a "connecting…"

--- a/cmd/hivegui/frontend/src/app/dom.ts
+++ b/cmd/hivegui/frontend/src/app/dom.ts
@@ -23,7 +23,7 @@ import { mustEl } from './el.js';
 // The `single` class that used to be added here moved to main.ts: it is
 // initial paint state, not a property of holding the handle, and this
 // module is imported by ~30 jsdom tests that never render a view.
-// showSingle() re-adds it on the first paint either way (view.ts).
+// applySingle() re-adds it on the first paint either way (grid-layout.ts).
 export const termsHost = mustEl('terms');
 
 // The flash engine stays here rather than moving into the store: it is

--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -54,10 +54,9 @@ export interface EventsDeps {
   // The sidebar, the minimized tray and the empty-state pane all render
   // themselves from the store since Phase 2 of the React rewrite, so
   // none of them needs a repaint call here any more.
-  // renderGrid / enforceViewFloor come through the deps seam rather
-  // than a direct view.ts import: view.ts pulls in sidebar and the
-  // modals, and events.ts is deliberately kept out of that graph.
-  renderGrid: () => void;
+  // enforceViewFloor comes through the deps seam rather than a direct
+  // view.ts import: view.ts pulls in sidebar and the modals, and
+  // events.ts is deliberately kept out of that graph.
   enforceViewFloor: () => void;
   updateAppTitle: () => void;
   focusActiveTerm: () => void;
@@ -74,7 +73,6 @@ export interface EventsDeps {
 // and the stub can't drift out of the interface.
 let deps: EventsDeps = {
   switchTo: () => {},
-  renderGrid: () => {},
   enforceViewFloor: () => {},
   updateAppTitle: () => {},
   focusActiveTerm: () => {},
@@ -450,24 +448,18 @@ export function wireDaemonEvents(injected: EventsDeps) {
       // Killing the second-to-last tile leaves a one-tile grid, which is
       // the degenerate state setView refuses to enter.
       deps.enforceViewFloor();
-      // Repaint the grid: one of its cells just went away. Previously
-      // the only repaint on this path was the switchTo above, which
-      // fires solely when the *active* tile was the one killed — so a
-      // grid that lost any other tile kept a stale layout. Focus now
-      // moves at `closing`, so by the time `removed` lands the active
-      // id is already the neighbour and switchTo never runs; without
-      // this, closing a session never refreshed the grid at all.
-      if (state.view !== 'single') deps.renderGrid();
+      // No repaint call: removeSession() drops the id from the grid
+      // scope, which moves GridView's signature. (The explicit
+      // renderGrid() that used to stand here existed because the only
+      // other repaint on this path was the switchTo above, which fires
+      // solely when the *active* tile was the one killed.)
     } else if (ev.kind === 'updated') {
       // A reorder arrives as `updated` events carrying new .order
-      // values. renderGrid appends tiles in gridScopeSessions order, so
-      // without a repaint the sidebar reorders while the tiles keep
-      // their stale DOM order.
-      const prevOrder = i >= 0 ? state.sessions[i].order : undefined;
+      // values. The layout pass appends tiles in gridScopeSessions
+      // order, and that order is part of GridView's signature, so the
+      // store write below is the repaint — a rename, which changes the
+      // sessions array but not the order, still costs nothing.
       if (i >= 0) updateSession(ev.session);
-      if (prevOrder !== ev.session.order && state.view !== 'single') {
-        deps.renderGrid();
-      }
       // Push the new name/color/worktree branch into the cached
       // SessionTerm so the grid tile-header refreshes immediately.
       // Without this, renames look broken in grid mode — the sidebar
@@ -486,8 +478,8 @@ export function wireDaemonEvents(injected: EventsDeps) {
         // off and set needsReattach. Now that the daemon has confirmed
         // a fresh alive=true PTY, reattach the visible term so its
         // resumed stream starts flowing without a manual switch.
-        // Hidden terms are left dirty; switchTo/showSingle/renderGrid
-        // will ensureAttached when they next become visible.
+        // Hidden terms are left dirty; switchTo and the next layout
+        // pass will ensureAttached when they next become visible.
         if (st.needsReattach && ev.session.alive) {
           st.needsReattach = false;
           try {

--- a/cmd/hivegui/frontend/src/app/focus.ts
+++ b/cmd/hivegui/frontend/src/app/focus.ts
@@ -58,7 +58,7 @@ export function setActive(id: string | null) {
   }
   setActiveId(id);
   // Schedule focus after the next paint so any DOM reorder / visibility
-  // change from renderGrid / showSingle has settled. xterm.focus()
+  // change from applyGridLayout / applySingle has settled. xterm.focus()
   // moves focus to its hidden textarea; that fires .onFocus, which
   // adds .term-focused to the host (the source of truth for the
   // visual focus border).
@@ -73,14 +73,14 @@ export function setActive(id: string | null) {
 // Pass state.activeId to focus the active session. Pass null to drop
 // the visual focus everywhere (e.g. when opening the launcher or a
 // rename input). Every state transition that could change which tile
-// should be focused (setActive, setView, renderGrid, modal open/close,
+// should be focused (setActive, setView, the grid layout pass, modal open/close,
 // rename open/close, dialog close, OS fullscreen toggle, …) MUST end
 // by calling setFocusedTile(...).
 //
 // Previously visual focus was event-driven from focusin/focusout on
 // each .term-host, and keyboard focus was driven separately by
 // focusActiveTerm()'s ta.focus() call. During view transitions (most
-// visibly single → grid: renderGrid's appendChild reorder and the
+// visibly single → grid: applyGridLayout's appendChild reorder and the
 // helper-textarea mounted by xterm.open() for newly-materialized
 // tiles), the two could end up on different tiles. The user would
 // see a session lit up while keystrokes went nowhere. Single writer
@@ -88,7 +88,7 @@ export function setActive(id: string | null) {
 // rAF as the helper-textarea focus.
 // Transient focus guard for the post-view-switch settle window.
 //
-// Switching to grid reparents the active tile (renderGrid's appendChild
+// Switching to grid reparents the active tile (applyGridLayout's appendChild
 // reorder) and triggers async ResizeObserver → fit → WebGL resize on the
 // newly-visible neighbour tiles. Both momentarily blur the active
 // helper-textarea to <body>. A keystroke typed in that sub-frame gap lands
@@ -159,7 +159,7 @@ export function setFocusedTile(id: string | null) {
   }
   // Arm the synchronous blur guard for the settle window, then schedule
   // the focus drive after the next paint so any in-flight DOM transition
-  // (showSingle / renderGrid / appendChild / xterm.open) settles before we
+  // (applySingle / applyGridLayout / appendChild / xterm.open) settles before we
   // read activeElement and move focus.
   armFocusGuard(id);
   requestAnimationFrame(() => applyFocus(id, /*attempt=*/ 0));
@@ -175,7 +175,7 @@ function applyFocus(id: string, attempt: number) {
   // setFocusedTile() calls fire during a grid switch and each arms an
   // 8-frame rAF retry chain; in grid mode with many tiles those chains
   // overlap and can hammer focus() every frame. A focusApply count that
-  // dwarfs the renderGrid count — or focus-apply events that never stop
+  // dwarfs the layout-pass count — or focus-apply events that never stop
   // — would mark the focus reconciliation loop as the storm source.
   if (scrollTrace.rec.enabled) {
     scrollTrace.count('focusApply');
@@ -200,7 +200,7 @@ function applyFocus(id: string, attempt: number) {
   // Drive browser focus to the DOM helper-textarea. xterm's
   // term.focus() early-returns on a stale-true _focused flag (#159);
   // after this transition the flag is stale-false because the
-  // synchronous display:none flip during renderGrid's parent class
+  // synchronous display:none flip during the layout pass's parent class
   // swap (single → grid) fires focusout. ta.focus() drives the real
   // event; the follow-up term.focus() resyncs xterm's internal state.
   const ta = st.host.querySelector<HTMLTextAreaElement>(
@@ -222,13 +222,13 @@ function applyFocus(id: string, attempt: number) {
   // Schedule a verification rAF *next frame* (not this one — focus()
   // just fired and synchronously updated activeElement, so an in-tick
   // check would trivially pass and miss the real failure mode):
-  // post-renderGrid side-effects (ResizeObserver → fit → WebGL canvas
+  // post-layout-pass side-effects (ResizeObserver → fit → WebGL canvas
   // resize on newly-visible neighbour tiles) can synchronously fire
   // focusout ~10ms later. If activeElement has drifted off `ta` by
   // then, re-focus. Cap retries so a genuine modal-takeover or rename
   // doesn't busy-loop.
   // Poll for several frames. A single rAF check is insufficient
-  // because post-renderGrid side-effects (ResizeObserver → fit →
+  // because post-layout-pass side-effects (ResizeObserver → fit →
   // WebGL canvas resize on neighbour tiles) can fire focusout AFTER
   // the rAF batch completes — the disturbance arrives one event-loop
   // turn later than the verify. We watch for FOCUS_MAX_RETRIES frames

--- a/cmd/hivegui/frontend/src/app/grid-layout.ts
+++ b/cmd/hivegui/frontend/src/app/grid-layout.ts
@@ -1,0 +1,354 @@
+// ---------- grid layout (imperative DOM half of the grid) ----------
+//
+// Everything in this file was moved out of view.ts by Phase 5 of the
+// React rewrite, deliberately unchanged: the order of operations in
+// applyGridLayout() encodes several shipped bug fixes (grid template
+// before attach, reparent-never-recreate, the deferred attach stagger),
+// and re-expressing it as JSX children would lose all of them.
+//
+// components/GridView.tsx owns the *when*: it subscribes to the store
+// and calls into here from one layout effect. This module owns the
+// *what*, and nothing here reads React.
+//
+// The terminal hosts come from store/terms.ts — the registry deliberately
+// outside the reactive store, because a SessionTerm holds an xterm, a
+// WebGL slot and a live PTY attachment that must never be recreated.
+
+import { LogFrontend } from '../bridge.js';
+import { state, type SessionInfo, type TermTile } from './state.js';
+import { termsHost } from './dom.js';
+import { orderedSessions, activeProjectId } from './selectors.js';
+import { getTerm, termsMap } from '../store/terms.js';
+import {
+  buildGridLayout,
+  computeSpatialMove,
+  type GridLayout,
+} from '../lib/grid.js';
+import type { ViewMode } from '../lib/view.js';
+import { filterHidden } from '../lib/minimized.js';
+import { preserveFocus } from '../lib/preserve-focus.js';
+import { createScrollTrace, type ScrollTrace } from '../lib/scroll-debug.js';
+
+// The same injection seam view.ts has, and for the same reason: this
+// module is imported by session-term.ts's dependents, so importing
+// ensureTerm from it directly would close a cycle. view.ts's initView()
+// forwards its deps here, so a caller (main.ts, a dom test) that wires
+// the view wires the grid with it. Both seams go away in Phase 6.
+export interface GridDeps {
+  ensureTerm: (info: SessionInfo) => TermTile;
+  scrollTrace: Pick<ScrollTrace, 'rec' | 'count'>;
+}
+
+let deps: GridDeps = {
+  ensureTerm: () => undefined as unknown as TermTile,
+  scrollTrace: createScrollTrace({ enabled: false }),
+};
+
+export function initGridLayout(injected: GridDeps) {
+  deps = injected;
+}
+
+// applySingle hides every tile but the active one. Was showSingle().
+export function applySingle(id: string | null) {
+  termsHost.classList.add('single');
+  termsHost.classList.remove('grid');
+  // Hide everything except the active tile.
+  for (const [sid, st] of termsMap()) {
+    if (sid === id) st.show();
+    else st.hide();
+    st.host.classList.remove('in-grid', 'active');
+  }
+  const st = id ? getTerm(id) : null;
+  if (st) st.ensureAttached();
+}
+
+// gridLayout caches the (rows, cols) chosen for the current scope plus
+// the per-tile placement so the keyboard navigation logic doesn't have
+// to recompute. assignments[i] = { row, col, rowSpan } — tiles above
+// last-row empty cells extend downward to fill the grid (matches
+// current Hive's behavior). cellMap[row*cols + col] = session index.
+let gridLayout: GridLayout & { sessions: SessionInfo[] } = {
+  rows: 1,
+  cols: 1,
+  sessions: [],
+  assignments: [],
+  cellMap: [],
+};
+
+// Read-only view of the cache for keyboard navigation (view.ts's
+// gridSpatialMove). Exported instead of the binding itself so a caller
+// cannot leave a stale layout behind.
+export function currentGridLayout(): GridLayout & { sessions: SessionInfo[] } {
+  return gridLayout;
+}
+
+// spatialTarget resolves a directional move against the cached layout.
+// Kept next to the cache so the two can't drift.
+export function spatialTarget(
+  idx: number,
+  dCol: number,
+  dRow: number,
+): number | null {
+  return computeSpatialMove(gridLayout, idx, dCol, dRow);
+}
+
+// attachDeferred attaches non-active grid tiles one per idle callback so
+// the first paint isn't blocked by N synchronous fit()+replay passes.
+// ensureAttached is idempotent for the ATTACH itself (it returns early once
+// attached), so re-running the layout — which re-queues everything — never
+// re-opens a session. It is NOT side-effect-free though: ensureAttached
+// re-latches follow-intent and snaps to the bottom on every call, so each
+// layout pass (switch, minimize, container resize, …) re-anchors every
+// grid tile to the newest output. That is the intended "grid always shows
+// the latest" behavior — the cost is that a background tile can't be parked
+// scrolled up in history across a relayout.
+// requestIdleCallback isn't available in all webviews; fall back to a
+// short-timeout chain so the stagger still happens.
+const _ric = (cb: () => void) =>
+  typeof requestIdleCallback === 'function'
+    ? requestIdleCallback(cb, { timeout: 500 })
+    : setTimeout(cb, 16);
+function attachDeferred(terms: TermTile[]) {
+  let i = 0;
+  const step = () => {
+    if (i >= terms.length) return;
+    const st = terms[i++];
+    // Skip tiles that left the grid before their turn came up.
+    if (st.host.classList.contains('in-grid')) st.ensureAttached();
+    if (i < terms.length) _ric(step);
+  };
+  if (terms.length) _ric(step);
+}
+
+// applyGridLayout lays out every tile that should be visible in the
+// current grid scope. Tiles for other sessions are hidden but kept
+// alive (so their xterm scrollback persists across mode switches).
+// Was renderGrid().
+export function applyGridLayout() {
+  const _t0 = deps.scrollTrace.rec.enabled ? performance.now() : 0;
+  termsHost.classList.remove('single');
+  termsHost.classList.add('grid');
+  const gridSessions = gridScopeSessions();
+  const gridIDs = new Set(gridSessions.map((s) => s.id));
+  const n = gridSessions.length;
+
+  // Pick (rows, cols) that fills the container and apply the grid template
+  // BEFORE the attach loop. The active tile's ensureAttached() runs a
+  // synchronous fit.fit() that measures its body box — if the template
+  // isn't set yet, it measures the pre-grid (single/stale) width and
+  // rebaselineReplayCols('first-attach') anchors the replay baseline to
+  // that wrong width. The tile's ResizeObserver then fires once the
+  // template lays it out, sees a >=REPLAY_COL_THRESHOLD delta vs the stale
+  // baseline, and arms a SECOND scrollback replay on top of the attach
+  // replay — the double-restream that visibly jumps the active tile on
+  // grid entry. buildGridLayout only reads container dims + n, so it has
+  // no dependency on the attach loop. (Per-tile rowSpan is applied below,
+  // after ensureTerm creates the terms — it only affects row height, not
+  // the cols-driven replay trigger.)
+  const w = termsHost.clientWidth || 800;
+  const h = termsHost.clientHeight || 600;
+  const { rows, cols, assignments, cellMap } = buildGridLayout(n, w, h);
+  termsHost.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+  termsHost.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+
+  // Startup-fan-out probe: how many tiles this pass builds+attaches and
+  // the synchronous cost of the loop. grid-all attaches every session at
+  // once; ensureTerm builds a new xterm + WebGL addon and ensureAttached
+  // runs a synchronous fit() per tile — the suspected slow-startup stall.
+  // (ensureAttached's await is fire-and-forget here, so this captures the
+  // synchronous DOM/construction cost; the per-tile open latency lands in
+  // the "ensureAttached" feLog lines.)
+  const _fanoutStart = (() => {
+    try {
+      return performance.now();
+    } catch {
+      return 0;
+    }
+  })();
+  let _built = 0;
+
+  // Ensure every grid session has a SessionTerm; attach lazily. Every
+  // grid tile is on-screen (the grid fits all N into the viewport), but
+  // attaching all N synchronously runs N fit()s + kicks off N replays in
+  // one main-thread pass — the startup drag. Attach the ACTIVE tile now
+  // so the user's focus is live immediately; defer the rest to idle
+  // callbacks so they stream in without blocking the first paint.
+  // Move tiles into the desired DOM order (row-major) so that flexbox
+  // / CSS grid honors the navigation order without us having to set
+  // grid-row/column explicitly.
+  const _deferred: TermTile[] = [];
+  const _wanted: HTMLElement[] = [];
+  for (const info of gridSessions) {
+    const existed = termsMap().has(info.id);
+    const st = deps.ensureTerm(info);
+    if (!existed) _built += 1;
+    st.host.classList.add('in-grid');
+    st.host.classList.toggle('active', info.id === state.activeId);
+    st.host.classList.toggle('attention', state.attention.has(info.id));
+    if (info.id === state.activeId) st.ensureAttached();
+    else _deferred.push(st);
+    _wanted.push(st.host);
+  }
+  // Re-order to keep DOM == nav order — but ONLY when the order actually
+  // moved. appendChild on an already-attached node is a remove+insert, and
+  // the browser blurs whatever is focused inside it (the very blur
+  // focus.ts's _focusGuard exists to paper over). A layout pass runs on every
+  // repaint, and most of them change no order at all — killing a non-active
+  // session leaves the survivors exactly where they were — so an
+  // unconditional re-parent dropped keyboard focus for nothing.
+  const _domOrder = Array.from(termsHost.children).filter((c) =>
+    _wanted.includes(c as HTMLElement),
+  );
+  if (
+    _domOrder.length !== _wanted.length ||
+    _wanted.some((h, i) => _domOrder[i] !== h)
+  )
+    // A genuine re-order still moves nodes, so it still blurs. Put focus
+    // back on the same element afterwards — it survived, it just moved.
+    preserveFocus(termsHost, () => {
+      for (const host of _wanted) termsHost.appendChild(host);
+    });
+  attachDeferred(_deferred);
+  // Only log when the pass built new tiles — a layout pass runs on every
+  // repaint (switch, minimize, resize, …), and an unconditional line
+  // would spam the log with built=0 sync=0ms noise on every grid touch.
+  if (_built > 0) {
+    try {
+      const _ms = (() => {
+        try {
+          return Math.round(performance.now() - _fanoutStart);
+        } catch {
+          return -1;
+        }
+      })();
+      LogFrontend(
+        `renderGrid fanout tiles=${n} built=${_built} sync=${_ms}ms view=${state.view}`,
+      );
+    } catch {
+      /* bridge absent in tests */
+    }
+  }
+  // Hide / unmark tiles outside the scope.
+  for (const [sid, st] of termsMap()) {
+    if (!gridIDs.has(sid)) {
+      st.host.classList.remove('in-grid', 'active');
+      st.host.style.gridRow = '';
+      st.host.style.gridColumn = '';
+    }
+  }
+
+  // Apply each tile's row span. CSS grid 1-based; row indices are
+  // implicit row-major, so we only need to span when rowSpan > 1.
+  for (let i = 0; i < n; i++) {
+    const a = assignments[i];
+    const st = getTerm(gridSessions[i].id);
+    if (!st) continue;
+    if (a.rowSpan > 1) {
+      st.host.style.gridRow = `span ${a.rowSpan}`;
+    } else {
+      st.host.style.gridRow = '';
+    }
+    st.host.style.gridColumn = '';
+  }
+
+  gridLayout = { rows, cols, sessions: gridSessions, assignments, cellMap };
+
+  // Freeze probe: count + time each layout pass. A runaway count (the
+  // container ResizeObserver → layout → tile fit → container resize
+  // feedback loop) or a single multi-hundred-ms pass points straight at
+  // the grid relayout as the stall source. dur is the synchronous cost
+  // of this pass; ms is wall-clock so a storm shows as tight spacing.
+  if (deps.scrollTrace.rec.enabled) {
+    deps.scrollTrace.count('renderGrid');
+    deps.scrollTrace.rec('render-grid', {
+      n,
+      rows,
+      cols,
+      dur: Math.round(performance.now() - _t0),
+    });
+  }
+
+  // No explicit refit pass: each tile's ResizeObserver fires when its
+  // body box changes (CSS grid cell resized, in-grid class toggled,
+  // tile shown/hidden). That's the only place fit.fit() runs.
+}
+
+// gridScopeFor returns the sessions a given grid view would tile, for a
+// view the app is not necessarily in yet — setView needs the count
+// before it commits to the mode.
+export function gridScopeFor(view: ViewMode, projectId?: string) {
+  if (view === 'grid-all') {
+    return filterHidden(
+      orderedSessions(),
+      state.minimized,
+      state.minimizedProjects,
+    );
+  }
+  if (view === 'grid-project') {
+    const scoped = state.sessions
+      .filter((s) => (s.projectId ?? s.project_id) === projectId)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+    return filterHidden(scoped, state.minimized, state.minimizedProjects);
+  }
+  return [];
+}
+
+// gridScopeSessions returns the list of sessions that should be tiled
+// in the current grid view.
+export function gridScopeSessions() {
+  return gridScopeFor(state.view, state.gridProjectId || activeProjectId());
+}
+
+// rebaselineGridReplayCols defers a baseline reset to after the next
+// two animation frames. The first rAF lets the CSS grid layout settle
+// and ResizeObserver fire _onBodyResize on each affected tile (which
+// updates this.term.cols via fit.fit() and may arm a 100ms replay
+// debounce). The second rAF then snapshots the new term.cols as the
+// baseline and clears the pending debounce — turning a layout-driven
+// width change into a no-op rather than a spurious scrollback replay.
+// Pure user window resizes still flow through the threshold path in
+// _onBodyResize and continue to request replays as before.
+export function rebaselineGridReplayCols() {
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => {
+      for (const st of termsMap().values()) {
+        if (st.host.classList.contains('in-grid')) {
+          st.rebaselineReplayCols('layout');
+        }
+      }
+    }),
+  );
+}
+
+// ---------- resize ----------
+//
+// Per-tile fit is driven by each SessionTerm's own ResizeObserver
+// on its body. The only thing left at the page level is re-picking
+// (rows, cols) for the grid when the *container* changes shape —
+// e.g. landscape ↔ portrait window or sidebar drag — so tiles flow
+// from "side-by-side" to "stacked" and back.
+//
+// rAF coalesces the burst of RO entries during a continuous drag
+// into one layout pass per frame. The guard also dodges the dreaded
+// "ResizeObserver loop completed with undelivered notifications"
+// warning that fires when a callback synchronously mutates layout.
+//
+// This one stays outside React: a container resize changes no store
+// field, so there is nothing for GridView to subscribe to, and routing
+// it through a store bump would only add a render to a path that is
+// already coalesced to one pass per frame.
+let _gridReflowQueued = false;
+new ResizeObserver(() => {
+  // Freeze probe: count every container RO firing (including the ones
+  // coalesced away by the queued guard). If this races far ahead of the
+  // render-grid count, the container is being resized in a tight loop —
+  // the classic ResizeObserver feedback storm.
+  if (deps.scrollTrace.rec.enabled)
+    deps.scrollTrace.count('gridContainerResize');
+  if (state.view === 'single' || _gridReflowQueued) return;
+  _gridReflowQueued = true;
+  requestAnimationFrame(() => {
+    _gridReflowQueued = false;
+    if (state.view !== 'single') applyGridLayout();
+  });
+}).observe(termsHost);

--- a/cmd/hivegui/frontend/src/app/grid-layout.ts
+++ b/cmd/hivegui/frontend/src/app/grid-layout.ts
@@ -258,6 +258,10 @@ export function applyGridLayout() {
   // feedback loop) or a single multi-hundred-ms pass points straight at
   // the grid relayout as the stall source. dur is the synchronous cost
   // of this pass; ms is wall-clock so a storm shows as tight spacing.
+  // The `renderGrid` / `render-grid` keys keep the pre-Phase-5 names on
+  // purpose: they are what a freeze-probe dump is grepped for, and
+  // renaming them would make new traces incomparable with every archived
+  // one. Same reason the LogFrontend line above still says "renderGrid".
   if (deps.scrollTrace.rec.enabled) {
     deps.scrollTrace.count('renderGrid');
     deps.scrollTrace.rec('render-grid', {

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -86,12 +86,7 @@ import {
   type WheelEventLike,
 } from '../lib/wheel-scroll.js';
 import { onSessionBell, clearAttention } from './events.js';
-import {
-  minimizeSession,
-  updateAppTitle,
-  showSingle,
-  renderGrid,
-} from './view.js';
+import { minimizeSession, updateAppTitle } from './view.js';
 import { setActive, setFocusedTile, refocusActiveTerm } from './focus.js';
 import { beginInlineRename } from './inline-rename.js';
 
@@ -618,14 +613,11 @@ export class SessionTerm {
     // Click anywhere on the tile (header or body) selects this session.
     this.host.addEventListener('mousedown', () => {
       if (state.activeId !== this.info.id) {
+        // No repaint call: setActive writes activeId, and that is one of
+        // the fields GridView's signature watches — single mode swaps the
+        // shown tile, grid mode moves the .active ring, both from the
+        // layout effect.
         setActive(this.info.id);
-        if (state.view === 'single') {
-          // Switch terms in single mode; in grid mode every tile is
-          // already visible so there's nothing else to do.
-          showSingle(this.info.id);
-        } else {
-          renderGrid();
-        }
       } else {
         // Reclick on the active tile — still clears any leftover
         // attention indicator.

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -574,7 +574,7 @@ export class SessionTerm {
     // helper-textarea) are reconciled atomically by setFocusedTile(id),
     // which is the sole writer of .term-focused. Driving the class off
     // browser focusin/focusout events used to race with DOM churn during
-    // view transitions (single ↔ grid, renderGrid's appendChild reorder,
+    // view transitions (single ↔ grid, applyGridLayout's appendChild reorder,
     // xterm.open mounting new helper-textareas), leaving a tile visually
     // focused while keystrokes went nowhere. Visual focus is now a pure
     // projection of state.activeId, gated by whether a modal/rename

--- a/cmd/hivegui/frontend/src/app/view.ts
+++ b/cmd/hivegui/frontend/src/app/view.ts
@@ -1,34 +1,36 @@
-// ---------- view / grid ----------
+// ---------- view commands ----------
 //
-// Moved verbatim from main.js. ensureTerm / setActive /
-// focusActiveTerm and the scroll tracer are injected via
-// initView(deps) — they live in session-term/focus modules (stage 6)
-// and main.ts.
+// The verbs: switch to a session or project, change view mode, minimize
+// and restore, move the selection around the grid. What each of them
+// used to do LAST — call renderGrid() or showSingle() — is gone: they
+// write the store, and components/GridView.tsx repaints from a layout
+// effect. The layout code itself moved verbatim to app/grid-layout.ts in
+// Phase 5 of the React rewrite.
 //
-// The minimized tray and the empty state left in Phase 2 of the React
-// rewrite: both are pure projections of store state, so they are
-// components subscribed to it (components/MinimizedTray.tsx,
-// EmptyState.tsx) instead of renderX() calls this module had to
-// remember at every repaint.
+// ensureTerm / setActive / focusActiveTerm and the scroll tracer are
+// still injected via initView(deps) — they live in session-term/focus
+// modules and main.ts. Phase 6 deletes the seam with this file.
 
-import { WindowSetTitle, LogFrontend } from '../bridge.js';
+import { flushSync } from 'react-dom';
+import { WindowSetTitle } from '../bridge.js';
 import { state, type SessionInfo, type TermTile } from './state.js';
 import * as store from '../store/store.js';
-import { termsHost, setStatus, flashStatus, setModeHint } from './dom.js';
+import { setStatus, flashStatus, setModeHint } from './dom.js';
 import { orderedSessions, activeProjectId } from './selectors.js';
 import {
-  buildGridLayout,
-  computeSpatialMove,
-  type GridLayout,
-} from '../lib/grid.js';
+  currentGridLayout,
+  gridScopeFor,
+  gridScopeSessions,
+  initGridLayout,
+  rebaselineGridReplayCols,
+  spatialTarget,
+} from './grid-layout.js';
 import { resolveView, type ViewMode } from '../lib/view.js';
-import { filterHidden } from '../lib/minimized.js';
 import { snapVisibleTermsToBottom } from '../lib/view-scroll.js';
 import { readProjectId } from '../lib/wire.js';
 import { isMac } from '../lib/platform.js';
 import { modeHints } from '../lib/status.js';
 import { createScrollTrace, type ScrollTrace } from '../lib/scroll-debug.js';
-import { preserveFocus } from '../lib/preserve-focus.js';
 
 // Per-module deps (view wants focusActiveTerm where sidebar wants
 // refocusActiveTerm). Exported so wave 7 can check main.ts's injection.
@@ -48,7 +50,7 @@ let deps: ViewDeps = {
   // is confined to this default: every real path goes through
   // initView(). Kept as a no-op rather than a throw because switchTo()
   // discards the return value, so an uninjected call is a no-op today —
-  // renderGrid's `st.host` is what actually fails, as it already does.
+  // the grid layout's `st.host` is what actually fails, as it already does.
   ensureTerm: () => undefined as unknown as TermTile,
   setActive: () => {},
   focusActiveTerm: () => {},
@@ -61,19 +63,36 @@ let deps: ViewDeps = {
 
 export function initView(injected: ViewDeps) {
   deps = injected;
+  // One wiring call for both halves of the view: grid-layout.ts needs
+  // the same ensureTerm and tracer, and importing them there directly
+  // would close a session-term ↔ grid-layout cycle. Phase 6 deletes both
+  // seams together.
+  initGridLayout(injected);
 }
 
-export function showSingle(id: string | null) {
-  termsHost.classList.add('single');
-  termsHost.classList.remove('grid');
-  // Hide everything except the active tile.
-  for (const [sid, st] of state.terms) {
-    if (sid === id) st.show();
-    else st.hide();
-    st.host.classList.remove('in-grid', 'active');
+// withLayout runs the store writes of a command and flushes the React
+// work they queue, so GridView's layout effect has already repainted by
+// the time the caller reaches its post-layout work (focusActiveTerm,
+// snapVisibleTermsToBottom). Without the flush those updates would land
+// in a microtask AFTER the caller returned, and the snap would measure a
+// tile the grid had not laid out yet — the ordering invariants 3 and 4
+// pin. Same pattern the modals adopted in Phases 3-4 for plain listeners.
+//
+// The depth guard is for the commands that call each other (switchTo →
+// fallBackToSingleIfActiveHidden → setView, switchToProject → switchTo):
+// nested writes ride the outer flush instead of opening a second one,
+// which React does not allow mid-flush. Focus work inside a nested call
+// therefore runs before the repaint — harmless, because focusActiveTerm
+// retries for 8 frames and the outer command re-focuses at its end.
+let _flushDepth = 0;
+function withLayout<T>(fn: () => T): T {
+  if (_flushDepth > 0) return fn();
+  _flushDepth++;
+  try {
+    return flushSync(fn);
+  } finally {
+    _flushDepth--;
   }
-  const st = id ? state.terms.get(id) : null;
-  if (st) st.ensureAttached();
 }
 
 export function switchTo(id: string | null) {
@@ -81,26 +100,27 @@ export function switchTo(id: string | null) {
     deps.focusActiveTerm();
     return;
   }
-  deps.setActive(id);
-  let info: SessionInfo | null | undefined = null;
-  if (id) {
-    info = state.sessions.find((s) => s.id === id);
-    if (info) deps.ensureTerm(info);
-  }
-  // Retarget the grid scope if the new session belongs to a different
-  // project than the one currently shown in grid-project mode.
-  if (state.view === 'grid-project' && info) {
-    const pid = info.projectId ?? info.project_id;
-    if (pid && pid !== state.gridProjectId) store.setGridProjectId(pid);
-  }
-  // Before painting: a grid view has no tile for a hidden session, so
-  // drop to single first rather than rendering a grid the selection
-  // isn't in. Every "make this session active" path lands here —
-  // sidebar click, ⌘1–⌘9, the menu, switchToProject — so the guard
-  // belongs here and not at each caller.
-  fallBackToSingleIfActiveHidden();
-  if (state.view === 'single') showSingle(id);
-  else renderGrid();
+  const info = withLayout(() => {
+    deps.setActive(id);
+    let found: SessionInfo | undefined;
+    if (id) {
+      found = state.sessions.find((s) => s.id === id);
+      if (found) deps.ensureTerm(found);
+    }
+    // Retarget the grid scope if the new session belongs to a different
+    // project than the one currently shown in grid-project mode.
+    if (state.view === 'grid-project' && found) {
+      const pid = found.projectId ?? found.project_id;
+      if (pid && pid !== state.gridProjectId) store.setGridProjectId(pid);
+    }
+    // Before painting: a grid view has no tile for a hidden session, so
+    // drop to single first rather than rendering a grid the selection
+    // isn't in. Every "make this session active" path lands here —
+    // sidebar click, ⌘1–⌘9, the menu, switchToProject — so the guard
+    // belongs here and not at each caller.
+    fallBackToSingleIfActiveHidden();
+    return found;
+  });
   setStatus(info ? (info.name ?? '') : '');
   // fallBackToSingleIfActiveHidden above can drop us out of a grid, so
   // the hint is recomputed here too — a "focus / move" hint on a single
@@ -113,7 +133,7 @@ export function switchTo(id: string | null) {
   // session lands in whichever terminal had focus before.
   if (id) deps.focusActiveTerm();
   // Focusing a pane is a deliberate "show me the latest". ensureAttached
-  // (via showSingle/renderGrid above) already re-latched _followBottom;
+  // (via the layout pass above) already re-latched _followBottom;
   // this makes the move visible immediately for an already-attached tile
   // whose attach replay won't re-fire. Skips detached/zero-height terms,
   // so a still-deferring tile is a no-op here (Change A catches it on attach).
@@ -168,9 +188,7 @@ export function switchToProject(pid: string) {
   if (target) {
     switchTo(target.id);
   } else {
-    store.setActiveId(null);
-    if (state.view === 'single') showSingle(null);
-    else renderGrid();
+    withLayout(() => store.setActiveId(null));
   }
 }
 
@@ -202,216 +220,34 @@ function fallBackToSingleIfActiveHidden() {
   setView('single', { persist: false });
 }
 
-// gridLayout caches the (rows, cols) chosen for the current scope plus
-// the per-tile placement so the keyboard navigation logic doesn't have
-// to recompute. assignments[i] = { row, col, rowSpan } — tiles above
-// last-row empty cells extend downward to fill the grid (matches
-// current Hive's behavior). cellMap[row*cols + col] = session index.
-let gridLayout: GridLayout & { sessions: SessionInfo[] } = {
-  rows: 1,
-  cols: 1,
-  sessions: [],
-  assignments: [],
-  cellMap: [],
-};
-
-// attachDeferred attaches non-active grid tiles one per idle callback so
-// the first paint isn't blocked by N synchronous fit()+replay passes.
-// ensureAttached is idempotent for the ATTACH itself (it returns early once
-// attached), so re-running renderGrid — which re-queues everything — never
-// re-opens a session. It is NOT side-effect-free though: ensureAttached
-// re-latches follow-intent and snaps to the bottom on every call, so each
-// renderGrid pass (switch, minimize, container resize, …) re-anchors every
-// grid tile to the newest output. That is the intended "grid always shows
-// the latest" behavior — the cost is that a background tile can't be parked
-// scrolled up in history across a relayout.
-// requestIdleCallback isn't available in all webviews; fall back to a
-// short-timeout chain so the stagger still happens.
-const _ric = (cb: () => void) =>
-  typeof requestIdleCallback === 'function'
-    ? requestIdleCallback(cb, { timeout: 500 })
-    : setTimeout(cb, 16);
-function attachDeferred(terms: TermTile[]) {
-  let i = 0;
-  const step = () => {
-    if (i >= terms.length) return;
-    const st = terms[i++];
-    // Skip tiles that left the grid before their turn came up.
-    if (st.host.classList.contains('in-grid')) st.ensureAttached();
-    if (i < terms.length) _ric(step);
-  };
-  if (terms.length) _ric(step);
-}
-
-// renderGrid lays out every tile that should be visible in the
-// current grid scope. Tiles for other sessions are hidden but kept
-// alive (so their xterm scrollback persists across mode switches).
-export function renderGrid() {
-  const _t0 = deps.scrollTrace.rec.enabled ? performance.now() : 0;
-  termsHost.classList.remove('single');
-  termsHost.classList.add('grid');
-  const gridSessions = gridScopeSessions();
-  const gridIDs = new Set(gridSessions.map((s) => s.id));
-  const n = gridSessions.length;
-
-  // Pick (rows, cols) that fills the container and apply the grid template
-  // BEFORE the attach loop. The active tile's ensureAttached() runs a
-  // synchronous fit.fit() that measures its body box — if the template
-  // isn't set yet, it measures the pre-grid (single/stale) width and
-  // rebaselineReplayCols('first-attach') anchors the replay baseline to
-  // that wrong width. The tile's ResizeObserver then fires once the
-  // template lays it out, sees a >=REPLAY_COL_THRESHOLD delta vs the stale
-  // baseline, and arms a SECOND scrollback replay on top of the attach
-  // replay — the double-restream that visibly jumps the active tile on
-  // grid entry. buildGridLayout only reads container dims + n, so it has
-  // no dependency on the attach loop. (Per-tile rowSpan is applied below,
-  // after ensureTerm creates the terms — it only affects row height, not
-  // the cols-driven replay trigger.)
-  const w = termsHost.clientWidth || 800;
-  const h = termsHost.clientHeight || 600;
-  const { rows, cols, assignments, cellMap } = buildGridLayout(n, w, h);
-  termsHost.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-  termsHost.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
-
-  // Startup-fan-out probe: how many tiles this pass builds+attaches and
-  // the synchronous cost of the loop. grid-all attaches every session at
-  // once; ensureTerm builds a new xterm + WebGL addon and ensureAttached
-  // runs a synchronous fit() per tile — the suspected slow-startup stall.
-  // (ensureAttached's await is fire-and-forget here, so this captures the
-  // synchronous DOM/construction cost; the per-tile open latency lands in
-  // the "ensureAttached" feLog lines.)
-  const _fanoutStart = (() => {
-    try {
-      return performance.now();
-    } catch {
-      return 0;
-    }
-  })();
-  let _built = 0;
-
-  // Ensure every grid session has a SessionTerm; attach lazily. Every
-  // grid tile is on-screen (the grid fits all N into the viewport), but
-  // attaching all N synchronously runs N fit()s + kicks off N replays in
-  // one main-thread pass — the startup drag. Attach the ACTIVE tile now
-  // so the user's focus is live immediately; defer the rest to idle
-  // callbacks so they stream in without blocking the first paint.
-  // Move tiles into the desired DOM order (row-major) so that flexbox
-  // / CSS grid honors the navigation order without us having to set
-  // grid-row/column explicitly.
-  const _deferred: TermTile[] = [];
-  const _wanted: HTMLElement[] = [];
-  for (const info of gridSessions) {
-    const existed = state.terms.has(info.id);
-    const st = deps.ensureTerm(info);
-    if (!existed) _built += 1;
-    st.host.classList.add('in-grid');
-    st.host.classList.toggle('active', info.id === state.activeId);
-    st.host.classList.toggle('attention', state.attention.has(info.id));
-    if (info.id === state.activeId) st.ensureAttached();
-    else _deferred.push(st);
-    _wanted.push(st.host);
-  }
-  // Re-order to keep DOM == nav order — but ONLY when the order actually
-  // moved. appendChild on an already-attached node is a remove+insert, and
-  // the browser blurs whatever is focused inside it (the very blur
-  // focus.ts's _focusGuard exists to paper over). renderGrid runs on every
-  // repaint, and most of them change no order at all — killing a non-active
-  // session leaves the survivors exactly where they were — so an
-  // unconditional re-parent dropped keyboard focus for nothing.
-  const _domOrder = Array.from(termsHost.children).filter((c) =>
-    _wanted.includes(c as HTMLElement),
-  );
-  if (
-    _domOrder.length !== _wanted.length ||
-    _wanted.some((h, i) => _domOrder[i] !== h)
-  )
-    // A genuine re-order still moves nodes, so it still blurs. Put focus
-    // back on the same element afterwards — it survived, it just moved.
-    preserveFocus(termsHost, () => {
-      for (const host of _wanted) termsHost.appendChild(host);
-    });
-  attachDeferred(_deferred);
-  // Only log when the pass built new tiles — renderGrid runs on every
-  // repaint (switch, minimize, resize, …), and an unconditional line
-  // would spam the log with built=0 sync=0ms noise on every grid touch.
-  if (_built > 0) {
-    try {
-      const _ms = (() => {
-        try {
-          return Math.round(performance.now() - _fanoutStart);
-        } catch {
-          return -1;
-        }
-      })();
-      LogFrontend(
-        `renderGrid fanout tiles=${n} built=${_built} sync=${_ms}ms view=${state.view}`,
-      );
-    } catch {
-      /* bridge absent in tests */
-    }
-  }
-  // Hide / unmark tiles outside the scope.
-  for (const [sid, st] of state.terms) {
-    if (!gridIDs.has(sid)) {
-      st.host.classList.remove('in-grid', 'active');
-      st.host.style.gridRow = '';
-      st.host.style.gridColumn = '';
-    }
-  }
-
-  // Apply each tile's row span. CSS grid 1-based; row indices are
-  // implicit row-major, so we only need to span when rowSpan > 1.
-  for (let i = 0; i < n; i++) {
-    const a = assignments[i];
-    const st = state.terms.get(gridSessions[i].id);
-    if (!st) continue;
-    if (a.rowSpan > 1) {
-      st.host.style.gridRow = `span ${a.rowSpan}`;
-    } else {
-      st.host.style.gridRow = '';
-    }
-    st.host.style.gridColumn = '';
-  }
-
-  gridLayout = { rows, cols, sessions: gridSessions, assignments, cellMap };
-
-  // Freeze probe: count + time each layout pass. A runaway count (the
-  // container ResizeObserver → renderGrid → tile fit → container resize
-  // feedback loop) or a single multi-hundred-ms pass points straight at
-  // the grid relayout as the stall source. dur is the synchronous cost
-  // of this pass; ms is wall-clock so a storm shows as tight spacing.
-  if (deps.scrollTrace.rec.enabled) {
-    deps.scrollTrace.count('renderGrid');
-    deps.scrollTrace.rec('render-grid', {
-      n,
-      rows,
-      cols,
-      dur: Math.round(performance.now() - _t0),
-    });
-  }
-
-  // No explicit refit pass: each tile's ResizeObserver fires when its
-  // body box changes (CSS grid cell resized, in-grid class toggled,
-  // tile shown/hidden). That's the only place fit.fit() runs.
+// isSessionHidden answers the one question every "can I switch to this
+// with a tile to land on?" caller asks: the session is out of the grid
+// either because it was minimized itself, or because its project was.
+// keyboard.ts branches on this rather than on state.minimized directly,
+// so the two mechanisms can never drift apart. It stays here rather than
+// moving to grid-layout.ts with the scope helpers: it reads nothing but
+// the store, and keyboard.ts is the heaviest caller.
+export function isSessionHidden(id: string): boolean {
+  if (state.minimized.has(id)) return true;
+  const s = state.sessions.find((x) => x.id === id);
+  return !!s && state.minimizedProjects.has(readProjectId(s));
 }
 
 // gridSpatialMove moves the active tile in the given direction.
-// Uses cellMap to honor row-spanned tiles: e.g. with 3 sessions in a
-// 2x2 grid the bottom-right cell is absorbed by tile 1, so pressing
-// "right" from tile 2 lands on tile 1 instead of doing nothing.
+// Uses the cached layout's cellMap to honor row-spanned tiles: e.g. with
+// 3 sessions in a 2x2 grid the bottom-right cell is absorbed by tile 1,
+// so pressing "right" from tile 2 lands on tile 1 instead of doing nothing.
 export function gridSpatialMove(dCol: number, dRow: number) {
-  const { sessions } = gridLayout;
+  const { sessions } = currentGridLayout();
   if (sessions.length === 0) return;
   const idx = sessions.findIndex((s) => s.id === state.activeId);
   if (idx < 0) {
-    deps.setActive(sessions[0].id);
-    renderGrid();
+    withLayout(() => deps.setActive(sessions[0].id));
     return;
   }
-  const target = computeSpatialMove(gridLayout, idx, dCol, dRow);
+  const target = spatialTarget(idx, dCol, dRow);
   if (target == null) return;
-  deps.setActive(sessions[target].id);
-  renderGrid();
+  withLayout(() => deps.setActive(sessions[target].id));
   setStatus(sessions[target].name ?? '');
 }
 
@@ -432,90 +268,54 @@ export function shiftActiveProject(delta: number) {
     if (!state.minimizedProjects.has(cand.id)) next = cand;
   }
   if (!next) return;
-  store.setCurrentProjectId(next.id);
-  if (state.view === 'grid-project') store.setGridProjectId(next.id);
-
+  const chosen = next;
   const sessions = state.sessions
-    .filter((s) => (s.projectId ?? s.project_id) === next.id)
+    .filter((s) => (s.projectId ?? s.project_id) === chosen.id)
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   const target = firstVisible(sessions);
-  if (target) {
-    // ensureTerm before setActive: showSingle only shows a tile that
-    // already exists, and this path never went through switchTo. A
-    // session that has not been rendered this run — the normal case
-    // after a restart, and now reachable whenever the grid falls back
-    // to single — would otherwise leave a blank, unfocusable pane.
-    deps.ensureTerm(target);
-    deps.setActive(target.id);
-  } else {
-    // Empty project — keep the project selected but drop the active
-    // session so the user can ⌘N into it. activeProjectId() now
-    // returns the empty project because currentProjectId is set.
-    store.setActiveId(null);
-  }
-  if (state.view === 'single') showSingle(state.activeId);
-  else renderGrid();
-  // Same guard as switchToProject: ⌘[ / ⌘] can land on a project whose
-  // sessions the grid filters out.
-  fallBackToSingleIfActiveHidden();
-  setStatus(`${next.name}${sessions.length === 0 ? ' (empty)' : ''}`);
-}
-
-// gridScopeFor returns the sessions a given grid view would tile, for a
-// view the app is not necessarily in yet — setView needs the count
-// before it commits to the mode.
-export function gridScopeFor(view: ViewMode, projectId?: string) {
-  if (view === 'grid-all') {
-    return filterHidden(
-      orderedSessions(),
-      state.minimized,
-      state.minimizedProjects,
-    );
-  }
-  if (view === 'grid-project') {
-    const scoped = state.sessions
-      .filter((s) => (s.projectId ?? s.project_id) === projectId)
-      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-    return filterHidden(scoped, state.minimized, state.minimizedProjects);
-  }
-  return [];
-}
-
-// gridScopeSessions returns the list of sessions that should be tiled
-// in the current grid view.
-export function gridScopeSessions() {
-  return gridScopeFor(state.view, state.gridProjectId || activeProjectId());
-}
-
-// isSessionHidden answers the one question every "can I switch to this
-// with a tile to land on?" caller asks: the session is out of the grid
-// either because it was minimized itself, or because its project was.
-// keyboard.ts branches on this rather than on state.minimized directly,
-// so the two mechanisms can never drift apart.
-export function isSessionHidden(id: string): boolean {
-  if (state.minimized.has(id)) return true;
-  const s = state.sessions.find((x) => x.id === id);
-  return !!s && state.minimizedProjects.has(readProjectId(s));
+  withLayout(() => {
+    store.setCurrentProjectId(chosen.id);
+    if (state.view === 'grid-project') store.setGridProjectId(chosen.id);
+    if (target) {
+      // ensureTerm before setActive: the single-mode layout only shows a
+      // tile that already exists, and this path never went through
+      // switchTo. A session that has not been rendered this run — the
+      // normal case after a restart, and now reachable whenever the grid
+      // falls back to single — would otherwise leave a blank, unfocusable
+      // pane.
+      deps.ensureTerm(target);
+      deps.setActive(target.id);
+    } else {
+      // Empty project — keep the project selected but drop the active
+      // session so the user can ⌘N into it. activeProjectId() now
+      // returns the empty project because currentProjectId is set.
+      store.setActiveId(null);
+    }
+    // Same guard as switchToProject: ⌘[ / ⌘] can land on a project whose
+    // sessions the grid filters out.
+    fallBackToSingleIfActiveHidden();
+  });
+  setStatus(`${chosen.name}${sessions.length === 0 ? ' (empty)' : ''}`);
 }
 
 // minimizeSession hides a session from grid views by adding its id to
-// state.minimized. The session stays alive; its tile is removed on the
-// next renderGrid(). Single-session mode is unaffected — the user can
-// still switch to a minimized session via the sidebar / palette.
+// state.minimized. The session stays alive; its tile leaves on the
+// repaint that store write triggers. Single-session mode is unaffected —
+// the user can still switch to a minimized session via the sidebar / palette.
 export function minimizeSession(id: string | null) {
   if (!id || state.minimized.has(id)) return;
-  store.minimizeSession(id);
-  // If the active session is the one being minimized while in grid
-  // mode, hand focus to the next still-visible session so the focus
-  // ring doesn't vanish onto an offscreen tile.
-  if (state.activeId === id && state.view !== 'single') {
-    const next = gridScopeSessions().find((s) => s.id !== id);
-    if (next) deps.setActive(next.id);
-  }
-  if (state.view !== 'single') {
-    renderGrid();
-    rebaselineGridReplayCols();
-  }
+  const wasGrid = state.view !== 'single';
+  withLayout(() => {
+    store.minimizeSession(id);
+    // If the active session is the one being minimized while in grid
+    // mode, hand focus to the next still-visible session so the focus
+    // ring doesn't vanish onto an offscreen tile.
+    if (state.activeId === id && state.view !== 'single') {
+      const next = gridScopeSessions().find((s) => s.id !== id);
+      if (next) deps.setActive(next.id);
+    }
+  });
+  if (wasGrid) rebaselineGridReplayCols();
   enforceViewFloor();
 }
 
@@ -553,18 +353,20 @@ export function restoreSession(id: string | null) {
 // focus handoff, grid, view floor.
 export function minimizeProject(id: string | null) {
   if (!id || state.minimizedProjects.has(id)) return;
-  store.minimizeProject(id);
-  // Same reason as minimizeSession: don't leave the focus ring on a
-  // tile that just stopped being rendered.
-  if (state.view !== 'single') {
-    const active = state.sessions.find((x) => x.id === state.activeId);
-    if (active && readProjectId(active) === id) {
-      const next = gridScopeSessions()[0];
-      if (next) deps.setActive(next.id);
+  const wasGrid = state.view !== 'single';
+  withLayout(() => {
+    store.minimizeProject(id);
+    // Same reason as minimizeSession: don't leave the focus ring on a
+    // tile that just stopped being rendered.
+    if (state.view !== 'single') {
+      const active = state.sessions.find((x) => x.id === state.activeId);
+      if (active && readProjectId(active) === id) {
+        const next = gridScopeSessions()[0];
+        if (next) deps.setActive(next.id);
+      }
     }
-    renderGrid();
-    rebaselineGridReplayCols();
-  }
+  });
+  if (wasGrid) rebaselineGridReplayCols();
   enforceViewFloor();
 }
 
@@ -573,32 +375,10 @@ export function minimizeProject(id: string | null) {
 // project's Order, so the row reappears exactly where it was.
 export function restoreProject(id: string | null) {
   if (!id || !state.minimizedProjects.has(id)) return;
-  store.restoreProject(id);
+  withLayout(() => store.restoreProject(id));
   if (state.view !== 'single') {
-    renderGrid();
     rebaselineGridReplayCols();
   }
-}
-
-// rebaselineGridReplayCols defers a baseline reset to after the next
-// two animation frames. The first rAF lets the CSS grid layout settle
-// and ResizeObserver fire _onBodyResize on each affected tile (which
-// updates this.term.cols via fit.fit() and may arm a 100ms replay
-// debounce). The second rAF then snapshots the new term.cols as the
-// baseline and clears the pending debounce — turning a layout-driven
-// width change into a no-op rather than a spurious scrollback replay.
-// Pure user window resizes still flow through the threshold path in
-// _onBodyResize and continue to request replays as before.
-function rebaselineGridReplayCols() {
-  requestAnimationFrame(() =>
-    requestAnimationFrame(() => {
-      for (const st of state.terms.values()) {
-        if (st.host.classList.contains('in-grid')) {
-          st.rebaselineReplayCols('layout');
-        }
-      }
-    }),
-  );
 }
 
 export function setView(view: ViewMode, opts: { persist?: boolean } = {}) {
@@ -611,15 +391,12 @@ export function setView(view: ViewMode, opts: { persist?: boolean } = {}) {
   );
   if (target !== view) flashStatus('only one session — staying focused');
   view = target;
-  store.setView(view, opts.persist !== false);
-  if (view === 'grid-project') {
-    store.setGridProjectId(activeProjectId());
-  }
-  if (view === 'single') {
-    showSingle(state.activeId);
-  } else {
-    renderGrid();
-  }
+  withLayout(() => {
+    store.setView(view, opts.persist !== false);
+    if (view === 'grid-project') {
+      store.setGridProjectId(activeProjectId());
+    }
+  });
   // Toggling grid/fullscreen via the menu blurs the xterm; restore
   // focus so the user can keep typing into the active session.
   deps.focusActiveTerm();
@@ -649,31 +426,3 @@ export function setView(view: ViewMode, opts: { persist?: boolean } = {}) {
   setStatus(active ? (active.name ?? '') : '');
   setModeHint(modeHints(view, isMac));
 }
-
-// ---------- resize ----------
-//
-// Per-tile fit is driven by each SessionTerm's own ResizeObserver
-// on its body. The only thing left at the page level is re-picking
-// (rows, cols) for the grid when the *container* changes shape —
-// e.g. landscape ↔ portrait window or sidebar drag — so tiles flow
-// from "side-by-side" to "stacked" and back.
-//
-// rAF coalesces the burst of RO entries during a continuous drag
-// into one renderGrid per frame. The guard also dodges the dreaded
-// "ResizeObserver loop completed with undelivered notifications"
-// warning that fires when a callback synchronously mutates layout.
-let _gridReflowQueued = false;
-new ResizeObserver(() => {
-  // Freeze probe: count every container RO firing (including the ones
-  // coalesced away by the queued guard). If this races far ahead of the
-  // render-grid count, the container is being resized in a tight loop —
-  // the classic ResizeObserver feedback storm.
-  if (deps.scrollTrace.rec.enabled)
-    deps.scrollTrace.count('gridContainerResize');
-  if (state.view === 'single' || _gridReflowQueued) return;
-  _gridReflowQueued = true;
-  requestAnimationFrame(() => {
-    _gridReflowQueued = false;
-    if (state.view !== 'single') renderGrid();
-  });
-}).observe(termsHost);

--- a/cmd/hivegui/frontend/src/app/view.ts
+++ b/cmd/hivegui/frontend/src/app/view.ts
@@ -96,9 +96,23 @@ function withLayout<T>(fn: () => T): T {
 }
 
 export function switchTo(id: string | null) {
-  if (id === state.activeId && state.view === 'single') {
-    deps.focusActiveTerm();
-    return;
+  if (id === state.activeId) {
+    if (state.view === 'single') {
+      deps.focusActiveTerm();
+      return;
+    }
+    // Grid, same id: nothing GridView watches moved, so no layout pass
+    // runs — and that is the point, a pass would re-anchor every
+    // background tile to the bottom for a selection that did not change.
+    // But reselecting the active tile is also the user's "unstick this"
+    // gesture, and the pass this replaced was what re-attached a tile
+    // carrying needsReattach (set by pty:disconnect on Restart Session).
+    // events.ts reattaches visible tiles on the next alive=true event;
+    // this is the manual path for when that event never comes. Scoped to
+    // the one tile, where the old full pass hit all of them.
+    if (id) state.terms.get(id)?.ensureAttached();
+    // Falls through: the status text, mode hint, app title, focus and
+    // bottom-snap below all ran on this path before and still should.
   }
   const info = withLayout(() => {
     deps.setActive(id);

--- a/cmd/hivegui/frontend/src/components/GridView.tsx
+++ b/cmd/hivegui/frontend/src/components/GridView.tsx
@@ -1,0 +1,71 @@
+// The grid shell: React owns *when* the terminal area is laid out,
+// app/grid-layout.ts owns *what* it does. This component renders no DOM
+// of its own — the tiles are SessionTerm hosts, which React must never
+// create, destroy or reparent (each holds an xterm, a WebGL slot from the
+// 8-wide process budget, and a live PTY attachment).
+//
+// So: one subscription, one layout effect, no children.
+import { useLayoutEffect, type ReactNode } from 'react';
+import { state } from '../app/state.js';
+import {
+  applyGridLayout,
+  applySingle,
+  gridScopeSessions,
+} from '../app/grid-layout.js';
+import { useAppStore } from '../store/store.js';
+
+// The subscription is a derived SIGNATURE, not the raw store fields, and
+// what it leaves out is load-bearing:
+//
+// - `sessions` is out. `session:event(updated)` is the high-frequency
+//   kind — one per phase step, one per surviving session when a kill
+//   recompacts the order, one per agent-id capture poll — and each one
+//   replaces the array reference. Today only two of those branches
+//   repaint the grid (a removal, and an order change); both move this
+//   signature, while a rename moves neither the signature nor, today,
+//   the grid.
+// - `attention` is out for the same reason, sharper: a bell never called
+//   renderGrid(). events.ts and focus.ts patch the class straight onto
+//   the host, and applyGridLayout() reads `attention` non-reactively when
+//   a pass happens for some other reason. Subscribing would run a full
+//   pass per bell, and every pass calls ensureAttached() on every in-grid
+//   tile — which re-latches follow-bottom and would drag background tiles
+//   out of history at bell rate.
+//
+// What IS in: the view mode, the active tile, the grid's project scope,
+// and the ordered id list of the sessions the scope actually tiles —
+// which is what carries minimize/restore, add/remove and reorder.
+// A string, so the store's Object.is comparison holds and a notification
+// that changes none of it re-renders nothing.
+function gridSignature(): string {
+  return [
+    state.view,
+    state.activeId ?? '',
+    state.gridProjectId ?? '',
+    gridScopeSessions()
+      .map((s) => s.id)
+      .join(' '),
+  ].join('|');
+}
+
+export function GridView(): ReactNode {
+  const signature = useAppStore(gridSignature);
+
+  // useLayoutEffect, not useEffect: callers that mutate the store and then
+  // do post-layout work (focusActiveTerm, snapVisibleTermsToBottom) wrap
+  // the write in flushSync, and only a LAYOUT effect is guaranteed to have
+  // run by the time flushSync returns.
+  //
+  // The signature IS the dependency. The body reads the store through the
+  // non-reactive `state` facade on purpose — a pass needs fields, like
+  // `attention`, that must not be allowed to trigger one — so the linter
+  // sees a dependency it cannot connect to anything the body names.
+  // Dropping it would run the pass on every render instead.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
+  useLayoutEffect(() => {
+    if (state.view === 'single') applySingle(state.activeId);
+    else applyGridLayout();
+  }, [signature]);
+
+  return null;
+}

--- a/cmd/hivegui/frontend/src/lib/preserve-focus.ts
+++ b/cmd/hivegui/frontend/src/lib/preserve-focus.ts
@@ -1,6 +1,6 @@
 // Re-rendering steals the keyboard unless something puts focus back.
 //
-// app/view.ts's renderGrid re-parents tiles with appendChild — which, on
+// app/grid-layout.ts's applyGridLayout re-parents tiles with appendChild — which, on
 // an already-attached node, is a remove+insert the browser treats as a
 // blur. Focus lands on <body> and the next keystroke goes nowhere.
 //

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -260,7 +260,7 @@ initHelpOverlay({ setFocusedTile, focusActiveTerm });
 // a single root. The handles are kept so that phase has something to
 // unmount — see docs/exec-plans/active/react-ui-rewrite.md.
 // The pane starts in focused mode. Set before the first paint rather than
-// waiting for showSingle(), which only runs once a session exists —
+// waiting for applySingle(), which only runs once a session exists —
 // #terms.single drives the terminal arrangement in layout.css.
 termsHost.classList.add('single');
 

--- a/cmd/hivegui/frontend/src/main.ts
+++ b/cmd/hivegui/frontend/src/main.ts
@@ -56,6 +56,7 @@ import { BootState } from './components/BootState.js';
 import { EmptyState } from './components/EmptyState.js';
 import { MinimizedTray } from './components/MinimizedTray.js';
 import { Sidebar } from './components/Sidebar.js';
+import { GridView } from './components/GridView.js';
 import { Launcher } from './components/modals/Launcher.js';
 import { Settings } from './components/modals/Settings.js';
 import { ChoiceDialog } from './components/modals/ChoiceDialog.js';
@@ -80,7 +81,6 @@ import {
   minimizeSession,
   restoreSession,
   shiftActiveProject,
-  renderGrid,
   enforceViewFloor,
   initView,
 } from './app/view.js';
@@ -292,6 +292,13 @@ mountIsland(
     trayEl: pageEl('minimized-projects'),
   }),
 );
+// The grid shell. It renders nothing — its whole job is to run one
+// layout effect against app/grid-layout.ts when the store's view, active
+// tile or grid scope moves — so it mounts on its own empty, hidden root
+// rather than on #terms, whose children are SessionTerm hosts React must
+// never own. Mounted right after the sidebar so it is subscribed before
+// the first session list lands.
+mountIsland(pageEl('grid-root'), createElement(GridView));
 // #banners is `display: contents` (layout.css), so the three banners
 // stay direct children of the #app grid and keep their row placement.
 mountIsland(pageEl('banners'), createElement(Banners));
@@ -377,7 +384,6 @@ initKeyboard({
 });
 wireDaemonEvents({
   switchTo,
-  renderGrid,
   enforceViewFloor,
   updateAppTitle,
   focusActiveTerm,

--- a/cmd/hivegui/frontend/test/dom/events-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/events-focus.test.ts
@@ -69,7 +69,6 @@ describe('wireDaemonEvents window-focus handler', () => {
     const refocusActiveTerm = vi.fn();
     wireDaemonEvents({
       switchTo: vi.fn(),
-      renderGrid: vi.fn(),
       enforceViewFloor: vi.fn(),
       updateAppTitle: vi.fn(),
       focusActiveTerm: vi.fn(),

--- a/cmd/hivegui/frontend/test/dom/grid-layout.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/grid-layout.test.tsx
@@ -31,13 +31,17 @@ vi.mock('../../src/bridge.js', () => ({
 let state: typeof import('../../src/app/state.js').state;
 let grid: typeof import('../../src/app/grid-layout.js');
 let GridView: typeof import('../../src/components/GridView.js').GridView;
+let view: typeof import('../../src/app/view.js');
 
 // Every ensureAttached() call records the grid template as it stood at
 // that moment, which is what makes "template before attach" observable
 // as a sequence rather than an end state.
 const attachedWithTemplate: string[] = [];
+// Per-tile attach counts, for the assertions that care WHICH tiles a
+// path touched rather than how many attaches happened in total.
+const attachCount = new Map<string, number>();
 
-function fakeTerm(): TermTile {
+function fakeTerm(id: string): TermTile {
   const host = document.createElement('div');
   return {
     host,
@@ -50,6 +54,7 @@ function fakeTerm(): TermTile {
     ensureAttached() {
       const terms = document.getElementById('terms');
       attachedWithTemplate.push(terms?.style.gridTemplateColumns ?? '');
+      attachCount.set(id, (attachCount.get(id) ?? 0) + 1);
     },
     show() {},
     hide() {},
@@ -90,7 +95,14 @@ beforeAll(async () => {
   ({ state } = await import('../../src/app/state.js'));
   grid = await import('../../src/app/grid-layout.js');
   ({ GridView } = await import('../../src/components/GridView.js'));
-  grid.initGridLayout({
+  view = await import('../../src/app/view.js');
+  // initView forwards its deps to initGridLayout, so this wires both
+  // halves — and exercises that forwarding.
+  view.initView({
+    setActive: (id) => {
+      state.activeId = id;
+    },
+    focusActiveTerm: () => {},
     // The real ensureTerm builds an xterm; here the tile is pre-seeded
     // and this only hands it back, which is also what makes "reparent,
     // never recreate" checkable by node identity.
@@ -116,6 +128,7 @@ beforeEach(() => {
   // them on purpose; afterEach discards whatever is still queued.
   vi.useFakeTimers();
   attachedWithTemplate.length = 0;
+  attachCount.clear();
   termsHost().innerHTML = '';
   termsHost().removeAttribute('style');
   state.projects = [{ id: 'p1' }];
@@ -123,7 +136,7 @@ beforeEach(() => {
     { id: 'a', project_id: 'p1', order: 0 },
     { id: 'b', project_id: 'p1', order: 1 },
   ];
-  state.terms = new Map(state.sessions.map((s) => [s.id, fakeTerm()]));
+  state.terms = new Map(state.sessions.map((s) => [s.id, fakeTerm(s.id)]));
   state.activeId = 'a';
   state.currentProjectId = 'p1';
   state.view = 'grid-project';
@@ -274,5 +287,25 @@ describe('GridView', () => {
 
     expect(termsHost().classList.contains('single')).toBe(true);
     expect(termsHost().classList.contains('grid')).toBe(false);
+  });
+});
+
+describe('reselecting the active tile in a grid', () => {
+  // The pass this phase deleted from switchTo() was also what re-attached
+  // a tile carrying needsReattach (pty:disconnect sets it on Restart
+  // Session). events.ts covers the case where a fresh alive=true event
+  // follows; clicking the tile is the manual path when one never does.
+  it('re-attaches that tile without running a layout pass', () => {
+    render(<GridView />);
+    attachedWithTemplate.length = 0;
+    attachCount.clear();
+
+    view.switchTo('a');
+
+    expect(attachCount.get('a')).toBe(1);
+    // The whole point of not repainting: tile b is not re-anchored to the
+    // bottom for a selection that did not change. A full pass would
+    // ensureAttached() every in-grid tile.
+    expect(attachCount.get('b')).toBeUndefined();
   });
 });

--- a/cmd/hivegui/frontend/test/dom/grid-layout.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/grid-layout.test.tsx
@@ -107,6 +107,14 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  // jsdom has no requestIdleCallback, so grid-layout's _ric takes its
+  // setTimeout(16) fallback and every pass leaves a real timer behind for
+  // the deferred (non-active) tiles. Under real timers those stragglers
+  // outlive the test — and, for the last test in the file, the jsdom
+  // environment itself — firing ensureAttached() against a torn-down
+  // `document`. Fake timers keep the chain inert unless a test advances
+  // them on purpose; afterEach discards whatever is still queued.
+  vi.useFakeTimers();
   attachedWithTemplate.length = 0;
   termsHost().innerHTML = '';
   termsHost().removeAttribute('style');
@@ -126,6 +134,8 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.clearAllTimers();
+  vi.useRealTimers();
 });
 
 describe('a layout pass', () => {
@@ -157,7 +167,13 @@ describe('a layout pass', () => {
     ];
     grid.applyGridLayout();
 
-    expect(hostsInGrid()).toEqual([first[1], first[0]]);
+    // toBe, not toEqual: vitest compares DOM nodes structurally, so two
+    // freshly built hosts carrying the same classes pass toEqual. Only
+    // Object.is can tell "reparented" from "recreated", which is the
+    // whole invariant this case exists to pin.
+    const after = hostsInGrid();
+    expect(after[0]).toBe(first[1]);
+    expect(after[1]).toBe(first[0]);
   });
 
   it('leaves an out-of-scope tile its DOM node', () => {
@@ -167,7 +183,9 @@ describe('a layout pass', () => {
     state.minimized = new Set(['b']);
     grid.applyGridLayout();
 
-    expect(hostsInGrid().map((h) => h)).toEqual([state.terms.get('a')?.host]);
+    const inGrid = hostsInGrid();
+    expect(inGrid).toHaveLength(1);
+    expect(inGrid[0]).toBe(state.terms.get('a')?.host);
     // Still the same node, still in the document, just not in the grid:
     // its scrollback has to survive being minimized and restored.
     expect(state.terms.get('b')?.host).toBe(bHost);
@@ -191,6 +209,28 @@ describe('GridView', () => {
     });
 
     expect(hostsInGrid()).toHaveLength(1);
+  });
+
+  it('lays the grid out when the scope reorders', () => {
+    render(<GridView />);
+    const first = hostsInGrid();
+    expect(first).toHaveLength(2);
+
+    // events.ts no longer calls a repaint on an `updated` reorder — the
+    // ordered ids in GridView's signature are the repaint. This is the
+    // subscription half of it: a signature that stopped carrying order
+    // (sorted, set-ified) would leave the tiles in stale DOM order and
+    // every other case in this file would stay green.
+    act(() => {
+      state.sessions = [
+        { id: 'b', project_id: 'p1', order: 0 },
+        { id: 'a', project_id: 'p1', order: 1 },
+      ];
+    });
+
+    const after = hostsInGrid();
+    expect(after[0]).toBe(first[1]);
+    expect(after[1]).toBe(first[0]);
   });
 
   it('does not lay out again when a bell marks attention', () => {

--- a/cmd/hivegui/frontend/test/dom/grid-layout.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/grid-layout.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+//
+// The grid shell: app/grid-layout.ts (what a layout pass does) and
+// components/GridView.tsx (when one happens).
+//
+// The three assertions on the pass are the ones that cost a shipped bug
+// when they were violated: the grid template has to be set BEFORE any
+// tile attaches, a tile has to be reparented rather than recreated, and
+// a tile that leaves the scope has to keep its DOM node. The assertions
+// on GridView are the other half of invariant 2 — a pass calls
+// ensureAttached() on every in-grid tile, so a pass that today's code
+// does not run must not start running now that a subscription drives it.
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import type { TermTile } from '../../src/app/state.js';
+
+vi.mock('../../src/bridge.js', () => ({
+  LogFrontend: vi.fn(() => Promise.resolve()),
+  WindowSetTitle: vi.fn(),
+  EventsOn: vi.fn(),
+}));
+
+let state: typeof import('../../src/app/state.js').state;
+let grid: typeof import('../../src/app/grid-layout.js');
+let GridView: typeof import('../../src/components/GridView.js').GridView;
+
+// Every ensureAttached() call records the grid template as it stood at
+// that moment, which is what makes "template before attach" observable
+// as a sequence rather than an end state.
+const attachedWithTemplate: string[] = [];
+
+function fakeTerm(): TermTile {
+  const host = document.createElement('div');
+  return {
+    host,
+    attached: true,
+    needsReattach: false,
+    deadOverlayShown: false,
+    phase: '',
+    setPhase() {},
+    revealAfterReplay() {},
+    ensureAttached() {
+      const terms = document.getElementById('terms');
+      attachedWithTemplate.push(terms?.style.gridTemplateColumns ?? '');
+    },
+    show() {},
+    hide() {},
+    rebaselineReplayCols() {},
+    _onBodyResize() {},
+    setInfo() {},
+    setProject() {},
+    setDead() {},
+    writeData() {},
+    destroy() {},
+    _closeDead() {},
+    _dismissDead() {},
+  } as unknown as TermTile;
+}
+
+function termsHost(): HTMLElement {
+  const el = document.getElementById('terms');
+  if (!el) throw new Error('no #terms');
+  return el;
+}
+
+function hostsInGrid(): HTMLElement[] {
+  return Array.from(termsHost().children).filter((c) =>
+    c.classList.contains('in-grid'),
+  ) as HTMLElement[];
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  document.body.innerHTML = `
+    <div id="app"><ul id="projects"></ul><div id="status"><span id="status-text"></span><span id="status-hint"></span></div>
+    <div id="terms"></div><div id="minimized-tray"></div>
+    <div id="empty-state"></div><div id="grid-root" hidden></div></div>`;
+  ({ state } = await import('../../src/app/state.js'));
+  grid = await import('../../src/app/grid-layout.js');
+  ({ GridView } = await import('../../src/components/GridView.js'));
+  grid.initGridLayout({
+    // The real ensureTerm builds an xterm; here the tile is pre-seeded
+    // and this only hands it back, which is also what makes "reparent,
+    // never recreate" checkable by node identity.
+    ensureTerm: (info) => {
+      const t = state.terms.get(info.id);
+      if (!t) throw new Error(`no term stub for ${info.id}`);
+      return t;
+    },
+    scrollTrace: {
+      rec: Object.assign(() => {}, { enabled: false }),
+      count: () => {},
+    } as never,
+  });
+});
+
+beforeEach(() => {
+  attachedWithTemplate.length = 0;
+  termsHost().innerHTML = '';
+  termsHost().removeAttribute('style');
+  state.projects = [{ id: 'p1' }];
+  state.sessions = [
+    { id: 'a', project_id: 'p1', order: 0 },
+    { id: 'b', project_id: 'p1', order: 1 },
+  ];
+  state.terms = new Map(state.sessions.map((s) => [s.id, fakeTerm()]));
+  state.activeId = 'a';
+  state.currentProjectId = 'p1';
+  state.view = 'grid-project';
+  state.gridProjectId = 'p1';
+  state.minimized = new Set();
+  state.attention = new Set();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('a layout pass', () => {
+  it('sets the grid template before any tile attaches', () => {
+    grid.applyGridLayout();
+
+    // Not just "the template is set afterwards": the ACTIVE tile attaches
+    // synchronously inside the pass, and if it measures its body box
+    // before the template lays it out, the stale width arms a second
+    // scrollback replay on top of the attach replay — the double-restream
+    // that visibly jumps the tile on grid entry.
+    expect(attachedWithTemplate.length).toBeGreaterThan(0);
+    for (const template of attachedWithTemplate) {
+      expect(template).toMatch(/^repeat\(\d+, 1fr\)$/);
+    }
+  });
+
+  it('reparents tiles instead of recreating them', () => {
+    grid.applyGridLayout();
+    const first = hostsInGrid();
+    expect(first).toHaveLength(2);
+
+    // A reorder: the nodes genuinely move, and they must be the SAME
+    // nodes — a recreated host would drop the xterm, its WebGL slot and
+    // its live PTY attachment on the floor.
+    state.sessions = [
+      { id: 'b', project_id: 'p1', order: 0 },
+      { id: 'a', project_id: 'p1', order: 1 },
+    ];
+    grid.applyGridLayout();
+
+    expect(hostsInGrid()).toEqual([first[1], first[0]]);
+  });
+
+  it('leaves an out-of-scope tile its DOM node', () => {
+    grid.applyGridLayout();
+    const bHost = state.terms.get('b')?.host;
+
+    state.minimized = new Set(['b']);
+    grid.applyGridLayout();
+
+    expect(hostsInGrid().map((h) => h)).toEqual([state.terms.get('a')?.host]);
+    // Still the same node, still in the document, just not in the grid:
+    // its scrollback has to survive being minimized and restored.
+    expect(state.terms.get('b')?.host).toBe(bHost);
+    expect(bHost?.isConnected).toBe(true);
+    expect(bHost?.classList.contains('in-grid')).toBe(false);
+  });
+});
+
+describe('GridView', () => {
+  it('renders no DOM of its own', () => {
+    const { container } = render(<GridView />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('lays the grid out when the scope changes', () => {
+    render(<GridView />);
+    expect(hostsInGrid()).toHaveLength(2);
+
+    act(() => {
+      state.minimized = new Set(['b']);
+    });
+
+    expect(hostsInGrid()).toHaveLength(1);
+  });
+
+  it('does not lay out again when a bell marks attention', () => {
+    render(<GridView />);
+    const passes = attachedWithTemplate.length;
+
+    act(() => {
+      state.attention = new Set(['b']);
+    });
+
+    // A bell never called renderGrid(): events.ts patches the class onto
+    // the host. A pass here would call ensureAttached() on every in-grid
+    // tile, which re-latches follow-bottom — a background tile parked in
+    // history would jump to the bottom at bell rate.
+    expect(attachedWithTemplate.length).toBe(passes);
+  });
+
+  it('does not lay out again when a session is renamed', () => {
+    render(<GridView />);
+    const passes = attachedWithTemplate.length;
+
+    act(() => {
+      state.sessions = state.sessions.map((s) =>
+        s.id === 'b' ? { ...s, name: 'renamed' } : s,
+      );
+    });
+
+    // `updated` events replace the sessions array at the child program's
+    // redraw rate. Only the ones that move the grid's own scope — an
+    // add, a removal, a reorder — are a repaint.
+    expect(attachedWithTemplate.length).toBe(passes);
+  });
+
+  it('swaps to the single-tile layout when the view changes', () => {
+    render(<GridView />);
+    expect(termsHost().classList.contains('grid')).toBe(true);
+
+    act(() => {
+      state.view = 'single';
+    });
+
+    expect(termsHost().classList.contains('single')).toBe(true);
+    expect(termsHost().classList.contains('grid')).toBe(false);
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/grid-reorder-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/grid-reorder-focus.test.ts
@@ -63,6 +63,10 @@ vi.mock('../../src/bridge.js', () => {
 
 let state: typeof import('../../src/app/state.js').state;
 let view: typeof import('../../src/app/view.js');
+// The layout pass itself, called directly: this file is a unit test of
+// preserveFocus inside it, and mounting GridView would only add a
+// subscription between the store write and the same call.
+let applyGridLayout: typeof import('../../src/app/grid-layout.js').applyGridLayout;
 
 function fakeTerm(): TermTile {
   return {
@@ -106,6 +110,7 @@ beforeAll(async () => {
     <div id="empty-state"></div></div>`;
   ({ state } = await import('../../src/app/state.js'));
   view = await import('../../src/app/view.js');
+  ({ applyGridLayout } = await import('../../src/app/grid-layout.js'));
   const { setActive } = await import('../../src/app/focus.js');
   view.initView({
     ensureTerm: (info) => tile(info.id),
@@ -139,7 +144,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('renderGrid tile reordering', () => {
+describe('grid layout tile reordering', () => {
   // state.terms is re-seeded per test but #terms keeps every host a
   // previous test appended, so clear it or the order assertions below
   // compare against stale tiles.
@@ -168,6 +173,8 @@ describe('renderGrid tile reordering', () => {
 
   it('does not touch the DOM when the tile order already matches', () => {
     view.setView('grid-project');
+    applyGridLayout(); // setView writes the store; GridView, not mounted
+    // here, is what repaints in production.
     const before = hostsInDom();
     const ta = focusableIn(tile('a'));
     ta.focus();
@@ -182,7 +189,7 @@ describe('renderGrid tile reordering', () => {
     const seen = new MutationObserver(() => {});
     seen.observe(terms, { childList: true });
 
-    view.renderGrid();
+    applyGridLayout();
 
     expect(seen.takeRecords()).toEqual([]);
     seen.disconnect();
@@ -200,17 +207,21 @@ describe('renderGrid tile reordering', () => {
     ];
     state.terms = new Map(state.sessions.map((s) => [s.id, fakeTerm()]));
     view.setView('grid-project');
+    applyGridLayout(); // setView writes the store; GridView, not mounted
+    // here, is what repaints in production.
     const ta = focusableIn(tile('a'));
     ta.focus();
 
     state.sessions = state.sessions.filter((s) => s.id !== 'c');
-    view.renderGrid();
+    applyGridLayout();
 
     expect(document.activeElement).toBe(ta);
   });
 
   it('restores focus after a reorder that really does move the tile', () => {
     view.setView('grid-project');
+    applyGridLayout(); // setView writes the store; GridView, not mounted
+    // here, is what repaints in production.
     const ta = focusableIn(tile('a'));
     ta.focus();
 
@@ -220,7 +231,7 @@ describe('renderGrid tile reordering', () => {
       { id: 'b', project_id: 'p1', order: 0 },
       { id: 'a', project_id: 'p1', order: 1 },
     ];
-    view.renderGrid();
+    applyGridLayout();
 
     expect(gridHosts()).toEqual([tile('b').host, tile('a').host]);
     expect(document.activeElement).toBe(ta);

--- a/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
@@ -55,7 +55,7 @@ let state: typeof import('../../src/app/state.js').state;
 let Sidebar: (p: SidebarProps) => ReactNode;
 let sidebarProps: SidebarProps;
 let bridge: typeof import('../../src/bridge.js');
-let gridScopeFor: typeof import('../../src/app/view.js').gridScopeFor;
+let gridScopeFor: typeof import('../../src/app/grid-layout.js').gridScopeFor;
 let minimizeProject: typeof import('../../src/app/view.js').minimizeProject;
 let switchToProject: typeof import('../../src/app/view.js').switchToProject;
 let shiftActiveProject: typeof import('../../src/app/view.js').shiftActiveProject;
@@ -85,7 +85,7 @@ beforeAll(async () => {
   ({ state } = await import('../../src/app/state.js'));
   bridge = await import('../../src/bridge.js');
   const view = await import('../../src/app/view.js');
-  gridScopeFor = view.gridScopeFor;
+  gridScopeFor = (await import('../../src/app/grid-layout.js')).gridScopeFor;
   minimizeProject = view.minimizeProject;
   switchToProject = view.switchToProject;
   shiftActiveProject = view.shiftActiveProject;
@@ -393,7 +393,6 @@ describe('project events', () => {
     vi.mocked(bridge.EventsOn).mockClear();
     wireDaemonEvents({
       switchTo: noop,
-      renderGrid: noop,
       enforceViewFloor: noop,
       updateAppTitle: noop,
       focusActiveTerm: noop,

--- a/docs/exec-plans/active/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase5.md
@@ -133,6 +133,11 @@ violations, unit 403 passed, dom 539 passed (51 files), go all packages ok,
 e2e 258 passed / 31 skipped **three consecutive runs**, `e2e:real` 22 passed.
 No changeset: behaviour-preserving, `no-changeset` label per the master plan.
 
+**2026-09-03** — Manual `wails build` smoke passed (user-run, on the built
+`.app`): attach, resize, view toggle, scroll up in a background tile,
+minimize/restore, theme switch. That closes the last item of the Phase 5–6
+verification block; everything else in it was already green on this branch.
+
 ## PR convergence ledger
 
 Maintained by hand: `/hs-review-loop` writes into a plan it finds by an

--- a/docs/exec-plans/active/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase5.md
@@ -144,6 +144,8 @@ Maintained by hand: `/hs-review-loop` writes into a plan it finds by an
 `<NNN>`-prefixed name, which this feature's plans do not have (see the master
 plan's [Gating convention](react-ui-rewrite.md#gating-convention)).
 
+- **2026-09-03 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: e37a62b8; threads_open: 0; action: autofix+push; head_sha: 98bc37e. Autofix applied 5 safe fixes (the load-bearing one: the new dom test's deferred-attach `setTimeout` fired after jsdom teardown and made the Linux leg exit 1 with every test passing — fake timers fixed it). 2 risky items surfaced for a human call.
+
 ## Gate verdict
 
 Not yet run. `/hs-merge-gate` must be pointed at THIS plan, not the master plan

--- a/docs/exec-plans/active/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase5.md
@@ -3,6 +3,8 @@
 - **Master plan:** [react-ui-rewrite.md](react-ui-rewrite.md)
 - **Spec:** [docs/product-specs/react-ui-rewrite.md](../../product-specs/react-ui-rewrite.md)
 - **Issue:** —
+- **PR:** —
+- **Branch:** `feature/react-phase5-grid-shell`
 - **Status:** active
 
 All paths relative to `cmd/hivegui/frontend/` unless rooted.
@@ -12,7 +14,7 @@ All paths relative to `cmd/hivegui/frontend/` unless rooted.
 React owns orchestration/subscription; DOM operations stay imperative in one layout effect, ported verbatim. Do NOT re-express `renderGrid` as JSX children — its operation order encodes bug fixes.
 
 New files:
-- `src/components/GridView.tsx` — selector-subscribes to `sessions/view/activeId/gridProjectId/minimized/attention`; renders nothing; `useLayoutEffect` → `applyGridLayout()`.
+- `src/components/GridView.tsx` — subscribes to a derived *layout signature* (`view | activeId | gridProjectId | the ordered ids of the sessions the scope tiles`); renders nothing; `useLayoutEffect` → `applyGridLayout()`. Raw `sessions` and `attention` are deliberately NOT dependencies — see the master plan's Phase 5 brief for why each one would repaint at a rate today's code does not.
 - `src/app/grid-layout.ts` — `applyGridLayout(snapshot)` / `applySingle(snapshot)`: current `renderGrid()`/`showSingle()` bodies extracted intact — grid template before attach, reparent-not-recreate, out-of-scope tiles keep their DOM node, inline `gridRow` spans, `rebaselineGridReplayCols()` double-rAF, `attachDeferred` idle staggering, the `#terms` ResizeObserver + rAF coalescing, `setView`'s 250ms bottom-snap. Hosts come from `src/store/terms.ts`.
 
 Files to change: `src/app/view.ts` — render paths deleted; survivors (app-title timer, `focusActiveTerm` interop, nav helpers) move next to callers or into `grid-layout.ts`. `src/app/events.ts` — remaining `deps.renderGrid()` calls removed; `pty:*` handlers keep writing directly to SessionTerm instances via the registry (data plane bypasses React, as today). `src/app/session-term.ts` — imports only.
@@ -47,23 +49,86 @@ Violating any one reintroduces a shipped bug.
 Per the master plan's Verification block, compared against
 `.plans/react-rewrite-flake-baseline.md`.
 
-## Known spec-edit exception (carried from Phase 0 review)
+## Known spec-edit exception (carried from Phase 0 review) — not needed
 
-`test/e2e/nav-history.spec.ts:100` does
-`window.__hive_state?.minimized.add(id)` — an **in-place** mutation of a store
-Set, the one pattern the store's reference equality cannot see.
+Phase 0's review flagged `test/e2e/nav-history.spec.ts:100`
+(`window.__hive_state?.minimized.add(id)`, an in-place mutation of a store Set
+the reference equality cannot see) as breaking in "the first phase that
+subscribes to `minimized`" — Phase 2's `MinimizedTray`, and again in Phase 5's
+`GridView`.
 
-It is correct today and stays correct through Phase 1: the facade getter returns
-the live Set, and with no component subscribed to `minimized` the following
-render picks the change up. **It stops working in the first phase that
-subscribes to `minimized`** — Phase 2's `MinimizedTray` selector, and again in
-Phase 5's `GridView`.
+Phase 2 got there first and converted the line to an assignment
+(`s.minimized = new Set([...s.minimized, id])`), which routes through
+`setMinimized`. It is already correct for this phase's subscriber, so Phase 5
+spends no spec edit at all: **zero e2e specs change in this PR.**
 
-Deliberately NOT fixed in Phase 0: the migration's safety proof is that the e2e
-specs never change, and editing one to chase a latent issue would have spent
-that proof on a non-issue. When the subscriber lands, this is the **one
-sanctioned spec edit** — `window.__hive.store.minimizeSession(id)` (or the
-equivalent action exposed on the test global) instead of the raw `.add`. It is
-NOT a DOM-contract break, so the "a spec edit means the contract broke" rule
-does not apply to this line. Note it in that phase's PR description as the
-signed-off exception the master plan's Tests section requires.
+## Decision log
+
+**2026-09-03 — `attention` is not a GridView dependency, though this plan's
+Scope line listed it.** Verified against the code: a bell never called
+`renderGrid()` — `events.ts:174/177/184/226` and `focus.ts:54` patch the
+`attention` class straight onto the host. Subscribing would run a full layout
+pass per bell, and every pass calls `ensureAttached()` on every in-grid tile,
+which re-latches follow-bottom (invariant 2) — a background tile parked in
+history would be dragged to the bottom at bell rate. `applyGridLayout()` still
+sets the class during a pass, reading `attention` non-reactively, exactly as
+`renderGrid()` did. Same reasoning retires raw `sessions` as a dependency: an
+`updated` event replaces the array at the child program's redraw rate, and
+today only a removal or a reorder repaints — both of which move the signature,
+while a rename moves neither.
+
+**2026-09-03 — store writes with post-layout work are wrapped in `flushSync`.**
+`switchTo` and `setView` do their focus and bottom-snap work after the repaint;
+React would otherwise land the effect in a microtask after they returned, so
+`snapVisibleTermsToBottom` would measure a tile the grid had not laid out —
+inverting invariants 3 and 4. `view.ts`'s `withLayout()` carries a depth guard
+because these commands call each other (`switchTo` →
+`fallBackToSingleIfActiveHidden` → `setView`), and React does not allow a
+nested flush. Same pattern the six modals adopted in Phases 3–4.
+
+**2026-09-03 — `isSessionHidden()` stays in `view.ts`.** It reads nothing but
+the store, so it is not layout code; moving it next to `gridScopeFor()` would
+have pulled `grid-layout.ts` (and its module-scope `#terms` ResizeObserver)
+into `keyboard.ts`'s import graph, which four dom tests mock `view.js`
+specifically to avoid.
+
+**2026-09-03 — `GridView` mounts on a new empty `#grid-root`, not `#terms`.**
+It renders `null`, and `#terms`'s children are SessionTerm hosts React must
+never own. The element is `hidden` (so `display: none`, not an `#app` grid
+item, and every region's explicit row placement is untouched) and Phase 6
+removes it with the island array.
+
+**2026-09-03 — accepted behaviour delta.** `switchTo(id)` where `id` is already
+active in a grid view used to run a full `renderGrid()`, re-anchoring every
+background tile to the bottom. It now repaints nothing — no signature change —
+while the active tile still gets its explicit `snapVisibleTermsToBottom([st])`.
+Strictly fewer `ensureAttached()` calls, which is the direction the success
+criterion allows.
+
+## Progress
+
+**2026-09-03** — Implemented. New `src/app/grid-layout.ts` (`applyGridLayout`,
+`applySingle`, `attachDeferred`, `_ric`, the layout cache +
+`currentGridLayout()`/`spatialTarget()`, `gridScopeFor`, `gridScopeSessions`,
+`rebaselineGridReplayCols`, the `#terms` ResizeObserver — all moved verbatim
+bar the renames and the `state.terms` → `store/terms.ts` registry swap) and
+`src/components/GridView.tsx`. `view.ts` keeps the commands and lost every
+`renderGrid()`/`showSingle()` call; `events.ts` lost its `renderGrid` deps
+field and both calls; `session-term.ts`'s mousedown is `setActive` alone;
+`main.ts` mounts the island on the new `#grid-root`.
+
+Tests: new `test/dom/grid-layout.test.tsx` (8 cases — template-before-attach as
+a spy sequence, reparent-not-recreate by node identity, out-of-scope tile keeps
+its node, plus GridView renders no DOM, repaints on a scope change, and does
+NOT repaint on a bell or a rename). `grid-reorder-focus.test.ts` and
+`minimize-project.test.tsx` repoint to the new entry points;
+`events-focus.test.ts` drops the `renderGrid` dep. `view-floor`,
+`xterm-reflow`, `attention-jump`, `attention-jump-integration` and dom
+`nav-history` needed no change after all — they mock `view.js` or drive it
+through commands that still exist.
+
+Verification (all from a fresh worktree after `./scripts/ci-bootstrap.sh`):
+`npm run typecheck` clean, `biome ci .` clean, `scripts/ui-lint.sh --strict` 0
+violations, unit 403 passed, dom 539 passed (51 files), go all packages ok,
+e2e 258 passed / 31 skipped **three consecutive runs**, `e2e:real` 22 passed.
+No changeset: behaviour-preserving, `no-changeset` label per the master plan.

--- a/docs/exec-plans/active/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase5.md
@@ -132,3 +132,14 @@ Verification (all from a fresh worktree after `./scripts/ci-bootstrap.sh`):
 violations, unit 403 passed, dom 539 passed (51 files), go all packages ok,
 e2e 258 passed / 31 skipped **three consecutive runs**, `e2e:real` 22 passed.
 No changeset: behaviour-preserving, `no-changeset` label per the master plan.
+
+## PR convergence ledger
+
+Maintained by hand: `/hs-review-loop` writes into a plan it finds by an
+`<NNN>`-prefixed name, which this feature's plans do not have (see the master
+plan's [Gating convention](react-ui-rewrite.md#gating-convention)).
+
+## Gate verdict
+
+Not yet run. `/hs-merge-gate` must be pointed at THIS plan, not the master plan
+the spec's `Exec plan:` link resolves to — its success criteria are Phase 6's.

--- a/docs/exec-plans/active/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase5.md
@@ -98,12 +98,24 @@ never own. The element is `hidden` (so `display: none`, not an `#app` grid
 item, and every region's explicit row placement is untouched) and Phase 6
 removes it with the island array.
 
+**2026-09-03 — reselecting the active grid tile re-attaches just that tile.**
+Review re-raised the untested half of the delta below: the pass this phase
+deleted from `switchTo()` was also what re-attached a tile carrying
+`needsReattach` (`pty:disconnect` sets it on Restart Session), so clicking a
+stuck tile stopped being a recovery path. `events.ts` still reattaches visible
+tiles on the next `alive=true` event; this is the manual path for when one
+never arrives. `switchTo()` now calls `ensureAttached()` on that one tile —
+scoped where the old full pass hit every in-grid tile, so the scroll-parking
+improvement below survives. Pinned by `test/dom/grid-layout.test.tsx` ::
+`re-attaches that tile without running a layout pass` (verified non-vacuous:
+it fails with the line removed).
+
 **2026-09-03 — accepted behaviour delta.** `switchTo(id)` where `id` is already
 active in a grid view used to run a full `renderGrid()`, re-anchoring every
 background tile to the bottom. It now repaints nothing — no signature change —
 while the active tile still gets its explicit `snapVisibleTermsToBottom([st])`.
 Strictly fewer `ensureAttached()` calls, which is the direction the success
-criterion allows.
+criterion allows. The reattach half of this is handled by the entry above.
 
 ## Progress
 
@@ -146,6 +158,7 @@ plan's [Gating convention](react-ui-rewrite.md#gating-convention)).
 
 - **2026-09-03 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: e37a62b8; threads_open: 0; action: autofix+push; head_sha: 98bc37e. Autofix applied 5 safe fixes (the load-bearing one: the new dom test's deferred-attach `setTimeout` fired after jsdom teardown and made the Linux leg exit 1 with every test passing — fake timers fixed it). 2 risky items surfaced for a human call.
 - **2026-09-03 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: c247977c; threads_open: 0; action: stop (escalated: risky fix needs human decision); head_sha: 99ea356. Zero BLOCKING, zero MINOR surviving; the one IMPORTANT is the accepted `switchTo(activeId)` delta, re-raised because no test pins the `needsReattach` half of it.
+- **2026-09-03 post-loop** — the one escalated item resolved by user decision: targeted `ensureAttached()` on reselect + a non-vacuous regression test (see the Decision log). Re-verified: typecheck, `biome ci`, `ui-lint --strict`, unit 403, dom 541, e2e 258.
 
 ## Gate verdict
 

--- a/docs/exec-plans/active/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase5.md
@@ -145,6 +145,7 @@ Maintained by hand: `/hs-review-loop` writes into a plan it finds by an
 plan's [Gating convention](react-ui-rewrite.md#gating-convention)).
 
 - **2026-09-03 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: e37a62b8; threads_open: 0; action: autofix+push; head_sha: 98bc37e. Autofix applied 5 safe fixes (the load-bearing one: the new dom test's deferred-attach `setTimeout` fired after jsdom teardown and made the Linux leg exit 1 with every test passing — fake timers fixed it). 2 risky items surfaced for a human call.
+- **2026-09-03 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: c247977c; threads_open: 0; action: stop (escalated: risky fix needs human decision); head_sha: 99ea356. Zero BLOCKING, zero MINOR surviving; the one IMPORTANT is the accepted `switchTo(activeId)` delta, re-raised because no test pins the `needsReattach` half of it.
 
 ## Gate verdict
 

--- a/docs/exec-plans/active/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/active/react-ui-rewrite-phase5.md
@@ -3,7 +3,7 @@
 - **Master plan:** [react-ui-rewrite.md](react-ui-rewrite.md)
 - **Spec:** [docs/product-specs/react-ui-rewrite.md](../../product-specs/react-ui-rewrite.md)
 - **Issue:** —
-- **PR:** —
+- **PR:** [#321](https://github.com/lucascaro/hive/pull/321)
 - **Branch:** `feature/react-phase5-grid-shell`
 - **Status:** active
 

--- a/docs/exec-plans/active/react-ui-rewrite.md
+++ b/docs/exec-plans/active/react-ui-rewrite.md
@@ -469,11 +469,11 @@ named in "lines that change". Nothing else in these bodies is touched.
 
 | From `view.ts` | To `grid-layout.ts` | Lines that change |
 |---|---|---|
-| `showSingle()` :66 | `applySingle(id)` | rename; `state.terms` → `allTerms()` / `getTerm()` |
+| `showSingle()` :66 | `applySingle(id)` | rename; `state.terms` → `termsMap()` / `getTerm()` |
 | `_ric` :230 | `_ric` | none |
 | `attachDeferred()` :234 | `attachDeferred` | none |
-| `renderGrid()` :249 | `applyGridLayout()` | rename; `deps.ensureTerm` → imported `ensureTerm`; `deps.scrollTrace` → imported `scrollTrace`; `state.terms` → registry |
-| `gridLayout` cache :210 | module-local + `getGridLayout()` | export accessor for `gridSpatialMove` |
+| `renderGrid()` :249 | `applyGridLayout()` | rename; `state.terms` → registry. **As shipped:** `deps.ensureTerm` / `deps.scrollTrace` stay on a deps seam (`initGridLayout()`, forwarded from `initView()`) rather than becoming direct imports — importing `ensureTerm` here would close a `session-term` ↔ `grid-layout` cycle. Phase 6 deletes both seams. |
+| `gridLayout` cache :210 | module-local + `currentGridLayout()` | export accessor for `gridSpatialMove` (plus `spatialTarget()`, kept next to the cache so the two cannot drift) |
 | `rebaselineGridReplayCols()` :592 | exported | none |
 | `gridScopeFor()` :467, `gridScopeSessions()` :486 | same | none |
 | `#terms` ResizeObserver :665-679 | same | `renderGrid()` → `applyGridLayout()` |

--- a/docs/exec-plans/active/react-ui-rewrite.md
+++ b/docs/exec-plans/active/react-ui-rewrite.md
@@ -494,7 +494,7 @@ scope line is the authority; this plan's Tests line ("`src/app/view.js`
 to `sessions`:
 
 ```
-`${view}|${activeId}|${gridProjectId}|${gridScopeSessions().map(s => s.id).join('\0')}`
+`${view}|${activeId}|${gridProjectId}|${gridScopeSessions().map(s => s.id).join(' ')}`
 ```
 
 and its single `useLayoutEffect` depends on that string alone. Two findings

--- a/docs/exec-plans/active/react-ui-rewrite.md
+++ b/docs/exec-plans/active/react-ui-rewrite.md
@@ -2,8 +2,8 @@
 
 - **Spec:** [docs/product-specs/react-ui-rewrite.md](../../product-specs/react-ui-rewrite.md)
 - **Issue:** —
-- **PR:** [#320](https://github.com/lucascaro/hive/pull/320) — the phase currently in flight (Phase 4). This field tracks the open phase PR, because the spec's `Exec plan:` link points here and `/hs-merge-gate` resolves the plan through it; the per-phase PRs are in the table under [Phases](#phases).
-- **Branch:** `feature/react-phase4-modals-b`
+- **PR:** [#321](https://github.com/lucascaro/hive/pull/321) — the phase currently in flight (Phase 5). This field tracks the open phase PR, because the spec's `Exec plan:` link points here and `/hs-merge-gate` resolves the plan through it; the per-phase PRs are in the table under [Phases](#phases).
+- **Branch:** `feature/react-phase5-grid-shell`
 - **Status:** active
 
 ## Summary
@@ -122,8 +122,8 @@ implemented — the briefs deliberately do not all exist up front.
 | 1 — sidebar island | [phase1](react-ui-rewrite-phase1.md) | #317 | **merged** |
 | 2 — chrome island | [phase2](react-ui-rewrite-phase2.md) | #318 | **merged** |
 | 3 — modals A | [phase3](react-ui-rewrite-phase3.md) | #319 | **merged** (PR merged 2026-09-02; its gate has not been recorded, so the plan stays in `active/` for `/hs-merge-gate`) |
-| 4 — modals B + keyboard | [phase4](../completed/react-ui-rewrite-phase4.md) | #320 | **gate PASS**, PR open |
-| 5 — grid shell | [phase5](react-ui-rewrite-phase5.md) | — | not started |
+| 4 — modals B + keyboard | [phase4](../completed/react-ui-rewrite-phase4.md) | #320 | **merged** (2026-09-03, `d794caa`); gate PASS |
+| 5 — grid shell | [phase5](react-ui-rewrite-phase5.md) | #321 | **in flight** |
 | 6 — single root + deletion | [phase6](react-ui-rewrite-phase6.md) | — | not started |
 
 **Carried into Phase 6's deletion sweep** (each verified to have zero production
@@ -153,17 +153,30 @@ RTL = `@testing-library/react`. All rewritten tests keep asserting the same clas
   review — the mid-edit repaint, two keyboard-strand-on-close cases, and five
   covering the answers that delete a branch on a remote, which had no coverage
   at all. (Derivation: `grep -cE "^\s*it\("` on each side of `main...HEAD`.) Planned as rewrites but neither turned out to need one — corrected here at the gate rather than left as a forecast the shipped code contradicts: `focus-trap.test.ts` exercises pure helpers whose signatures did not change, so it took an import repoint (and two cases for the new nullable container) and stays plain jsdom; `keyboard-arrows.test.ts` covers arrow routing *below* the modal ladder and was not touched at all. New: `test/dom/choice-dialog.test.tsx` (open → answer → auto-cleanup, keyboard never stranded), `test/dom/keyboard-precedence.test.tsx` (table-driven over all 9 layers, store-backed ladder matches legacy order), `test/dom/inline-rename.test.ts` (the identity guard a React cleanup depends on), and dom coverage for the three modals that had none: `command-palette`, `project-editor`, `help-overlay`.
-- Phase 5 — New: `test/dom/grid-layout.test.tsx` (spy-sequence asserts template-set-before-attach; reparent not recreate — same node identity across renders; out-of-scope tile keeps its DOM node). Update to the new entry points: `view-floor.test.ts`, `xterm-reflow.test.ts`, and the three that import `initView` from `src/app/view.js` (deleted this phase) — `attention-jump.test.ts`, `attention-jump-integration.test.ts`, `test/dom/nav-history.test.ts`.
+- Phase 5 — New: `test/dom/grid-layout.test.tsx` (8 cases: spy-sequence asserts
+  template-set-before-attach; reparent not recreate — same node identity across
+  passes; out-of-scope tile keeps its DOM node; and on the React half, GridView
+  renders no DOM, repaints on a scope change, and does NOT repaint on a bell or
+  a rename). Repointed to the new entry points: `grid-reorder-focus.test.ts`
+  (calls `applyGridLayout()`), `minimize-project.test.tsx` (`gridScopeFor` from
+  `grid-layout.js`) and `events-focus.test.ts` (drops the `renderGrid` dep).
+  Forecast here as needing updates but in the event not touched, because they
+  mock `view.js` or drive it through commands that survive: `view-floor.test.ts`,
+  `xterm-reflow.test.ts`, `attention-jump.test.ts`,
+  `attention-jump-integration.test.ts`, `test/dom/nav-history.test.ts`.
+  `src/app/view.ts` itself is NOT deleted this phase — Phase 6's scope owns
+  that; what goes here is its render half.
 - Phase 6 — New: `test/dom/app-shell.test.tsx` (single root mounts all regions, ids present). Sweep: no test imports a deleted module.
 
 ## Known spec-edit exceptions
 
 Exactly one is sanctioned, surfaced by the Phase 0 review and carried into the
 phase plans that hit it: `test/e2e/nav-history.spec.ts:100` mutates the store's
-`minimized` Set in place. It works until a component subscribes to `minimized`
-(Phase 2's tray, Phase 5's grid), at which point that phase changes the line to
-call an action. It is not a DOM-contract break. Every other spec edit still
-means the contract broke.
+`minimized` Set in place. It worked until a component subscribed to `minimized`: Phase 2's tray got there
+first and converted the line to an assignment (`s.minimized = new Set([...])`,
+which routes through `setMinimized`), so Phase 5's grid found it already
+correct and changed no spec. It was not a DOM-contract break. Every other spec
+edit still means the contract broke.
 
 ## Verification
 
@@ -448,6 +461,87 @@ its own `return` — the ladder's shape is what the table-driven test pins.
   and a backdrop click resolve to it. Focus returns to the opener only if it is
   still connected (deleting a worktree takes its row's button with it).
 
+### Phase 5 — grid shell (written 2026-09-03 against `main` @ e6757d0)
+
+**Verbatim-move list.** Everything below moves from `src/app/view.ts` to the
+new `src/app/grid-layout.ts` unchanged except for the two mechanical edits
+named in "lines that change". Nothing else in these bodies is touched.
+
+| From `view.ts` | To `grid-layout.ts` | Lines that change |
+|---|---|---|
+| `showSingle()` :66 | `applySingle(id)` | rename; `state.terms` → `allTerms()` / `getTerm()` |
+| `_ric` :230 | `_ric` | none |
+| `attachDeferred()` :234 | `attachDeferred` | none |
+| `renderGrid()` :249 | `applyGridLayout()` | rename; `deps.ensureTerm` → imported `ensureTerm`; `deps.scrollTrace` → imported `scrollTrace`; `state.terms` → registry |
+| `gridLayout` cache :210 | module-local + `getGridLayout()` | export accessor for `gridSpatialMove` |
+| `rebaselineGridReplayCols()` :592 | exported | none |
+| `gridScopeFor()` :467, `gridScopeSessions()` :486 | same | none |
+| `#terms` ResizeObserver :665-679 | same | `renderGrid()` → `applyGridLayout()` |
+
+Stays in `view.ts` (commands, not rendering): `isSessionHidden` — it reads
+nothing but the store, and moving it would pull `grid-layout.ts`'s module-scope
+ResizeObserver into `keyboard.ts`'s import graph, which four dom tests mock
+`view.js` specifically to avoid — plus `switchTo`, `switchToProject`,
+`firstVisible`, `fallBackToSingleIfActiveHidden`, `gridSpatialMove`,
+`shiftActiveProject`, `minimizeSession`, `restoreSession`, `minimizeProject`,
+`restoreProject`, `enforceViewFloor`, `setView`, `updateAppTitle`. Each loses
+its `renderGrid()` / `showSingle()` call; the store write that used to precede
+it is what repaints now. `view.ts` is deleted in Phase 6, not here — Phase 6's
+scope line is the authority; this plan's Tests line ("`src/app/view.js`
+(deleted this phase)") is corrected to mean `initView` and the render exports.
+
+**Trigger model.** `GridView` subscribes to a *derived layout signature*, not
+to `sessions`:
+
+```
+`${view}|${activeId}|${gridProjectId}|${gridScopeSessions().map(s => s.id).join('\0')}`
+```
+
+and its single `useLayoutEffect` depends on that string alone. Two findings
+force this shape, both verified in the current code:
+
+- **`attention` must NOT be a dependency**, though this plan's Scope line
+  listed it. Today the attention class is patched straight onto the host by
+  `events.ts:174/177/184/226` and `focus.ts:54` — a bell never calls
+  `renderGrid()`. Subscribing to it would repaint on every bell, and
+  `attachDeferred` calls `ensureAttached()` on every in-grid tile, which
+  re-latches follow-bottom (invariant 2). `applyGridLayout` keeps setting the
+  class during a pass, reading `attention` non-reactively from
+  `store.getState()` — exactly what `renderGrid` does today.
+- **Raw `sessions` must NOT be a dependency.** `session:event(updated)` is the
+  high-frequency kind (one per phase step, one per surviving session after a
+  kill recompacts order, one per agent-id capture poll) and replaces the array
+  reference every time. Today only two of those branches repaint
+  (`events.ts:460` removal, `:469` order change) — both of which change the
+  signature. A rename changes the array but not the signature, and today it
+  does not repaint either.
+
+**Ordering.** Store writes made by a command that has post-layout work
+(`focusActiveTerm`, `snapVisibleTermsToBottom`, `rebaselineGridReplayCols`) are
+wrapped in `flushSync` so the layout effect has already run when that work
+starts — the same pattern the six modals adopted in Phases 3-4 for plain
+listeners. Without it the effect would land after `focusActiveTerm`, inverting
+invariants 3 and 4.
+
+**Call sites that lose their explicit repaint** (the store write now carries
+it): `events.ts` `deps.renderGrid` (seam field deleted, both calls with it);
+`session-term.ts:620-628` mousedown (`setActive` alone — the `activeId` change
+repaints); `main.ts`'s `renderGrid` import and its `wireDaemonEvents` argument.
+
+**Known behaviour delta, accepted:** `switchTo(id)` where `id` is already
+active in a grid view used to run a full `renderGrid()` and thereby re-anchor
+every background tile to the bottom. It now repaints nothing (no signature
+change); the active tile still gets its explicit
+`snapVisibleTermsToBottom([st])`. This is strictly fewer `ensureAttached()`
+calls, which is the direction the invariant allows.
+
+**Mount point.** `GridView` renders `null`, so it needs a container of its own
+rather than `#terms` (whose children are the terminal hosts React must never
+own): `index.html` gains `<div id="grid-root" hidden></div>`. `hidden` is
+`display: none`, so it is not a grid item and the `#app` row placement — every
+region of which is placed explicitly — is unchanged. Phase 6 removes the
+element with the island array.
+
 ## PR convergence ledger
 
 This feature ships as seven PRs against one spec, so convergence is recorded
@@ -461,7 +555,7 @@ test.
 - **Phase 1** — PR #317 — verdict: COMMENT; threads_open: 0; action: stop; head_sha: 9b68a26. Merged 2026-09-02 (`950dfaf`). Gate: not run.
 - **Phase 2** — PR #318 — verdict: APPROVE; threads_open: 0; action: stop; head_sha: 26697ec. Merged 2026-09-02 (`fff838f`). Gate: not run.
 - **Phase 3** — PR #319 — verdict: APPROVE; threads_open: 0; action: stop; head_sha: a65813f. Merged 2026-09-03 (`7af0f7c`). Gate: not run.
-- **Phase 4** — PR #320 — verdict: APPROVE; threads_open: 0; action: stop; head_sha: 8439446. Open, awaiting the gate. Five review iterations; see [phase4](../completed/react-ui-rewrite-phase4.md#pr-convergence-ledger). Gate PASS 2026-09-03 (doc accuracy failed twice on stale counts in the plan's own bookkeeping, fixed both times on the branch).
+- **Phase 4** — PR #320 — verdict: APPROVE; threads_open: 0; action: stop; head_sha: 8439446. Merged 2026-09-03 (`d794caa`). Five review iterations; see [phase4](../completed/react-ui-rewrite-phase4.md#pr-convergence-ledger). Gate PASS 2026-09-03 (doc accuracy failed twice on stale counts in the plan's own bookkeeping, fixed both times on the branch).
 
 ## Gate verdict
 

--- a/docs/product-specs/react-ui-rewrite.md
+++ b/docs/product-specs/react-ui-rewrite.md
@@ -4,7 +4,7 @@ title: "Incremental React 19 rewrite of the hivegui frontend"
 type: enhancement
 complexity: L
 priority: P2
-pr: 320
+pr: 321
 stage: IMPLEMENT
 ---
 


### PR DESCRIPTION
Phase 5 of the [React UI rewrite](docs/exec-plans/active/react-ui-rewrite.md) — [phase plan](docs/exec-plans/active/react-ui-rewrite-phase5.md). Behaviour-preserving; `no-changeset`.

## What moved

`src/app/grid-layout.ts` (new) takes the grid's DOM half out of `view.ts` **verbatim**: `applyGridLayout` (was `renderGrid`), `applySingle` (was `showSingle`), `attachDeferred` + `_ric`, the layout cache (`currentGridLayout()` / `spatialTarget()`), `gridScopeFor`, `gridScopeSessions`, `rebaselineGridReplayCols` and the `#terms` ResizeObserver. The only edits are the renames and `state.terms` → the `store/terms.ts` registry. Its order of operations encodes shipped bug fixes (template before attach, reparent-never-recreate, the idle attach stagger), so it is not re-expressed as JSX children.

`src/components/GridView.tsx` (new) owns *when*: renders `null`, one `useLayoutEffect`.

`view.ts` keeps the commands and loses every render call. `events.ts` loses its `renderGrid` deps field and both calls; `session-term.ts`'s mousedown is `setActive` alone; `main.ts` mounts the island on a new hidden `#grid-root` (`#terms`' children are SessionTerm hosts React must never own).

## Two deviations from the phase plan, both verified in code

- **`attention` is NOT a GridView dependency**, though the plan's Scope line listed it. A bell never called `renderGrid()` — `events.ts:174/177/184/226` and `focus.ts:54` patch the class straight onto the host. Subscribing would run a full pass per bell, and every pass calls `ensureAttached()` on every in-grid tile, which re-latches follow-bottom (invariant 2) — background tiles would be dragged out of scrollback history at bell rate. Same reasoning retires raw `sessions`: an `updated` event replaces the array at a child program's redraw rate, and today only a removal or a reorder repaints. GridView instead subscribes to a derived signature: `view | activeId | gridProjectId | ordered ids of the tiled scope`. `applyGridLayout()` still reads `attention` non-reactively during a pass, exactly as `renderGrid()` did.
- **`src/app/view.ts` is not deleted here** — Phase 6's scope owns that. The master plan's Tests line has been corrected to mean its render half.

## Ordering

`switchTo` and `setView` do focus and bottom-snap work *after* the repaint, so their store writes go through `view.ts`'s `withLayout()` → `flushSync` (depth-guarded, because these commands call each other and React does not allow a nested flush). Without it the effect lands in a microtask after the caller returned and `snapVisibleTermsToBottom` measures a tile the grid has not laid out — invariants 3 and 4.

## Spec edits

**None.** Phase 0's review earmarked `test/e2e/nav-history.spec.ts:100` as this phase's one sanctioned edit; Phase 2 got there first and already converted it to an assignment through `setMinimized`.

## Accepted behaviour delta

`switchTo(id)` where `id` is already active in a grid view used to run a full `renderGrid()`, re-anchoring every background tile to the bottom. It now repaints nothing (no signature change); the active tile still gets its explicit `snapVisibleTermsToBottom([st])`. Strictly fewer `ensureAttached()` calls — the direction the success criterion allows.

## Verification

Fresh worktree after `./scripts/ci-bootstrap.sh`:

- `npm run typecheck` clean; `biome ci .` clean; `scripts/ui-lint.sh --strict` 0 violations
- unit 403 passed; dom 539 passed (51 files); `go test ./...` all packages ok
- e2e 258 passed / 31 skipped, **three consecutive runs** (Phase 5 timing-flake requirement)
- `npm run test:e2e:real` 22 passed
- `wails build` (never `-s`) builds; the manual smoke — attach, resize, view toggle, background-tile scroll, minimize/restore, theme switch — is on the reviewer.

New `test/dom/grid-layout.test.tsx` (8 cases): template-before-attach as a spy sequence, reparent-not-recreate by node identity, out-of-scope tile keeps its node; plus GridView renders no DOM, repaints on a scope change, and does **not** repaint on a bell or a rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)