### PR TITLE
docs: name the gate labels in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,11 @@ These skills are provided by [hivesmith](https://github.com/lucascaro/hivesmith)
 
 ### GitHub Labels
 
-Each stage has a corresponding label applied to the GitHub issue: `triaged`, `researching`, `planned`, `implementing`. The `/hs-feature-*` commands manage these automatically.
+Each stage has a corresponding label applied to the GitHub issue: `triaged`,
+`researching`, `planned`, `implementing`, `gate`. `/hs-merge-gate` then swaps
+`gate` for its verdict: `gate-passed`, `gate-failed`, or `gate-followup`. The
+`/hs-feature-*`, `/hs-review-loop` and `/hs-merge-gate` commands manage these
+automatically.
 
 ### Ingesting New Issues
 


### PR DESCRIPTION
Docs-only. `no-changeset` applied per the pre-push hook's own instruction for docs/CI-only changes.

## What

`AGENTS.md` › "GitHub Labels" listed only `triaged`, `researching`, `planned`, `implementing` — it stopped at the stage the pipeline had before the merge gate existed, and never named `gate` or the three verdict labels `/hs-merge-gate` applies.

## Why now

The repo's actual labels had drifted the same way, and it broke a live run: while shipping #323 the gate's `gh issue edit --add-label gate` failed with `'gate' not found`, because the repo still carried the pre-rename `qa` / `qa-passed` / `qa-followup` set. `gate-failed` did not exist at all — so a FAIL verdict would have hit the same error at the exact moment the gate had something important to say.

Fixed on GitHub alongside this PR:

| old | new | issues carried |
|---|---|---|
| `qa` | `gate` | 6 |
| `qa-passed` | `gate-passed` | 7 |
| `qa-followup` | `gate-followup` | 0 |
| — | `gate-failed` (created) | 0 |

Renamed in place rather than recreated, so every existing assignment carried over; counts verified identical before and after.

This PR is the documentation catching up to that.

## Scope

The edit is at `AGENTS.md:280`, outside the `<!-- BEGIN HIVESMITH -->` block (line 332), so `/hs-hivesmith-init` will not overwrite it. The managed block already described the `GATE` stage and `/hs-merge-gate` correctly and is untouched.

Not changed: `AGENTS.md:296` (`QA, test the site → invoke qa`) refers to the gstack `/qa` skill, unrelated to labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)