### PR TITLE
fix(gui): keep focus put while the close confirmation is up

### DIFF
--- a/.changesets/330-close-confirm-no-switch.md
+++ b/.changesets/330-close-confirm-no-switch.md
@@ -1,6 +1,6 @@
 ---
 issue: 330
-pr: null
+pr: 331
 type: fixed
 bump: patch
 ---

--- a/.changesets/330-close-confirm-no-switch.md
+++ b/.changesets/330-close-confirm-no-switch.md
@@ -1,0 +1,12 @@
+---
+issue: 330
+pr: null
+type: fixed
+bump: patch
+---
+- Closing a session no longer moves you to a different session while the
+  "Close this session anyway?" confirmation is on screen. The jump used to
+  happen during the daemon's pre-flight worktree check — before you had been
+  asked anything — so the dialog appeared over a neighbouring session and
+  cancelling left you there. Focus now moves only once the session is really
+  closing.

--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -43,7 +43,7 @@ import { orderedSessions } from './selectors.js';
 import { handleWorktreesPayload } from './modals/worktrees.js';
 import { openChoiceDialog } from './modals/choice-dialog.js';
 import type { WorktreesPayload } from '../lib/worktrees.js';
-import { phaseOf, isReady, isClosing } from '../lib/phase-steps.js';
+import { PHASE, phaseOf, isReady, isClosing } from '../lib/phase-steps.js';
 import { pruneNav } from '../lib/nav-history.js';
 import { handleScrollbackEvent, abandonReplays } from '../lib/scrollback.js';
 import { createScrollTrace } from '../lib/scroll-debug.js';
@@ -422,11 +422,18 @@ export function wireDaemonEvents(injected: EventsDeps) {
       if (i >= 0) updateSession(ev.session);
       return;
     }
