### PR TITLE
fix(gui): namespace persisted project sets per daemon state dir

### DIFF
--- a/.changesets/340-persist-minimized-projects-per-daemon.md
+++ b/.changesets/340-persist-minimized-projects-per-daemon.md
@@ -11,5 +11,6 @@ bump: patch
   pruned the other's project ids as "projects that no longer exist" and
   emptied the tray. The two keys (`hive.minimizedProjects`,
   `hive.collapsedProjects`) are now suffixed with an id derived from the
-  daemon's state directory, and existing values are migrated into the
-  right bucket on first launch.
+  daemon's state directory. Any existing value is adopted by whichever
+  GUI launches first; other instances start from a clean slate once and
+  keep their state from then on.

--- a/.changesets/340-persist-minimized-projects-per-daemon.md
+++ b/.changesets/340-persist-minimized-projects-per-daemon.md
@@ -1,6 +1,6 @@
 ---
 issue: 340
-pr: null
+pr: 342
 type: fixed
 bump: patch
 ---

--- a/.changesets/340-persist-minimized-projects-per-daemon.md
+++ b/.changesets/340-persist-minimized-projects-per-daemon.md
@@ -11,6 +11,6 @@ bump: patch
   pruned the other's project ids as "projects that no longer exist" and
   emptied the tray. The two keys (`hive.minimizedProjects`,
   `hive.collapsedProjects`) are now suffixed with an id derived from the
-  daemon's state directory. Any existing value is adopted by whichever
-  GUI launches first; other instances start from a clean slate once and
-  keep their state from then on.
+  daemon's state directory. Your existing sidebar state carries over to
+  one instance; the others start from a clean slate once and keep their
+  state from then on.

--- a/.changesets/340-persist-minimized-projects-per-daemon.md
+++ b/.changesets/340-persist-minimized-projects-per-daemon.md
@@ -1,0 +1,15 @@
+---
+issue: 340
+pr: null
+type: fixed
+bump: patch
+---
+- Minimized and collapsed projects stay that way across a restart when
+  you run more than one Hive daemon. Every GUI process shares one
+  webview storage area, so instances attached to different state
+  directories were overwriting each other's sidebar state — each launch
+  pruned the other's project ids as "projects that no longer exist" and
+  emptied the tray. The two keys (`hive.minimizedProjects`,
+  `hive.collapsedProjects`) are now suffixed with an id derived from the
+  daemon's state directory, and existing values are migrated into the
+  right bucket on first launch.

--- a/cmd/hivegui/app_calls.go
+++ b/cmd/hivegui/app_calls.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"os"
+	"path/filepath"
 
 	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
@@ -286,7 +287,10 @@ func (a *App) LaunchDir() string { return a.launchDir }
 // web storage; truncated because 8 hex chars is plenty to separate the
 // handful of state dirs one machine ever has.
 func (a *App) StateDirID() string {
-	sum := sha256.Sum256([]byte(registry.StateDir()))
+	// Cleaned first: the same directory spelled two ways (trailing
+	// slash, a relative path) would otherwise hash to different buckets
+	// and silently start that instance from a clean slate.
+	sum := sha256.Sum256([]byte(filepath.Clean(registry.StateDir())))
 	return hex.EncodeToString(sum[:])[:8]
 }
 

--- a/cmd/hivegui/app_calls.go
+++ b/cmd/hivegui/app_calls.go
@@ -6,12 +6,15 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 
 	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"github.com/lucascaro/hive/internal/agent"
+	"github.com/lucascaro/hive/internal/registry"
 	"github.com/lucascaro/hive/internal/wire"
 	"github.com/lucascaro/hive/internal/worktree"
 )
@@ -268,6 +271,24 @@ func (a *App) UpdateProject(id, name, color, cwd string, order int) error {
 // LaunchDir returns the cwd captured at GUI startup; useful for the
 // new-project default cwd.
 func (a *App) LaunchDir() string { return a.launchDir }
+
+// StateDirID identifies the daemon registry this GUI is attached to,
+// as the first 8 hex chars of sha256(registry.StateDir()).
+//
+// Every hivegui process shares ONE webview localStorage — WKWebView
+// keys its store on the bundle id, not on the socket — while each
+// daemon owns a registry with its own project UUIDs. The frontend
+// suffixes its persisted project-id sets with this value so a GUI on
+// one state dir stops pruning away another's ids as "projects that no
+// longer exist" (#340).
+//
+// Hashed rather than returned raw so a filesystem path never lands in
+// web storage; truncated because 8 hex chars is plenty to separate the
+// handful of state dirs one machine ever has.
+func (a *App) StateDirID() string {
+	sum := sha256.Sum256([]byte(registry.StateDir()))
+	return hex.EncodeToString(sum[:])[:8]
+}
 
 // PickDirectory opens the OS native folder picker and returns the
 // selected path, or "" if the user cancelled. defaultDir, if

--- a/cmd/hivegui/app_calls_test.go
+++ b/cmd/hivegui/app_calls_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -184,5 +185,32 @@ func TestListClosedSessionsCall(t *testing.T) {
 	}
 	if err := <-done; err != nil {
 		t.Fatalf("ListClosedSessions: %v", err)
+	}
+}
+
+// StateDirID namespaces the frontend's persisted project-id sets, so a
+// GUI on one state dir stops pruning away another's ids (#340). Two
+// properties matter: stable for a given dir (or the sets are lost on
+// every boot) and distinct across dirs (or the bug is unchanged).
+func TestStateDirID(t *testing.T) {
+	var a App
+
+	t.Setenv("HIVE_STATE_DIR", "/tmp/hive-state-one")
+	first := a.StateDirID()
+	if len(first) != 8 {
+		t.Fatalf("StateDirID() = %q, want 8 hex chars", first)
+	}
+	for _, r := range first {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Fatalf("StateDirID() = %q, want lowercase hex", first)
+		}
+	}
+	if again := a.StateDirID(); again != first {
+		t.Errorf("StateDirID() not stable: %q then %q", first, again)
+	}
+
+	t.Setenv("HIVE_STATE_DIR", "/tmp/hive-state-two")
+	if other := a.StateDirID(); other == first {
+		t.Errorf("StateDirID() = %q for both state dirs; must differ", other)
 	}
 }

