### PR TITLE
ci: cut 179s off the Windows leg; parallelise e2e within spec files

### DIFF
--- a/.changesets/ci-playwright-runtime.md
+++ b/.changesets/ci-playwright-runtime.md
@@ -1,12 +1,11 @@
 ---
 issue: null
-pr: null
+pr: 345
 type: changed
 bump: patch
 ---
-- CI finishes in about half the time. Three things were paying for it:
-  the Windows leg spent three minutes on every run enabling a Windows
-  media codec feature that no test uses, the Playwright suite ran on
-  half the available CPUs, and two pushes to the same pull request both
-  ran to completion instead of the first being cancelled. Developer-facing
-  only — nothing about the app itself changes.
+- CI is a little faster and its cancellation rules are now correct. The
+  Windows leg spent three minutes of every run enabling a Windows media
+  codec feature that no test uses, and two pushes to the same pull request
+  both ran the full three-platform matrix instead of the first being
+  superseded. Developer-facing only — nothing about the app itself changes.

--- a/.changesets/ci-playwright-runtime.md
+++ b/.changesets/ci-playwright-runtime.md
@@ -1,0 +1,12 @@
+---
+issue: null
+pr: null
+type: changed
+bump: patch
+---
+- CI finishes in about half the time. Three things were paying for it:
+  the Windows leg spent three minutes on every run enabling a Windows
+  media codec feature that no test uses, the Playwright suite ran on
+  half the available CPUs, and two pushes to the same pull request both
+  ran to completion instead of the first being cancelled. Developer-facing
+  only — nothing about the app itself changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ on:
   pull_request:
     branches: [main]
 
+# A second push to a PR supersedes the first: cancel the in-flight matrix
+# rather than paying for two full runs and queueing behind the stale one.
+#
+# `main` gets a per-run group (`github.run_id` is unique), NOT a shared one.
+# `cancel-in-progress: false` alone would not have kept the promise below:
+# GitHub's queue default is to cancel any previously PENDING run in the
+# group when a new one queues — at most one running and one pending survive.
+# So two merges landing while a run is in flight would silently cancel the
+# middle commit's run before it ever started. A group that can never
+# collide is the only form that actually guarantees the invariant:
+# every commit on `main` keeps its own green check.
+concurrency:
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build, Vet & Test (${{ matrix.label }})
@@ -254,7 +269,14 @@ jobs:
         # CI the `install chromium` step alone has been observed to skip
         # the shell, leading to "Executable doesn't exist" at launch.
         working-directory: cmd/hivegui/frontend
-        run: ./node_modules/.bin/playwright install --with-deps chromium chromium-headless-shell
+        #
+        # `--with-deps` is Linux-only on purpose. On Linux it apt-installs the
+        # shared libs Chromium needs, which are not cacheable and genuinely
+        # required. On Windows it does exactly one thing: enable the Media
+        # Foundation optional feature (audio/video codecs) — 179s of the
+        # Windows leg's 10.6m, every run, behind a browser cache that already
+        # HIT. No spec plays media. On macOS it is a no-op. So: Linux only.
+        run: ./node_modules/.bin/playwright install ${{ runner.os == 'Linux' && '--with-deps' || '' }} chromium chromium-headless-shell
 
       - name: Assert every spec file is collected
         if: matrix.biome

--- a/cmd/hivegui/frontend/playwright.config.js
+++ b/cmd/hivegui/frontend/playwright.config.js
@@ -7,22 +7,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './test/e2e',
   testMatch: '**/*.spec.{js,ts}',
-  // EXPERIMENT (see PR #345) — revert this hunk if CI does not improve.
-  //
-  // With `fullyParallel: false` each FILE is a serial chain pinned to one
-  // worker, so wall clock floors at the longest single file. This suite is
-  // badly unbalanced: theme.spec.ts is 59 tests, focus-traps.spec.ts 41,
-  // worktrees.spec.ts 40 — 140 of 303 in three files. That is why simply
-  // raising the worker count bought exactly nothing (Linux: 4.9m on 2
-  // workers, 4.9m on 4) and cost Windows 2.3m: there was no second unit of
-  // work for the extra workers to pick up, only more contention.
-  //
-  // Parallelising WITHIN files is the only thing that lowers that floor.
-  // Verified green locally at 4 workers (272 passed, 3 runs), but local has
-  // far more cores than a 4-vCPU runner, so the local timing says nothing
-  // about the CI gain. This PR's own CI run is the measurement.
-  fullyParallel: true,
-  workers: process.env.CI ? 4 : undefined,
+  fullyParallel: false,
   timeout: 30000,
   // One retry on CI, but `failOnFlakyTests` means a retry buys diagnostics
   // (both attempts' traces), NOT a green check. Spec 245's re-gate criterion

--- a/cmd/hivegui/frontend/playwright.config.js
+++ b/cmd/hivegui/frontend/playwright.config.js
@@ -7,7 +7,22 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './test/e2e',
   testMatch: '**/*.spec.{js,ts}',