-    if (ev.kind === 'updated' && isClosing(phaseOf(ev.session))) {
+    if (ev.kind === 'updated' && phaseOf(ev.session) === PHASE.closing) {
       // Don't make the user watch a teardown: the moment the daemon
       // starts closing, hand focus to the neighbour. The tile itself
       // stays (dimmed) until `removed` lands, which can be seconds
       // later on a big worktree.
+      //
+      // `closing` only, not isClosing() — that also covers `checking`,
+      // the daemon's pre-flight `git status` on the worktree, which can
+      // still end in a refusal and the "Close this session anyway?"
+      // dialog. Switching then puts that dialog over a different
+      // session than the one it is about, and a cancel leaves the user
+      // parked on the neighbour.
       if (appData().activeId === ev.session.id) {
         const next = neighbourOf(ev.session.id);
         if (next) deps.switchTo(next);

--- a/cmd/hivegui/frontend/test/dom/close-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/close-focus.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+//
+// Regression test for the focus switch on the close path
+// (src/app/events.ts, session:event kind `updated`).
+//
+// The daemon publishes phase `checking` while it runs the pre-flight
+// `git status` on the session's worktree, and that check can still end
+// in a refusal — the "Close this session anyway?" dialog. The switch
+// used to fire on isClosing(), which covers `checking` too, so the
+// dialog appeared over a *different* session than the one it was about
+// and a cancel left the user parked on the neighbour.
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { createScrollTrace } from '../../src/lib/scroll-debug.js';
+import * as store from '../../src/store/store.js';
+
+// The bridge re-exports the Wails runtime, which doesn't exist under
+// vitest. Mock the full surface so the whole src/app import graph
+// resolves; EventsOn is the seam this test drives.
+vi.mock('../../src/bridge.js', () => {
+  const fn = () => vi.fn(() => Promise.resolve());
+  return {
+    ConnectControl: fn(),
+    OpenSession: fn(),
+    CloseAttach: fn(),
+    WriteStdin: fn(),
+    ResizeSession: fn(),
+    RequestScrollbackReplay: fn(),
+    CreateSession: fn(),
+    DuplicateSession: fn(),
+    KillSession: fn(),
+    KillSessionAndWorktree: fn(),
+    RestartSession: fn(),
+    UpdateSession: fn(),
+    RestoreSession: fn(),
+    ListAgents: fn(),
+    ListCustomAgents: fn(),
+    SaveCustomAgents: fn(),
+    CreateProject: fn(),
+    KillProject: fn(),
+    UpdateProject: fn(),
+    LaunchDir: fn(),
+    PickDirectory: fn(),
+    OpenNewWindow: fn(),
+    CloseWindow: fn(),
+    IsGitRepo: fn(),
+    OpenURL: fn(),
+    OpenTerminalAt: fn(),
+    Notify: fn(),
+    Confirm: fn(),
+    RestartDaemon: fn(),
+    CheckForUpdate: fn(),
+    SetClipboardText: fn(),
+    LogFrontend: vi.fn(),
+    EventsOn: vi.fn(),
+    WindowSetTitle: vi.fn(),
+    ClipboardGetText: fn(),
+  };
+});
+
+let bridge: typeof import('../../src/bridge.js');
+let state: typeof import('../../src/store/store.js').hiveStateView;
+let wireDaemonEvents: typeof import('../../src/app/events.js').wireDaemonEvents;
+
+const SESSIONS = [
+  { id: 's1', name: 'one', order: 0 },
+  { id: 's2', name: 'two', order: 1 },
+];
+
+beforeAll(async () => {
+  // dom.ts dereferences these at import time.
+  document.body.innerHTML =
+    '<div id="terms"></div><ul id="projects"></ul><div id="status"><span id="status-text"></span><span id="status-hint"></span></div>';
+  bridge = await import('../../src/bridge.js');
+  ({ hiveStateView: state } = await import('../../src/store/store.js'));
+  ({ wireDaemonEvents } = await import('../../src/app/events.js'));
+});
+
+// Wires a fresh set of handlers and returns the session:event one plus
+// the switchTo spy it was built with.
+function sessionEventHandler() {
+  const switchTo = vi.fn();
+  vi.mocked(bridge.EventsOn).mockClear();
+  wireDaemonEvents({
+    switchTo,
+    enforceViewFloor: vi.fn(),
+    updateAppTitle: vi.fn(),
+    focusActiveTerm: vi.fn(),
+    refocusActiveTerm: vi.fn(),
+    isDaemonRestarting: () => false,
+    scrollTrace: createScrollTrace({ enabled: false }),
+  });
+  const call = vi
+    .mocked(bridge.EventsOn)
+    .mock.calls.find(([name]) => name === 'session:event');
+  if (!call) throw new Error('session:event handler was never registered');
+  return { emit: call[1] as (json: string) => void, switchTo };
+}
+
+function emitPhase(
+  emit: (json: string) => void,
+  id: string,
+  phase: string,
+): void {
+  const session = { ...SESSIONS.find((s) => s.id === id), phase };
+  emit(JSON.stringify({ kind: 'updated', session }));
+}
+
+beforeEach(() => {
+  store.setSessions(structuredClone(SESSIONS));
+  state.activeId = 's2';
+});
+
+describe('session:event updated — focus on the close path', () => {
+  it('keeps focus while the daemon is only checking the worktree', () => {
+    const { emit, switchTo } = sessionEventHandler();
+    emitPhase(emit, 's2', 'checking');
+    expect(switchTo).not.toHaveBeenCalled();
+  });
+
+  it('switches to the neighbour once the session is really closing', () => {
+    const { emit, switchTo } = sessionEventHandler();
+    emitPhase(emit, 's2', 'closing');
+    expect(switchTo).toHaveBeenCalledWith('s1');
+  });
+
+  it('leaves an inactive session alone while it closes', () => {
+    const { emit, switchTo } = sessionEventHandler();
+    emitPhase(emit, 's1', 'closing');
+    expect(switchTo).not.toHaveBeenCalled();
+  });
+});

--- a/cmd/hivegui/frontend/test/dom/close-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/close-focus.test.ts
@@ -101,7 +101,11 @@ function emitPhase(
   id: string,
   phase: string,
 ): void {
-  const session = { ...SESSIONS.find((s) => s.id === id), phase };
+  const known = SESSIONS.find((s) => s.id === id);
+  // Spreading a missing session would make the two negative assertions
+  // pass vacuously — an id typo has to fail loudly instead.
+  if (!known) throw new Error(`no such fixture session: ${id}`);
+  const session = { ...known, phase };
   emit(JSON.stringify({ kind: 'updated', session }));
 }
 

--- a/docs/exec-plans/active/close-confirm-no-switch.md
+++ b/docs/exec-plans/active/close-confirm-no-switch.md
@@ -66,6 +66,11 @@ worktree and is exactly when the user wants to see that something is happening.
 
 - **2026-09-03** — Plan-first scaffold; stage = IMPLEMENT (set in spec frontmatter).
 - **2026-09-03** — Implemented; PR #331 open; stage = REVIEW.
+- **2026-09-03** — Review loop converged (APPROVE, 1 iteration, 0 open threads); applied the one MINOR test-hygiene nit; stage = GATE.
+
+## PR convergence ledger
+
+- **2026-09-03 iter 1** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 53d3532.
 
 ## Open questions
 

--- a/docs/exec-plans/active/close-confirm-no-switch.md
+++ b/docs/exec-plans/active/close-confirm-no-switch.md
@@ -1,0 +1,69 @@
+# GUI: don't switch sessions while the close confirmation is up
+
+- **Spec:** [docs/product-specs/close-confirm-no-switch.md](../../product-specs/close-confirm-no-switch.md)
+- **Issue:** #330
+- **Status:** active
+
+## Summary
+
+Focus jumps to a neighbouring session during the pre-flight worktree check, so the
+worktree-dirty close dialog is shown over the wrong session. Narrow the focus-switch
+branch in `events.ts` to the real `closing` phase.
+
+## Research
+
+Authored via plan-first mode.
+
+- `cmd/hivegui/frontend/src/app/events.ts` — the `session:event` handler; the
+  `ev.kind === 'updated' && isClosing(phaseOf(ev.session))` branch hands focus to
+  `neighbourOf(...)` when the active session is going away. Same file's
+  `control:error` handler raises the three-way `worktree_dirty` choice dialog.
+- `cmd/hivegui/frontend/src/lib/phase-steps.ts` — `isClosing()` returns true for
+  both `checking` and `closing`; `PHASE` carries the phase constants.
+- `internal/registry/registry.go` — `Registry.kill` sets phase `checking`, runs
+  `worktree.HasUncommitted`, and on a dirty worktree sets the phase back to `ready`
+  and returns `ErrWorktreeDirty` without touching anything else. Phase `closing` is
+  only set past that pre-flight, i.e. once the close is really happening.
+- Other `isClosing()` callers — `src/app/session-term.ts` (tile `.closing`
+  dimming), `src/components/SessionRow.tsx` ("Closing…" label),
+  `src/app/events.ts` `pty:disconnect` guard — none switch focus, so the shared
+  predicate stays as-is.
+
+## Approach
+
+Narrow the one focus-switch site instead of redefining `isClosing()`: compare
+`phaseOf(ev.session)` against `PHASE.closing` directly. The alternative — dropping
+`checking` from `isClosing()` — would also stop the tile dimming and the "Closing…"
+row label during the pre-flight `git status`, which can take seconds on a large
+worktree and is exactly when the user wants to see that something is happening.
+
+### Files to change
+
+- `cmd/hivegui/frontend/src/app/events.ts` — switch focus only on `PHASE.closing`;
+  comment says why `checking` is excluded.
+
+### New files
+
+- `cmd/hivegui/frontend/test/dom/close-focus.test.ts` — regression test.
+- `.changesets/330-close-confirm-no-switch.md` — user-visible fix.
+
+### Tests
+
+- `close-focus.test.ts` › "keeps focus on the session while its worktree is only
+  being checked" — active session, `updated` with phase `checking`, `switchTo` spy
+  not called.
+- `close-focus.test.ts` › "switches to the neighbour once the session is really
+  closing" — same session, phase `closing`, `switchTo` called with the neighbour id.
+
+## Decision log
+
+- **2026-09-03** — Narrowed the call site, not `isClosing()`. Why: the other three
+  callers want `checking` included.
+
+## Progress
+
+- **2026-09-03** — Plan-first scaffold; stage = IMPLEMENT (set in spec frontmatter).
+
+## Open questions
+
+None.

--- a/docs/exec-plans/active/close-confirm-no-switch.md
+++ b/docs/exec-plans/active/close-confirm-no-switch.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/close-confirm-no-switch.md](../../product-specs/close-confirm-no-switch.md)
 - **Issue:** #330
+- **PR:** #331
+- **Branch:** `feature/330-close-confirm-no-switch`
 - **Status:** active
 
 ## Summary
@@ -63,6 +65,7 @@ worktree and is exactly when the user wants to see that something is happening.
 ## Progress
 
 - **2026-09-03** — Plan-first scaffold; stage = IMPLEMENT (set in spec frontmatter).
+- **2026-09-03** — Implemented; PR #331 open; stage = REVIEW.
 
 ## Open questions
 

--- a/docs/exec-plans/completed/close-confirm-no-switch.md
+++ b/docs/exec-plans/completed/close-confirm-no-switch.md
@@ -4,7 +4,7 @@
 - **Issue:** #330
 - **PR:** #331
 - **Branch:** `feature/330-close-confirm-no-switch`
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -66,11 +66,20 @@ worktree and is exactly when the user wants to see that something is happening.
 
 - **2026-09-03** — Plan-first scaffold; stage = IMPLEMENT (set in spec frontmatter).
 - **2026-09-03** — Implemented; PR #331 open; stage = REVIEW.
+- **2026-09-03** — Gate PASS; stage = DONE.
 - **2026-09-03** — Review loop converged (APPROVE, 1 iteration, 0 open threads); applied the one MINOR test-hygiene nit; stage = GATE.
 
 ## PR convergence ledger
 
 - **2026-09-03 iter 1** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 53d3532.
+
+## Gate verdict
+
+- **2026-09-03** — verdict: PASS; checks: 3 passed / 0 failed / 0 followups; followups: none; one-line: all three success criteria demonstrated, no non-goal bleed, changeset and docs accurate.
+  - 2026-09-03 dimensions:
+    - acceptance — PASS — `checking` no longer switches focus, `closing` still does, cancel leaves the user in place (daemon resets to ready on refusal).
+    - non-goals — PASS — `isClosing()` untouched and its three other callers still cover both phases; no Go/daemon change.
+    - doc accuracy — PASS — changeset present and schema-correct; spec/plan match the diff; no README/AGENTS.md claim invalidated.
 
 ## Open questions
 

--- a/docs/product-specs/close-confirm-no-switch.md
+++ b/docs/product-specs/close-confirm-no-switch.md
@@ -5,7 +5,7 @@ type: bug
 complexity: S
 priority: P2
 pr: 331
-stage: REVIEW
+stage: GATE
 ---
 
 # GUI: don't switch sessions while the close confirmation is up

--- a/docs/product-specs/close-confirm-no-switch.md
+++ b/docs/product-specs/close-confirm-no-switch.md
@@ -5,7 +5,8 @@ type: bug
 complexity: S
 priority: P2
 pr: 331
-stage: GATE
+stage: DONE
+shipped: 2026-09-03
 ---
 
 # GUI: don't switch sessions while the close confirmation is up
@@ -14,7 +15,7 @@ stage: GATE
 - **Type:** bug
 - **Complexity:** S
 - **Priority:** P2
-- **Exec plan:** [docs/exec-plans/active/close-confirm-no-switch.md](../exec-plans/active/close-confirm-no-switch.md)
+- **Exec plan:** [docs/exec-plans/completed/close-confirm-no-switch.md](../exec-plans/completed/close-confirm-no-switch.md)
 
 ## Problem
 

--- a/docs/product-specs/close-confirm-no-switch.md
+++ b/docs/product-specs/close-confirm-no-switch.md
@@ -1,0 +1,55 @@
+---
+issue: 330
+title: "GUI: don't switch sessions while the close confirmation is up"
+type: bug
+complexity: S
+priority: P2
+stage: IMPLEMENT
+---
+
+# GUI: don't switch sessions while the close confirmation is up
+
+- **Issue:** #330
+- **Type:** bug
+- **Complexity:** S
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/close-confirm-no-switch.md](../exec-plans/active/close-confirm-no-switch.md)
+
+## Problem
+
+Closing a session whose worktree has uncommitted changes makes the GUI jump to a
+neighbouring session before the "Close this session anyway?" dialog is shown. The
+daemon publishes a `checking` phase while it runs the pre-flight `git status`, and
+the GUI treats that as "already closing" and hands focus to the neighbour. The
+dialog therefore appears over a different session than the one being closed, which
+implies the wrong session is at risk — and cancelling leaves the user parked on the
+neighbour with no way back except manual navigation.
+
+## Desired behavior
+
+The active session stays focused for the whole confirmation. Focus moves to the
+neighbour only once the close is actually happening — after the user has confirmed,
+or immediately when there was nothing to confirm.
+
+## Success criteria
+
+- A `session:event` `updated` carrying phase `checking` for the active session does
+  not change the focused session.
+- A `session:event` `updated` carrying phase `closing` for the active session still
+  hands focus to the neighbour, as before.
+- Cancelling the worktree-dirty dialog leaves the user on the session they tried to
+  close.
+
+## Non-goals
+
+- Changing what `isClosing()` means for the tile dimming, the sidebar "Closing…"
+  label, or the `pty:disconnect` guard — those legitimately cover both phases.
+- Changing the daemon's phase sequence or the dirty pre-flight itself.
+
+## Notes
+
+Root cause: `cmd/hivegui/frontend/src/app/events.ts` switches on
+`isClosing(phaseOf(ev.session))`, and `isClosing()`
+(`cmd/hivegui/frontend/src/lib/phase-steps.ts`) covers both `checking` and `closing`.
+The daemon sets `checking` in `Registry.kill` (`internal/registry/registry.go`)
+before it may refuse with `ErrWorktreeDirty`.

--- a/docs/product-specs/close-confirm-no-switch.md
+++ b/docs/product-specs/close-confirm-no-switch.md
@@ -4,7 +4,8 @@ title: "GUI: don't switch sessions while the close confirmation is up"
 type: bug
 complexity: S
 priority: P2
-stage: IMPLEMENT
+pr: 331
+stage: REVIEW
 ---
 
 # GUI: don't switch sessions while the close confirmation is up


### PR DESCRIPTION
Fixes #330

## What

Closing a session whose worktree has uncommitted changes moved focus to a neighbouring session **before** the "Close this session anyway?" dialog appeared — so the dialog looked like it was about the session now in view, and cancelling left the user parked on the neighbour.

## Root cause

`src/app/events.ts` switched focus on `isClosing(phaseOf(ev.session))`. `isClosing()` (`src/lib/phase-steps.ts`) covers `checking` as well as `closing`, and `checking` is the daemon's pre-flight `git status` (`Registry.kill`, `internal/registry/registry.go`) — the exact window in which the close can still be refused with `worktree_dirty`.

## Fix

Narrow that one call site to `PHASE.closing`. `isClosing()` itself is unchanged: its other callers (tile `.closing` dimming, the "Closing…" sidebar label, the `pty:disconnect` guard) legitimately want both phases — the pre-flight can take seconds on a big worktree and should look busy.

## Tests

New `test/dom/close-focus.test.ts` drives the real `session:event` handler through `wireDaemonEvents`:
- phase `checking` on the active session → no switch (fails before this change)
- phase `closing` on the active session → switches to the neighbour
- phase `closing` on an inactive session → no switch

Verified red before / green after. Full `scripts/test.sh` (go · unit · dom · e2e) green, plus `biome ci` and `tsc --noEmit`.