### PR TITLE
fix(daemon): don't unlink a replacement daemon's live socket

### DIFF
--- a/.changesets/daemon-socket-inode-reuse.md
+++ b/.changesets/daemon-socket-inode-reuse.md
@@ -1,0 +1,13 @@
+---
+issue: null
+pr: null
+type: fixed
+bump: patch
+---
+- Restarting Hive no longer risks leaving the daemon unreachable. When
+  the old `hived` shut down while its replacement had already taken
+  over the socket path, it could delete the replacement's socket —
+  inode numbers get reused, so "is this still my socket?" answered yes
+  for a file the old daemon never bound. The dying daemon now asks the
+  socket instead of the filesystem, and leaves any socket that is still
+  being served alone.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/lucascaro/hive/internal/buildinfo"
 	"github.com/lucascaro/hive/internal/registry"
@@ -405,6 +406,12 @@ func (d *Daemon) Close() error {
 // an unconditional unlink here would delete the live daemon's socket
 // and leave it serving an inode nobody can dial. Same shape as
 // removePidfile in cmd/hived.
+// socketOwnerProbeTimeout bounds the "is somebody else serving this
+// path?" dial in removeOwnSocket. A live local daemon accepts a unix
+// connection immediately; anything slower is not worth blocking
+// teardown for.
+const socketOwnerProbeTimeout = 250 * time.Millisecond
+
 func (d *Daemon) removeOwnSocket() {
 	if d.sockInfo == nil {
 		return
@@ -415,6 +422,18 @@ func (d *Daemon) removeOwnSocket() {
 	}
 	if !os.SameFile(cur, d.sockInfo) {
 		log.Printf("hived: socket %s now belongs to another daemon; leaving it alone", d.sock)
+		return
+	}
+	// SameFile is dev+inode, and inode numbers get reused: a
+	// replacement daemon's brand-new socket at this path can compare
+	// equal to the one we bound (measured on Linux /tmp — same ino,
+	// mtimes a millisecond apart). So ask the socket rather than the
+	// filesystem. Our own listener is closed by the time we get here,
+	// so anything that still accepts a connection is somebody else's
+	// live daemon.
+	if c, err := net.DialTimeout("unix", d.sock, socketOwnerProbeTimeout); err == nil {
+		_ = c.Close()
+		log.Printf("hived: socket %s is being served by another daemon; leaving it alone", d.sock)
 		return
 	}
 	if err := os.Remove(d.sock); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/internal/daemon/socket_owner_test.go
+++ b/internal/daemon/socket_owner_test.go
@@ -1,0 +1,54 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+)
+
+// An inode number is reusable, so a replacement daemon's fresh socket
+// can be os.SameFile as the one this daemon bound — observed on Linux
+// /tmp, where the dying daemon then unlinked the live daemon's socket
+// and left it serving an inode nobody can dial.
+//
+// This fabricates that collision exactly: a Daemon whose sockInfo IS
+// the stat of a live daemon's socket (what inode reuse produces) must
+// still leave the file alone, because something is serving it.
+func TestRemoveOwnSocketLeavesALiveSocketAlone(t *testing.T) {
+	skipOnWindows(t)
+	live := startTestDaemon(t)
+	sock := live.SocketPath()
+	info, err := os.Stat(sock)
+	if err != nil {
+		t.Fatalf("stat live socket: %v", err)
+	}
+
+	dying := &Daemon{sock: sock, sockInfo: info}
+	dying.removeOwnSocket()
+
+	if _, err := os.Stat(sock); err != nil {
+		t.Fatalf("the live daemon's socket was unlinked: %v", err)
+	}
+	c := dial(t, live)
+	_ = c.Close()
+}
+
+// The other half: with nothing serving the path, teardown still cleans
+// up after itself.
+func TestRemoveOwnSocketRemovesADeadSocket(t *testing.T) {
+	skipOnWindows(t)
+	tmp := shortTempDir(t)
+	sock := tmp + "/s"
+	if err := os.WriteFile(sock, nil, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	info, err := os.Stat(sock)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	(&Daemon{sock: sock, sockInfo: info}).removeOwnSocket()
+
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Fatalf("stat after removeOwnSocket = %v, want not-exist", err)
+	}
+}


### PR DESCRIPTION
`Daemon.removeOwnSocket` identified "is this still my socket?" with `os.SameFile` (dev+inode). Inode numbers get reused, so a replacement daemon's brand-new socket at the same path can compare equal to the one the dying daemon bound — measured on Linux `/tmp`: same `ino=2018165`, mtimes 1 ms apart, `SameFile == true`. The old daemon then unlinks the live daemon's socket, leaving it serving an inode nobody can dial. That is the GUI "Restart Daemon" path, and it is why `TestCloseLeavesAReplacementSocketAlone` was flaky on Linux CI (~1 full-package `-race` run in 4 at 2 CPUs; reproduced in a `golang:1.25` container against unmodified `main`).

## Fix

After `d.ln.Close()`, dial the path. Our own listener is gone, so anything that still accepts a connection is another daemon's. `SameFile` stays as the cheap "definitely not mine" gate — only its false positives needed catching.

## Tests

- `TestRemoveOwnSocketLeavesALiveSocketAlone` fabricates the inode collision exactly (a `Daemon` whose `sockInfo` is the stat of a live daemon's socket) and asserts the file survives and still dials. Verified red without the guard.
- `TestRemoveOwnSocketRemovesADeadSocket` keeps the other half honest.
- 18 × `go test -race ./internal/daemon/ -count=3` on Linux/2 CPUs: clean, against a ~1-in-4 baseline failure rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)