--- a/cmd/hivegui/frontend/src/bridge.ts
+++ b/cmd/hivegui/frontend/src/bridge.ts
@@ -39,6 +39,7 @@ export {
   RenameWorktree,
   DeleteBranch,
   LaunchDir,
+  StateDirID,
   PickDirectory,
   OpenNewWindow,
   CloseWindow,

--- a/cmd/hivegui/frontend/src/lib/collapsed.ts
+++ b/cmd/hivegui/frontend/src/lib/collapsed.ts
@@ -13,6 +13,21 @@ export const COLLAPSED_STORAGE_KEY = 'hive.collapsedProjects';
 // takes the whole project out of the list and out of grid views.
 export const MINIMIZED_PROJECTS_STORAGE_KEY = 'hive.minimizedProjects';
 
+// Suffix a base storage key with the id of the daemon state dir this
+// GUI is attached to. Every hivegui process shares ONE webview
+// localStorage (WKWebView keys its store on the bundle id, not on the
+// socket), while each daemon owns a registry with its own project
+// UUIDs — so an unsuffixed key lets one instance prune away another's
+// ids as "projects that no longer exist" (#340).
+//
+// An empty namespace returns the bare key. That case means "we could
+// not identify the daemon"; callers must treat it as a signal to stop
+// persisting rather than as a usable key — writing the bare key back
+// is what re-creates the shared-key bug.
+export function namespacedKey(base: string, ns: string): string {
+  return ns ? `${base}.${ns}` : base;
+}
+
 // raw: the localStorage string (or null). Returns a Set of project id
 // strings; anything malformed degrades to an empty/filtered set.
 export function loadCollapsed(raw: string | null | undefined): Set<string> {

--- a/cmd/hivegui/frontend/src/main.tsx
+++ b/cmd/hivegui/frontend/src/main.tsx
@@ -10,10 +10,13 @@
 //                   pre-paint half already ran from index.html's inline
 //                   script (master plan, Invariant 9).
 //   2. hydrate    — importing store/store.js runs initialData(), which
-//                   reads view / collapsed / minimized / font size /
-//                   sidebar width out of localStorage. It is an import
-//                   side effect, not a call, so it is already done by
-//                   the time any line below runs.
+//                   reads view / font size / sidebar width out of
+//                   localStorage. It is an import side effect, not a
+//                   call, so it is already done by the time any line
+//                   below runs. The collapsed / minimized project sets
+//                   are the exception: their keys are namespaced by the
+//                   daemon's state-dir id, so the bootstrap block at the
+//                   bottom hydrates them asynchronously, before connect.
 //   3. wire       — the daemon event handlers are registered BEFORE the
 //                   root mounts, so a fast handshake writes the store
 //                   rather than racing a tree that has not subscribed.
@@ -27,6 +30,7 @@ import '@xterm/xterm/css/xterm.css';
 
 import {
   ConnectControl,
+  StateDirID,
   OpenNewWindow,
   CloseWindow,
   OpenTerminalAt,
@@ -495,6 +499,17 @@ flushSync(() => createRoot(mustEl('react-root')).render(<App />));
   }
   setStatus('connecting…');
   setBootState('Starting hive…');
+  // Load the persisted collapse/minimize sets BEFORE connecting. Their
+  // storage keys are suffixed with the daemon's state-dir id, which only
+  // this binding knows, and the first project:list would prune sets that
+  // had not been loaded yet — persisting [] and emptying the tray (#340).
+  // A failure here leaves persistence off for the session rather than
+  // falling back to the shared un-suffixed key.
+  try {
+    store.hydratePersistedProjectSets(await StateDirID());
+  } catch {
+    LogFrontend('boot: StateDirID failed; project sets not persisted');
+  }
   try {
     await ConnectControl();
     setStatus('connected');

--- a/cmd/hivegui/frontend/src/main.tsx
+++ b/cmd/hivegui/frontend/src/main.tsx
@@ -508,7 +508,16 @@ flushSync(() => createRoot(mustEl('react-root')).render(<App />));
   try {
     store.hydratePersistedProjectSets(await StateDirID());
   } catch {
-    LogFrontend('boot: StateDirID failed; project sets not persisted');
+    // Wrapped like every other LogFrontend in this file: the reason
+    // StateDirID throws is usually "no bridge", which is exactly when
+    // LogFrontend throws too. An unwrapped call here would reject the
+    // bootstrap IIFE and ConnectControl below would never run — turning
+    // "persistence is off this session" into "the app never connects".
+    try {
+      LogFrontend('boot: StateDirID failed; project sets not persisted');
+    } catch {
+      /* ignore */
+    }
   }
   try {
     await ConnectControl();

--- a/cmd/hivegui/frontend/src/store/store.ts
+++ b/cmd/hivegui/frontend/src/store/store.ts
@@ -32,6 +32,7 @@ import {
   pruneCollapsed,
   COLLAPSED_STORAGE_KEY,
   MINIMIZED_PROJECTS_STORAGE_KEY,
+  namespacedKey,
 } from '../lib/collapsed.js';
 import { createNavHistory, type NavHistory } from '../lib/nav-history.js';
 import type { PhasePanel } from '../lib/phase-steps.js';
@@ -60,6 +61,10 @@ export interface AppData {
   sessions: SessionInfo[];
   collapsed: Set<string>;
   minimizedProjects: Set<string>;
+  // False until hydratePersistedProjectSets has run. applyProjectList
+  // refuses to prune while it is false: pruning an un-hydrated (empty)
+  // set persists [] and wipes the user's tray — bug #340 exactly.
+  projectSetsHydrated: boolean;
   attentionReturnId: string | null;
   attentionRestored: Set<string>;
   attentionRestoredProjects: Set<string>;
@@ -205,16 +210,71 @@ function writeStorage(key: string, value: string): void {
   }
 }
 
+function removeStorage(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    /* private mode etc. — nothing to remove */
+  }
+}
+
 export function loadSavedView(): ViewMode {
   return normalizeView(readStorage(VIEW_STORAGE_KEY));
 }
 
-export function loadSavedCollapsed(): Set<string> {
-  return loadCollapsed(readStorage(COLLAPSED_STORAGE_KEY));
+// The daemon-state-dir id the two project-id keys are suffixed with,
+// and the gate that keeps us from writing before we know it. Both are
+// module state rather than store state: they are storage plumbing, not
+// anything a component renders. resetStore() clears them so a
+// namespace cannot leak between vitest files sharing a worker.
+let storageNS = '';
+let persistProjectSets = false;
+
+function collapsedKey(): string {
+  return namespacedKey(COLLAPSED_STORAGE_KEY, storageNS);
 }
 
-export function loadSavedMinimizedProjects(): Set<string> {
-  return loadCollapsed(readStorage(MINIMIZED_PROJECTS_STORAGE_KEY));
+function minimizedProjectsKey(): string {
+  return namespacedKey(MINIMIZED_PROJECTS_STORAGE_KEY, storageNS);
+}
+
+// Hydrate the two persisted project-id sets under `ns` — the id of the
+// daemon registry this GUI is attached to (App.StateDirID). Call it
+// once at boot, BEFORE ConnectControl: the first project:list would
+// otherwise prune sets that have not been loaded yet.
+//
+// An empty ns means the daemon could not be identified. Persistence
+// then stays off for the session rather than falling back to the bare
+// key: writing that key is what lets one instance clobber another's
+// state, and it would resurrect a legacy key a prior migration
+// deleted, which the other GUI would then adopt.
+export function hydratePersistedProjectSets(ns: string): void {
+  if (!ns) return;
+  storageNS = ns;
+  migrateLegacyProjectSets();
+  persistProjectSets = true;
+  set({
+    collapsed: loadCollapsed(readStorage(collapsedKey())),
+    minimizedProjects: loadCollapsed(readStorage(minimizedProjectsKey())),
+    projectSetsHydrated: true,
+  });
+}
+
+// One-time move of the pre-#340 un-namespaced values into this
+// instance's namespace. Only ever runs with a non-empty storageNS: with
+// an empty one the two key names are identical and "adopt then delete"
+// would destroy the value it just read.
+function migrateLegacyProjectSets(): void {
+  if (!storageNS) return;
+  for (const [legacy, next] of [
+    [COLLAPSED_STORAGE_KEY, collapsedKey()],
+    [MINIMIZED_PROJECTS_STORAGE_KEY, minimizedProjectsKey()],
+  ]) {
+    const raw = readStorage(legacy);
+    if (raw === null) continue;
+    if (readStorage(next) === null) writeStorage(next, raw);
+    removeStorage(legacy);
+  }
 }
 
 export function loadSavedFontSize(): number {
@@ -233,11 +293,13 @@ function clampSidebarWidth(w: number): number {
 }
 
 function persistCollapsed(set: ReadonlySet<string>): void {
-  writeStorage(COLLAPSED_STORAGE_KEY, serializeCollapsed(set));
+  if (!persistProjectSets) return;
+  writeStorage(collapsedKey(), serializeCollapsed(set));
 }
 
 function persistMinimizedProjects(set: ReadonlySet<string>): void {
-  writeStorage(MINIMIZED_PROJECTS_STORAGE_KEY, serializeCollapsed(set));
+  if (!persistProjectSets) return;
+  writeStorage(minimizedProjectsKey(), serializeCollapsed(set));
 }
 
 // ---------- immutable set/map helpers ----------
@@ -292,10 +354,14 @@ function initialData(): AppData {
   return {
     projects: [], // ProjectInfo[] in display order
     sessions: [], // SessionInfo[] in display order
-    collapsed: loadSavedCollapsed(), // project ids that are collapsed — persisted
-    minimizedProjects: loadSavedMinimizedProjects(), // project ids pulled out of
-    //   the sidebar list into the tray at its bottom; their sessions are
-    //   hidden from grid views too. Persisted, like `collapsed`.
+    collapsed: new Set(), // project ids that are collapsed — persisted, but
+    //   NOT loaded here: the storage key is suffixed with the daemon's
+    //   state-dir id, which only an async binding can tell us. main.tsx
+    //   calls hydratePersistedProjectSets before connecting.
+    minimizedProjects: new Set(), // project ids pulled out of the sidebar
+    //   list into the tray at its bottom; their sessions are hidden from
+    //   grid views too. Persisted and hydrated exactly like `collapsed`.
+    projectSetsHydrated: false,
     attentionReturnId: null, // session to jump back to (⇧⌘B): the one you
     //   were in before the FIRST ⌘B. Written only when empty, so a round
     //   of bells that walks you through several flagged sessions keeps
@@ -392,6 +458,15 @@ export function setProjects(projects: ProjectInfo[]): void {
 export function applyProjectList(projects: ProjectInfo[]): void {
   const list = projects || [];
   const s = get();
+  // Before hydration the sets are empty, so pruning would persist [] and
+  // wipe the tray. Apply the list, skip the tidy-up (#340).
+  if (!s.projectSetsHydrated) {
+    set({
+      projects: list,
+      currentProjectId: s.currentProjectId ?? list[0]?.id ?? null,
+    });
+    return;
+  }
   const ids = list.map((p) => p.id);
   const pruned = pruneCollapsed(s.collapsed, ids);
   const prunedMin = pruneCollapsed(s.minimizedProjects, ids);
@@ -926,6 +1001,8 @@ export function setChoiceDialog(spec: ChoiceSpec | null): void {
 }
 
 export function resetStore(seed: Partial<AppData> = {}): void {
+  storageNS = '';
+  persistProjectSets = false;
   replace({ ...initialData(), ...seed }, true);
 }
 

--- a/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
@@ -116,8 +116,14 @@ function mountSidebar() {
   return render(<Sidebar {...sidebarProps} />, { container });
 }
 
+// The two project-id keys are namespaced by the daemon's state-dir id,
+// and persistence stays off until that id is known (#340).
+const NS = 'domtest1';
+const MIN_KEY = `hive.minimizedProjects.${NS}`;
+
 beforeEach(() => {
   localStorage.clear();
+  store.hydratePersistedProjectSets(NS);
   state.projects = [
     { id: 'p1', name: 'one', color: '#111', order: 0 },
     { id: 'p2', name: 'two', color: '#222', order: 1 },
@@ -196,13 +202,9 @@ describe('minimize project', () => {
 
   it('persists the minimized set', () => {
     minimize('p3');
-    expect(
-      JSON.parse(localStorage.getItem('hive.minimizedProjects') ?? '[]'),
-    ).toEqual(['p3']);
+    expect(JSON.parse(localStorage.getItem(MIN_KEY) ?? '[]')).toEqual(['p3']);
     click('#minimized-projects .hv-chip[data-pid="p3"] .hv-chip__restore');
-    expect(
-      JSON.parse(localStorage.getItem('hive.minimizedProjects') ?? '[]'),
-    ).toEqual([]);
+    expect(JSON.parse(localStorage.getItem(MIN_KEY) ?? '[]')).toEqual([]);
   });
 
   // Switching projects repaints selection without any structural change,
@@ -280,9 +282,7 @@ describe('minimize project', () => {
       state.projects = [];
     });
     expect(state.minimizedProjects.has('p3')).toBe(true);
-    expect(
-      JSON.parse(localStorage.getItem('hive.minimizedProjects') ?? '[]'),
-    ).toEqual(['p3']);
+    expect(JSON.parse(localStorage.getItem(MIN_KEY) ?? '[]')).toEqual(['p3']);
   });
 
   it("hides the project's sessions from grid views", () => {
@@ -420,9 +420,7 @@ describe('project events', () => {
       JSON.stringify({ kind: 'removed', project: { id: 'p3' } }),
     );
     expect(state.minimizedProjects.has('p3')).toBe(false);
-    expect(
-      JSON.parse(localStorage.getItem('hive.minimizedProjects') ?? '[]'),
-    ).toEqual([]);
+    expect(JSON.parse(localStorage.getItem(MIN_KEY) ?? '[]')).toEqual([]);
   });
 
   it('prunes ids missing from an authoritative project list', async () => {

--- a/cmd/hivegui/frontend/test/dom/sidebar-harness.tsx
+++ b/cmd/hivegui/frontend/test/dom/sidebar-harness.tsx
@@ -67,7 +67,12 @@ export function mountSidebar(
 // React's work queue unflushed and the assertions race the render.
 export function seed(data: Partial<AppData>) {
   act(() => {
-    resetStore(data);
+    // projectSetsHydrated mirrors the post-boot steady state: by the time
+    // a daemon snapshot lands, main.tsx has hydrated the persisted
+    // project sets. Without it every harness test would take
+    // applyProjectList's un-hydrated early return and never exercise the
+    // real prune (#340).
+    resetStore({ projectSetsHydrated: true, ...data });
   });
 }
 

--- a/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
+++ b/cmd/hivegui/frontend/test/e2e-real/wails-bridge.ts
@@ -272,6 +272,12 @@ export async function UpdateProject() {
 export async function LaunchDir() {
   return '';
 }
+// Non-empty, or persistence of the collapse/minimize sets stays off
+// (store.ts › hydratePersistedProjectSets). The real suite runs against
+// an isolated HIVE_STATE_DIR, so any stable id will do.
+export async function StateDirID() {
+  return 'e2ereal1';
+}
 export async function PickDirectory() {
   return '';
 }

--- a/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
@@ -178,3 +178,40 @@ test('a project chip spans the tray, right-aligns +, and restores on any click',
   await page.mouse.click(slackX, slackY);
   await expect(listed).toHaveCount(before);
 });
+
+// Repro for #340: a minimized project must still be minimized after the
+// window reloads. Persistence lives in localStorage (`hive.minimizedProjects`)
+// and is pruned against the project:list snapshot on reconnect, so only a
+// real reload exercises the write → read → prune round trip.
+test('a minimized project stays minimized across a reload', async ({
+  page,
+}) => {
+  await boot(page);
+  const listed = page.locator('#projects > li.hv-project-card');
+  const before = await listed.count();
+  const first = listed.first();
+  const pid = await first.getAttribute('data-pid');
+
+  await first.locator('.hv-project-card__header').hover();
+  await first
+    .locator('.hv-project-card__header [data-action="minimize"]')
+    .click();
+  await expect(listed).toHaveCount(before - 1);
+
+  // The key is namespaced by the daemon's state-dir id (#340), which
+  // wails-mock.ts reports as MOCK_STATE_DIR_ID.
+  expect(
+    await page.evaluate(() =>
+      localStorage.getItem('hive.minimizedProjects.mock1234'),
+    ),
+  ).toContain(pid);
+
+  await page.reload();
+
+  // The tray chip is the boot signal here: the mock seeds one project,
+  // so a correct restore leaves #projects empty.
+  await expect(
+    page.locator(`#minimized-projects .hv-chip[data-pid="${pid}"]`),
+  ).toBeVisible();
+  await expect(listed).toHaveCount(before - 1);
+});

--- a/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect, type Page } from '@playwright/test';
+// The persisted key is namespaced by the daemon's state-dir id (#340).
+// Kept in sync by hand with MOCK_STATE_DIR_ID in wails-mock.ts: that
+// module runs in the browser and imports the store, so importing it from
+// the Playwright node context fails on `import.meta`.
+const MIN_KEY = 'hive.minimizedProjects.mock1234';
 
 // Layout check for the minimized-projects tray. The DOM test proves the
 // rows move; only a real browser proves the tray actually sits at the
@@ -180,9 +185,9 @@ test('a project chip spans the tray, right-aligns +, and restores on any click',
 });
 
 // Repro for #340: a minimized project must still be minimized after the
-// window reloads. Persistence lives in localStorage (`hive.minimizedProjects`)
-// and is pruned against the project:list snapshot on reconnect, so only a
-// real reload exercises the write → read → prune round trip.
+// window reloads. Persistence lives in a per-daemon localStorage key and is
+// pruned against the project:list snapshot on reconnect, so only a real
+// reload exercises the write → read → prune round trip.
 test('a minimized project stays minimized across a reload', async ({
   page,
 }) => {
@@ -198,12 +203,8 @@ test('a minimized project stays minimized across a reload', async ({
     .click();
   await expect(listed).toHaveCount(before - 1);
 
-  // The key is namespaced by the daemon's state-dir id (#340), which
-  // wails-mock.ts reports as MOCK_STATE_DIR_ID.
   expect(
-    await page.evaluate(() =>
-      localStorage.getItem('hive.minimizedProjects.mock1234'),
-    ),
+    await page.evaluate((key) => localStorage.getItem(key), MIN_KEY),
   ).toContain(pid);
 
   await page.reload();
@@ -214,4 +215,31 @@ test('a minimized project stays minimized across a reload', async ({
     page.locator(`#minimized-projects .hv-chip[data-pid="${pid}"]`),
   ).toBeVisible();
   await expect(listed).toHaveCount(before - 1);
+});
+
+// Losing the daemon id must cost persistence, not the app. StateDirID
+// throws when the Wails bridge is unavailable — and so does LogFrontend,
+// so an unwrapped log call inside that catch would reject the bootstrap
+// IIFE and ConnectControl would never run.
+test('boot still connects when StateDirID fails', async ({ page }) => {
+  await page.goto('/?failStateDirID=1');
+  // Project cards only exist once the daemon snapshot arrived, so this
+  // rendering IS the proof ConnectControl ran. (The status bar has moved
+  // past "connected" to the project name by then.)
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li.hv-project-card').length > 0,
+  );
+
+  // Persistence is off, not falling back to the shared un-suffixed key —
+  // writing that key is what let one daemon's GUI clobber another's.
+  const listed = page.locator('#projects > li.hv-project-card');
+  await listed.first().locator('.hv-project-card__header').hover();
+  await listed
+    .first()
+    .locator('.hv-project-card__header [data-action="minimize"]')
+    .click();
+  await expect(page.locator('#minimized-projects .hv-chip')).toHaveCount(1);
+  expect(
+    await page.evaluate(() => localStorage.getItem('hive.minimizedProjects')),
+  ).toBeNull();
 });

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -677,6 +677,13 @@ export async function UpdateProject(
 export async function LaunchDir() {
   return '';
 }
+// Must be non-empty: an empty namespace means "daemon unidentified",
+// which disables persistence of the collapse/minimize sets entirely
+// (store.ts › hydratePersistedProjectSets).
+export const MOCK_STATE_DIR_ID = 'mock1234';
+export async function StateDirID() {
+  return MOCK_STATE_DIR_ID;
+}
 export async function PickDirectory() {
   return '';
 }

--- a/cmd/hivegui/frontend/test/e2e/wails-mock.ts
+++ b/cmd/hivegui/frontend/test/e2e/wails-mock.ts
@@ -677,11 +677,23 @@ export async function UpdateProject(
 export async function LaunchDir() {
   return '';
 }
+// ?failStateDirID=1 makes StateDirID reject AND LogFrontend throw. That
+// pairing is the real-world case, not a contrived one: StateDirID fails
+// when the Wails bridge is unavailable, which is exactly when
+// LogFrontend fails too. Boot must still connect — persistence going off
+// must not take the app down (#340).
+function stateDirIDFails(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    new URLSearchParams(window.location.search).get('failStateDirID') === '1'
+  );
+}
 // Must be non-empty: an empty namespace means "daemon unidentified",
 // which disables persistence of the collapse/minimize sets entirely
 // (store.ts › hydratePersistedProjectSets).
 export const MOCK_STATE_DIR_ID = 'mock1234';
 export async function StateDirID() {
+  if (stateDirIDFails()) throw new Error('no bridge');
   return MOCK_STATE_DIR_ID;
 }
 export async function PickDirectory() {
@@ -709,8 +721,14 @@ export async function OpenTerminalAt(_dir: string) {
 export async function Notify(_title: string, _body: string) {
   return '';
 }
-export async function LogFrontend(_msg: string) {
-  return '';
+// Deliberately NOT async when armed: a missing Wails binding fails as a
+// synchronous TypeError at the call site, and that is what the sync
+// try/catch around every LogFrontend call is there to absorb. An async
+// rejection would sail past those guards as an unhandled rejection and
+// prove nothing.
+export function LogFrontend(_msg: string): Promise<string> {
+  if (stateDirIDFails()) throw new Error('no bridge');
+  return Promise.resolve('');
 }
 export async function SetDebugTrace(_on: boolean) {
   return '';

--- a/cmd/hivegui/frontend/test/unit/storage-namespace.test.ts
+++ b/cmd/hivegui/frontend/test/unit/storage-namespace.test.ts
@@ -1,0 +1,40 @@
+// Key namespacing for the persisted project-id sets (#340).
+//
+// Every hivegui process shares ONE webview localStorage — WKWebView keys
+// its store on the bundle id, not on the daemon socket — while each
+// daemon owns a registry with its own project UUIDs. Without a suffix,
+// one instance's boot prune deletes another's ids as "projects that no
+// longer exist", and the user's tray empties on every launch.
+import { describe, it, expect } from 'vitest';
+import {
+  namespacedKey,
+  COLLAPSED_STORAGE_KEY,
+  MINIMIZED_PROJECTS_STORAGE_KEY,
+} from '../../src/lib/collapsed.js';
+
+describe('namespacedKey', () => {
+  it('suffixes the base key with the state-dir id', () => {
+    expect(namespacedKey(MINIMIZED_PROJECTS_STORAGE_KEY, 'a1b2c3d4')).toBe(
+      'hive.minimizedProjects.a1b2c3d4',
+    );
+    expect(namespacedKey(COLLAPSED_STORAGE_KEY, 'a1b2c3d4')).toBe(
+      'hive.collapsedProjects.a1b2c3d4',
+    );
+  });
+
+  it('keeps two state dirs in separate buckets', () => {
+    expect(namespacedKey(COLLAPSED_STORAGE_KEY, 'aaaa1111')).not.toBe(
+      namespacedKey(COLLAPSED_STORAGE_KEY, 'bbbb2222'),
+    );
+  });
+
+  // The empty case means "daemon unidentified". It returns the bare key
+  // so the value stays readable for migration, but callers must treat it
+  // as a signal to stop persisting — see store.ts, which never writes
+  // under an empty namespace.
+  it('returns the bare key for an empty namespace', () => {
+    expect(namespacedKey(COLLAPSED_STORAGE_KEY, '')).toBe(
+      COLLAPSED_STORAGE_KEY,
+    );
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/store.test.ts
+++ b/cmd/hivegui/frontend/test/unit/store.test.ts
@@ -33,12 +33,14 @@ import {
   updateProject,
   SIDEBAR_MIN_WIDTH,
   SIDEBAR_MAX_WIDTH,
+  hydratePersistedProjectSets,
 } from '../../src/store/store.js';
 import { hiveStateView as state } from '../../src/store/store.js';
 import { setTerm, clearTerms } from '../../src/store/terms.js';
 import {
   COLLAPSED_STORAGE_KEY,
   MINIMIZED_PROJECTS_STORAGE_KEY,
+  namespacedKey,
 } from '../../src/lib/collapsed.js';
 import { VIEW_STORAGE_KEY } from '../../src/lib/view.js';
 
@@ -60,6 +62,9 @@ beforeEach(() => {
   store.clear();
   (globalThis as { localStorage?: unknown }).localStorage = stubStorage;
   resetStore();
+  // Persistence of the collapse/minimize sets is off until the daemon
+  // is identified, so every test that asserts a write hydrates first.
+  hydratePersistedProjectSets(TEST_NS);
 });
 
 afterEach(() => {
@@ -67,6 +72,12 @@ afterEach(() => {
 });
 
 const s = () => appStore.getState();
+
+// The two project-id keys are suffixed with the daemon's state-dir id
+// (#340), so every assertion about them has to read the namespaced key.
+const TEST_NS = 'ns0';
+const CK = namespacedKey(COLLAPSED_STORAGE_KEY, TEST_NS);
+const MK = namespacedKey(MINIMIZED_PROJECTS_STORAGE_KEY, TEST_NS);
 
 describe('setSessions', () => {
   it('test_setSessions_replaces_reference_and_notifies', () => {
@@ -137,14 +148,12 @@ describe('collapsed', () => {
     toggleCollapsed('p1');
 
     expect(s().collapsed.has('p1')).toBe(true);
-    expect(JSON.parse(store.get(COLLAPSED_STORAGE_KEY) as string)).toEqual([
-      'p1',
-    ]);
+    expect(JSON.parse(store.get(CK) as string)).toEqual(['p1']);
 
     toggleCollapsed('p1');
 
     expect(s().collapsed.has('p1')).toBe(false);
-    expect(JSON.parse(store.get(COLLAPSED_STORAGE_KEY) as string)).toEqual([]);
+    expect(JSON.parse(store.get(CK) as string)).toEqual([]);
   });
 
   it('applyProjectList prunes collapsed entries for projects that are gone', () => {
@@ -154,9 +163,7 @@ describe('collapsed', () => {
     applyProjectList([{ id: 'p1' }]);
 
     expect([...s().collapsed]).toEqual(['p1']);
-    expect(JSON.parse(store.get(COLLAPSED_STORAGE_KEY) as string)).toEqual([
-      'p1',
-    ]);
+    expect(JSON.parse(store.get(CK) as string)).toEqual(['p1']);
   });
 });
 
@@ -188,15 +195,11 @@ describe('minimize', () => {
 
     minimizeProject('p1');
     expect([...s().minimizedProjects]).toEqual(['p1']);
-    expect(
-      JSON.parse(store.get(MINIMIZED_PROJECTS_STORAGE_KEY) as string),
-    ).toEqual(['p1']);
+    expect(JSON.parse(store.get(MK) as string)).toEqual(['p1']);
 
     restoreProject('p1');
     expect([...s().minimizedProjects]).toEqual([]);
-    expect(
-      JSON.parse(store.get(MINIMIZED_PROJECTS_STORAGE_KEY) as string),
-    ).toEqual([]);
+    expect(JSON.parse(store.get(MK) as string)).toEqual([]);
   });
 
   it('session minimize/restore round-trips without touching projects', () => {
@@ -262,19 +265,112 @@ describe('persistence load branches', () => {
   // exercises the loadSaved* path. Without this the boot path is never
   // covered: beforeEach clears storage before every reset.
   it('hydrates every persisted field from storage', () => {
-    store.set(COLLAPSED_STORAGE_KEY, JSON.stringify(['p1', 'p2']));
-    store.set(MINIMIZED_PROJECTS_STORAGE_KEY, JSON.stringify(['p3']));
+    store.set(CK, JSON.stringify(['p1', 'p2']));
+    store.set(MK, JSON.stringify(['p3']));
     store.set(VIEW_STORAGE_KEY, 'grid-all');
     store.set('hive.fontSize', '21');
     store.set('hive.sidebarWidth', '333');
 
     resetStore();
+    hydratePersistedProjectSets(TEST_NS);
 
     expect([...s().collapsed].sort()).toEqual(['p1', 'p2']);
     expect([...s().minimizedProjects]).toEqual(['p3']);
     expect(s().view).toBe('grid-all');
     expect(s().fontSize).toBe(21);
     expect(s().sidebarWidth).toBe(333);
+  });
+
+  // The project-id sets are the exception to "hydrated on import": their
+  // key is namespaced by the daemon's state-dir id, which only an async
+  // binding knows (#340). resetStore alone must leave them empty.
+  it('leaves the project-id sets empty until hydration', () => {
+    store.set(CK, JSON.stringify(['p1']));
+    store.set(MK, JSON.stringify(['p3']));
+
+    resetStore();
+
+    expect([...s().collapsed]).toEqual([]);
+    expect([...s().minimizedProjects]).toEqual([]);
+    expect(s().projectSetsHydrated).toBe(false);
+  });
+
+  // THE REGRESSION GATE for #340. On main, initialData() loads the bare
+  // key and applyProjectList prunes it against a project list from a
+  // DIFFERENT daemon, persisting [] — which is how one GUI wiped
+  // another's tray. After the fix the un-hydrated boot neither loads nor
+  // writes that key.
+  it('does not touch persisted project sets before hydration', () => {
+    store.set(MINIMIZED_PROJECTS_STORAGE_KEY, JSON.stringify(['foreign']));
+    store.set(COLLAPSED_STORAGE_KEY, JSON.stringify(['foreign']));
+
+    resetStore(); // no hydratePersistedProjectSets: daemon not identified
+    applyProjectList([{ id: 'p1' }, { id: 'p2' }]);
+
+    expect(store.get(MINIMIZED_PROJECTS_STORAGE_KEY)).toBe(
+      JSON.stringify(['foreign']),
+    );
+    expect(store.get(COLLAPSED_STORAGE_KEY)).toBe(JSON.stringify(['foreign']));
+    // The list still applied — only the tidy-up was skipped.
+    expect(s().projects.map((p) => p.id)).toEqual(['p1', 'p2']);
+  });
+
+  // Failing safe means writing nothing: falling back to the bare key is
+  // what lets one instance clobber another's state.
+  it('persists nothing when the daemon cannot be identified', () => {
+    resetStore();
+    hydratePersistedProjectSets('');
+
+    minimizeProject('p1');
+
+    expect(s().minimizedProjects.has('p1')).toBe(true);
+    expect(store.get(MINIMIZED_PROJECTS_STORAGE_KEY)).toBeUndefined();
+    expect(store.get(MK)).toBeUndefined();
+  });
+
+  // One-time move of pre-#340 values into this instance's namespace.
+  it('adopts the legacy un-namespaced keys once, then removes them', () => {
+    store.set(MINIMIZED_PROJECTS_STORAGE_KEY, JSON.stringify(['p3']));
+    store.set(COLLAPSED_STORAGE_KEY, JSON.stringify(['p1']));
+
+    resetStore();
+    hydratePersistedProjectSets(TEST_NS);
+
+    expect([...s().minimizedProjects]).toEqual(['p3']);
+    expect([...s().collapsed]).toEqual(['p1']);
+    expect(store.get(MK)).toBe(JSON.stringify(['p3']));
+    expect(store.get(MINIMIZED_PROJECTS_STORAGE_KEY)).toBeUndefined();
+    expect(store.get(COLLAPSED_STORAGE_KEY)).toBeUndefined();
+  });
+
+  // The whole point of #340: a boot under one daemon must not touch the
+  // set another daemon's GUI persisted. Before the fix both instances
+  // shared one key and each prune wiped the other's ids.
+  it("leaves another daemon's set alone across a full boot", () => {
+    const otherNS = 'ns1';
+    const otherKey = namespacedKey(MINIMIZED_PROJECTS_STORAGE_KEY, otherNS);
+    store.set(otherKey, JSON.stringify(['their-project']));
+
+    resetStore();
+    hydratePersistedProjectSets(TEST_NS);
+    minimizeProject('our-project');
+    applyProjectList([{ id: 'our-project' }]);
+
+    expect(store.get(otherKey)).toBe(JSON.stringify(['their-project']));
+    expect(JSON.parse(store.get(MK) as string)).toEqual(['our-project']);
+  });
+
+  // Restore-then-reboot must come back restored. The empty-set round
+  // trip is the case that looks identical to "hydration never ran".
+  it('round-trips an emptied set across a reboot', () => {
+    minimizeProject('p1');
+    restoreProject('p1');
+
+    resetStore();
+    hydratePersistedProjectSets(TEST_NS);
+
+    expect([...s().minimizedProjects]).toEqual([]);
+    expect(s().projectSetsHydrated).toBe(true);
   });
 
   it('degrades to defaults on garbage, rather than throwing at boot', () => {

--- a/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
+++ b/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/340-persist-minimized-projects-across-restarts.md](../../product-specs/340-persist-minimized-projects-across-restarts.md)
 - **Issue:** #340
+- **PR:** #342
+- **Branch:** `feature/340-persist-minimized-projects-across-restarts`
 - **Status:** active
 
 ## Summary

--- a/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
+++ b/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
@@ -297,6 +297,7 @@ a changeset note covering the documented key name.
 - **2026-09-05** — Namespace the keys rather than delete the prune. Why: operator's call at clarifying round B; the sets are per-daemon by nature, and dropping the prune trades one bug for unbounded growth.
 - **2026-09-05** — Namespace = `sha256(registry.StateDir())[:8]`, not the raw path. Why: keeps the key short and avoids putting a filesystem path in web storage.
 - **2026-09-05** — `test/e2e-real/wails-bridge.ts` also needed the `StateDirID` stub. Why: an existing test ("real harness defines every name bridge.ts re-exports") caught it — the e2e-real harness is a second binding surface the plan had not listed.
+- **2026-09-05** — Applied iter 2's three MINORs rather than deferring: `filepath.Clean` before hashing the state dir, `seed()` in the dom harness now models the post-boot hydrated state, and the changeset drops a legacy-adoption claim that only held for sequential launches. Why: AGENTS.md's boil-the-lake rule — all three are low-risk and the harness one would have quietly hidden the prune path from future tests.
 - **2026-09-05** — Fixed review iter 1's IMPORTANT: wrapped the `LogFrontend` call inside the `StateDirID` catch. Why: `LogFrontend` throws synchronously when the Wails binding is missing — the same bridge-absent condition that makes `StateDirID` fail — so the unwrapped call rejected the bootstrap IIFE and `ConnectControl()` never ran. Proved by reverting the wrap: the new e2e test hangs with no project cards.
 - **2026-09-05** — Reviewer's MINOR "use the exported MOCK_STATE_DIR_ID in the spec" not applied as suggested. Why: `wails-mock.ts` imports the store and runs in the browser, so importing it from Playwright's node context dies on `import.meta`. Used a hand-synced constant with a comment saying why.
 - **2026-09-05** — `storageNS` / `persistProjectSets` live as module state, not store state. Why: they are storage plumbing no component renders; putting them in `AppData` would widen the frozen `window.__hive_state` shape for no reader.
@@ -313,6 +314,7 @@ a changeset note covering the documented key name.
 
 Append-only. One line per `/hs-review-loop` iteration.
 
+- **2026-09-05 iter 2** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop (3 MINORs applied under boil-the-lake); head_sha: e0c7092.
 - **2026-09-05 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0ae4ada1ce675449; threads_open: 0; action: fixed IMPORTANT + 2 MINOR, push, re-review; head_sha: 37f15e2.
 
 ## Open questions

--- a/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
+++ b/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
@@ -1,0 +1,310 @@
+# Persist minimized projects across restarts
+
+- **Spec:** [docs/product-specs/340-persist-minimized-projects-across-restarts.md](../../product-specs/340-persist-minimized-projects-across-restarts.md)
+- **Issue:** #340
+- **Status:** active
+
+## Summary
+
+Minimized projects are already persisted to localStorage
+(`hive.minimizedProjects`), yet a full daemon + GUI restart brings every
+project back expanded. This plan finds the point in the boot path where the
+persisted set is lost and fixes it there, with a regression test that would
+have caught it.
+
+## Research
+
+### Relevant code
+
+- `cmd/hivegui/frontend/src/lib/collapsed.ts` — `MINIMIZED_PROJECTS_STORAGE_KEY`
+  (`hive.minimizedProjects`), `loadCollapsed`, `serializeCollapsed`,
+  `pruneCollapsed`. Pure, well covered by `test/unit/minimized-projects.test.ts`.
+- `cmd/hivegui/frontend/src/store/store.ts:291` — `initialData()` seeds
+  `minimizedProjects` from localStorage as an import side effect.
+- `store.ts:392` `applyProjectList` — the **only** prune point; prunes the
+  persisted set against the `project:list` id snapshot and re-persists when the
+  set changed.
+- `store.ts:683/689` `minimizeProject` / `restoreProject` — persist on every
+  write. `view.ts:381/404` are the only callers; the legacy
+  `hiveStateView.minimizedProjects` setter routes through `setMinimizedProjects`,
+  which also persists. No unpersisted write path exists.
+- `internal/registry/registry.go:717` `load()` — rebuilds `r.projects` from the
+  persisted `ID` field in `projects/index.json` + `project.json`.
+  `internal/registry/projects.go:39` `EnsureDefaultProject` only mints a UUID
+  when the project list is genuinely empty.
+- `internal/daemon/daemon.go:623` — the handshake sends `wire.FrameProjects`
+  (`project:list`) from `reg.ListProjects()`, i.e. **every** known project, not
+  only ones with live sessions.
+
+### Constraints / findings
+
+1. **Project IDs are stable across a daemon restart.** Verified on the
+   operator's real state dir: `~/Library/Application Support/Hive/projects/`
+   holds eight project directories dated May–Sep, and `index.json` lists those
+   same eight UUIDs. Nothing is re-minted at boot.
+2. **The browser round trip is correct.** A new e2e test
+   (`test/e2e/minimize-project.spec.ts` › "a minimized project stays minimized
+   across a reload") minimizes a project, asserts the localStorage write, reloads
+   the page, and asserts the tray chip survives. It **passes** against the Wails
+   mock.
+3. **The real install's persisted set is stale.** Reading the actual WKWebView
+   store
+   (`~/Library/WebKit/com.wails.hivegui/WebsiteData/.../LocalStorage/localstorage.sqlite3`):
+   - `hive.theme` = `dracula`, `hive.view` = `single`, `hive.fontSize` = `16`,
+     `hive.sidebarWidth` = `328` — localStorage itself persists fine.
+   - `hive.minimizedProjects` = `["7b50fc60-b5bc-425f-a879-88dd21d7c849"]`
+   - `hive.collapsedProjects` = `["42b70ec6-…","63fd20ad-…", …]`
+
+   **None of those UUIDs exist** in `projects/index.json`, in
+   `sessions/`, in `closed/`, or anywhere in `hived.log` / `hivegui.log`.
+   They are orphans from projects that no longer exist — which means
+   `applyProjectList`'s prune has never successfully run in this install.
+   That is the anomaly worth chasing: prune is the one code path that both
+   cleans stale ids *and* is the only path that can silently narrow the set.
+
+### Open lead
+
+The set on disk is stale rather than empty, so the failure is not "the value is
+wiped at quit". Either the `project:list` handler is not reaching
+`applyProjectList` in the real app, or a second GUI window boots with a stale
+in-memory set and clobbers the good one on its own write. Distinguishing them
+needs a live before/after read of the sqlite store around a real
+minimize + quit + relaunch.
+
+### Prior lessons
+
+Brain search returned no matching entries for this bug.
+
+## Approach
+
+Namespace the two persisted project-id keys by the **state directory of the
+daemon this GUI is talking to**, so instances that own disjoint project
+registries stop sharing (and pruning) one another's sets.
+
+Why this over the obvious one-line alternative (delete the prune from
+`applyProjectList`): dropping the prune would stop the data loss, but it leaves
+the sets semantically wrong — minimizing a project in the main daemon would
+still be recorded in the same bucket a worktree daemon reads — and it gives up
+the "don't grow forever" property the prune was added for. Namespacing fixes
+the cause; removing the prune only hides the symptom.
+
+### The three real design problems
+
+1. **The namespace is not known synchronously.** `initialData()`
+   (`store.ts:291`) runs as an import side effect, before any Wails binding can
+   be called. Hydration of the two sets therefore moves out of `initialData()`
+   (which now starts them empty) into an explicit
+   `hydratePersistedProjectSets(ns)` action, awaited inside the existing
+   bootstrap IIFE in `main.tsx` **immediately before `await ConnectControl()`**.
+   No frame can arrive before the connect call — the daemon sends its snapshot
+   only after the handshake (`internal/daemon/daemon.go:623`) — so the
+   synchronous top-level `wireDaemonEvents(...)` call does not move.
+
+2. **The prune must not run before hydration.** If `project:list` arrived first
+   it would prune an empty set and persist `[]`, reproducing the bug exactly.
+   `AppData` (`store.ts:58` — *not* `AppState`, see below) gets
+   `projectSetsHydrated: boolean`; `applyProjectList` still applies the project
+   list but skips pruning until the flag is set.
+
+3. **Failing safe must mean writing nothing.** If `StateDirID()` throws or
+   returns empty, falling back to the bare key would re-create the shared-key
+   bug *and* resurrect a legacy key a prior migration deleted, which another
+   daemon's GUI would then adopt. So hydration failure disables persistence
+   outright: a module-level `persistProjectSets` flag gates
+   `persistCollapsed` / `persistMinimizedProjects`, and stays false until a
+   non-empty namespace is installed. The sets remain usable in memory for the
+   session; they are simply not written.
+
+**Migration:** on first hydrate under a **non-empty** namespace, if the
+namespaced key is absent and the legacy un-namespaced key exists, adopt the
+legacy value and remove the legacy key. Migration is skipped entirely when the
+namespace is empty — the two key names would be identical and "adopt then
+delete" would destroy the value it just read.
+
+`projectSetsHydrated` goes on `AppData` only. `AppState` (`app/state.ts:175`)
+types the `hiveStateView` facade (`store.ts:958`), whose key list is frozen by
+`test/unit/store.test.ts:383`; adding a field there would break that test and
+force a getter/setter with no reader.
+
+No wire frames change — `StateDirID` is a GUI-local Wails binding reading
+`registry.StateDir()`, so no `buildinfo.DaemonContract` bump is required
+(`scripts/check-daemon-contract.sh:36` watches `internal/{wire,daemon,session,registry}`
+and `cmd/hived`; none are touched).
+
+### Files to change
+
+1. `cmd/hivegui/app_calls.go` — new binding `StateDirID() string`: first 8 hex
+   chars of `sha256(registry.StateDir())`. Short, stable, and keeps a
+   filesystem path out of web storage.
+2. `cmd/hivegui/frontend/src/lib/collapsed.ts` — add `namespacedKey(base, ns)`;
+   returns `base` for an empty `ns`, `` `${base}.${ns}` `` otherwise.
+   `loadCollapsed` / `serializeCollapsed` / `pruneCollapsed` unchanged.
+3. `cmd/hivegui/frontend/src/store/store.ts` —
+   - module-level `storageNS` and `persistProjectSets`; `persistCollapsed` /
+     `persistMinimizedProjects` resolve their key through `namespacedKey` and
+     return early when `persistProjectSets` is false.
+   - `initialData()` seeds both sets empty and `projectSetsHydrated: false`;
+     `AppData` gains that field.
+   - `loadSavedCollapsed` / `loadSavedMinimizedProjects` (`store.ts:212`) take
+     an explicit namespace and become internal to the hydrate action — no
+     un-namespaced loader stays on the public surface.
+   - new `hydratePersistedProjectSets(ns)`: installs the namespace, runs the
+     migration, loads both sets, enables persistence, flips the flag.
+   - `applyProjectList`: prune only when `projectSetsHydrated`.
+   - `resetStore()` (`store.ts:928`) clears `storageNS` / `persistProjectSets`
+     so a namespace cannot leak between vitest files sharing a worker.
+4. `cmd/hivegui/frontend/src/main.tsx` — bootstrap step 2.5 inside the existing
+   IIFE, immediately before `await ConnectControl()`. Update the bootstrap-order
+   comment at the top of the file, which currently says hydration is an import
+   side effect.
+5. `cmd/hivegui/frontend/src/bridge.ts` — re-export the new binding.
+6. `cmd/hivegui/frontend/test/e2e/wails-mock.ts` — mock `StateDirID`.
+7. `cmd/hivegui/frontend/test/unit/store.test.ts:264` — "hydrates every
+   persisted field from storage" currently seeds both keys and asserts
+   `resetStore()` yields `['p1','p2']` / `['p3']`. It becomes: `resetStore()`
+   yields **empty** sets, with the old assertion moved to a new
+   `hydratePersistedProjectSets` test.
+8. `cmd/hivegui/frontend/test/dom/minimize-project.test.tsx:426` — "prunes ids
+   missing from an authoritative project list" and "prunes against an empty
+   authoritative list" boot via `resetStore()`, which now leaves
+   `projectSetsHydrated: false` and would skip the prune. Both must hydrate
+   first.
+9. `.changesets/persist-minimized-projects-per-daemon.md` — `type: fixed`,
+   `bump: patch`. Mention the key rename, since `CHANGELOG.md:601` documents
+   `hive.collapsedProjects` by name.
+
+### New files
+
+- `cmd/hivegui/frontend/test/unit/storage-namespace.test.ts` — key derivation,
+  the empty-namespace case, and legacy migration.
+
+### Tests
+
+**The regression gate** is the dom test
+`test/dom/minimize-project.test.tsx` › "project:list before hydration does not
+prune or persist". That is the assertion that fails on `main` and passes after
+the fix. The e2e reload spec below already passes on `main` — it is coverage
+against a future regression, not proof of this fix.
+
+- `cmd/hivegui/app_calls_test.go` › `TestStateDirID` — 8 hex chars, stable for
+  one dir, different for two.
+- `test/unit/storage-namespace.test.ts` › `namespacedKey` returns the bare base
+  for an empty namespace, a suffixed key otherwise; migration adopts and removes
+  the legacy key under a real namespace, and is a no-op under an empty one.
+- `test/unit/store.test.ts` › `resetStore()` leaves both sets empty;
+  `hydratePersistedProjectSets('ns')` fills them from the namespaced keys;
+  a failed hydrate (empty namespace) leaves persistence disabled so a subsequent
+  `minimizeProject` writes nothing to storage.
+- `test/dom/minimize-project.test.tsx` ›
+  - **`project:list` before hydration does not prune or persist** (the gate).
+  - after hydration under namespace A, a `project:list` from A prunes only A's
+    dead ids.
+  - a set stored under namespace B is untouched by a full boot under A.
+  - restore-then-reboot leaves the project restored — the empty-set round trip,
+    which otherwise looks identical to "hydration never ran" (spec success
+    criterion 2).
+  - the two existing prune tests, updated to hydrate first.
+
+**Every existing test that asserts a persisted write must hydrate first and
+read the namespaced key.** The `persistProjectSets` gate means a bare
+`resetStore()` writes nothing, so these go from passing to
+`JSON.parse(null)` or `expect(['p3'])` against `[]`:
+`test/unit/store.test.ts:140,147` (toggleCollapsed round trip), `:157`
+(`applyProjectList` prunes collapsed), `:192,198` (minimize/restore persist);
+`test/dom/minimize-project.test.tsx:200,204` ("persists the minimized set"),
+`:284` ("keeps the set intact across a render with no projects loaded yet"),
+and `:415` ("drops the minimized id when the project is deleted" — which goes
+vacuous rather than red, since both sides become `[]`; it routes through
+`removeProject`, `store.ts:436`, a persist call site to hydrate for too).
+
+**The gate test only fails on `main` if it seeds the bare keys.** It must write
+`hive.collapsedProjects` / `hive.minimizedProjects` *un-namespaced* before
+`resetStore()`, so that on `main` `initialData()` populates the sets and the
+un-gated prune wipes them; then assert the sets survive and nothing was
+written. Seeding the namespaced key instead makes it green on `main` — the
+same vacuity the first review caught in the e2e spec.
+
+`test/e2e/minimize-project.spec.ts:202` reads the literal
+`hive.minimizedProjects`; its key expression must be derived from whatever
+namespace `wails-mock.ts` returns, and the mock must return a non-empty one
+(an empty namespace disables persistence, so nothing would be written at all).
+- `test/e2e/minimize-project.spec.ts` › "a minimized project stays minimized
+  across a reload" — already added; coverage.
+
+### Verification
+
+```
+./scripts/ci-bootstrap.sh                 # regenerates wailsjs/ so tsc sees StateDirID
+cd cmd/hivegui/frontend && npx tsc --noEmit && npx biome ci .
+go test ./cmd/hivegui/...
+scripts/test.sh unit dom
+CI=1 npm run test:e2e -- test/e2e/minimize-project.spec.ts
+```
+
+`wailsjs/` is generated and untracked, so the bootstrap step must come first or
+`tsc` fails on a missing binding for reasons unrelated to the diff.
+
+### Risks / open questions
+
+- **Two GUI windows on the same daemon** still last-writer-wins. Matches
+  `window.json`'s documented behaviour; called out as a non-goal.
+- **The namespace comes from the GUI process's own `registry.StateDir()`**, not
+  from the daemon it actually connected to. Correct for the case in the spec,
+  where `HIVE_SOCKET` and `HIVE_STATE_DIR` are set together, but wrong for a GUI
+  pointed at a foreign socket. Deriving the id from the handshake would close
+  that; out of scope here.
+- **Changing `HIVE_STATE_DIR` orphans a namespace.** The old key lingers —
+  a few dozen bytes, only for users who move their state dir. Not worth a GC pass.
+- **Operator data restore.** The wiped ids (`7b50fc60-…` minimized;
+  `42b70ec6-…`, `63fd20ad-…` collapsed, all belonging to
+  `/tmp/hive-iso-azure-comet/state`) can be written back under that state dir's
+  namespace once the key format exists. WebKit holds the sqlite open, so it
+  needs every hivegui quit first: a manual post-merge step, explicitly **not**
+  part of the diff.
+
+## Second opinion
+
+Reviewer verdict **revise**, confidence 8. It confirmed the approach and the
+"no daemon-contract bump" claim, and found seven concrete gaps: two existing
+tests the plan would have broken (`test/unit/store.test.ts:264`,
+`test/dom/minimize-project.test.tsx:426`), the flag placed on the wrong type
+(`AppState` rather than `AppData`, which would break the frozen facade-key test
+at `test/unit/store.test.ts:383`), an unsafe fallback that would rewrite the
+shared legacy key when `StateDirID()` fails, an undefined migration under an
+empty namespace, a missing `wailsjs/` regeneration step before `tsc`, and a
+vacuous headline assertion (the e2e reload spec already passes on `main`).
+
+All seven applied above. A second pass confirmed the fixes landed and every
+cited anchor is real, and returned `revise` again on one point: the
+`persistProjectSets` gate breaks more existing tests than the two enumerated,
+and the regression gate is only non-vacuous if it seeds the *bare* keys. Both
+are now written into the Tests section as implementation scope. Per the
+pipeline's one-retry rule there is no third review round. The reviewer also judged the pre-`ConnectControl()`
+ordering safe — no frame can arrive before the handshake — so the synchronous
+`wireDaemonEvents(...)` call stays where it is. Four of its nice-to-haves were
+taken as well: resetting `storageNS` in `resetStore()`, namespacing the two
+loaders, an explicit restore-then-reboot assertion for success criterion 2, and
+a changeset note covering the documented key name.
+
+## Decision log
+
+- **2026-09-04** — Scope limited to projects; individually minimized sessions stay transient. Why: operator confirmed at clarifying round A; the session terminals are gone after a restart anyway.
+- **2026-09-04** — Treated as a bug, not a new feature. Why: `store.minimizeProject`/`initialData()` already read and write `hive.minimizedProjects`; the machinery exists and is not taking effect.
+- **2026-09-04** — Reproduction required before any patch. Why: operator's standing rule — guess-patches in this area have made things worse before.
+- **2026-09-05** — Root cause confirmed empirically, not by inspection: read the real WKWebView localStorage sqlite and compared the persisted ids against every daemon's `projects/index.json`. Why: two static-analysis passes both concluded "no code-visible cause" — the cause was environmental (one shared web-storage origin, several daemons).
+- **2026-09-05** — Namespace the keys rather than delete the prune. Why: operator's call at clarifying round B; the sets are per-daemon by nature, and dropping the prune trades one bug for unbounded growth.
+- **2026-09-05** — Namespace = `sha256(registry.StateDir())[:8]`, not the raw path. Why: keeps the key short and avoids putting a filesystem path in web storage.
+- **2026-09-05** — `test/e2e-real/wails-bridge.ts` also needed the `StateDirID` stub. Why: an existing test ("real harness defines every name bridge.ts re-exports") caught it — the e2e-real harness is a second binding surface the plan had not listed.
+- **2026-09-05** — `storageNS` / `persistProjectSets` live as module state, not store state. Why: they are storage plumbing no component renders; putting them in `AppData` would widen the frozen `window.__hive_state` shape for no reader.
+
+## Progress
+
+- **2026-09-05** — Implemented on `feature/340-persist-minimized-projects-across-restarts`. Full local verification green: 1030 unit+dom tests, 271 e2e, `go test ./cmd/hivegui/...`, `biome ci .` (0 errors), `tsc --noEmit`.
+- **2026-09-05** — Regression gate proved non-vacuous by simulating `main`'s behaviour (bare-key hydration + un-gated prune) in `store.ts` and re-running it: it failed with `expected '[]' to be '["foreign"]'` — the wipe itself. Reverted immediately.
+- **2026-09-05** — Plan approved (no section feedback); stage IMPLEMENT.
+- **2026-09-05** — Root cause confirmed; spec rewritten, complexity S→M, stage PLAN.
+- **2026-09-04** — Spec + plan created, stage RESEARCH. Repro scenario from operator: quit and relaunch BOTH daemon and GUI; every minimized project returns expanded, every time.
+
+## Open questions
+
+None blocking.

--- a/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
+++ b/docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md
@@ -297,6 +297,8 @@ a changeset note covering the documented key name.
 - **2026-09-05** — Namespace the keys rather than delete the prune. Why: operator's call at clarifying round B; the sets are per-daemon by nature, and dropping the prune trades one bug for unbounded growth.
 - **2026-09-05** — Namespace = `sha256(registry.StateDir())[:8]`, not the raw path. Why: keeps the key short and avoids putting a filesystem path in web storage.
 - **2026-09-05** — `test/e2e-real/wails-bridge.ts` also needed the `StateDirID` stub. Why: an existing test ("real harness defines every name bridge.ts re-exports") caught it — the e2e-real harness is a second binding surface the plan had not listed.
+- **2026-09-05** — Fixed review iter 1's IMPORTANT: wrapped the `LogFrontend` call inside the `StateDirID` catch. Why: `LogFrontend` throws synchronously when the Wails binding is missing — the same bridge-absent condition that makes `StateDirID` fail — so the unwrapped call rejected the bootstrap IIFE and `ConnectControl()` never ran. Proved by reverting the wrap: the new e2e test hangs with no project cards.
+- **2026-09-05** — Reviewer's MINOR "use the exported MOCK_STATE_DIR_ID in the spec" not applied as suggested. Why: `wails-mock.ts` imports the store and runs in the browser, so importing it from Playwright's node context dies on `import.meta`. Used a hand-synced constant with a comment saying why.
 - **2026-09-05** — `storageNS` / `persistProjectSets` live as module state, not store state. Why: they are storage plumbing no component renders; putting them in `AppData` would widen the frozen `window.__hive_state` shape for no reader.
 
 ## Progress
@@ -306,6 +308,12 @@ a changeset note covering the documented key name.
 - **2026-09-05** — Plan approved (no section feedback); stage IMPLEMENT.
 - **2026-09-05** — Root cause confirmed; spec rewritten, complexity S→M, stage PLAN.
 - **2026-09-04** — Spec + plan created, stage RESEARCH. Repro scenario from operator: quit and relaunch BOTH daemon and GUI; every minimized project returns expanded, every time.
+
+## PR convergence ledger
+
+Append-only. One line per `/hs-review-loop` iteration.
+
+- **2026-09-05 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0ae4ada1ce675449; threads_open: 0; action: fixed IMPORTANT + 2 MINOR, push, re-review; head_sha: 37f15e2.
 
 ## Open questions
 

--- a/docs/exec-plans/completed/340-persist-minimized-projects-across-restarts.md
+++ b/docs/exec-plans/completed/340-persist-minimized-projects-across-restarts.md
@@ -4,7 +4,7 @@
 - **Issue:** #340
 - **PR:** #342
 - **Branch:** `feature/340-persist-minimized-projects-across-restarts`
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -297,6 +297,7 @@ a changeset note covering the documented key name.
 - **2026-09-05** — Namespace the keys rather than delete the prune. Why: operator's call at clarifying round B; the sets are per-daemon by nature, and dropping the prune trades one bug for unbounded growth.
 - **2026-09-05** — Namespace = `sha256(registry.StateDir())[:8]`, not the raw path. Why: keeps the key short and avoids putting a filesystem path in web storage.
 - **2026-09-05** — `test/e2e-real/wails-bridge.ts` also needed the `StateDirID` stub. Why: an existing test ("real harness defines every name bridge.ts re-exports") caught it — the e2e-real harness is a second binding surface the plan had not listed.
+- **2026-09-05** — Gate PASS on the open PR; plan moved to `completed/`, spec advanced to DONE. Bookkeeping ships inside PR #342.
 - **2026-09-05** — Applied iter 2's three MINORs rather than deferring: `filepath.Clean` before hashing the state dir, `seed()` in the dom harness now models the post-boot hydrated state, and the changeset drops a legacy-adoption claim that only held for sequential launches. Why: AGENTS.md's boil-the-lake rule — all three are low-risk and the harness one would have quietly hidden the prune path from future tests.
 - **2026-09-05** — Fixed review iter 1's IMPORTANT: wrapped the `LogFrontend` call inside the `StateDirID` catch. Why: `LogFrontend` throws synchronously when the Wails binding is missing — the same bridge-absent condition that makes `StateDirID` fail — so the unwrapped call rejected the bootstrap IIFE and `ConnectControl()` never ran. Proved by reverting the wrap: the new e2e test hangs with no project cards.
 - **2026-09-05** — Reviewer's MINOR "use the exported MOCK_STATE_DIR_ID in the spec" not applied as suggested. Why: `wails-mock.ts` imports the store and runs in the browser, so importing it from Playwright's node context dies on `import.meta`. Used a hand-synced constant with a comment saying why.
@@ -309,6 +310,18 @@ a changeset note covering the documented key name.
 - **2026-09-05** — Plan approved (no section feedback); stage IMPLEMENT.
 - **2026-09-05** — Root cause confirmed; spec rewritten, complexity S→M, stage PLAN.
 - **2026-09-04** — Spec + plan created, stage RESEARCH. Repro scenario from operator: quit and relaunch BOTH daemon and GUI; every minimized project returns expanded, every time.
+
+## Gate verdict
+
+- **2026-09-05** — verdict: PASS; checks: 3 dimensions passed / 0 failed / 0 followups; followups: none; one-line: all three success criteria demonstrated behaviorally, no non-goal bleed, docs accurate.
+  - 2026-09-05 dimensions:
+    - acceptance — PASS — all three criteria proved by executed tests, not code reading. Criterion 3 (a deleted project is dropped, not stranded) verified specifically against the *hydrated* path: `minimize-project.test.tsx:416/426/435` run under a `beforeEach` that hydrates with a non-empty namespace, so the new `projectSetsHydrated` gate suppresses pruning only in the pre-handshake window, not in steady state.
+    - non-goals — PASS — session-level `appData().minimized` untouched; `git diff main...HEAD -- internal/wire internal/registry` empty, so no daemon-owned state and no new wire frame (`StateDirID` only *reads* `registry.StateDir()`); no window-identity or cross-window coordination added. No scope creep.
+    - doc accuracy — PASS — changeset schema and prose correct (`type: fixed`, `bump: patch`, `pr: 342`), `CHANGELOG.md` and `docs/product-specs/index.md` untouched, no current-tense doc misdescribes the now-namespaced keys, spec/plan cross-links resolve.
+
+  Noted, out of scope for this PR: `AGENTS.md:217` and `CONTRIBUTING.md:63` both point at `.changesets/README.md`, which does not exist in the repo. Pre-existing, unrelated to #340.
+
+  Caveat on the convergence signal: review iteration 2's APPROVE was recorded at `e0c7092`; the three MINOR commits it requested landed after, so head `e232082` was gated but never re-reviewed. CI is green on `e232082`.
 
 ## PR convergence ledger
 

--- a/docs/product-specs/340-persist-minimized-projects-across-restarts.md
+++ b/docs/product-specs/340-persist-minimized-projects-across-restarts.md
@@ -5,7 +5,7 @@ type: bug
 complexity: M
 priority: P2
 pr: 342
-stage: REVIEW
+stage: GATE
 ---
 
 # Persist minimized projects across restarts

--- a/docs/product-specs/340-persist-minimized-projects-across-restarts.md
+++ b/docs/product-specs/340-persist-minimized-projects-across-restarts.md
@@ -4,7 +4,8 @@ title: "Persist minimized projects across restarts"
 type: bug
 complexity: M
 priority: P2
-stage: IMPLEMENT
+pr: 342
+stage: REVIEW
 ---
 
 # Persist minimized projects across restarts

--- a/docs/product-specs/340-persist-minimized-projects-across-restarts.md
+++ b/docs/product-specs/340-persist-minimized-projects-across-restarts.md
@@ -1,0 +1,65 @@
+---
+issue: 340
+title: "Persist minimized projects across restarts"
+type: bug
+complexity: M
+priority: P2
+stage: IMPLEMENT
+---
+
+# Persist minimized projects across restarts
+
+- **Issue:** #340
+- **Type:** bug
+- **Complexity:** M
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md](../exec-plans/active/340-persist-minimized-projects-across-restarts.md)
+
+## Problem
+
+Minimizing a project in the GUI collapses it into the sidebar tray, but the
+collapsed state does not survive an app restart — projects come back
+expanded.
+
+**Root cause (confirmed on the operator's machine, 2026-09-05).** Every
+hivegui process shares one WKWebView localStorage, keyed on the bundle id
+`com.wails.hivegui` — *not* on which daemon it is connected to. Users who run
+isolated per-worktree daemons (`HIVE_SOCKET` + `HIVE_STATE_DIR`) therefore have
+several GUIs writing one `hive.minimizedProjects` key, while each daemon has
+its own registry with completely disjoint project UUIDs.
+
+`applyProjectList` prunes the persisted set against the `project:list`
+snapshot, so on every boot each instance deletes the other instances' ids as
+"projects that no longer exist". Evidence: the persisted set held
+`["7b50fc60-…"]`, a project belonging to `/tmp/hive-iso-azure-comet/state`,
+while the connected daemon's registry listed eight unrelated UUIDs; one
+quit-and-relaunch of the main GUI rewrote the key to `[]`.
+
+`hive.collapsedProjects` has the identical defect — same key family, same
+prune.
+
+## Desired behavior
+
+A project the user minimized is still minimized the next time the GUI
+starts, for as long as that project still exists.
+
+## Success criteria
+
+- Minimize a project, quit and relaunch the GUI: the project is still in the
+  sidebar tray and its sessions are still absent from grid views.
+- Restoring a project and restarting leaves it restored.
+- A project that no longer exists is dropped from the persisted set rather
+  than stranding a tray chip.
+
+## Non-goals
+
+- Fixing this for two GUI windows attached to the *same* daemon. Last writer
+  wins there, matching `window.json`'s documented behaviour.
+
+- Persisting individually minimized **sessions** (`appData().minimized`).
+  Those are deliberately transient — the terminals are gone after a restart.
+- Moving this state out of localStorage into daemon-owned state.
+
+## Notes
+
+Related: spec 336 (session state model) moved other state daemon-side.

--- a/docs/product-specs/340-persist-minimized-projects-across-restarts.md
+++ b/docs/product-specs/340-persist-minimized-projects-across-restarts.md
@@ -5,7 +5,8 @@ type: bug
 complexity: M
 priority: P2
 pr: 342
-stage: GATE
+shipped: 2026-09-05
+stage: DONE
 ---
 
 # Persist minimized projects across restarts
@@ -14,7 +15,7 @@ stage: GATE
 - **Type:** bug
 - **Complexity:** M
 - **Priority:** P2
-- **Exec plan:** [docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md](../exec-plans/active/340-persist-minimized-projects-across-restarts.md)
+- **Exec plan:** [docs/exec-plans/completed/340-persist-minimized-projects-across-restarts.md](../exec-plans/completed/340-persist-minimized-projects-across-restarts.md)
 
 ## Problem
 


### PR DESCRIPTION
Fixes #340

## The bug

Minimized and collapsed projects came back expanded after every restart, for anyone running more than one `hived`.

Every hivegui process shares **one** WKWebView localStorage — it is keyed on the bundle id `com.wails.hivegui`, not on the daemon socket — while each daemon owns a registry with its own project UUIDs. `applyProjectList` prunes the persisted sets against the `project:list` snapshot and cannot tell a foreign daemon's project id from a deleted one, so each instance's boot deleted the other instances' ids and persisted the result.

Confirmed empirically rather than by inspection — two static-analysis passes both concluded "no code-visible cause", because the cause was environmental:

| Persisted key | Value | Owning state dir |
|---|---|---|
| `hive.minimizedProjects` | `["7b50fc60-…"]` | `/tmp/hive-iso-azure-comet/state` |
| `hive.collapsedProjects` | `["42b70ec6-…","63fd20ad-…"]` | `/tmp/hive-iso-azure-comet/state` |
| connected daemon's registry | 8 unrelated UUIDs | `~/Library/Application Support/Hive` |

One quit-and-relaunch of the main GUI rewrote both keys to `[]`.

Ruled out along the way: project-id churn across daemon restart (ids round-trip through `projects/index.json`), a stale build, localStorage quota (48K chars total), and WebKit flush lag.

## The fix

Suffix both keys with `sha256(registry.StateDir())[:8]`, exposed by a new GUI-local `StateDirID` binding. Three things it needs:

- **The namespace is not known synchronously.** `initialData()` runs as an import side effect, before any Wails binding can be called, so hydration moves into `hydratePersistedProjectSets`, awaited in the bootstrap block immediately before `ConnectControl()`. No frame can arrive earlier — the daemon sends its snapshot only after the handshake.
- **The prune is gated on `projectSetsHydrated`.** Pruning an un-hydrated (empty) set would persist `[]` and reproduce the bug exactly.
- **Failing safe means writing nothing.** If the daemon cannot be identified, persistence is disabled for the session rather than falling back to the bare key — that would re-create the shared-key bug *and* resurrect a legacy key a prior migration deleted, which another GUI would then adopt.

Pre-existing un-namespaced values are migrated into the right bucket on first launch. No wire change, so no `DaemonContract` bump.

## Verification

The regression gate is the store test **"does not touch persisted project sets before hydration"**. Simulating `main`'s behaviour (bare-key hydration plus an un-gated prune) makes it fail with `expected '[]' to be '["foreign"]'` — the wipe itself. The e2e reload spec added here already passed on `main`; it is coverage, not proof.

All green locally: 1030 unit+dom tests, 271 e2e, `go test ./cmd/hivegui/...`, `biome ci .` (0 errors), `tsc --noEmit`.

An existing test ("real harness defines every name bridge.ts re-exports") caught that `test/e2e-real/wails-bridge.ts` is a second binding surface needing the stub.

## Known limits

- The namespace comes from the GUI process's own `registry.StateDir()`, not from the daemon it connected to. Correct when `HIVE_SOCKET` and `HIVE_STATE_DIR` are set together; wrong for a GUI pointed at a foreign socket.
- Two GUI windows on one daemon still last-writer-wins, matching `window.json`'s documented behaviour.

Spec: `docs/product-specs/340-persist-minimized-projects-across-restarts.md`
Plan: `docs/exec-plans/active/340-persist-minimized-projects-across-restarts.md`