### PR TITLE
feat(state): hivebar counts what waits, tooltips say why (336 phase 4)

### DIFF
--- a/.changesets/336-stale-tick-source.md
+++ b/.changesets/336-stale-tick-source.md
@@ -1,0 +1,11 @@
+---
+issue: null
+pr: 344
+type: fixed
+bump: patch
+---
+- A session whose agent stopped reporting no longer claims the agent
+  said it was idle. When Hive falls back to guessing because an agent's
+  hooks went quiet, the state icon's tooltip now says "guessed from
+  terminal output" instead of continuing to credit the agent for a
+  state it never sent.

--- a/.changesets/336-waiting-count-and-tooltip.md
+++ b/.changesets/336-waiting-count-and-tooltip.md
@@ -6,7 +6,9 @@ bump: minor
 ---
 - The menu bar's summary now reads "2 waiting on you" instead of
   "2 need you", and says the same thing the dots beside the sessions
-  do.
+  do. The collapsed project card in the main window uses the same
+  wording, so the two surfaces no longer describe the same count
+  differently.
 - Hovering a session's state icon, in the sidebar or on a tile, now
   shows what that session was asked to do, the last thing the agent
   said, and whether the state was reported by the agent or guessed from

--- a/.changesets/336-waiting-count-and-tooltip.md
+++ b/.changesets/336-waiting-count-and-tooltip.md
@@ -4,11 +4,9 @@ pr: 344
 type: changed
 bump: minor
 ---
-- The menu bar now counts the sessions actually blocked on you —
-  "2 waiting on you" — instead of the ones whose bell you have not
-  cleared yet, and the dot beside a session means the same thing. An
-  agent that rang once and went back to work no longer counts against
-  you.
+- The menu bar's summary now reads "2 waiting on you" instead of
+  "2 need you", and says the same thing the dots beside the sessions
+  do.
 - Hovering a session's state icon, in the sidebar or on a tile, now
   shows what that session was asked to do, the last thing the agent
   said, and whether the state was reported by the agent or guessed from

--- a/.changesets/336-waiting-count-and-tooltip.md
+++ b/.changesets/336-waiting-count-and-tooltip.md
@@ -1,0 +1,18 @@
+---
+issue: null
+pr: null
+type: changed
+bump: minor
+---
+- The menu bar now counts the sessions actually blocked on you —
+  "2 waiting on you" — instead of the ones whose bell you have not
+  cleared yet, and the dot beside a session means the same thing. An
+  agent that rang once and went back to work no longer counts against
+  you.
+- Hovering a session's state icon, in the sidebar or on a tile, now
+  shows what that session was asked to do, the last thing the agent
+  said, and whether the state was reported by the agent or guessed from
+  its terminal output.
+- Desktop notifications say which kind of answer is wanted: "waiting
+  for permission" when an agent is blocked on a yes/no, "waiting for
+  input" otherwise.

--- a/.changesets/336-waiting-count-and-tooltip.md
+++ b/.changesets/336-waiting-count-and-tooltip.md
@@ -1,6 +1,6 @@
 ---
 issue: null
-pr: null
+pr: 344
 type: changed
 bump: minor
 ---

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ also the only time you can't ask the GUI. It shows:
   daemon is too old for this build to drive;
 - how many sessions are open across how many projects, and how many are
   waiting on you;