-  fullyParallel: false,
+  // EXPERIMENT (see PR #345) — revert this hunk if CI does not improve.
+  //
+  // With `fullyParallel: false` each FILE is a serial chain pinned to one
+  // worker, so wall clock floors at the longest single file. This suite is
+  // badly unbalanced: theme.spec.ts is 59 tests, focus-traps.spec.ts 41,
+  // worktrees.spec.ts 40 — 140 of 303 in three files. That is why simply
+  // raising the worker count bought exactly nothing (Linux: 4.9m on 2
+  // workers, 4.9m on 4) and cost Windows 2.3m: there was no second unit of
+  // work for the extra workers to pick up, only more contention.
+  //
+  // Parallelising WITHIN files is the only thing that lowers that floor.
+  // Verified green locally at 4 workers (272 passed, 3 runs), but local has
+  // far more cores than a 4-vCPU runner, so the local timing says nothing
+  // about the CI gain. This PR's own CI run is the measurement.
+  fullyParallel: true,
+  workers: process.env.CI ? 4 : undefined,
   timeout: 30000,
   // One retry on CI, but `failOnFlakyTests` means a retry buys diagnostics
   // (both attempts' traces), NOT a green check. Spec 245's re-gate criterion


### PR DESCRIPTION
## Why

CI was 11-12m per run. Measured against run [33983507921](https://github.com/lucascaro/hive/actions/runs/33983507921), the critical path was the **Windows leg at 10.6m**, and Playwright was 75-77% of *every* leg. Everything else — Go build/vet/test, staticcheck, govulncheck, Biome, tsc, ui-lint — is already cached and totals ~1-2m combined.

## Commit 1 — proven

**`--with-deps` is Linux-only.** The Windows browser cache *hit* (restored in 4s), then the install step ran 179s anyway. The log says why:

```
Success Restart Needed Exit Code      Feature Result
True    No             Success        {Media Foundation}
```

On Windows `--with-deps` only enables the Media Foundation optional feature (audio/video codecs). No spec plays media. Uncacheable, every run. Linux keeps it (apt libs Chromium genuinely needs); on macOS it is a no-op. **Confirmed on run [33985300182](https://github.com/lucascaro/hive/actions/runs/33985300182): the step drops off the Windows profile entirely.**

**Concurrency group.** No workflow except `pages.yml` had one, so two pushes to a PR both ran the full matrix. Non-PR events get a *per-run* group rather than a shared one — `cancel-in-progress: false` would not have kept `main` safe, because [GitHub's queue default](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) cancels any previously **pending** run in the group when a new one queues (at most one running + one pending survive). Two merges landing while a run is in flight would have silently cancelled the middle commit's run before it started. Caught in review; the first version of this PR had the bug.

## Commit 2 — experiment, revert if CI doesn't improve

**First attempt failed and is worth recording.** I raised `workers` to 4 on the theory the suite was CPU-bound. It was not:

| Leg | mock e2e before | after workers:4 | Δ |
|---|---|---|---|
| Linux | 4.9m (2 workers) | 4.9m (4 workers) | **0** |
| macOS | 3.8m (1 worker) | 3.5m (4 workers) | −0.3m |
| Windows | 5.2m (2 workers) | **7.5m** (4 workers) | **+2.3m** |

`fullyParallel: false` pins each *file* to one worker as a serial chain, so wall clock floors at the longest single file. The suite is badly unbalanced — `theme.spec.ts` 59 tests, `focus-traps.spec.ts` 41, `worktrees.spec.ts` 40: **140 of 303 tests in three files**. The extra workers had no second unit of work to pick up, only more contention for the same 4 vCPU. Windows, with the slowest process spawn of the three, ate the difference.

Commit 2 sets `fullyParallel: true` (plus `workers: 4`), which is the only change that lowers that floor.

Green locally at 4 workers with `CI=1` (so `retries: 1` and `failOnFlakyTests` are both live): **272 passed, 31 skipped**, establishing that the specs don't depend on intra-file ordering or shared state. That is all it establishes — this box has far more cores than a 4-vCPU runner, and extrapolating from local is precisely what produced the failed first attempt. **This PR's own CI run is the measurement.** If the mock e2e step doesn't drop, revert commit 2 and merge commit 1 alone.

`playwright.real.config.js` stays at `workers: 1` throughout — those 28 specs share one live hived daemon, so parallelising them would be a correctness bug, not a speed knob.

## Expected

Commit 1 alone: Windows 10.6m → ~7.6m. Commit 2: unknown until CI reports, by construction.

## Also noticed, not fixed

Windows computes a different `hashFiles('package.json')` than Linux/macOS (`1722…` vs `9c70…`) — checkout converts LF→CRLF. Harmless today (the key is stable per-OS so the cache still hits), but it means "the same pin" isn't verifiable across legs.

## Considered and rejected

Sharding with `--shard=i/2` would cut Linux to ~5m, but each shard re-pays ~2.5m of setup and doubles billed minutes on the most expensive step. Not worth it before the above is measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)