### PR TITLE
chore: gate pass for React rewrite phase 5

### DIFF
--- a/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/grid-scroll-regressions.spec.ts
@@ -161,7 +161,7 @@ test.describe('#208 grid-mode scroll regressions', () => {
   // history, replay MUST fire.
   //
   // Runs in SINGLE view on purpose. In grid, the container ResizeObserver
-  // routes a viewport change through renderGrid → ensureAttached, which
+  // routes a viewport change through applyGridLayout → ensureAttached, which
   // re-latches _followBottom to true for every tile (see attachDeferred) —
   // so a grid tile cannot be held scrolled-up across a resize by design.
   // The single-view observer early-returns (view.ts), so the scrolled-up

--- a/cmd/hivegui/frontend/test/e2e/nav-history.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/nav-history.spec.ts
@@ -88,7 +88,7 @@ test.describe('session back / forward history', () => {
     page,
   }) => {
     // The regression this catches: gridScopeSessions filters
-    // state.minimized and renderGrid strips .in-grid from every tile
+    // state.minimized and the layout pass strips .in-grid from every tile
     // outside the scope, so a bare switchTo makes the session active
     // with a zero-area tile and keyboard focus on <body> — keystrokes
     // silently dropped. Only a real browser sees the layout, which is

--- a/cmd/hivegui/frontend/test/e2e/session-lifecycle.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/session-lifecycle.spec.ts
@@ -144,7 +144,7 @@ test('closing a session in grid mode repaints the grid', async ({ page }) => {
   await expect(page.locator('.term-host.in-grid')).toHaveCount(4);
 
   // The layout signature: the container's track template plus each
-  // tile's row span. renderGrid gives the tile above a trailing empty
+  // tile's row span. applyGridLayout gives the tile above a trailing empty
   // cell a `span 2` so the grid has no hole — which is exactly what a
   // missing repaint leaves behind.
   const layout = () =>

--- a/docs/exec-plans/active/react-ui-rewrite.md
+++ b/docs/exec-plans/active/react-ui-rewrite.md
@@ -2,8 +2,8 @@
 
 - **Spec:** [docs/product-specs/react-ui-rewrite.md](../../product-specs/react-ui-rewrite.md)
 - **Issue:** —
-- **PR:** [#321](https://github.com/lucascaro/hive/pull/321) — the phase currently in flight (Phase 5). This field tracks the open phase PR, because the spec's `Exec plan:` link points here and `/hs-merge-gate` resolves the plan through it; the per-phase PRs are in the table under [Phases](#phases).
-- **Branch:** `feature/react-phase5-grid-shell`
+- **PR:** — (no phase PR open; Phase 5 merged as [#321](https://github.com/lucascaro/hive/pull/321), Phase 6 not started). This field tracks the open phase PR, because the spec's `Exec plan:` link points here and `/hs-merge-gate` resolves the plan through it; the per-phase PRs are in the table under [Phases](#phases).
+- **Branch:** —
 - **Status:** active
 
 ## Summary
@@ -123,7 +123,7 @@ implemented — the briefs deliberately do not all exist up front.
 | 2 — chrome island | [phase2](react-ui-rewrite-phase2.md) | #318 | **merged** |
 | 3 — modals A | [phase3](react-ui-rewrite-phase3.md) | #319 | **merged** (PR merged 2026-09-02; its gate has not been recorded, so the plan stays in `active/` for `/hs-merge-gate`) |
 | 4 — modals B + keyboard | [phase4](../completed/react-ui-rewrite-phase4.md) | #320 | **merged** (2026-09-03, `d794caa`); gate PASS |
-| 5 — grid shell | [phase5](react-ui-rewrite-phase5.md) | #321 | **in flight** |
+| 5 — grid shell | [phase5](../completed/react-ui-rewrite-phase5.md) | #321 | **merged** (2026-09-03, `b9ca655`); gate PASS |
 | 6 — single root + deletion | [phase6](react-ui-rewrite-phase6.md) | — | not started |
 
 **Carried into Phase 6's deletion sweep** (each verified to have zero production
@@ -153,11 +153,12 @@ RTL = `@testing-library/react`. All rewritten tests keep asserting the same clas
   review — the mid-edit repaint, two keyboard-strand-on-close cases, and five
   covering the answers that delete a branch on a remote, which had no coverage
   at all. (Derivation: `grep -cE "^\s*it\("` on each side of `main...HEAD`.) Planned as rewrites but neither turned out to need one — corrected here at the gate rather than left as a forecast the shipped code contradicts: `focus-trap.test.ts` exercises pure helpers whose signatures did not change, so it took an import repoint (and two cases for the new nullable container) and stays plain jsdom; `keyboard-arrows.test.ts` covers arrow routing *below* the modal ladder and was not touched at all. New: `test/dom/choice-dialog.test.tsx` (open → answer → auto-cleanup, keyboard never stranded), `test/dom/keyboard-precedence.test.tsx` (table-driven over all 9 layers, store-backed ladder matches legacy order), `test/dom/inline-rename.test.ts` (the identity guard a React cleanup depends on), and dom coverage for the three modals that had none: `command-palette`, `project-editor`, `help-overlay`.
-- Phase 5 — New: `test/dom/grid-layout.test.tsx` (8 cases: spy-sequence asserts
+- Phase 5 — New: `test/dom/grid-layout.test.tsx` (10 cases: spy-sequence asserts
   template-set-before-attach; reparent not recreate — same node identity across
   passes; out-of-scope tile keeps its DOM node; and on the React half, GridView
-  renders no DOM, repaints on a scope change, and does NOT repaint on a bell or
-  a rename). Repointed to the new entry points: `grid-reorder-focus.test.ts`
+  renders no DOM, repaints on a scope change and on a reorder, swaps to the
+  single-tile layout on a view change, does NOT repaint on a bell or a rename,
+  and re-attaches a reselected active tile without running a pass). Repointed to the new entry points: `grid-reorder-focus.test.ts`
   (calls `applyGridLayout()`), `minimize-project.test.tsx` (`gridScopeFor` from
   `grid-layout.js`) and `events-focus.test.ts` (drops the `renderGrid` dep).
   Forecast here as needing updates but in the event not touched, because they
@@ -556,6 +557,7 @@ test.
 - **Phase 2** — PR #318 — verdict: APPROVE; threads_open: 0; action: stop; head_sha: 26697ec. Merged 2026-09-02 (`fff838f`). Gate: not run.
 - **Phase 3** — PR #319 — verdict: APPROVE; threads_open: 0; action: stop; head_sha: a65813f. Merged 2026-09-03 (`7af0f7c`). Gate: not run.
 - **Phase 4** — PR #320 — verdict: APPROVE; threads_open: 0; action: stop; head_sha: 8439446. Merged 2026-09-03 (`d794caa`). Five review iterations; see [phase4](../completed/react-ui-rewrite-phase4.md#pr-convergence-ledger). Gate PASS 2026-09-03 (doc accuracy failed twice on stale counts in the plan's own bookkeeping, fixed both times on the branch).
+- **Phase 5** — PR #321 — verdict: COMMENT; threads_open: 0; action: stop; head_sha: ac1158f. Merged 2026-09-03 (`b9ca655`). Two review iterations; see [phase5](../completed/react-ui-rewrite-phase5.md#pr-convergence-ledger). Gate ran post-merge: FAIL on two stale doc claims, then PASS on the re-run once they were fixed.
 
 ## Gate verdict
 

--- a/docs/exec-plans/completed/react-ui-rewrite-phase5.md
+++ b/docs/exec-plans/completed/react-ui-rewrite-phase5.md
@@ -1,11 +1,11 @@
 # React UI rewrite — Phase 5: Grid shell
 
-- **Master plan:** [react-ui-rewrite.md](react-ui-rewrite.md)
+- **Master plan:** [react-ui-rewrite.md](../active/react-ui-rewrite.md)
 - **Spec:** [docs/product-specs/react-ui-rewrite.md](../../product-specs/react-ui-rewrite.md)
 - **Issue:** —
 - **PR:** [#321](https://github.com/lucascaro/hive/pull/321)
 - **Branch:** `feature/react-phase5-grid-shell`
-- **Status:** active
+- **Status:** completed
 
 All paths relative to `cmd/hivegui/frontend/` unless rooted.
 
@@ -129,10 +129,11 @@ bar the renames and the `state.terms` → `store/terms.ts` registry swap) and
 field and both calls; `session-term.ts`'s mousedown is `setActive` alone;
 `main.ts` mounts the island on the new `#grid-root`.
 
-Tests: new `test/dom/grid-layout.test.tsx` (8 cases — template-before-attach as
-a spy sequence, reparent-not-recreate by node identity, out-of-scope tile keeps
-its node, plus GridView renders no DOM, repaints on a scope change, and does
-NOT repaint on a bell or a rename). `grid-reorder-focus.test.ts` and
+Tests: new `test/dom/grid-layout.test.tsx` (10 cases — template-before-attach
+as a spy sequence, reparent-not-recreate by node identity, out-of-scope tile
+keeps its node, plus GridView renders no DOM, repaints on a scope change and on
+a reorder, swaps to the single-tile layout on a view change, does NOT repaint on
+a bell or a rename, and re-attaches a reselected active tile without a pass). `grid-reorder-focus.test.ts` and
 `minimize-project.test.tsx` repoint to the new entry points;
 `events-focus.test.ts` drops the `renderGrid` dep. `view-floor`,
 `xterm-reflow`, `attention-jump`, `attention-jump-integration` and dom
@@ -154,7 +155,7 @@ verification block; everything else in it was already green on this branch.
 
 Maintained by hand: `/hs-review-loop` writes into a plan it finds by an
 `<NNN>`-prefixed name, which this feature's plans do not have (see the master
-plan's [Gating convention](react-ui-rewrite.md#gating-convention)).
+plan's [Gating convention](../active/react-ui-rewrite.md#gating-convention)).
 
 - **2026-09-03 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: e37a62b8; threads_open: 0; action: autofix+push; head_sha: 98bc37e. Autofix applied 5 safe fixes (the load-bearing one: the new dom test's deferred-attach `setTimeout` fired after jsdom teardown and made the Linux leg exit 1 with every test passing — fake timers fixed it). 2 risky items surfaced for a human call.
 - **2026-09-03 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: c247977c; threads_open: 0; action: stop (escalated: risky fix needs human decision); head_sha: 99ea356. Zero BLOCKING, zero MINOR surviving; the one IMPORTANT is the accepted `switchTo(activeId)` delta, re-raised because no test pins the `needsReattach` half of it.
@@ -162,5 +163,20 @@ plan's [Gating convention](react-ui-rewrite.md#gating-convention)).
 
 ## Gate verdict
 
-Not yet run. `/hs-merge-gate` must be pointed at THIS plan, not the master plan
-the spec's `Exec plan:` link resolves to — its success criteria are Phase 6's.
+Run against THIS plan's success criteria, not the master plan's — the spec's
+`Exec plan:` link resolves to the master plan, whose criteria are Phase 6's.
+Both entries below are from the **degraded post-merge path**: PR #321 merged
+(`b9ca655`) before the gate ran, so the range under test was
+`b9ca655~1..b9ca655`.
+
+- **2026-09-03** — verdict: FAIL; checks: 2 dimensions passed / 1 failed / 2 followups; followups: none filed (both items were documentation, fixed in the gate's own bookkeeping commit rather than tracked as debt); one-line: code and non-goals clean, two stale doc claims.
+  - 2026-09-03 dimensions:
+    - acceptance — NEEDS_FOLLOWUP — all seven criteria verified, two of them adversarially: reversing the `gridTemplate*` assignment to after the attach loop makes the spy-sequence test fail (`expected '' to match /^repeat\(\d+, 1fr\)$/`), and forcing a fresh host per pass fails four identity (`toBe`) assertions. The `renderGrid`/`showSingle` bodies byte-diff against `applyGridLayout`/`applySingle` with only the documented renames. Open only because the validator did not reproduce the "e2e 3× consecutively + `wails build` smoke" sub-claim.
+    - non-goals — PASS — zero CSS, zero `hv-*`, zero `data-testid`, `test/e2e` untouched (0 lines — the "zero spec edits" claim holds), `keyboard.ts`/`bridge.ts`/`*.go` untouched, invariants 1/5/6/9 intact. Both behaviour deltas in the diff match this plan's Decision log verbatim; no undeclared third.
+    - doc accuracy — FAIL — (a) this plan's Progress and the master plan's Tests bullet both said `grid-layout.test.tsx` has "8 cases"; it has 10. (b) Three e2e specs described current behaviour in the present tense using the retired name `renderGrid`: `nav-history.spec.ts:91`, `session-lifecycle.spec.ts:147`, `grid-scroll-regressions.spec.ts:164`. Changeset, master-plan brief and the Phase 6 doc assignment all check out.
+
+- **2026-09-03 (re-run after fixes)** — verdict: PASS; checks: 3 dimensions passed / 0 failed / 0 followups; followups: none; one-line: both doc-accuracy items fixed and the acceptance follow-up closed by re-running the suite.
+  - 2026-09-03 dimensions:
+    - acceptance — PASS — e2e re-run **three consecutive times on the merged code**: 258 passed / 31 skipped each time. The `wails build` smoke (attach, resize, view toggle, background-tile scroll, minimize/restore, theme switch) passed on the branch build; the single commit after it — the one-line reselect `ensureAttached()` — was not re-smoked by hand and is covered by CI on all three platforms plus its own dom test.
+    - non-goals — PASS — unchanged from the first run.
+    - doc accuracy — PASS — the "8 cases" claim corrected to 10 in both plans; the three e2e comments now name the layout pass / `applyGridLayout`. Comment-only edits, no selector or assertion touched.


### PR DESCRIPTION
Bookkeeping-only follow-up to #321, which merged before `/hs-merge-gate` ran. No production code.

The gate ran on its degraded post-merge path (range `b9ca655~1..b9ca655`), against **the phase plan's** success criteria rather than the spec's — the spec's criteria describe the finished migration and are Phase 6's gate, per the master plan's `## Gating convention`.

## Verdict: FAIL, then PASS after the fixes in this PR

**acceptance — PASS.** All seven criteria verified, two adversarially by mutation:
- reversing the `gridTemplate*` assignment to after the attach loop makes the spy-sequence test fail (`expected '' to match /^repeat\(\d+, 1fr\)$/`), so it really does pin the ordering that the double-scrollback-restream fix depends on;
- forcing a fresh host element per pass fails four `toBe` identity assertions, so reparent-never-recreate is identity-sensitive.

The `renderGrid`/`showSingle` bodies byte-diff against `applyGridLayout`/`applySingle` with only the documented renames. e2e re-run **three consecutive times on the merged code**: 258 passed / 31 skipped each time.

**non-goals — PASS.** Zero CSS, zero `hv-*`, zero `data-testid`; `test/e2e` had 0 changed lines in #321 (the "zero spec edits" claim holds); `keyboard.ts`, `bridge.ts` and all Go untouched; invariants 1/5/6/9 intact. Both behaviour deltas in the diff match the plan's Decision log verbatim, with no undeclared third.

**doc accuracy — FAIL, fixed here.** Two stale claims:
1. Both plans said `grid-layout.test.tsx` has "8 cases". It has 10 — the count was written before review added one case and the gate-escalation fix added another. Corrected in the phase plan's Progress and the master plan's Tests bullet.
2. Three e2e specs described *current* behaviour in the present tense using the retired name `renderGrid` — `nav-history.spec.ts:91`, `session-lifecycle.spec.ts:147`, `grid-scroll-regressions.spec.ts:164`. Renamed to the layout pass / `applyGridLayout`. Comment-only: no selector, no assertion, no test logic touched.

These were fixed rather than filed as follow-up issues: the degraded path files issues because shipped code cannot be fixed in a merged PR, and neither of these is code.

## Bookkeeping

- Phase 5 plan → `docs/exec-plans/completed/`, `Status: completed`, gate verdict recorded (both entries, append-only).
- Master plan: Phases table marks Phase 5 merged + gate PASS, `PR:`/`Branch:` cleared (no phase PR is open), convergence-ledger index line added for Phase 5.
- The spec's frontmatter `stage:` deliberately **stays `IMPLEMENT`** and no `shipped:` date is set — this feature ships across seven PRs and only reaches `DONE` after the Phase 6 gate, exactly as `ui-design-system` did.

Next phase is 6 — single root, legacy deletion, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)