-- every session, `project · session`, with a dot on the ones that rang.
+- every session, `project · session`, with a dot on the ones that are
+  actually blocked on you — an agent waiting for input or for a
+  permission answer, not merely one that rang the bell a while ago.
   Clicking one jumps straight to it, launching Hive if it isn't running.
 
 Plus **Reload GUI**, **Restart Daemon…** (confirmed — it ends every

--- a/README.md
+++ b/README.md
@@ -81,9 +81,8 @@ also the only time you can't ask the GUI. It shows:
   daemon is too old for this build to drive;
 - how many sessions are open across how many projects, and how many are
   waiting on you;
-- every session, `project · session`, with a dot on the ones that are
-  actually blocked on you — an agent waiting for input or for a
-  permission answer, not merely one that rang the bell a while ago.
+- every session, `project · session`, with a dot on the ones blocked on
+  you — an agent waiting for input or for a permission answer.
   Clicking one jumps straight to it, launching Hive if it isn't running.
 
 Plus **Reload GUI**, **Restart Daemon…** (confirmed — it ends every

--- a/cmd/hivebar/model.go
+++ b/cmd/hivebar/model.go
@@ -33,8 +33,11 @@ type Model struct {
 
 	Projects []ProjectGroup
 
-	Sessions  int
-	Attention int
+	Sessions int
+	// Waiting counts the sessions actually blocked on the user —
+	// state ∈ {waiting_input, waiting_permission} — rather than the
+	// sessions whose bell happens to be unacknowledged.
+	Waiting int
 }
 
 // ProjectGroup is one project and the sessions under it, in the order
@@ -50,11 +53,35 @@ type SessionRow struct {
 	ID    string
 	Name  string
 	Title string
-	// NeedsAttention drives the marker on the row. Rendered rather than
-	// counted-only because "3 need you" without saying which is a
-	// prompt to open the GUI and hunt.
-	NeedsAttention bool
-	Alive          bool
+	// Waiting drives the marker on the row. Rendered rather than
+	// counted-only because "3 waiting on you" without saying which is a
+	// prompt to open the GUI and hunt. It is the same predicate the
+	// count uses, so the marker and the summary can never disagree.
+	Waiting bool
+	Alive   bool
+}
+
+// stateContract is the DaemonContract generation that introduced
+// SessionInfo.state (internal/buildinfo/contract.go, history entry 3).
+//
+// It exists because `state` cannot answer "does this daemon report
+// state at all": StateIdle is the empty string, so an idle session on a
+// current daemon and every session on an old one look identical on the
+// wire. The daemon's own contract number is the only honest
+// discriminator, and Welcome already carries it.
+const stateContract = 3
+
+// waiting reports whether a session is blocked on the user.
+//
+// Below stateContract the daemon sends no state, so needs_attention —
+// the bell-driven flag hivebar read before this — is all there is, and
+// falling back to it keeps an old daemon's menu working rather than
+// showing a permanent zero.
+func waiting(s wire.SessionInfo, daemonContract int) bool {
+	if daemonContract < stateContract {
+		return s.NeedsAttention
+	}
+	return s.State == wire.StateWaitingInput || s.State == wire.StateWaitingPermission
 }
 
 // BuildModel groups a snapshot into what the menu shows.
@@ -94,15 +121,16 @@ func BuildModel(
 		return sortedSessions[i].Order < sortedSessions[j].Order
 	})
 	for _, s := range sortedSessions {
-		if s.NeedsAttention {
-			m.Attention++
+		w := waiting(s, welcome.DaemonContract)
+		if w {
+			m.Waiting++
 		}
 		row := SessionRow{
-			ID:             s.ID,
-			Name:           s.Name,
-			Title:          s.Title,
-			NeedsAttention: s.NeedsAttention,
-			Alive:          s.Alive,
+			ID:      s.ID,
+			Name:    s.Name,
+			Title:   s.Title,
+			Waiting: w,
+			Alive:   s.Alive,
 		}
 		g, ok := byID[s.ProjectID]
 		if !ok {
@@ -173,8 +201,8 @@ func (m Model) SummaryLine() string {
 	}
 	s := fmt.Sprintf("%s across %s",
 		plural(m.Sessions, "session"), plural(len(m.Projects), "project"))
-	if m.Attention > 0 {
-		s += fmt.Sprintf(" · %d need%s you", m.Attention, verbS(m.Attention))
+	if m.Waiting > 0 {
+		s += fmt.Sprintf(" · %d waiting on you", m.Waiting)
 	}
 	return s
 }
@@ -192,7 +220,7 @@ func (m SessionRow) LabelIn(project string) string {
 		name = m.ID
 	}
 	prefix := "  "
-	if m.NeedsAttention {
+	if m.Waiting {
 		// A leading marker rather than a trailing one: menu items are
 		// left-aligned and of wildly differing widths, so a trailing
 		// glyph lands in a different place on every row and stops
@@ -216,11 +244,4 @@ func plural(n int, noun string) string {
 		return fmt.Sprintf("1 %s", noun)
 	}
 	return fmt.Sprintf("%d %ss", n, noun)
-}
-
-func verbS(n int) string {
-	if n == 1 {
-		return "s"
-	}
-	return ""
 }

--- a/cmd/hivebar/model_test.go
+++ b/cmd/hivebar/model_test.go
@@ -79,32 +79,77 @@ func TestBuildModelDropsEmptyProjects(t *testing.T) {
 	}
 }
 
-func TestBuildModelCountsAttention(t *testing.T) {
+func TestBuildModelCountsWaiting(t *testing.T) {
+	m := BuildModel(
+		[]wire.ProjectInfo{{ID: "p1", Name: "p"}},
+		[]wire.SessionInfo{
+			{ID: "a", ProjectID: "p1", Alive: true, State: wire.StateWaitingInput},
+			{ID: "b", ProjectID: "p1", Alive: true, State: wire.StateWorking},
+			{ID: "c", ProjectID: "p1", Alive: true, State: wire.StateWaitingPermission},
+			// Idle is the empty state, and must not be mistaken for
+			// "waiting" by a predicate that only tests for non-empty.
+			{ID: "d", ProjectID: "p1", Alive: true, State: wire.StateIdle},
+		},
+		welcome(buildinfo.DaemonContract), buildinfo.DaemonContract,
+	)
+	if m.Waiting != 2 {
+		t.Errorf("Waiting = %d, want 2", m.Waiting)
+	}
+	if !strings.Contains(m.SummaryLine(), "2 waiting on you") {
+		t.Errorf("SummaryLine = %q", m.SummaryLine())
+	}
+}
+
+// The bell no longer drives the count on a daemon that reports state:
+// an unacknowledged bell on a session that has since gone back to work
+// is not a session waiting on the user.
+func TestBuildModelIgnoresBellWhenStateIsAvailable(t *testing.T) {
+	m := BuildModel(
+		[]wire.ProjectInfo{{ID: "p1", Name: "p"}},
+		[]wire.SessionInfo{
+			{ID: "a", ProjectID: "p1", Alive: true, NeedsAttention: true, State: wire.StateWorking},
+		},
+		welcome(buildinfo.DaemonContract), buildinfo.DaemonContract,
+	)
+	if m.Waiting != 0 {
+		t.Errorf("Waiting = %d, want 0", m.Waiting)
+	}
+	if strings.Contains(m.SummaryLine(), "waiting on you") {
+		t.Errorf("SummaryLine = %q, want no waiting clause", m.SummaryLine())
+	}
+}
+
+// Against a daemon too old to send `state`, every session's State is ""
+// — which is also StateIdle. Reading it literally would report a
+// permanent zero, so below stateContract the bell is still the answer.
+func TestBuildModelFallsBackToBellOnOldDaemon(t *testing.T) {
+	old := stateContract - 1
 	m := BuildModel(
 		[]wire.ProjectInfo{{ID: "p1", Name: "p"}},
 		[]wire.SessionInfo{
 			{ID: "a", ProjectID: "p1", Alive: true, NeedsAttention: true},
 			{ID: "b", ProjectID: "p1", Alive: true},
-			{ID: "c", ProjectID: "p1", Alive: true, NeedsAttention: true},
 		},
-		welcome(buildinfo.DaemonContract), buildinfo.DaemonContract,
+		welcome(old), buildinfo.DaemonContract,
 	)
-	if m.Attention != 2 {
-		t.Errorf("Attention = %d, want 2", m.Attention)
+	if m.Waiting != 1 {
+		t.Errorf("Waiting = %d, want 1", m.Waiting)
 	}
-	if !strings.Contains(m.SummaryLine(), "2 need you") {
-		t.Errorf("SummaryLine = %q", m.SummaryLine())
+	if !m.Projects[0].Sessions[0].Waiting {
+		t.Error("row marker did not follow the fallback count")
 	}
 }
 
 func TestSummaryLinePluralisation(t *testing.T) {
 	one := BuildModel(
 		[]wire.ProjectInfo{{ID: "p1", Name: "p"}},
-		[]wire.SessionInfo{{ID: "a", ProjectID: "p1", Alive: true, NeedsAttention: true}},
+		[]wire.SessionInfo{{ID: "a", ProjectID: "p1", Alive: true, State: wire.StateWaitingInput}},
 		welcome(buildinfo.DaemonContract), buildinfo.DaemonContract,
 	)
 	got := one.SummaryLine()
-	for _, want := range []string{"1 session", "1 project", "1 needs you"} {
+	// "waiting on you" reads correctly at any count, so unlike the
+	// session/project nouns it takes no plural form.
+	for _, want := range []string{"1 session", "1 project", "1 waiting on you"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("SummaryLine = %q, missing %q", got, want)
 		}
@@ -161,7 +206,7 @@ func TestSessionRowLabel(t *testing.T) {
 	}{
 		{"plain", SessionRow{Name: "alpha", Alive: true}, "", "  alpha"},
 		{"project named", SessionRow{Name: "alpha", Alive: true}, "hive", "  hive · alpha"},
-		{"attention marker leads", SessionRow{Name: "alpha", Alive: true, NeedsAttention: true}, "hive", "● hive · alpha"},
+		{"waiting marker leads", SessionRow{Name: "alpha", Alive: true, Waiting: true}, "hive", "● hive · alpha"},
 		{"dead session", SessionRow{Name: "alpha"}, "", "  alpha (stopped)"},
 		{"title appended", SessionRow{Name: "alpha", Title: "npm test", Alive: true}, "", "  alpha — npm test"},
 		// A title identical to the name is noise, not information.

--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -45,6 +45,7 @@ import { openChoiceDialog } from './modals/choice-dialog.js';
 import type { WorktreesPayload } from '../lib/worktrees.js';
 import { PHASE, phaseOf, isReady, isClosing } from '../lib/phase-steps.js';
 import { pruneNav } from '../lib/nav-history.js';
+import { DAEMON_STATE } from '../lib/session-state.js';
 import { handleScrollbackEvent, abandonReplays } from '../lib/scrollback.js';
 import { createScrollTrace } from '../lib/scroll-debug.js';
 import type { ScrollTrace } from '../lib/scroll-debug.js';
@@ -248,7 +249,16 @@ function fireBellNotification(info: SessionInfo) {
   const projectName = proj?.name ?? '';
   const title = info.name || 'Session';
   const subtitle = projectName;
-  const body = 'Waiting for input — click to switch.';
+  // Name the state rather than saying "input" for everything: a
+  // permission prompt is a different ask from an open-ended question,
+  // and a notification that blurs the two makes the user open the
+  // window to find out which it was. Anything else that reaches
+  // needs_attention (a bare bell on the heuristic tier) keeps the
+  // original wording, which is still true for it.
+  const body =
+    info.state === DAEMON_STATE.waitingPermission
+      ? 'Waiting for permission — click to switch.'
+      : 'Waiting for input — click to switch.';
   Notify(title, subtitle, body, info.id).catch(() => {
     // Best-effort; the visual sidebar pulse covers the user even if
     // the OS notification fails (no notify-send installed, etc.).

--- a/cmd/hivegui/frontend/src/components/Icon.tsx
+++ b/cmd/hivegui/frontend/src/components/Icon.tsx
@@ -34,9 +34,15 @@ export function Icon({ name, size = 14 }: { name: IconName; size?: 12 | 14 }) {
 export function StateIcon({
   state,
   className,
+  detail,
 }: {
   state: SessionState;
   className?: string;
+  // Overrides the <title> words with a fuller tooltip (see
+  // lib/session-state.ts stateTooltip). Optional so a call site with no
+  // session behind it — the phase-step icon in TileOverlays — keeps the
+  // plain state words.
+  detail?: string;
 }) {
   ensureSprite();
   return (
@@ -53,7 +59,7 @@ export function StateIcon({
       focusable="false"
       data-state={state}
     >
-      <title>{STATE_WORDS[state]}</title>
+      <title>{detail ?? STATE_WORDS[state]}</title>
       <use href={`#hv-state-${state}`} />
     </svg>
   );

--- a/cmd/hivegui/frontend/src/components/ProjectCard.tsx
+++ b/cmd/hivegui/frontend/src/components/ProjectCard.tsx
@@ -48,7 +48,10 @@ function countText(p: ProjectCardProps): string {
   if (!p.collapsed) return String(p.sessionCount);
   const n = `${p.sessionCount} session${p.sessionCount === 1 ? '' : 's'}`;
   if (p.attentionCount === 0) return n;
-  return `${n} · ${p.attentionCount} need${p.attentionCount === 1 ? 's' : ''} you`;
+  // Same words as the menu bar's summary line (cmd/hivebar/model.go):
+  // one predicate, one vocabulary. "waiting on you" needs no plural
+  // form, which is why the conjugation went away with it.
+  return `${n} · ${p.attentionCount} waiting on you`;
 }
 
 export function ProjectCard(p: ProjectCardProps) {

--- a/cmd/hivegui/frontend/src/components/SessionRow.tsx
+++ b/cmd/hivegui/frontend/src/components/SessionRow.tsx
@@ -23,7 +23,7 @@ import { StateIcon } from './Icon.js';
 import { IconButton } from './IconButton.js';
 import { Kbd } from './Kbd.js';
 import { isClosing, phaseOf } from '../lib/phase-steps.js';
-import type { SessionState } from '../lib/session-state.js';
+import { type SessionState, stateTooltip } from '../lib/session-state.js';
 import { displayTitle } from '../lib/term-title.js';
 import type { SessionInfo } from '../app/state.js';
 
@@ -135,7 +135,11 @@ export function SessionRow(p: SessionRowProps) {
       onDragOver={p.onDragOver}
       onDrop={p.onDrop}
     >
-      <StateIcon state={p.state} className="hv-session-row__state" />
+      <StateIcon
+        state={p.state}
+        className="hv-session-row__state"
+        detail={stateTooltip(s, p.state)}
+      />
       <span className="hv-session-row__text">
         <span className="hv-session-row__name" ref={p.nameRef}>
           {s.name ?? ''}

--- a/cmd/hivegui/frontend/src/components/TileChrome.tsx
+++ b/cmd/hivegui/frontend/src/components/TileChrome.tsx
@@ -34,7 +34,7 @@ import { beginInlineRename } from '../app/inline-rename.js';
 import { setFocusedTile, refocusActiveTerm } from '../app/focus.js';
 import { minimizeSession } from '../app/view.js';
 import { openWorktrees } from '../app/modals/worktrees.js';
-import { sessionState } from '../lib/session-state.js';
+import { sessionState, stateTooltip } from '../lib/session-state.js';
 import { displayTitle } from '../lib/term-title.js';
 import { appStore, useAppStore, type TileChromeState } from '../store/store.js';
 import { getTerm, useTermIds } from '../store/terms.js';
@@ -121,7 +121,10 @@ function TileHeader({
   if (!info) return null;
   return (
     <>
-      <StateIcon state={state} />
+      <StateIcon
+        state={state}
+        detail={stateTooltip({ ...info, phase: chrome.phase }, state)}
+      />
       {/* Double-click the tile name to rename inline, the same affordance
           the sidebar row has (SessionRow.tsx carries the identical
           ignore, for the identical reason). The listener is carried over

--- a/cmd/hivegui/frontend/src/lib/session-state.ts
+++ b/cmd/hivegui/frontend/src/lib/session-state.ts
@@ -72,14 +72,17 @@ export const STATE_WORDS: Record<SessionState, string> = {
 // How the state was arrived at, in words. Rendered because "the agent
 // told us it is waiting for permission" and "no bytes arrived for two
 // seconds" are not the same claim (internal/wire/control.go on
-// StateSource). hook and extension collapse to one phrase on purpose:
+// StateSource). Every reported tier collapses to one phrase on purpose:
 // which transport the agent used to say it is not the user's business,
 // only that the agent said it rather than us inferring it.
-const SOURCE_WORDS: Record<string, string> = {
-  hook: 'reported by the agent',
-  extension: 'reported by the agent',
-};
-const HEURISTIC_WORDS = 'guessed from terminal output';
+//
+// A truthiness test rather than a map of the known tiers: only the
+// heuristic tier is spelled "" on the wire, so any tier a future daemon
+// adds reads as reported — which is what it would be. A lookup table
+// would silently relabel it as a guess.
+function sourceWords(source: string | undefined): string {
+  return source ? 'reported by the agent' : 'guessed from terminal output';
+}
 
 /**
  * The full tooltip for a session's state icon: the state in words, what
@@ -92,12 +95,21 @@ const HEURISTIC_WORDS = 'guessed from terminal output';
  * doing.
  */
 export function stateTooltip(s: StateCarrier, state?: SessionState): string {
-  const lines = [STATE_WORDS[state ?? sessionState(s)]];
+  const resolved = state ?? sessionState(s);
+  const lines = [STATE_WORDS[resolved]];
   // Quoted: a prompt is the user's own words being read back, and
   // without the quotes it runs together with the state line above it.
   if (s.last_prompt) lines.push(`“${s.last_prompt}”`);
   if (s.last_summary) lines.push(s.last_summary);
-  lines.push(SOURCE_WORDS[s.state_source ?? ''] ?? HEURISTIC_WORDS);
+  // The tier line is a claim about where a state came from, so it is
+  // only honest for the states a tier actually produced. `starting`
+  // is resolved here from `phase`, and a dead session's exited/error
+  // comes from the process exiting — no tier observed either, and
+  // saying "guessed from terminal output" over them would be a
+  // fabricated provenance.
+  if (resolved !== 'starting' && s.alive) {
+    lines.push(sourceWords(s.state_source));
+  }
   return lines.join('\n');
 }
 

--- a/cmd/hivegui/frontend/src/lib/session-state.ts
+++ b/cmd/hivegui/frontend/src/lib/session-state.ts
@@ -49,6 +49,13 @@ export interface StateCarrier {
   // writers; no client keeps a second copy (see the frozen transition
   // table in docs/exec-plans/active/336-session-state-model.md).
   needs_attention?: boolean;
+  // Which tier produced `state` (internal/wire/control.go StateSource*).
+  // Absent = heuristic.
+  state_source?: string;
+  // What the agent reported it was asked to do, and what it said as it
+  // finished its last turn. Both absent on the heuristic tier.
+  last_prompt?: string;
+  last_summary?: string;
 }
 
 /** Words for the icon's <title>: state is shape + colour + words. */
@@ -61,6 +68,38 @@ export const STATE_WORDS: Record<SessionState, string> = {
   exited: 'Exited',
   error: 'Exited with an error',
 };
+
+// How the state was arrived at, in words. Rendered because "the agent
+// told us it is waiting for permission" and "no bytes arrived for two
+// seconds" are not the same claim (internal/wire/control.go on
+// StateSource). hook and extension collapse to one phrase on purpose:
+// which transport the agent used to say it is not the user's business,
+// only that the agent said it rather than us inferring it.
+const SOURCE_WORDS: Record<string, string> = {
+  hook: 'reported by the agent',
+  extension: 'reported by the agent',
+};
+const HEURISTIC_WORDS = 'guessed from terminal output';
+
+/**
+ * The full tooltip for a session's state icon: the state in words, what
+ * the session was asked to do, what the agent last said, and how we
+ * know. Lines are dropped when the underlying field is empty, so a
+ * heuristic-tier session still gets the one-line tooltip it has today.
+ *
+ * One helper for the same reason as sessionState above: the sidebar row
+ * and the tile header must never disagree about what a session is
+ * doing.
+ */
+export function stateTooltip(s: StateCarrier, state?: SessionState): string {
+  const lines = [STATE_WORDS[state ?? sessionState(s)]];
+  // Quoted: a prompt is the user's own words being read back, and
+  // without the quotes it runs together with the state line above it.
+  if (s.last_prompt) lines.push(`“${s.last_prompt}”`);
+  if (s.last_summary) lines.push(s.last_summary);
+  lines.push(SOURCE_WORDS[s.state_source ?? ''] ?? HEURISTIC_WORDS);
+  return lines.join('\n');
+}
 
 export function sessionState(s: StateCarrier): SessionState {
   // A session mid-create has no PTY yet; `alive: false` there means

--- a/cmd/hivegui/frontend/test/dom/attention-icon.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/attention-icon.test.tsx
@@ -78,7 +78,7 @@ describe('sidebar row state icon on attention', () => {
       '#hv-state-attention',
     );
     expect(dot('a').querySelector('title')?.textContent).toBe(
-      'Waiting for you',
+      'Waiting for you\nguessed from terminal output',
     );
 
     update(() => setAttn('a', false));
@@ -87,7 +87,9 @@ describe('sidebar row state icon on attention', () => {
     expect(dot('a').querySelector('use')?.getAttribute('href')).toBe(
       '#hv-state-running',
     );
-    expect(dot('a').querySelector('title')?.textContent).toBe('Idle');
+    expect(dot('a').querySelector('title')?.textContent).toBe(
+      'Idle\nguessed from terminal output',
+    );
   });
 
   it('renders the daemon state glyphs the sidebar gained in spec 336', () => {
@@ -100,7 +102,9 @@ describe('sidebar row state icon on attention', () => {
     expect(dot('w').querySelector('use')?.getAttribute('href')).toBe(
       '#hv-state-working',
     );
-    expect(dot('w').querySelector('title')?.textContent).toBe('Working');
+    expect(dot('w').querySelector('title')?.textContent).toBe(
+      'Working\nguessed from terminal output',
+    );
 
     // The distinction the whole state model exists for: a yes/no the
     // agent is blocked on does not look like a bell.
@@ -109,7 +113,27 @@ describe('sidebar row state icon on attention', () => {
       '#hv-state-waiting-permission',
     );
     expect(dot('p').querySelector('title')?.textContent).toBe(
-      'Waiting for permission',
+      'Waiting for permission\nguessed from terminal output',
+    );
+  });
+
+  // The tooltip is where "what is this session even for" gets answered
+  // in a sidebar of ten rows — the glyph can only carry the state.
+  it('stacks the agent-reported prompt, summary and tier into the tooltip', () => {
+    withSessions([
+      {
+        id: 'q',
+        name: 'api',
+        order: 0,
+        state: 'waiting_permission',
+        state_source: 'hook',
+        last_prompt: 'refactor the parser',
+        last_summary: 'Needs to run rm -rf build/',
+      },
+    ]);
+
+    expect(dot('q').querySelector('title')?.textContent).toBe(
+      'Waiting for permission\n\u201crefactor the parser\u201d\nNeeds to run rm -rf build/\nreported by the agent',
     );
   });
 

--- a/cmd/hivegui/frontend/test/dom/attention-icon.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/attention-icon.test.tsx
@@ -166,7 +166,7 @@ describe('project card on a store update', () => {
 
     expect(card('p1')).toBe(before); // re-rendered, not rebuilt
     expect(card('p1')?.dataset.state).toBe('attention');
-    expect(count()).toBe('1 session · 1 needs you');
+    expect(count()).toBe('1 session · 1 waiting on you');
 
     update(() => setAttn('a', false));
     expect(card('p1')?.dataset.state).toBeUndefined();

--- a/cmd/hivegui/frontend/test/dom/events-focus.test.ts
+++ b/cmd/hivegui/frontend/test/dom/events-focus.test.ts
@@ -278,6 +278,51 @@ describe('the desktop notification edge', () => {
 
     vi.mocked(document.hasFocus).mockRestore();
   });
+
+  // A permission prompt and an open-ended question are different asks.
+  // Blurring them into one word makes the user open the window just to
+  // learn which one it was.
+  it('names the state in the body, and keeps the old wording for a bare bell', () => {
+    const notify = vi.mocked(bridge.Notify);
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+    emit(
+      'session:list',
+      JSON.stringify({ sessions: [{ id: 'sess-7' }, { id: 'sess-8' }] }),
+    );
+
+    notify.mockClear();
+    emit(
+      'session:event',
+      JSON.stringify({
+        kind: 'attention',
+        session: {
+          id: 'sess-7',
+          needs_attention: true,
+          state: 'waiting_permission',
+        },
+      }),
+    );
+    expect(notify.mock.calls[0]?.[2]).toBe(
+      'Waiting for permission — click to switch.',
+    );
+
+    // The heuristic tier reports no state at all; its bell still means
+    // "waiting for input", which is what it always said.
+    notify.mockClear();
+    emit(
+      'session:event',
+      JSON.stringify({
+        kind: 'attention',
+        session: { id: 'sess-8', needs_attention: true },
+      }),
+    );
+    expect(notify.mock.calls[0]?.[2]).toBe(
+      'Waiting for input — click to switch.',
+    );
+
+    vi.mocked(document.hasFocus).mockRestore();
+  });
 });
 
 // Typing into a session is what answers its request. This is the

--- a/cmd/hivegui/frontend/test/dom/ui-project-card.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/ui-project-card.test.tsx
@@ -64,7 +64,7 @@ describe('ProjectCard', () => {
     expect(root.style.getPropertyValue('--project-color')).toBe('#0af');
   });
 
-  it('shows the session count expanded and "n sessions · k need you" collapsed', () => {
+  it('shows the session count expanded and "n sessions · k waiting on you" collapsed', () => {
     expect(
       make().root.querySelector('.hv-project-card__count')?.textContent,
     ).toBe('2');
@@ -72,7 +72,7 @@ describe('ProjectCard', () => {
     expect(collapsed.root.dataset.collapsed).toBe('');
     expect(
       collapsed.root.querySelector('.hv-project-card__count')?.textContent,
-    ).toBe('2 sessions · 1 needs you');
+    ).toBe('2 sessions · 1 waiting on you');
     expect(
       make({
         collapsed: true,
@@ -166,7 +166,7 @@ describe('ProjectCard', () => {
     expect(root.dataset.state).toBe('attention');
     expect(root.dataset.collapsed).toBe('');
     expect(root.querySelector('.hv-project-card__count')?.textContent).toBe(
-      '3 sessions · 2 need you',
+      '3 sessions · 2 waiting on you',
     );
     const chev = root.querySelector('.hv-project-card__chevron');
     expect(chev?.getAttribute('aria-expanded')).toBe('false');

--- a/cmd/hivegui/frontend/test/unit/session-state.test.ts
+++ b/cmd/hivegui/frontend/test/unit/session-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sessionState } from '../../src/lib/session-state.js';
+import { sessionState, stateTooltip } from '../../src/lib/session-state.js';
 
 describe('sessionState', () => {
   it('is starting for any non-ready phase, alive or not', () => {
@@ -65,5 +65,45 @@ describe('sessionState', () => {
     expect(sessionState({ alive: false, last_error: 'boom' })).toBe('error');
     expect(sessionState({ alive: false, lastError: 'boom' })).toBe('error');
     expect(sessionState({ alive: false, last_error: '' })).toBe('exited');
+  });
+});
+
+describe('stateTooltip', () => {
+  it('is the state words plus the tier when the agent reported nothing', () => {
+    // The heuristic tier knows neither field, and must still produce
+    // the one-line tooltip the icon had before prompt/summary existed.
+    expect(stateTooltip({ alive: true })).toBe(
+      'Idle\nguessed from terminal output',
+    );
+  });
+  it('stacks prompt then summary then tier', () => {
+    expect(
+      stateTooltip({
+        alive: true,
+        state: 'waiting_permission',
+        state_source: 'hook',
+        last_prompt: 'refactor the parser',
+        last_summary: 'Needs to run rm -rf build/',
+      }),
+    ).toBe(
+      'Waiting for permission\n“refactor the parser”\nNeeds to run rm -rf build/\nreported by the agent',
+    );
+  });
+  it('drops the lines whose fields are empty', () => {
+    expect(
+      stateTooltip({
+        alive: true,
+        state: 'working',
+        state_source: 'extension',
+        last_prompt: 'ship it',
+      }),
+    ).toBe('Working\n“ship it”\nreported by the agent');
+  });
+  it('honours a caller-resolved state so the icon and its words agree', () => {
+    // TileChrome resolves with an overriding phase; passing the result
+    // back in is what stops the tooltip disagreeing with the glyph.
+    expect(stateTooltip({ alive: true }, 'starting')).toBe(
+      'Starting\nguessed from terminal output',
+    );
   });
 });

--- a/cmd/hivegui/frontend/test/unit/session-state.test.ts
+++ b/cmd/hivegui/frontend/test/unit/session-state.test.ts
@@ -102,8 +102,23 @@ describe('stateTooltip', () => {
   it('honours a caller-resolved state so the icon and its words agree', () => {
     // TileChrome resolves with an overriding phase; passing the result
     // back in is what stops the tooltip disagreeing with the glyph.
-    expect(stateTooltip({ alive: true }, 'starting')).toBe(
-      'Starting\nguessed from terminal output',
+    expect(stateTooltip({ alive: true }, 'starting')).toBe('Starting');
+  });
+  it('claims no tier for a state no tier produced', () => {
+    // `starting` is resolved here from phase, and a dead session's
+    // exited/error comes from the process exiting. Appending "guessed
+    // from terminal output" to either invents a provenance.
+    expect(stateTooltip({ alive: false, phase: 'worktree' })).toBe('Starting');
+    expect(stateTooltip({ alive: false })).toBe('Exited');
+    expect(stateTooltip({ alive: false, last_error: 'boom' })).toBe(
+      'Exited with an error',
+    );
+  });
+  it('reads any non-empty tier as reported, not just the two we ship', () => {
+    // Only the heuristic tier is spelled "" on the wire, so a tier a
+    // future daemon adds must not silently read as a guess.
+    expect(stateTooltip({ alive: true, state_source: 'something-new' })).toBe(
+      'Idle\nreported by the agent',
     );
   });
 });

--- a/docs/design-docs/control-plane.md
+++ b/docs/design-docs/control-plane.md
@@ -35,7 +35,7 @@ session carries which tier it is on (`state_source` on the wire):
 
 | Tier | Source | Agents | What Hive learns |
 |------|--------|--------|------------------|
-| `hook` | Agent-native lifecycle hooks calling back into `hived` | Claude Code | exact turn boundaries, permission prompts, prompt/summary text, subagent activity |
+| `hook` | Agent-native lifecycle hooks calling back into `hived` | Claude Code | exact turn boundaries, permission prompts, prompt/summary text |
 | `extension` | A Hive-shipped extension loaded into the agent at spawn | Pi | exact turn boundaries (`agent_start` / `agent_settled`), prompt/summary text, a per-session inbox socket |
 | `heuristic` | PTY output cadence + bell + OSC title + process exit | shell, Codex, Gemini, Copilot, Aider, custom | working / idle / exited, "waiting" only via bell |
 
@@ -134,14 +134,16 @@ Rules that follow:
    surface is skipped, not attempted. Above an *observed-broken*
    maximum (a constant bumped by hand when drift is found) it is also
    skipped, so a known-bad release does not spam logs.
-5. **Drift probe, not drift hope.** `scripts/probe-claude.sh` launches
-   `claude -p` with Hive's hook settings against a trivial prompt and
-   asserts that the expected `AGENT_EVENT`s reach a scratch `hived`;
-   for 338 it also checks that `~/.claude/sessions/*.json` still carries
-   the three fields. It runs in CI when `claude` is on PATH (the macOS
-   leg) and is part of the release checklist. Recorded hook payloads
-   live under `testdata/claude-hooks/` with the Claude version in the
-   filename, so a diff against a fresh capture is the review.
+5. **Drift probe, not drift hope.** `cmd/hived/claude_probe_test.go`
+   launches a real `claude` from the daemon with Hive's hook settings
+   and asserts that the expected `AGENT_EVENT`s arrive with
+   `src=hook`. It is opt-in rather than automatic — `HIVE_PROBE_CLAUDE=1`,
+   with `HIVE_PROBE_AGENTS=1` for the equivalent TUI-tier probe in
+   `internal/registry` — because it needs the real binary, which no CI
+   leg has. What *does* run everywhere is the fixture table:
+   recorded hook payloads live under `cmd/hived/testdata/hooks/`, and
+   `TestHookMapsEveryEvent` replays every one of them, so a diff
+   against a fresh capture is the review.
 6. **One file per surface.** Each row above maps to one Go file; a
    Claude change is a one-file diff plus a fixture refresh. Nothing in
    `internal/registry/` or `internal/daemon/` knows a Claude field name.

--- a/docs/design-docs/ui/components.md
+++ b/docs/design-docs/ui/components.md
@@ -48,7 +48,7 @@ Decided in [mocks/sidebar-structure.html](mocks/sidebar-structure.html) (S2 insi
 - `--surface-raised` body, 1px `--border`, `--radius-md`, margin `var(--space-1) var(--space-2) var(--space-2)`.
 - Header 30px: chevron (collapsed state), 8px colour swatch (`--session-color` data), name `--text-md` 500, session count `--font-mono --text-xs --fg-subtle` right-aligned, then hover actions (`plus` new session, `branch` worktrees, `settings` edit project, `minus` minimize project, `x` delete project). The five buttons take an 18px box, not the primitive's 24px — at the 220px sidebar floor the default size squeezes the name to ~3px.
 - The card ROOT gets `data-state="attention"` when any child session has attention (that is what the CSS selects): the header's swatch gains the pulse ring. Nothing else on the header changes.
-- Collapsed: body hidden, header shows "n sessions · k need you" in the count slot.
+- Collapsed: body hidden, header shows "n sessions · k waiting on you" in the count slot — the same wording the menu bar summary uses, off the same predicate.
 
 ## `chip({ label, color?, state?, onClick, onRestore? })` — `src/components/Chip.tsx`
 

--- a/docs/design-docs/ui/icons.md
+++ b/docs/design-docs/ui/icons.md
@@ -34,9 +34,22 @@ else                           → running
 
 `state` is `SessionInfo.state` (`internal/wire/control.go` `State*`), owned by the daemon. Empty means idle — both the `omitempty` case and what a daemon predating spec 336 sends, so no branch here needs an "unknown".
 
-The daemon derives it by sampling what the session's screen *renders*, not by watching bytes arrive: a measured idle Claude Code session emits an `ESC[?6n` cursor-position query every 200 ms, which changes no cell. Keying off byte arrival pinned every agent to `working` forever and let a redraw bury a bell within one tick. `waiting-permission` is what the hook and extension tiers report (spec 336 phases 2–3); `cmd/hived/hook.go` produces it today from Claude's `PermissionRequest`, and the Pi extension will in phase 3.
+The daemon derives it by sampling what the session's screen *renders*, not by watching bytes arrive: a measured idle Claude Code session emits an `ESC[?6n` cursor-position query every 200 ms, which changes no cell. Keying off byte arrival pinned every agent to `working` forever and let a redraw bury a bell within one tick. `waiting-permission` is what the hook and extension tiers report (spec 336 phases 2–3); `cmd/hived/hook.go` produces it from Claude's `PermissionRequest`, and `internal/agent/pi/hive.ts` from Pi's blocking `confirm`/`select` prompts.
 
 Two rules in that order are deliberate. An agent-reported permission prompt outranks `needs_attention`, because "blocked on a yes/no" versus "rang the bell" is the distinction the state model exists to draw. An unacknowledged bell outranks `working`, because the one that wants a human is the one worth showing.
+
+### The icon's words
+
+The glyph carries the state; its `<title>` carries everything the glyph cannot. `stateTooltip()` (same module, so the two can never disagree) stacks, dropping any line whose field is empty:
+
+```
+Waiting for permission          ← STATE_WORDS[state]
+“refactor the parser”           ← last_prompt, quoted: the user's own words read back
+Needs to run rm -rf build/      ← last_summary
+reported by the agent           ← state_source; heuristic reads "guessed from terminal output"
+```
+
+The tier line is always present, because it is what explains the uncertain ring to someone who hovered to ask about it. `hook` and `extension` deliberately collapse to one phrase: which transport the agent used to speak is not the user's business, only that it spoke rather than we inferred.
 
 `state-working` and `state-waiting-permission` reuse `--state-running` and `--state-attention` rather than claiming tokens of their own: those two colours are already picked for all 18 themes, and shape plus motion carries the busy/idle and bell/permission difference without asking anyone to pick 18 more values.
 

--- a/docs/design-docs/ui/icons.md
+++ b/docs/design-docs/ui/icons.md
@@ -49,7 +49,7 @@ Needs to run rm -rf build/      ← last_summary
 reported by the agent           ← state_source; heuristic reads "guessed from terminal output"
 ```
 
-The tier line is always present, because it is what explains the uncertain ring to someone who hovered to ask about it. `hook` and `extension` deliberately collapse to one phrase: which transport the agent used to speak is not the user's business, only that it spoke rather than we inferred.
+The tier line carries the whole weight of the `state_source` distinction, because nothing else in the UI does: the glyph is identical whether the agent reported the state or Hive inferred it from PTY cadence, and those are not the same claim. It appears for every state a tier actually produced, and is omitted for `starting` (resolved here from `phase`) and for a dead session's `exited`/`error` (observed from the process exiting) — asserting a tier over those would invent a provenance. Any non-empty `state_source` reads as reported: only the heuristic tier is spelled `""`, so a tier a future daemon adds is described correctly rather than relabelled a guess.
 
 `state-working` and `state-waiting-permission` reuse `--state-running` and `--state-attention` rather than claiming tokens of their own: those two colours are already picked for all 18 themes, and shape plus motion carries the busy/idle and bell/permission difference without asking anyone to pick 18 more values.
 

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -1050,6 +1050,30 @@ decision-log entry with the log excerpt BEFORE any code changes.
   entry above, and `docs/exec-plans/active/338-session-messaging.md`
   no longer presupposes the script exists.
 
+- **2026-09-05 (phase 4, gate iter 3)** — `TestExitedReachesTheStateThroughTheRealPTY`
+  read state through `r.Get(id).Info()` and raced `watchSessionExit`
+  deterministically under `-race`. `Get` drops the registry mutex before
+  returning the entry, so `Info()` reads `e.sess` unlocked while the
+  exit path writes it. Every other test in `state_test.go` uses the same
+  `Get().Info()` idiom and gets away with it only because its process
+  stays alive for the assertion; this test races the exit path by
+  construction, which is the whole point of it. Fixed by reading through
+  `r.List()`, which holds the lock across `Info()`. Production is not
+  affected — its `Info()` calls are all under the lock
+  (`broadcastLocked` and friends). CI runs plain `go test ./...` with no
+  `-race`, so nothing would have caught this before merge; three
+  consecutive `-race` runs are now clean.
+
+- **2026-09-05 (phase 4, gate iter 3)** — Criterion 5's wait exception
+  named `ClearWaiting` and process exit as the ONLY ways out of a wait.
+  A probe showed `permission_resolved`, `turn_end` and `session_end`
+  also end one. The true invariant is narrower and is what the design
+  actually rests on: a wait is immune to elapsed time and to output,
+  because neither is evidence an unanswered prompt was answered — it
+  ends only on something that constitutes an answer. Corrected in the
+  spec, in `HookStaleAfter`'s comment, and in `Output`'s, which carried
+  the same absolute claim.
+
 ## Review log
 
 - **2026-09-04** — `/hs-feature-plan-review` (three `hs-reviewer` passes:

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -983,6 +983,15 @@ decision-log entry with the log excerpt BEFORE any code changes.
   user-visible change is the wording alone. README carried the same
   misleading contrast and was trimmed with it.
 
+- **2026-09-05 (phase 4, review iter 2)** — The GUI's collapsed project
+  card said "k need(s) you" while the menu bar now said "N waiting on
+  you", off the same predicate. Aligned on the menu bar's wording
+  rather than the card's: it is the one the spec's success criterion
+  names, and "waiting on you" needs no plural form, so the card's
+  conjugation went away with it. `docs/design-docs/ui/components.md`
+  and three test assertions moved with it. The divergence was this
+  PR's own doing, which is why it is fixed here rather than deferred.
+
 ## Review log
 
 - **2026-09-04** — `/hs-feature-plan-review` (three `hs-reviewer` passes:
@@ -1320,6 +1329,24 @@ decision-log entry with the log excerpt BEFORE any code changes.
   Not done in this pass: the manual smoke checklist in an iso build
   (rows 1–6 and 13–14 still unrun, and no row covers the menu bar).
 
+- **2026-09-05 (phase 4, review converged)** — PR #344 converged on
+  review iteration 2: APPROVE, zero unresolved threads, MERGEABLE.
+  Iteration 1 returned COMMENT with three IMPORTANT findings, all of
+  them prose asserting things the tree did not support (see the
+  correction entries in the Decision log); iteration 2 verified each
+  fix individually against the tree and found the diff's remaining doc
+  claims — `control-plane.md`'s five named probe artefacts,
+  `icons.md`'s Pi claim, the plan header's branch — all resolve to
+  things that exist. Its one MINOR (menu-bar vs project-card wording)
+  was fixed in the same pass.
+  Verified after the wording alignment: `biome ci .` clean, `tsc
+  --noEmit` clean, vitest 1029/1029 across 88 files, `CI=1 npx
+  playwright test` 270 passed / 31 skipped, `go vet ./...` clean.
+  Still not done, and not in phase 4's scope to fix: the manual smoke
+  checklist in an iso build. Rows 1–6 and 13–14 have been outstanding
+  since phase 2, and no row covers the menu bar at all — so the waiting
+  count and the tooltip have never been seen in a running app.
+
 ## Open questions
 
 <Empty — resolved into the Decision log.>
@@ -1342,3 +1369,4 @@ decision-log entry with the log excerpt BEFORE any code changes.
     - non-goals — PASS — all six negative checks clean. Strongest evidence on "no persisted state": `persist.go`/`closed.go`/`store.go` have zero diff in `ad8f4aa~1..origin/main`, `TestMetaFileUnchangedByState` byte-compares `session.json` across a full state tour, and a runtime enumeration of `agent.All()` confirms `SpawnArgs` is non-nil only for `claude` and `pi`.
     - doc accuracy — FAIL — `docs/design-docs/control-plane.md:137-144` states in the present tense that `scripts/probe-claude.sh` exists, runs in CI and is on the release checklist, and that fixtures live under `testdata/claude-hooks/`; neither exists in the tree or anywhere in history. `docs/design-docs/ui/icons.md:37` still says the Pi extension "will in phase 3" after phase 3 merged as `d49551c`. `docs/design-docs/control-plane.md:38` claims the hook tier learns "subagent activity"; no `Subagent*` handling exists in Go. Changesets (5), CHANGELOG generation, README, and the plan header/Progress log all PASS.
 - **2026-09-05 iter 1 (PR #344)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: b530c88feba83824bccf91b3c0e9765522fe74e8635811954d5b27a4a2b83238; threads_open: 0; action: continue (stop rule met — COMMENT, strict off, zero threads — but 3 IMPORTANT prose findings stood and boil-the-lake says fix them); head_sha: 8abfa67.
+- **2026-09-05 iter 2 (PR #344)** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop (converged; iter 1's three IMPORTANT findings each re-verified as fixed, one MINOR wording divergence fixed in the same pass); head_sha: 20f21f5.

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -345,7 +345,12 @@ assistant message ends with `?` — a heuristic, flagged in a comment
   (new `components/StateDot.tsx`) taking `state` + `source`; CSS in the
   design system tokens (`docs/design-docs/ui/` — add the six states and
   the heuristic "uncertain" ring treatment); reuse `hv-state-pulse` /
-  `--motion-pulse` for the waiting states. `title` attribute /
+  `--motion-pulse` for the waiting states.
+  **SUPERSEDED (phases 1 and 4):** no `StateDot.tsx` was built (the
+  existing `StateIcon` already had the job), and the "uncertain" ring
+  was never built either — the tiers differ only in the tooltip's last
+  line. Both decisions are in the Decision log; this paragraph is kept
+  as the original intent, not as a description of the tree. `title` attribute /
   tooltip: `last_prompt` on the first line, `last_summary` on the
   second, `state_source` in the footer.
 - `hivebar` (`cmd/hivebar/client.go`, `model.go`): thread `state` /

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -1074,6 +1074,18 @@ decision-log entry with the log excerpt BEFORE any code changes.
   spec, in `HookStaleAfter`'s comment, and in `Output`'s, which carried
   the same absolute claim.
 
+- **2026-09-05 (phase 4, CI)** — `TestExitedReachesTheStateThroughTheRealPTY`
+  ends the child with `sess.Close()`, not by writing EOT to the
+  terminal. The first CI run was green on macOS and Windows and failed
+  on Linux with "session never reported the exit" after 10 s: whether a
+  lone `^D` means EOF depends on the line discipline's canonical-mode
+  state, so EOT ends `/bin/cat` on macOS but not dependably under
+  Linux's. The transition under test is "the child process is gone", so
+  the test now ends the process directly instead of asking the terminal
+  to ask it to end. It also fails faster when the wiring breaks (0.03 s
+  rather than a 10 s timeout). Local `-race` cannot catch a
+  line-discipline difference; only the Linux CI leg could, and did.
+
 ## Review log
 
 - **2026-09-04** — `/hs-feature-plan-review` (three `hs-reviewer` passes:

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -3,9 +3,10 @@
 - **Spec:** [docs/product-specs/336-session-state-model.md](../../product-specs/336-session-state-model.md)
 - **Design:** [docs/design-docs/control-plane.md](../../design-docs/control-plane.md)
 - **Issue:** —
-- **Branch:** `feature/336-phase3-pi-extension` (phases 1–2 shipped from
-  `feature/336-session-state-model`, now merged and dead)
-- **PR:** #338 (phases 1–2, merged) · #341 (phase 3)
+- **Branch:** `feature/336-phase4-hivebar-tooltip` (phases 1–2 shipped
+  from `feature/336-session-state-model`, phase 3 from
+  `feature/336-phase3-pi-extension`; both merged and dead)
+- **PR:** #338 (phases 1–2, merged) · #341 (phase 3, merged) · #344 (phase 4)
 - **Status:** active
 
 ## Summary

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -1447,6 +1447,18 @@ decision-log entry with the log excerpt BEFORE any code changes.
   - No committed test drives `exited` through a real child exit.
   Non-goals passed clean. Stage stays at GATE.
 
+- **2026-09-05 (re-gate)** — Gate NEEDS_FOLLOWUP, down from FAIL on two
+  dimensions. Everything fixable from this branch is fixed: the
+  `Tick` source defect, the `-race` failure, the `exited` coverage gap,
+  criterion 5's wording (twice), and every stale prose reference.
+  What remains is manual verification that no code change can close:
+  - Criterion 2: `error` never observed on a real `claude`; checklist
+    rows 1–6 and 13–14 unrun in an iso build.
+  - Criterion 3: no state observed from a real `pi` (row 14).
+  - Criteria 6 and 7: rows 15–16 now exist for the menu bar and the
+    tooltip, but have never been run.
+  These need `wails build` (never `-s`) and a human. Stage stays GATE.
+
 ## Open questions
 
 <Empty — resolved into the Decision log.>
@@ -1462,6 +1474,16 @@ decision-log entry with the log excerpt BEFORE any code changes.
 - **2026-09-05 iter 5 (PR #341)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 012bd1b0cb5b268652d7f421b16e0ddc5b99a330710aa60401cc653899411c66; threads_open: 0; action: converged (2 IMPORTANT fixed: boundary test + comment scope; reviewer re-derived iter 4's riskiest changes independently and found them correct); head_sha: d27c756.
 
 ## Gate verdict
+
+- **2026-09-05 (re-gate after fixes)** — verdict: NEEDS_FOLLOWUP; checks: 6 passed / 0 failed / 2 followups; followups: none filed (manual verification only); one-line: every criterion is implemented, evidenced and now race-clean, and the prose defects are swept; what remains is that four criteria have never been exercised against a real binary or a running app.
+  - 2026-09-05 dimensions (after `fc020de`):
+    - acceptance — NEEDS_FOLLOWUP — criteria 1, 4, 6, 7, 8 PASS. Criterion 5 now PASSES in substance: the gate found `Tick` demoted `state` without `source`, that was fixed and pinned by `TestStaleTickDemotesTheSourceNotJustTheState` (mutation-checked), and the criterion was reworded against probes. Criteria 2 and 3 remain followups purely for want of a real `claude` / `pi` binary. The `exited` coverage gap is closed by `TestExitedReachesTheStateThroughTheRealPTY`.
+    - non-goals — PASS — unchanged from the previous run; all six hold, the bell survives as both a heuristic input and the shell notification path.
+    - doc accuracy — PASS (after three rounds) — every `scripts/probe-claude.sh` and "uncertain ring" reference in the tree is now either labelled intent-not-built, labelled superseded, or a record correctly stating the thing does not exist. Verified by tree-wide grep across all file types, not just docs.
+  - 2026-09-05 defects the gate itself found and got fixed, for the record:
+    - `agentstate.Machine.Tick` moved `state` but not `source`, so a stale-tier idle reported `state_source=hook`. Invisible until phase 4 rendered provenance in the tooltip.
+    - `TestExitedReachesTheStateThroughTheRealPTY` raced `watchSessionExit` under `-race` (deterministic). CI runs no `-race`, so nothing else would have caught it before merge.
+    - Two rounds of my own corrections were themselves unsupported: an "uncertain ring" that was never built, and a citation to a probe test that cannot observe the property it was cited for.
 
 - **2026-09-05** — verdict: NEEDS_FOLLOWUP; checks: 5 passed / 0 failed / 3 followups; followups: none filed (pending user decision); one-line: every criterion is implemented and unit-evidenced and all six non-goals hold, but four criteria have never been exercised against a real binary or a running app, criterion 5's fallback is not the one the spec words, and two stale prose references survive outside the docs that were swept.
   - 2026-09-05 dimensions:

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -406,10 +406,14 @@ assistant message ends with `?` — a heuristic, flagged in a comment
 - `testdata/claude-hooks/<claude-version>/*.json` — one recorded payload
   per hook event (capture from a real session with `HIVE_HOOK_DEBUG=1`
   once; the version directory is what a drift diff compares against)
-- `scripts/probe-claude.sh` — drift probe: scratch `hived` on a temp
-  socket + state dir (`HIVE_SOCKET`/`HIVE_STATE_DIR`, never the user's),
-  `claude -p "say ok"` launched with Hive's `--settings` JSON, assert
-  `prompt` and `turn_end` events arrive within 60 s, and that a
+- `scripts/probe-claude.sh` — **NEVER BUILT (see Progress).** The drift
+  probe shipped instead as `cmd/hived/claude_probe_test.go` behind
+  `HIVE_PROBE_CLAUDE=1`, and the recorded payloads live at
+  `cmd/hived/testdata/hooks/`, not under a version directory. The
+  original intent, kept for the record: drift probe: scratch `hived` on
+  a temp socket + state dir (`HIVE_SOCKET`/`HIVE_STATE_DIR`, never the
+  user's), `claude -p "say ok"` launched with Hive's `--settings` JSON,
+  assert `prompt` and `turn_end` events arrive within 60 s, and that a
   project-level `Stop` hook in the scratch dir still fires alongside
   Hive's (hooks concatenate). Exits 0 with
   "skipped" when `claude` is not on PATH. Wired into `scripts/test.sh`
@@ -555,10 +559,15 @@ decision-log entry with the log excerpt BEFORE any code changes.
   Code 2.1.260: a project `.claude/settings.json` `Stop` hook and a
   `--settings '{…}'` `Stop` hook both fired on one `-p` turn. So the
   Claude adapter emits only Hive's hooks and never has to read the
-  user's settings. `scripts/probe-claude.sh` repeats this exact check
-  (two `Stop` hooks, both must fire) so a future change in merge
-  semantics shows up as a probe failure, not a silent loss of the
-  user's hooks. Resolves former open question 1.
+  user's settings. The intent was for `scripts/probe-claude.sh` to repeat
+  this exact check (two `Stop` hooks, both must fire) so a future change
+  in merge semantics would show up as a probe failure rather than a
+  silent loss of the user's hooks. That script was never written, and
+  `cmd/hived/claude_probe_test.go` does NOT cover this: it installs only
+  Hive's own hooks, so it cannot tell concatenate from replace. The
+  finding therefore rests on the one manual check above, and a drift in
+  it would surface as the user's own hooks quietly not firing.
+  Resolves former open question 1.
 - **2026-09-04 (phase 1)** — Every machine mutator returns `changed
   bool`; the registry broadcasts on that rather than diffing snapshots
   before/after. Why: the plan specified both mechanisms (a bool from
@@ -1025,6 +1034,21 @@ decision-log entry with the log excerpt BEFORE any code changes.
   stale session with no output at all. The lesson is the one this
   feature keeps re-teaching: prose about a state machine has to be
   written against a probe, not against a reading.
+
+- **2026-09-05 (phase 4, gate iter 2)** — The comment that replaced the
+  stale `scripts/probe-claude.sh` reference in `internal/agent/claude.go`
+  was ITSELF an overclaim, caught by the gate's doc re-check: it told
+  the reader to re-verify the hooks-concatenate finding with
+  `cmd/hived/claude_probe_test.go`, which installs only Hive's own hooks
+  and therefore cannot tell concatenation from replacement. Fixing a
+  false citation by writing a second false citation is the exact loop
+  this feature keeps falling into. The comment now says what is true and
+  uncomfortable: the finding rests on one manual check on Claude Code
+  2.1.260, nothing re-checks it, and a change in Anthropic's merge
+  semantics would surface as the user's own hooks silently not firing.
+  The same correction is recorded against the `--settings` decision
+  entry above, and `docs/exec-plans/active/338-session-messaging.md`
+  no longer presupposes the script exists.
 
 ## Review log
 

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -999,6 +999,33 @@ decision-log entry with the log excerpt BEFORE any code changes.
   and three test assertions moved with it. The divergence was this
   PR's own doing, which is why it is fixed here rather than deferred.
 
+- **2026-09-05 (phase 4, gate iter 2)** — `Machine.Tick` now demotes
+  `source` alongside `state`, and `daemon-contract-override` is claimed
+  for it rather than bumping `DaemonContract` 4 → 5. The change is
+  daemon-side and client-visible in the strict sense — a tick-derived
+  idle on a stale tier now reports `state_source=heuristic` instead of
+  `hook` — but a GUI built from this tree drives a daemon built without
+  it perfectly. The only difference an old daemon shows is the previous
+  wrong tooltip line ("reported by the agent") on a state no agent
+  reported, in the narrow window where a hooked session's hook has died
+  AND its screen has gone quiet. That is a cosmetic staleness, not a
+  mixing hazard, and a bump costs every user their running agents to
+  ship it. Same reasoning, and same override, as the phase-3 entry
+  above.
+
+- **2026-09-05 (phase 4, gate iter 2)** — Criterion 5 was reworded
+  TWICE. The first rewording was written from my reading of
+  `machine.go` and was wrong in both directions; the gate's acceptance
+  re-check probed the machine instead of trusting the prose and
+  demonstrated both errors. (a) "holds its last reported state until
+  output resumes" is false for a wait: `Output` returns early on
+  `waiting_*` before the demotion branch, so resumed output never
+  releases one — only `ClearWaiting` or `Exit` does. (b) "demotion is
+  driven by output" is false for `working`: `Tick` demotes a quiet
+  stale session with no output at all. The lesson is the one this
+  feature keeps re-teaching: prose about a state machine has to be
+  written against a probe, not against a reading.
+
 ## Review log
 
 - **2026-09-04** — `/hs-feature-plan-review` (three `hs-reviewer` passes:

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -943,6 +943,46 @@ decision-log entry with the log excerpt BEFORE any code changes.
   presentational component; its button already carries a `title`, and
   the success criterion names the sidebar row and the tile header.
 
+- **2026-09-05 (phase 4, review iter 1)** — CORRECTS the phase-4 entry
+  above, which justified the always-on tier line as "what explains the
+  uncertain ring to someone who hovered to ask about it". There is no
+  uncertain ring. Nothing in `theme/` or `Icon.tsx` reads
+  `state_source`; the glyph is identical on every tier. The entry
+  described an affordance the tree does not have — the same drift class
+  the merge gate had just flagged in `control-plane.md`, reintroduced
+  in the commit that fixed it. The tier line's real justification is
+  that it is the ONLY surface carrying the `state_source` distinction,
+  which is why it stays; `docs/design-docs/ui/icons.md` now says that
+  instead.
+
+- **2026-09-05 (phase 4, review iter 1)** — The tier line is omitted for
+  `starting` and for a dead session's `exited`/`error`. It is a claim
+  about where a state came from, and no tier produced those:
+  `starting` is resolved client-side from `phase`, and death is
+  observed from the process exiting. Appending "guessed from terminal
+  output" to them fabricated a provenance — and two tests had pinned
+  the fabrication as expected.
+
+- **2026-09-05 (phase 4, review iter 1)** — `SOURCE_WORDS`, a map of
+  the two tiers that exist, became `sourceWords()`, a truthiness test.
+  Only the heuristic tier is spelled `""` on the wire, so a tier a
+  future daemon adds is reported by definition; the map would have
+  silently relabelled it a guess.
+
+- **2026-09-05 (phase 4, review iter 1)** — The changeset's claim that
+  "an agent that rang once and went back to work no longer counts
+  against you" was withdrawn: it describes #338, not this PR.
+  `internal/registry/registry.go:211` sets `NeedsAttention:
+  needsAttention(st.State)`, and `needsAttention` (`:184`) is
+  bit-for-bit the predicate `waiting()` now applies — so on any daemon
+  at contract ≥ 3 the old count and the new one are identical, and
+  below it `waiting()` returns `NeedsAttention` verbatim. The rename is
+  still worth having (hivebar stops depending on a derivation it does
+  not own, and the old-daemon fallback becomes explicit rather than
+  accidental), but it is a decoupling, not a user-visible fix. The
+  user-visible change is the wording alone. README carried the same
+  misleading contrast and was trimmed with it.
+
 ## Review log
 
 - **2026-09-04** — `/hs-feature-plan-review` (three `hs-reviewer` passes:
@@ -1301,3 +1341,4 @@ decision-log entry with the log excerpt BEFORE any code changes.
     - acceptance — FAIL — criterion 7 ("`hivebar` shows 'N waiting on you' using the new state, not the bell") not delivered: `cmd/hivebar/model.go:53,97,104,195` build rows solely from `wire.SessionInfo.NeedsAttention`, and the string appears nowhere in the tree. Criterion 6 partially delivered: glyphs ship and are covered (`test/e2e/state-glyphs.spec.ts`, 35 unit tests), but the tooltip half is absent — `last_prompt`/`last_summary` exist only as optional type fields at `cmd/hivegui/frontend/src/app/state.ts:72-73` and are read by zero components. Criteria 1, 4, 5, 8 PASS with green tests; 2 and 3 NEEDS_FOLLOWUP on their manual halves only (checklist rows 1–6 and 13–14 unrun in an iso build; `TestAgentTUIStateFlow` skips by default).
     - non-goals — PASS — all six negative checks clean. Strongest evidence on "no persisted state": `persist.go`/`closed.go`/`store.go` have zero diff in `ad8f4aa~1..origin/main`, `TestMetaFileUnchangedByState` byte-compares `session.json` across a full state tour, and a runtime enumeration of `agent.All()` confirms `SpawnArgs` is non-nil only for `claude` and `pi`.
     - doc accuracy — FAIL — `docs/design-docs/control-plane.md:137-144` states in the present tense that `scripts/probe-claude.sh` exists, runs in CI and is on the release checklist, and that fixtures live under `testdata/claude-hooks/`; neither exists in the tree or anywhere in history. `docs/design-docs/ui/icons.md:37` still says the Pi extension "will in phase 3" after phase 3 merged as `d49551c`. `docs/design-docs/control-plane.md:38` claims the hook tier learns "subagent activity"; no `Subagent*` handling exists in Go. Changesets (5), CHANGELOG generation, README, and the plan header/Progress log all PASS.
+- **2026-09-05 iter 1 (PR #344)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: b530c88feba83824bccf91b3c0e9765522fe74e8635811954d5b27a4a2b83238; threads_open: 0; action: continue (stop rule met — COMMENT, strict off, zero threads — but 3 IMPORTANT prose findings stood and boil-the-lake says fix them); head_sha: 8abfa67.

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -506,9 +506,11 @@ version and the table in Progress before each push that touches state.
 | 11 | claude | leave it idle > 60 s after a reply | waiting_input (Claude `idle_prompt`) | `reason=waiting_input src=hook` |
 | 12 | claude | `/exit` | exited | `-> exited reason=session_end` or `reason=exit` |
 | 13 | claude | kill `hived`, restart, reopen GUI | every session idle / heuristic, empty tooltip | no state lines until output |
-| 14 | codex or pi | run a prompt | working → idle on the heuristic tier; glyph shows the uncertain ring | `src=heuristic` only |
+| 14 | codex or pi | run a prompt | codex: working → idle, `src=heuristic`. pi: working → idle with `src=extension` and the prompt in the tooltip — the glyph itself is identical on every tier, so read the tooltip's last line, not the shape | `src=heuristic` (codex) / `src=extension` (pi) |
+| 15 | claude + shell | with one agent at a permission prompt and one shell idle, open the menu bar | summary reads "… · 1 waiting on you"; the dot is on the agent row only | — (hivebar has no state log; read the menu) |
+| 16 | claude | hover the sidebar row's state glyph mid-turn, then after the reply | tooltip stacks state, the prompt in quotes, the last summary, then "reported by the agent"; a shell's tooltip ends "guessed from terminal output" | — |
 
-Rows 7–12 are phase 2. A row that fails goes into this plan as a
+Rows 7–12 are phase 2; rows 15–16 are phase 4. A row that fails goes into this plan as a
 decision-log entry with the log excerpt BEFORE any code changes.
 
 ## Decision log
@@ -1347,6 +1349,24 @@ decision-log entry with the log excerpt BEFORE any code changes.
   since phase 2, and no row covers the menu bar at all — so the waiting
   count and the tooltip have never been seen in a running app.
 
+- **2026-09-05 (merge gate, phase 4)** — Gate NEEDS_FOLLOWUP on the
+  open PR #344 (pre-merge path; ledger converged at iter 2, APPROVE,
+  zero threads). Items:
+  - Criterion 2: `error` never observed on a real `claude`; checklist
+    rows 1–6 and 13–14 still unrun in an iso build.
+  - Criterion 3: no state ever observed from a real `pi` (row 14).
+  - Criteria 6 and 7: implemented and unit-covered, but never seen in a
+    running app — the checklist has no menu-bar row at all.
+  - Criterion 5: implementation demotes at `HookStaleAfter = 30s` and
+    only while the screen changes, not "within the quiet threshold" as
+    the spec words it. Deliberate; the spec bullet is what is wrong.
+  - `internal/agent/claude.go:111` cites `scripts/probe-claude.sh`,
+    which has never existed.
+  - Plan checklist row 14 (`:509`) instructs the operator to look for
+    an "uncertain ring" that this plan refutes at `:948`.
+  - No committed test drives `exited` through a real child exit.
+  Non-goals passed clean. Stage stays at GATE.
+
 ## Open questions
 
 <Empty — resolved into the Decision log.>
@@ -1362,6 +1382,12 @@ decision-log entry with the log excerpt BEFORE any code changes.
 - **2026-09-05 iter 5 (PR #341)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 012bd1b0cb5b268652d7f421b16e0ddc5b99a330710aa60401cc653899411c66; threads_open: 0; action: converged (2 IMPORTANT fixed: boundary test + comment scope; reviewer re-derived iter 4's riskiest changes independently and found them correct); head_sha: d27c756.
 
 ## Gate verdict
+
+- **2026-09-05** — verdict: NEEDS_FOLLOWUP; checks: 5 passed / 0 failed / 3 followups; followups: none filed (pending user decision); one-line: every criterion is implemented and unit-evidenced and all six non-goals hold, but four criteria have never been exercised against a real binary or a running app, criterion 5's fallback is not the one the spec words, and two stale prose references survive outside the docs that were swept.
+  - 2026-09-05 dimensions:
+    - acceptance — NEEDS_FOLLOWUP — criteria 1, 4, 6, 7, 8 PASS with executed evidence (`TestBuildModelCountsWaiting`/`IgnoresBellWhenStateIsAvailable`/`FallsBackToBellOnOldDaemon`; tooltip text asserted verbatim at `test/dom/attention-icon.test.tsx:135`; `TestMetaFileUnchangedByState`; real-PTY working/idle/bell). Criterion 2 followup: the recorded manual transcript covers rows 7–12 on claude 2.1.261 but never observed `error`, and `TestClaudeProbe*` skip without a real binary. Criterion 3 followup: no state ever observed from a real `pi` (row 14 unrun). Criterion 5 deviation: spec says fallback "within the quiet threshold", implementation demotes at `HookStaleAfter = 30s` (`internal/agentstate/machine.go:48`) and only while the screen keeps changing — a hooked session whose hook dies with a static screen holds its last hook state indefinitely; deliberate and recorded in the Approach, but not the spec's wording. Coverage gap: no committed test drives `exited` through a real child exit (`registry.go:1113`); a throwaway PTY test proved the path works and was deleted.
+    - non-goals — PASS — all six hold after phase 4. The one at risk was the bell: `events.ts:249-261` branches the notification body only on `waiting_permission` and falls through to the original wording for bare-bell sessions (pinned by `events-focus.test.ts:284`), and hivebar's switch to the state predicate cannot drop bell sessions because a bell sets `waiting_input` and `waiting()` falls back below contract 3.
+    - doc accuracy — NEEDS_FOLLOWUP — all three original gate failures and all three review-iteration-1 prose defects verified genuinely fixed by executed commands (every artefact `control-plane.md` now names exists; no `Subagent*` in Go; nothing under `src/theme/` or `Icon.tsx` reads `state_source`, so the tier line's replacement justification is true). Two residuals: `internal/agent/claude.go:111` still cites `scripts/probe-claude.sh` as an existing verification source (pre-existing from #338, the same defect class phase 4 swept from the docs but not from Go comments), and the plan's own smoke checklist row 14 (`:509`) still tells the operator to expect "the uncertain ring", which this file refutes at `:948`. Rows 13–14 are outstanding work, so that is live wrong guidance.
 
 - **2026-09-05** — verdict: FAIL; checks: 11 passed / 3 failed / 2 followups; followups: none filed (pending user decision); one-line: phases 1–3 are delivered and evidenced, but two of the spec's eight success criteria (hivebar count, prompt+summary tooltip) are phase-4 work that was never implemented, and three design-doc paragraphs describe unshipped or already-shipped things in the wrong tense.
   - 2026-09-05 dimensions:

--- a/docs/exec-plans/active/336-session-state-model.md
+++ b/docs/exec-plans/active/336-session-state-model.md
@@ -892,6 +892,56 @@ decision-log entry with the log excerpt BEFORE any code changes.
   `TestApplyStillDropsARealInversion`).
 
 
+- **2026-09-05 (phase 4)** — hivebar decides "is this session waiting"
+  from the daemon's contract number, NOT from whether `state` is empty.
+  The Approach above says to "fall back to `needs_attention` when
+  `state` is empty (old daemon)", and that rule is wrong: `StateIdle`
+  IS the empty string, so an idle session on a current daemon and every
+  session on a pre-contract-3 daemon are byte-identical on the wire.
+  Reading it literally would have made an old daemon report a permanent
+  zero and — worse — made every idle session on a current one fall
+  through to the bell flag, resurrecting exactly the "rang once an hour
+  ago, still counted" behavior phase 4 exists to kill.
+  `internal/buildinfo/contract.go`'s own history entry 3 names this
+  trap ("a GUI built after it, talking to an older daemon, would show
+  every session as permanently idle"). `Welcome.DaemonContract` already
+  reaches `BuildModel`, so the discriminator cost nothing: `waiting()`
+  falls back to `needs_attention` below contract 3 and reads `state`
+  at or above it. Pinned by `TestBuildModelFallsBackToBellOnOldDaemon`
+  and `TestBuildModelIgnoresBellWhenStateIsAvailable`.
+
+- **2026-09-05 (phase 4)** — The notification wording is composed in
+  `app/events.ts` (`fireBellNotification`), not in `cmd/hivegui/app.go`
+  as the Files-to-change list says. `App.Notify` is a four-argument
+  pass-through to `internal/notify`; it has no idea what a session is,
+  and giving it one would have put a second state vocabulary in Go for
+  no gain. Only `waiting_permission` gets its own body — everything
+  else that reaches `needs_attention` (a bare bell on the heuristic
+  tier) keeps "Waiting for input", which is still true for it.
+
+- **2026-09-05 (phase 4)** — No `StateDot.tsx`, and no separate tooltip
+  element: the tooltip is the existing `StateIcon`'s `<title>`, filled
+  from a new `stateTooltip()` beside `sessionState()` in
+  `lib/session-state.ts`. Same argument the phase-1 entry above makes
+  for not adding the component — the icon already exists, already has
+  the words channel, and a second surface for the same session could
+  disagree with the first. The tier line ("reported by the agent" /
+  "guessed from terminal output") is always present because it is what
+  explains the uncertain ring to someone who hovered to ask about it;
+  `hook` and `extension` collapse to one phrase, since which transport
+  the agent used to speak is not the user's business.
+
+- **2026-09-05 (phase 4)** — `verbS()` is deleted from
+  `cmd/hivebar/model.go`. "N waiting on you" reads correctly at every
+  count, so the helper that existed only to conjugate "N need/needs
+  you" had no second caller.
+
+- **2026-09-05 (phase 4)** — The minimized `Chip` does NOT get the new
+  tooltip. It takes a resolved `SessionState` rather than a session, so
+  feeding it one would have meant threading the carrier through a
+  presentational component; its button already carries a `title`, and
+  the success criterion names the sidebar row and the tile header.
+
 ## Review log
 
 - **2026-09-04** — `/hs-feature-plan-review` (three `hs-reviewer` passes:
@@ -1187,6 +1237,48 @@ decision-log entry with the log excerpt BEFORE any code changes.
   green; `node --test internal/agent/pi/hive.test.ts` 10/10.
 
 
+- **2026-09-05 (merge gate)** — Gate FAIL, run on the degraded post-merge
+  path (PR #341 already merged as `d49551c`; range evaluated as the whole
+  feature, `ad8f4aa~1..origin/main`). Failing checks:
+  - Success criterion 7 (`hivebar` count off the new state) — not
+    implemented; phase 4 work.
+  - Success criterion 6, tooltip half (prompt + summary) — not
+    implemented; phase 4 work. Glyph half passes.
+  - `docs/design-docs/control-plane.md:137-144` documents
+    `scripts/probe-claude.sh` and `testdata/claude-hooks/` as existing;
+    neither is in the tree or in history.
+  - `docs/design-docs/ui/icons.md:37` says the Pi extension "will in
+    phase 3" after phase 3 shipped.
+  - `docs/design-docs/control-plane.md:38` claims the hook tier learns
+    "subagent activity"; no `Subagent*` handling exists.
+  Non-goals dimension passed clean. Stage stays at GATE. No follow-up
+  issues filed yet — the gate's failing criteria are the already-planned
+  phase 4 plus a three-paragraph doc correction, not unplanned debt.
+
+- **2026-09-05 (phase 4)** — hivebar, notification wording and the
+  state tooltip. `cmd/hivebar/model.go`: `Model.Attention` →
+  `Model.Waiting` and `SessionRow.NeedsAttention` → `SessionRow.Waiting`,
+  both fed by one `waiting()` predicate so the summary line and the row
+  markers cannot disagree; summary reads "N waiting on you".
+  `lib/session-state.ts` gained `stateTooltip()`, wired into
+  `StateIcon`'s new optional `detail` prop from `SessionRow.tsx` and
+  `TileChrome.tsx`. `app/events.ts` names `waiting_permission` in the
+  notification body. Docs: `control-plane.md` drift-probe paragraph now
+  describes the probe that exists (`cmd/hived/claude_probe_test.go`,
+  `HIVE_PROBE_CLAUDE=1`, fixtures at `cmd/hived/testdata/hooks/`)
+  instead of the never-committed `scripts/probe-claude.sh`; the tier
+  table drops the "subagent activity" claim (no `Subagent*` handling
+  exists); `ui/icons.md` stops saying the Pi extension "will" report
+  waiting_permission and documents the tooltip stack; README's menu-bar
+  bullet says the dot means blocked-on-you, not rang.
+  Verified: `go vet` host/linux/windows clean; `go test ./internal/...
+  ./cmd/hived/ ./cmd/hivebar/` green; `scripts/check-daemon-contract.sh
+  origin/main HEAD` → "no daemon-side changes" (so no contract bump);
+  `biome ci .` clean; `tsc --noEmit` clean; vitest 1027/1027 in 88
+  files; `CI=1 npx playwright test` 270 passed / 31 skipped.
+  Not done in this pass: the manual smoke checklist in an iso build
+  (rows 1–6 and 13–14 still unrun, and no row covers the menu bar).
+
 ## Open questions
 
 <Empty — resolved into the Decision log.>
@@ -1200,3 +1292,11 @@ decision-log entry with the log excerpt BEFORE any code changes.
 - **2026-09-05 iter 3 (PR #341)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: be5b1f45d0d6110670ca570825b18153cb3812780652253e88c0861f28d5277a; threads_open: 0; action: continue (3 IMPORTANT remain; loop's stop rule met but boil-the-lake says fix them); head_sha: 7c97502.
 - **2026-09-05 iter 4 (PR #341)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 27e41405647bee014b40872c51634cc5e5605e836fb8f36b328c2543d025406d; threads_open: 0; action: continue (3 IMPORTANT + 5 MINOR fixed; stop rule met but one finding was a regression from iter 2); head_sha: 9592c67.
 - **2026-09-05 iter 5 (PR #341)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 012bd1b0cb5b268652d7f421b16e0ddc5b99a330710aa60401cc653899411c66; threads_open: 0; action: converged (2 IMPORTANT fixed: boundary test + comment scope; reviewer re-derived iter 4's riskiest changes independently and found them correct); head_sha: d27c756.
+
+## Gate verdict
+
+- **2026-09-05** — verdict: FAIL; checks: 11 passed / 3 failed / 2 followups; followups: none filed (pending user decision); one-line: phases 1–3 are delivered and evidenced, but two of the spec's eight success criteria (hivebar count, prompt+summary tooltip) are phase-4 work that was never implemented, and three design-doc paragraphs describe unshipped or already-shipped things in the wrong tense.
+  - 2026-09-05 dimensions:
+    - acceptance — FAIL — criterion 7 ("`hivebar` shows 'N waiting on you' using the new state, not the bell") not delivered: `cmd/hivebar/model.go:53,97,104,195` build rows solely from `wire.SessionInfo.NeedsAttention`, and the string appears nowhere in the tree. Criterion 6 partially delivered: glyphs ship and are covered (`test/e2e/state-glyphs.spec.ts`, 35 unit tests), but the tooltip half is absent — `last_prompt`/`last_summary` exist only as optional type fields at `cmd/hivegui/frontend/src/app/state.ts:72-73` and are read by zero components. Criteria 1, 4, 5, 8 PASS with green tests; 2 and 3 NEEDS_FOLLOWUP on their manual halves only (checklist rows 1–6 and 13–14 unrun in an iso build; `TestAgentTUIStateFlow` skips by default).
+    - non-goals — PASS — all six negative checks clean. Strongest evidence on "no persisted state": `persist.go`/`closed.go`/`store.go` have zero diff in `ad8f4aa~1..origin/main`, `TestMetaFileUnchangedByState` byte-compares `session.json` across a full state tour, and a runtime enumeration of `agent.All()` confirms `SpawnArgs` is non-nil only for `claude` and `pi`.
+    - doc accuracy — FAIL — `docs/design-docs/control-plane.md:137-144` states in the present tense that `scripts/probe-claude.sh` exists, runs in CI and is on the release checklist, and that fixtures live under `testdata/claude-hooks/`; neither exists in the tree or anywhere in history. `docs/design-docs/ui/icons.md:37` still says the Pi extension "will in phase 3" after phase 3 merged as `d49551c`. `docs/design-docs/control-plane.md:38` claims the hook tier learns "subagent activity"; no `Subagent*` handling exists in Go. Changesets (5), CHANGELOG generation, README, and the plan header/Progress log all PASS.

--- a/docs/exec-plans/active/338-session-messaging.md
+++ b/docs/exec-plans/active/338-session-messaging.md
@@ -165,7 +165,9 @@ shell) message any other session with the same semantics the GUI has.
 - `cmd/hived/msg.go`, `msg_test.go`
 - `cmd/hivegui/frontend/src/components/modals/MessageSession.tsx` + test
 - `scripts/check-no-claude-keys.sh` (grep guard, wired into `scripts/test.sh`)
-- `scripts/probe-claude.sh` gains a 338 section: assert
+- The drift probe (which shipped as `cmd/hived/claude_probe_test.go`
+  behind `HIVE_PROBE_CLAUDE=1`, NOT as the `scripts/probe-claude.sh`
+  this line originally assumed) gains a 338 section: assert
   `~/.claude/sessions/<pid>.json` for the probe session still carries
   `sessionId`, `messagingSocketPath`, `pid`; send one message over the
   socket and assert the `-p` session's output echoes it.

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -76,8 +76,15 @@ settings untouched.
   flows, `idle` after two seconds of silence, `waiting_input` on a bell,
   `exited` on exit — verified by a Go test feeding a fake PTY.
 - A session whose hook stops firing (simulated by killing the event
-  connection path) falls back to heuristic state within the quiet
-  threshold; `state_source` flips to `heuristic`.
+  connection path) but whose screen keeps changing falls back to
+  heuristic state within 30 s of the last hook event
+  (`agentstate.HookStaleAfter`); `state_source` flips to `heuristic`.
+  Note the deliberate limit: demotion is driven by output, so a hooked
+  session whose hook dies while its screen is static holds its last
+  reported state until either output resumes or the process exits.
+  Nothing polls it back to reality, because a timer that overrode a
+  quiet `waiting_permission` would erase a real prompt the user has
+  not answered yet.
 - Sidebar rows and tile headers render the six states; the tooltip
   shows prompt + summary when present. Playwright mock e2e covers the
   glyphs; unit tests cover the store reducers.

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -5,7 +5,7 @@ title: "Session state model: know what every agent is doing"
 type: enhancement
 complexity: L
 priority: P1
-stage: GATE
+stage: IMPLEMENT
 ---
 
 # Session state model: know what every agent is doing

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -5,7 +5,7 @@ title: "Session state model: know what every agent is doing"
 type: enhancement
 complexity: L
 priority: P1
-stage: REVIEW
+stage: GATE
 ---
 
 # Session state model: know what every agent is doing

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -76,15 +76,19 @@ settings untouched.
   flows, `idle` after two seconds of silence, `waiting_input` on a bell,
   `exited` on exit — verified by a Go test feeding a fake PTY.
 - A session whose hook stops firing (simulated by killing the event
-  connection path) but whose screen keeps changing falls back to
-  heuristic state within 30 s of the last hook event
-  (`agentstate.HookStaleAfter`); `state_source` flips to `heuristic`.
-  Note the deliberate limit: demotion is driven by output, so a hooked
-  session whose hook dies while its screen is static holds its last
-  reported state until either output resumes or the process exits.
-  Nothing polls it back to reality, because a timer that overrode a
-  quiet `waiting_permission` would erase a real prompt the user has
-  not answered yet.
+  connection path) falls back to the heuristic tier once its last hook
+  event is older than `agentstate.HookStaleAfter` (30 s), and
+  `state_source` flips to `heuristic` with it. Both routes back are
+  covered: `Output` takes a still-painting session to
+  `working`/`heuristic`, and `Tick` takes a quiet one to
+  `idle`/`heuristic`.
+  The deliberate exception is a wait. `waiting_input` and
+  `waiting_permission` are held on every tier until the user acts
+  (`ClearWaiting`) or the process exits — no amount of elapsed time is
+  evidence that an unanswered prompt was answered, and a timer that
+  flipped a quiet `waiting_permission` to idle would erase a real
+  request the user has not seen yet. So a session whose hook dies
+  mid-prompt keeps that prompt until a human resolves it.
 - Sidebar rows and tile headers render the six states; the tooltip
   shows prompt + summary when present. Playwright mock e2e covers the
   glyphs; unit tests cover the store reducers.

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -1,11 +1,11 @@
 ---
 issue: null
-pr: 341
+pr: 344
 title: "Session state model: know what every agent is doing"
 type: enhancement
 complexity: L
 priority: P1
-stage: IMPLEMENT
+stage: REVIEW
 ---
 
 # Session state model: know what every agent is doing

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -83,12 +83,15 @@ settings untouched.
   `working`/`heuristic`, and `Tick` takes a quiet one to
   `idle`/`heuristic`.
   The deliberate exception is a wait. `waiting_input` and
-  `waiting_permission` are held on every tier until the user acts
-  (`ClearWaiting`) or the process exits — no amount of elapsed time is
-  evidence that an unanswered prompt was answered, and a timer that
-  flipped a quiet `waiting_permission` to idle would erase a real
-  request the user has not seen yet. So a session whose hook dies
-  mid-prompt keeps that prompt until a human resolves it.
+  `waiting_permission` are never ended by elapsed time or by output on
+  any tier — only by something that constitutes an actual answer: the
+  user acting (`ClearWaiting`), the agent reporting the wait resolved
+  (`permission_resolved`, `turn_end`, `session_end`), or the process
+  exiting. No amount of silence is evidence that an unanswered prompt
+  was answered, and a timer that flipped a quiet `waiting_permission`
+  to idle would erase a real request the user has not seen yet. So a
+  session whose hook dies mid-prompt — with no agent left to report a
+  resolution — keeps that prompt until a human resolves it.
 - Sidebar rows and tile headers render the six states; the tooltip
   shows prompt + summary when present. Playwright mock e2e covers the
   glyphs; unit tests cover the store reducers.

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -107,11 +107,17 @@ var claudeHivedPathWarnOnce sync.Once
 // hived path, or claude's version is outside the verified range).
 //
 // --settings hooks CONCATENATE with hooks from other settings sources
-// rather than replacing them (verified by hand on Claude Code 2.1.260;
-// see the plan's decision log), so this never has to read the user's
-// own settings.json first. Re-check it with
-// cmd/hived/claude_probe_test.go under HIVE_PROBE_CLAUDE=1, which
-// drives a real claude — there is no probe script.
+// rather than replacing them, so this never has to read the user's own
+// settings.json first.
+//
+// That was verified BY HAND on Claude Code 2.1.260 (a project
+// .claude/settings.json Stop hook and a --settings Stop hook both fired
+// on one -p turn; see the plan's decision log) and nothing re-checks it
+// automatically: cmd/hived/claude_probe_test.go drives a real claude
+// but installs only Hive's own hooks, so it cannot see the difference
+// between concatenate and replace. If Anthropic ever changes the merge
+// semantics, the symptom is the user's own hooks silently not firing in
+// Hive sessions, and no test in this repo will catch it.
 func claudeSpawnArgs(sp SpawnInfo) []string {
 	if sp.HivedPath == "" {
 		claudeHivedPathWarnOnce.Do(func() {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -107,9 +107,11 @@ var claudeHivedPathWarnOnce sync.Once
 // hived path, or claude's version is outside the verified range).
 //
 // --settings hooks CONCATENATE with hooks from other settings sources
-// rather than replacing them (verified on Claude Code 2.1.260 — see
-// the plan's decision log and scripts/probe-claude.sh), so this never
-// has to read the user's own settings.json first.
+// rather than replacing them (verified by hand on Claude Code 2.1.260;
+// see the plan's decision log), so this never has to read the user's
+// own settings.json first. Re-check it with
+// cmd/hived/claude_probe_test.go under HIVE_PROBE_CLAUDE=1, which
+// drives a real claude — there is no probe script.
 func claudeSpawnArgs(sp SpawnInfo) []string {
 	if sp.HivedPath == "" {
 		claudeHivedPathWarnOnce.Do(func() {

--- a/internal/agentstate/machine.go
+++ b/internal/agentstate/machine.go
@@ -49,10 +49,12 @@ const (
 	// crashed hook would pin a session at whatever state it last
 	// reported, forever.
 	//
-	// The one state this does NOT rescue is a wait: waiting_input and
-	// waiting_permission are held until the user acts (ClearWaiting) or
-	// the process exits, on every tier, because no amount of elapsed
-	// time is evidence that an unanswered prompt was answered.
+	// The one state this does NOT rescue is a wait: on every tier,
+	// waiting_input and waiting_permission are immune to elapsed time
+	// and to output, because neither is evidence that an unanswered
+	// prompt was answered. A wait ends only on an actual answer —
+	// ClearWaiting, an agent event that resolves it
+	// (permission_resolved / turn_end / session_end), or Exit.
 	HookStaleAfter = 30 * time.Second
 )
 
@@ -147,11 +149,12 @@ func (m *Machine) Output(now time.Time) bool {
 	if m.state == wire.StateExited {
 		return false
 	}
-	// A session that asked for the user stays asking until the user
-	// answers. Redrawing is not an answer — and a program that rings
-	// and then keeps painting would otherwise bury its own request
-	// within one tick. ClearWaiting, driven by the client that sees
-	// the user look, is the only way out.
+	// A session that asked for the user stays asking until it is
+	// actually answered. Redrawing is not an answer — and a program
+	// that rings and then keeps painting would otherwise bury its own
+	// request within one tick. The ways out are ClearWaiting (driven by
+	// the client that sees the user look), an agent event resolving the
+	// wait, and Exit; output is not one of them.
 	if m.state == wire.StateWaitingInput || m.state == wire.StateWaitingPermission {
 		m.lastOutputAt = now
 		return false

--- a/internal/agentstate/machine.go
+++ b/internal/agentstate/machine.go
@@ -28,8 +28,10 @@ type State = string
 // Source records which tier produced the current State. It matters
 // because the tiers are not equally trustworthy: a hook knows the agent
 // asked a question, while the heuristic tier only knows bytes stopped
-// arriving. Clients render the difference (an "uncertain" ring on
-// heuristic states) and the machine uses it to decide who wins.
+// arriving. The machine uses it to decide who wins, and clients render
+// the difference in words — the state icon's tooltip ends "reported by
+// the agent" or "guessed from terminal output" (see the frontend's
+// stateTooltip). The glyph itself is identical on every tier.
 type Source = string
 
 // Tunables for the heuristic tier.
@@ -41,10 +43,16 @@ const (
 	QuietAfter = 2 * time.Second
 
 	// HookStaleAfter is how long the machine keeps trusting a hook or
-	// extension tier that has gone silent while output keeps arriving.
-	// Past it, output demotes the session back to the heuristic tier —
-	// otherwise a crashed hook would pin a session at whatever state it
-	// last reported, forever.
+	// extension tier that has gone silent. Past it the heuristic tier
+	// takes the session back — through Output if the screen is still
+	// changing, through Tick if it has gone quiet — because otherwise a
+	// crashed hook would pin a session at whatever state it last
+	// reported, forever.
+	//
+	// The one state this does NOT rescue is a wait: waiting_input and
+	// waiting_permission are held until the user acts (ClearWaiting) or
+	// the process exits, on every tier, because no amount of elapsed
+	// time is evidence that an unanswered prompt was answered.
 	HookStaleAfter = 30 * time.Second
 )
 
@@ -231,6 +239,14 @@ func (m *Machine) Tick(now time.Time) bool {
 		return false
 	}
 	m.state = wire.StateIdle
+	// The tier is stale by definition here — trusted() said so above —
+	// so this idle is ours, inferred from silence, not something the
+	// agent reported. Say so, the way Output does when it takes a
+	// stale session back. Without this the session reports idle while
+	// still claiming state_source=hook, and every surface that renders
+	// provenance (the tooltip's last line) credits the agent with a
+	// state it never sent.
+	m.source = wire.StateSourceHeuristic
 	return true
 }
 

--- a/internal/agentstate/machine_test.go
+++ b/internal/agentstate/machine_test.go
@@ -534,3 +534,29 @@ func TestApplyOrderingBoundary(t *testing.T) {
 		}
 	})
 }
+
+// A hooked session whose hook dies with a STATIC screen is demoted by
+// Tick, not by Output — and Tick used to change the state while
+// leaving source at the dead tier, so the session reported idle with
+// state_source=hook. Phase 4 made that visible: the tooltip's last
+// line credits the agent ("reported by the agent") for a state no
+// agent sent. Found by the merge gate on PR #344.
+func TestStaleTickDemotesTheSourceNotJustTheState(t *testing.T) {
+	m := New(t0)
+	m.Apply(hookEvent(KindPrompt, t0, "do the thing"))
+	if got := m.Snapshot(); got.State != wire.StateWorking || got.Source != wire.StateSourceHook {
+		t.Fatalf("setup: %+v, want working/hook", got)
+	}
+
+	// Well past HookStaleAfter, with nothing painted since.
+	m.Tick(t0.Add(HookStaleAfter + time.Second))
+
+	got := m.Snapshot()
+	if got.State != wire.StateIdle {
+		t.Errorf("State = %q, want idle", got.State)
+	}
+	if got.Source != wire.StateSourceHeuristic {
+		t.Errorf("Source = %q, want heuristic — a tick-derived idle is our "+
+			"inference, not the agent's report", got.Source)
+	}
+}

--- a/internal/registry/state_test.go
+++ b/internal/registry/state_test.go
@@ -448,12 +448,17 @@ func TestExitedReachesTheStateThroughTheRealPTY(t *testing.T) {
 	}
 
 	if got := infoOf(t).State; got == wire.StateExited {
-		t.Fatal("test setup: session was already exited before EOT")
+		t.Fatal("test setup: session was already exited before we ended it")
 	}
 
-	// EOT closes cat's stdin, which ends the process.
-	if _, err := sess.Write([]byte{0x04}); err != nil {
-		t.Fatalf("write EOT: %v", err)
+	// Close kills the child and releases the PTY. Deliberately NOT an
+	// EOT written to the terminal: that ends /bin/cat on macOS but not
+	// reliably on Linux (this test timed out there at 10 s on the first
+	// CI run), because whether a lone ^D means EOF depends on the line
+	// discipline's canonical-mode state. The transition under test is
+	// "the child process is gone", so end it by ending it.
+	if err := sess.Close(); err != nil {
+		t.Fatalf("close session: %v", err)
 	}
 
 	deadline := time.Now().Add(10 * time.Second)

--- a/internal/registry/state_test.go
+++ b/internal/registry/state_test.go
@@ -447,8 +447,12 @@ func TestExitedReachesTheStateThroughTheRealPTY(t *testing.T) {
 		return wire.SessionInfo{}
 	}
 
-	if got := infoOf(t).State; got == wire.StateExited {
-		t.Fatal("test setup: session was already exited before we ended it")
+	// Assert the live shape positively: `got == StateExited` could never
+	// fire here, since a live session's state is StateIdle ("") — a
+	// guard that cannot fail is not a guard.
+	if got := infoOf(t); !got.Alive || got.State == wire.StateExited {
+		t.Fatalf("test setup: want a live non-exited session, got alive=%v state=%q",
+			got.Alive, got.State)
 	}
 
 	// Close kills the child and releases the PTY. Deliberately NOT an

--- a/internal/registry/state_test.go
+++ b/internal/registry/state_test.go
@@ -430,7 +430,24 @@ func TestExitedReachesTheStateThroughTheRealPTY(t *testing.T) {
 	r := freshRegistry(t)
 	e, sess := liveSession(t, r, wire.CreateSpec{Name: "dying"})
 
-	if got := r.Get(e.ID).Info().State; got == wire.StateExited {
+	// Read through List(), never r.Get(id).Info(): Get drops the
+	// registry mutex before returning the entry, so Info() would read
+	// e.sess while watchSessionExit is writing it. Every other test in
+	// this file gets away with Get().Info() only because its process
+	// stays alive; this one races the exit path by construction, which
+	// is the whole point of it. List() holds the lock across Info().
+	infoOf := func(t *testing.T) wire.SessionInfo {
+		t.Helper()
+		for _, s := range r.List() {
+			if s.ID == e.ID {
+				return s
+			}
+		}
+		t.Fatalf("session %s vanished from the registry", e.ID)
+		return wire.SessionInfo{}
+	}
+
+	if got := infoOf(t).State; got == wire.StateExited {
 		t.Fatal("test setup: session was already exited before EOT")
 	}
 
@@ -441,7 +458,7 @@ func TestExitedReachesTheStateThroughTheRealPTY(t *testing.T) {
 
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		info := r.Get(e.ID).Info()
+		info := infoOf(t)
 		if !info.Alive {
 			if info.State != wire.StateExited {
 				t.Fatalf("dead session reports state %q, want %q",

--- a/internal/registry/state_test.go
+++ b/internal/registry/state_test.go
@@ -416,3 +416,40 @@ func TestBellReachesAttentionThroughTheRealPTY(t *testing.T) {
 		}
 	}
 }
+
+// The exit path is the one state transition no other test drives
+// through a real process: watchSessionExit calls machine().Exit()
+// inline (registry.go, next to the Alive:false write) rather than
+// through a session hook, so a unit test on the machine proves the
+// mapping but not the wiring. /bin/cat exits on EOT.
+//
+// The gate that found this gap proved it with a throwaway; this is
+// that test, kept.
+func TestExitedReachesTheStateThroughTheRealPTY(t *testing.T) {
+	skipNonPosix(t)
+	r := freshRegistry(t)
+	e, sess := liveSession(t, r, wire.CreateSpec{Name: "dying"})
+
+	if got := r.Get(e.ID).Info().State; got == wire.StateExited {
+		t.Fatal("test setup: session was already exited before EOT")
+	}
+
+	// EOT closes cat's stdin, which ends the process.
+	if _, err := sess.Write([]byte{0x04}); err != nil {
+		t.Fatalf("write EOT: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		info := r.Get(e.ID).Info()
+		if !info.Alive {
+			if info.State != wire.StateExited {
+				t.Fatalf("dead session reports state %q, want %q",
+					info.State, wire.StateExited)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("session never reported the exit")
+}

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -238,8 +238,10 @@ const (
 	// StateSourceHeuristic is derived from the PTY alone: bytes
 	// arrived, bytes stopped, a bell rang. Available for every
 	// session including plain shells, and never more than a guess —
-	// clients mark it as uncertain. The empty string, so it is also
-	// what a pre-field daemon reads as.
+	// clients say so in the state icon's tooltip ("guessed from
+	// terminal output"), which is the only place the tiers look
+	// different. The empty string, so it is also what a pre-field
+	// daemon reads as.
 	StateSourceHeuristic = ""
 	// StateSourceHook is reported by the agent's own hook mechanism
 	// (Claude Code hooks calling `hived hook`).


### PR DESCRIPTION
Last phase of spec 336 (session state model). Phases 1–2 shipped in #338, phase 3 in #341; this closes the two success criteria those left open, plus the doc drift the merge gate found.

## What changes

**hivebar reads state instead of a flag derived from it.** `Model.Attention` → `Model.Waiting`, fed by `state ∈ {waiting_input, waiting_permission}` and rendered as "N waiting on you" (was "N need you"). `SessionRow.NeedsAttention` → `SessionRow.Waiting` uses the same predicate, so the summary line and the row dots can't disagree.

Worth being precise about what this does and does not change, because the first draft of this PR overclaimed it: `registry.go:211` already sets `NeedsAttention` from `needsAttention(st.State)`, which is bit-for-bit the predicate `waiting()` applies. So the count is **behaviourally identical** on any daemon at contract ≥ 3, and below it `waiting()` returns `NeedsAttention` verbatim. This is a decoupling — hivebar stops depending on a derivation it doesn't own, and the old-daemon fallback becomes explicit rather than accidental. The user-visible change is the wording.

**The state icon's tooltip says why.** `stateTooltip()` lands beside `sessionState()` in `lib/session-state.ts` and stacks state words / the prompt the agent was given / its last summary / whether the state was reported or guessed, dropping any line whose field is empty. Wired through a new optional `detail` prop on `StateIcon`, from the sidebar row and the tile header. `last_prompt` and `last_summary` have been on the wire since phase 1 with zero readers; this is what reads them.

**Notifications name a permission prompt as one** instead of calling everything "waiting for input".

## One deliberate departure from the plan

The exec plan's Approach says hivebar should fall back to `needs_attention` "when `state` is empty (old daemon)". That rule is wrong, and implementing it literally would have been a regression: `StateIdle` **is** the empty string, so an idle session on a current daemon and every session on a pre-contract-3 daemon are byte-identical on the wire. Every idle session would have fallen through to the bell flag — resurrecting exactly the "rang an hour ago, still counted" behaviour this phase exists to kill.

`internal/buildinfo/contract.go`'s own history entry 3 names the trap. The discriminator is `Welcome.DaemonContract >= 3`, which `BuildModel` already receives, so it cost nothing. Both directions are pinned: `TestBuildModelFallsBackToBellOnOldDaemon`, `TestBuildModelIgnoresBellWhenStateIsAvailable`.

Second, smaller: the notification wording lives in `app/events.ts`, not `cmd/hivegui/app.go` as the plan's file list said — `App.Notify` is a four-argument pass-through with no idea what a session is.

## Docs this change made (or found) incorrect

Caught by `/hs-merge-gate` on the phase-3 tree:

- `control-plane.md` described `scripts/probe-claude.sh` running in CI and fixtures under `testdata/claude-hooks/`. Neither was ever committed. It now describes the probe that exists — `cmd/hived/claude_probe_test.go` behind `HIVE_PROBE_CLAUDE=1`, with the fixture table at `cmd/hived/testdata/hooks/` that does run everywhere.
- The hook-tier row claimed Hive learns "subagent activity". No `Subagent*` handling exists in Go.
- `ui/icons.md` still said the Pi extension "will in phase 3", two phases after it shipped. It also now documents the tooltip stack.
- README's menu-bar bullet said the dot marks sessions "that rang".

## Verification

`go vet` host/linux/windows clean · `go test ./internal/... ./cmd/hived/ ./cmd/hivebar/` green · `scripts/check-daemon-contract.sh origin/main HEAD` → "no daemon-side changes", so no contract bump · `biome ci .` clean · `tsc --noEmit` clean · vitest 1027/1027 across 88 files · `CI=1 npx playwright test` 270 passed / 31 skipped.

## Not done

The manual smoke checklist in an iso build. Rows 1–6 and 13–14 were already outstanding from earlier phases, and no row covers the menu bar — so the hivebar count and the tooltip are unverified against a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
