### PR TITLE
feat(gui): session count and attention state on minimized project chips

### DIFF
--- a/.changesets/343-minimized-project-chip-count-and-attention.md
+++ b/.changesets/343-minimized-project-chip-count-and-attention.md
@@ -1,6 +1,6 @@
 ---
 issue: 343
-pr: null
+pr: 346
 type: changed
 bump: minor
 ---

--- a/.changesets/343-minimized-project-chip-count-and-attention.md
+++ b/.changesets/343-minimized-project-chip-count-and-attention.md
@@ -1,0 +1,13 @@
+---
+issue: 343
+pr: null
+type: changed
+bump: minor
+---
+- A minimized project chip now shows how many sessions the project holds
+  and how many of them are waiting on you, next to the same state icon the
+  sidebar rows and grid tiles use — so a minimized project tells you what
+  a collapsed one does, including whether a session is waiting for
+  permission rather than just waiting. The collapsed card and the chip now
+  derive that count from one shared helper, which also means a session
+  that has exited no longer leaves a stale bell behind on either.

--- a/.changesets/343-minimized-project-chip-count-and-attention.md
+++ b/.changesets/343-minimized-project-chip-count-and-attention.md
@@ -8,6 +8,9 @@ bump: minor
   and how many of them are waiting on you, next to the same state icon the
   sidebar rows and grid tiles use — so a minimized project tells you what
   a collapsed one does, including whether a session is waiting for
-  permission rather than just waiting. The collapsed card and the chip now
-  derive that count from one shared helper, which also means a session
-  that has exited no longer leaves a stale bell behind on either.
+  permission rather than just waiting.
+- A minimized chip and a collapsed project card now derive "needs you"
+  from one shared rule, so the two can no longer disagree. That rule is
+  stricter than the old one on both: a session that has exited, or that
+  has not finished starting, no longer counts as waiting on you, so a
+  stale bell can't outlive the session that raised it.

--- a/cmd/hivegui/frontend/src/components/Chip.tsx
+++ b/cmd/hivegui/frontend/src/components/Chip.tsx
@@ -8,7 +8,7 @@
 import type { CSSProperties } from 'react';
 import { StateIcon } from './Icon.js';
 import { IconButton } from './IconButton.js';
-import type { SessionState } from '../lib/session-state.js';
+import type { AttentionSummary, SessionState } from '../lib/session-state.js';
 
 export interface ChipProps {
   label: string;
@@ -24,8 +24,17 @@ export interface ChipProps {
   /** data-pid / data-sid, whichever the tray keys its chips by. */
   pid?: string;
   sid?: string;
-  /** data-state='attention' for a project whose sessions are ringing. */
-  attention?: boolean;
+  /**
+   * Total sessions, for a chip that stands for a project. The session
+   * tray leaves it unset — a session has no sessions.
+   */
+  count?: number;
+  /**
+   * What a project's sessions collectively want from the user, from
+   * attentionSummary(). Drives data-state and the alert slot; unset when
+   * nothing is ringing, and always unset on a session chip.
+   */
+  attention?: Omit<AttentionSummary, 'state'> & { state: SessionState };
 }
 
 export function Chip({
@@ -41,6 +50,7 @@ export function Chip({
   restoreLabel,
   pid,
   sid,
+  count,
   attention,
 }: ChipProps) {
   // Only set when the user actually picked a colour: the CSS falls back to
@@ -54,7 +64,7 @@ export function Chip({
       className="hv-chip"
       data-pid={pid}
       data-sid={sid}
-      data-state={state ?? (attention ? 'attention' : undefined)}
+      data-state={state ?? attention?.state}
       data-active={active ? '' : undefined}
       style={style}
     >
@@ -70,8 +80,10 @@ export function Chip({
       >
         {/* State icon when the chip stands for a session (it carries the
             bell for a session that has no row on screen); a plain colour
-            dot when it stands for a project, whose state is the union of
-            its sessions' and is carried by the pulse on the dot. */}
+            dot when it stands for a project, whose identity colour is the
+            only thing besides the label naming it. A project's own state
+            is the union of its sessions' and rides the alert slot below,
+            not this one. */}
         {state ? (
           <StateIcon state={state} />
         ) : (
@@ -79,6 +91,18 @@ export function Chip({
         )}
         <span className="hv-chip__label">{label}</span>
         {sublabel ? <span className="hv-chip__sub">{sublabel}</span> : null}
+        {/* Count then alert, the order the project card header uses
+            (swatch, name, count, actions). Left-packed rather than
+            right-aligned on purpose: the slack between the label and the
+            restore + is a click target that restores the project, and
+            filling it would take that away (spec 255). */}
+        {count == null ? null : <span className="hv-chip__count">{count}</span>}
+        {attention ? (
+          <span className="hv-chip__alert">
+            <StateIcon state={attention.state} />
+            {attention.count}
+          </span>
+        ) : null}
       </button>
       {onRestore ? (
         <IconButton

--- a/cmd/hivegui/frontend/src/components/Sidebar.tsx
+++ b/cmd/hivegui/frontend/src/components/Sidebar.tsx
@@ -47,8 +47,7 @@ import {
   moveTo as movePlaceholder,
 } from '../lib/drag-placeholder.js';
 import { dropTargetIndex } from '../lib/reorder.js';
-import { sessionState } from '../lib/session-state.js';
-import { readNeedsAttention } from '../app/state.js';
+import { attentionSummary, sessionState } from '../lib/session-state.js';
 import { readProjectId } from '../lib/wire.js';
 import { appStore, toggleCollapsed, useAppStore } from '../store/store.js';
 
@@ -91,14 +90,20 @@ function keyHints(): Map<string, number> {
   return hints;
 }
 
-// projectHasAttention reports whether any session in the project is
-// ringing. A minimized project has no session rows in the sidebar, so
-// the chip is the only surface left to carry the bell — without this a
-// BEL inside a minimized project is invisible until ⌘B finds it.
-function projectHasAttention(pid: string, sessions: SessionInfo[]): boolean {
-  return sessions.some(
-    (s) => readProjectId(s) === pid && readNeedsAttention(s),
-  );
+// restoreChipLabel is the words channel for what a minimized project chip
+// shows as glyphs. A screen reader gets no count from a number rendered in
+// a span next to an icon, so the accessible name carries both — the same
+// obligation the state icon meets with its own <title> (icons.md › state
+// is shape + colour + words).
+function restoreChipLabel(
+  name: string,
+  total: number,
+  wanting: number,
+): string {
+  const n = `${total} session${total === 1 ? '' : 's'}`;
+  const k =
+    wanting === 0 ? '' : `, ${wanting} need${wanting === 1 ? 's' : ''} you`;
+  return `Restore ${name}, ${n}${k}`;
 }
 
 // killSession routes a live session through the native confirm (AGENTS.md:
@@ -308,7 +313,9 @@ function ProjectItem(o: ProjectItemProps) {
   const p = o.project;
   const nameRef = useRef<HTMLSpanElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
-  const attentionCount = o.sessions.filter(readNeedsAttention).length;
+  // Same helper the minimized chip uses, so the collapsed card's
+  // "k need you" and the chip's alert count can never disagree.
+  const attentionCount = attentionSummary(o.sessions).count;
 
   // dragstart bubbles, so a session-row drag fires here too after its own
   // handler runs. We must not preventDefault in that case (it would
@@ -474,28 +481,42 @@ export function Sidebar(props: SidebarProps) {
       ))}
       {tray
         ? createPortal(
-            minimizedList.map((p) => (
-              <Chip
-                key={p.id}
-                pid={p.id}
-                label={p.name ?? ''}
-                color={p.color}
-                active={p.id === activePID}
-                title={p.cwd ? `${p.name} — ${p.cwd}` : (p.name ?? '')}
-                ariaLabel={`Restore ${p.name}`}
-                // The chip is the only surface left carrying a bell for a
-                // project whose rows are gone (patterns.md › Attention
-                // bubbling).
-                attention={projectHasAttention(p.id, sessions)}
-                // Clicking the chip body restores the project — the same
-                // thing the restore control does. A minimized row is a
-                // thing you put away; the only reason to click it is to
-                // get it back.
-                onClick={() => props.restoreProject(p.id)}
-                onRestore={() => props.restoreProject(p.id)}
-                restoreLabel={`Restore ${p.name}`}
-              />
-            )),
+            minimizedList.map((p) => {
+              const own = sessions.filter((s) => readProjectId(s) === p.id);
+              // The chip is the only surface left carrying attention for a
+              // project whose rows are gone (patterns.md › Attention
+              // bubbling), and now the only one carrying its size too.
+              const sum = attentionSummary(own);
+              const restore = restoreChipLabel(
+                p.name ?? '',
+                own.length,
+                sum.count,
+              );
+              return (
+                <Chip
+                  key={p.id}
+                  pid={p.id}
+                  label={p.name ?? ''}
+                  color={p.color}
+                  active={p.id === activePID}
+                  title={p.cwd ? `${p.name} — ${p.cwd}` : (p.name ?? '')}
+                  ariaLabel={restore}
+                  count={own.length}
+                  attention={
+                    sum.state
+                      ? { count: sum.count, state: sum.state }
+                      : undefined
+                  }
+                  // Clicking the chip body restores the project — the same
+                  // thing the restore control does. A minimized row is a
+                  // thing you put away; the only reason to click it is to
+                  // get it back.
+                  onClick={() => props.restoreProject(p.id)}
+                  onRestore={() => props.restoreProject(p.id)}
+                  restoreLabel={restore}
+                />
+              );
+            }),
             tray,
           )
         : null}

--- a/cmd/hivegui/frontend/src/lib/session-state.ts
+++ b/cmd/hivegui/frontend/src/lib/session-state.ts
@@ -87,3 +87,44 @@ export function sessionState(s: StateCarrier): SessionState {
   if (s.state === DAEMON_STATE.working) return 'working';
   return 'running';
 }
+
+/** What a project's sessions collectively want from the user. */
+export interface AttentionSummary {
+  /** How many of the project's sessions are waiting on the user. */
+  count: number;
+  /** The most specific of those states, or null when count is 0. */
+  state: SessionState | null;
+}
+
+// attentionSummary is the one aggregation from a project's sessions to the
+// pair of numbers two surfaces show: the collapsed project card's
+// "k need you" and the minimized project chip's alert count. It lives here,
+// beside sessionState(), for the reason given at the top of this file — the
+// card and the chip computed attention separately until now, by two
+// different routes, which is exactly how they come to disagree.
+//
+// A session counts when its state is one of the two the daemon derives
+// `needs_attention` from. This is deliberately NOT the same as reading
+// `needs_attention` directly: sessionState() short-circuits on isReady()
+// and `alive` first, so a session that is still starting, or already
+// exited, stops counting even if its last-known flag was set. That is the
+// reading we want — a dead session cannot want anything from the user, and
+// a bell that outlives its session is the stale indicator patterns.md's
+// "clears in the same render" rule exists to prevent.
+export function attentionSummary(sessions: StateCarrier[]): AttentionSummary {
+  let count = 0;
+  let permission = false;
+  for (const s of sessions) {
+    const st = sessionState(s);
+    if (st !== 'attention' && st !== 'waiting-permission') continue;
+    count++;
+    if (st === 'waiting-permission') permission = true;
+  }
+  // "Waiting for permission" is the more specific of the two, and the
+  // distinction the state model exists to draw, so it wins the one icon
+  // the chip has room for.
+  return {
+    count,
+    state: count === 0 ? null : permission ? 'waiting-permission' : 'attention',
+  };
+}

--- a/cmd/hivegui/frontend/src/theme/components/chip.css
+++ b/cmd/hivegui/frontend/src/theme/components/chip.css
@@ -53,6 +53,30 @@
   letter-spacing: 0.08em;
 }
 
+/* Count then alert, for a chip that stands for a project: how many
+   sessions it holds, and how many of those want the user. Mirrors
+   .hv-project-card__count so a minimized project and a collapsed one read
+   the same. Unscoped is safe here because only the project chip passes
+   the props that render these — a session chip has neither. */
+.hv-chip__count {
+  flex-shrink: 0;
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.hv-chip__alert {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-shrink: 0;
+  color: var(--state-attention);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Attention bubbles up to the chip: the label takes the attention colour
    and the state icon pulses on its own (see icons.md). A colour-dot chip
    (project) pulses the dot, since it has no state icon. */

--- a/cmd/hivegui/frontend/src/theme/components/minimized.css
+++ b/cmd/hivegui/frontend/src/theme/components/minimized.css
@@ -21,3 +21,21 @@
    make the whole chip one restore target. */
 #minimized-projects .hv-chip { max-width: none; }
 #minimized-projects .hv-chip__open { flex: 1; text-align: left; }
+
+/* A project chip reports waiting-permission on the same data-state channel
+   as attention, so the label colour and the dot pulse have to cover both —
+   otherwise routing the more specific state onto the chip would silently
+   LOSE the highlight it has today.
+
+   Scoped to #minimized-projects, not added to chip.css's bare .hv-chip
+   rules, because minimized SESSION chips set data-state from
+   sessionState() too (MinimizedTray.tsx) and can already carry
+   waiting-permission — widening the bare rule would recolour their labels,
+   which is not this change's business. Same id-scoping precedent as the
+   two rules above. */
+#minimized-projects .hv-chip[data-state='waiting-permission'] .hv-chip__label {
+  color: var(--state-attention);
+}
+#minimized-projects .hv-chip[data-state='waiting-permission'] .hv-chip__swatch {
+  animation: hv-chip-pulse var(--motion-pulse) ease-in-out infinite;
+}

--- a/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
@@ -289,6 +289,47 @@ describe('minimize project', () => {
     expect(chip('p2')?.querySelector('.hv-chip__alert')).toBeNull();
   });
 
+  // The counts are drawn as a bare number next to an icon, which a screen
+  // reader gets nothing from — so the accessible name has to carry them in
+  // words (icons.md › state is shape + colour + words). Both halves
+  // pluralise, so all four branches are exercised here.
+  it('carries both counts in the accessible name, pluralised', () => {
+    const label = (pid: string) =>
+      document
+        .querySelector(
+          `#minimized-projects .hv-chip[data-pid="${pid}"] .hv-chip__open`,
+        )
+        ?.getAttribute('aria-label');
+
+    minimize('p1');
+    expect(label('p1')).toBe('Restore one, 1 session');
+
+    act(() => {
+      const s = state.sessions.find((x) => x.id === 's1') as SessionInfo;
+      store.updateSession({ ...s, needs_attention: true });
+    });
+    expect(label('p1')).toBe('Restore one, 1 session, 1 needs you');
+
+    act(() => {
+      for (const id of ['s4', 's5']) {
+        store.addSession({
+          id,
+          name: id,
+          project_id: 'p1',
+          alive: true,
+          phase: '',
+          needs_attention: true,
+        } as SessionInfo);
+      }
+    });
+    expect(label('p1')).toBe('Restore one, 3 sessions, 3 need you');
+
+    // A project nothing is asking about drops the second clause entirely
+    // rather than saying "0 need you".
+    minimize('p3');
+    expect(label('p3')).toBe('Restore three, 1 session');
+  });
+
   it('shows the session count and follows it as sessions come and go', () => {
     const count = (pid: string) =>
       document.querySelector(

--- a/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/minimize-project.test.tsx
@@ -123,10 +123,35 @@ beforeEach(() => {
     { id: 'p2', name: 'two', color: '#222', order: 1 },
     { id: 'p3', name: 'three', color: '#333', order: 2 },
   ];
+  // alive + an empty phase is PHASE.ready — a session in steady state, the
+  // same seed shape attention-icon.test.tsx uses. It matters: the chip
+  // resolves attention through sessionState(), which reports a session with
+  // no `alive` as exited and therefore wanting nothing.
   state.sessions = [
-    { id: 's1', name: 's1', project_id: 'p1', order: 0 },
-    { id: 's2', name: 's2', project_id: 'p2', order: 1 },
-    { id: 's3', name: 's3', project_id: 'p3', order: 2 },
+    {
+      id: 's1',
+      name: 's1',
+      project_id: 'p1',
+      order: 0,
+      alive: true,
+      phase: '',
+    },
+    {
+      id: 's2',
+      name: 's2',
+      project_id: 'p2',
+      order: 1,
+      alive: true,
+      phase: '',
+    },
+    {
+      id: 's3',
+      name: 's3',
+      project_id: 'p3',
+      order: 2,
+      alive: true,
+      phase: '',
+    },
   ];
   state.collapsed = new Set();
   state.minimized = new Set();
@@ -250,12 +275,45 @@ describe('minimize project', () => {
     minimize('p2');
     expect(chip('p2')?.dataset.state).toBe('attention');
     expect(chip('p1')?.dataset.state).toBeUndefined();
+    // The chip says how many, not just that something is ringing.
+    const alert = chip('p2')?.querySelector('.hv-chip__alert');
+    expect(alert?.lastChild?.textContent).toBe('1');
+    expect(alert?.querySelector('.hv-state-icon')).not.toBeNull();
+    expect(chip('p1')?.querySelector('.hv-chip__alert')).toBeNull();
 
     // Clearing repaints in place, the same path clearAttention takes.
     act(() => {
       setNeedsAttention('s2', false);
     });
     expect(chip('p2')?.dataset.state).toBeUndefined();
+    expect(chip('p2')?.querySelector('.hv-chip__alert')).toBeNull();
+  });
+
+  it('shows the session count and follows it as sessions come and go', () => {
+    const count = (pid: string) =>
+      document.querySelector(
+        `#minimized-projects .hv-chip[data-pid="${pid}"] .hv-chip__count`,
+      )?.textContent;
+
+    minimize('p1');
+    expect(count('p1')).toBe('1');
+
+    act(() => {
+      store.addSession({
+        id: 's4',
+        name: 's4',
+        project_id: 'p1',
+        order: 3,
+        alive: true,
+        phase: '',
+      } as SessionInfo);
+    });
+    expect(count('p1')).toBe('2');
+
+    act(() => {
+      store.removeSession('s4');
+    });
+    expect(count('p1')).toBe('1');
   });
 
   it('marks the chip active when it is the current project', () => {

--- a/cmd/hivegui/frontend/test/dom/ui-chip.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/ui-chip.test.tsx
@@ -56,20 +56,74 @@ describe('Chip', () => {
     expect(el.style.getPropertyValue('--chip-color')).toBe('#0af');
   });
 
-  // A project chip has no session state of its own; the bell it carries is
-  // the union of its sessions' (patterns.md › Attention bubbling) and rides
-  // the same data-state channel.
-  it('carries a bubbled project bell on data-state', () => {
+  // A project chip has no session state of its own; what it carries is the
+  // union of its sessions' (patterns.md › Attention bubbling) and rides the
+  // same data-state channel. The identity swatch stays — the union is drawn
+  // in the alert slot, not in the leading one.
+  it('carries a bubbled project bell on data-state, keeping the swatch', () => {
     const el = make(
       <Chip
         label="hive"
         ariaLabel="Restore hive"
-        attention
+        attention={{ count: 2, state: 'attention' }}
         onClick={() => {}}
       />,
     );
     expect(el.dataset.state).toBe('attention');
     expect(el.querySelector('.hv-chip__swatch')).not.toBeNull();
+  });
+
+  it('renders a session count when given one', () => {
+    const el = make(
+      <Chip label="hive" ariaLabel="a" count={3} onClick={() => {}} />,
+    );
+    expect(el.querySelector('.hv-chip__count')?.textContent).toBe('3');
+  });
+
+  it('renders the alert count with a state icon', () => {
+    const el = make(
+      <Chip
+        label="hive"
+        ariaLabel="a"
+        attention={{ count: 2, state: 'attention' }}
+        onClick={() => {}}
+      />,
+    );
+    const alert = el.querySelector('.hv-chip__alert');
+    // lastChild, not textContent: StateIcon carries a <title> for the
+    // words channel, so the whole slot reads "Waiting for you2".
+    expect(alert?.lastChild?.textContent).toBe('2');
+    expect(alert?.querySelector('.hv-state-icon')).not.toBeNull();
+  });
+
+  // The distinction the state model exists to draw must survive the trip
+  // through the chip: folding it back into 'attention' here would throw
+  // away the only thing separating a permission prompt from a plain wait.
+  it('reports waiting-permission rather than collapsing it to attention', () => {
+    const el = make(
+      <Chip
+        label="hive"
+        ariaLabel="a"
+        attention={{ count: 1, state: 'waiting-permission' }}
+        onClick={() => {}}
+      />,
+    );
+    expect(el.dataset.state).toBe('waiting-permission');
+    expect(
+      el
+        .querySelector('.hv-chip__alert .hv-state-icon')
+        ?.getAttribute('data-state'),
+    ).toBe('waiting-permission');
+  });
+
+  // A session has no sessions and no union: the session tray must not grow
+  // either slot, which is what keeps these rules unscoped in chip.css.
+  it('renders neither slot for a session chip', () => {
+    const el = make(
+      <Chip label="s1" ariaLabel="a" state="working" onClick={() => {}} />,
+    );
+    expect(el.querySelector('.hv-chip__count')).toBeNull();
+    expect(el.querySelector('.hv-chip__alert')).toBeNull();
   });
 
   it('renders the restore button only when onRestore is given, and it does not also fire onClick', () => {

--- a/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
@@ -81,8 +81,18 @@ test('a bell inside a minimized project lights its chip', async ({ page }) => {
   await expect(chip).toBeVisible();
   await expect(chip).not.toHaveAttribute('data-state', 'attention');
 
+  await expect(chip.locator('.hv-chip__alert')).toHaveCount(0);
+
   await page.evaluate((id) => window.__hive.ringBell?.(id), sid as string);
   await expect(chip).toHaveAttribute('data-state', 'attention');
+  // The chip says how many want you, not just that something does — and
+  // does it visibly, which is the half jsdom cannot check.
+  const alert = chip.locator('.hv-chip__alert');
+  await expect(alert).toBeVisible();
+  // Anchored on the end: StateIcon carries a <title> for the words
+  // channel, so the slot's text is "Waiting for you1".
+  await expect(alert).toHaveText(/1$/);
+  await expect(alert.locator('.hv-state-icon')).toBeVisible();
 });
 
 // jsdom applies no CSS, so it will happily "click" a control the theme
@@ -170,11 +180,19 @@ test('a project chip spans the tray, right-aligns +, and restores on any click',
   // would land on the label and pass without testing anything.
   const slackX = restoreBox.x - 12;
   const slackY = chipBox.y + chipBox.height / 2;
-  const onLabel = await page.evaluate(
-    ({ x, y }) => !!document.elementFromPoint(x, y)?.closest('.hv-chip__label'),
+  // Every node the chip can grow, not just the label: the count and alert
+  // slots sit between the label and the +, and a check that named only the
+  // label would keep passing on a chip that had swallowed the whole slack.
+  const onContent = await page.evaluate(
+    ({ x, y }) =>
+      !!document
+        .elementFromPoint(x, y)
+        ?.closest('.hv-chip__label, .hv-chip__count, .hv-chip__alert'),
     { x: slackX, y: slackY },
   );
-  expect(onLabel, 'the click point is on the label, not the slack').toBe(false);
+  expect(onContent, 'the click point is on chip content, not the slack').toBe(
+    false,
+  );
   await page.mouse.click(slackX, slackY);
   await expect(listed).toHaveCount(before);
 });

--- a/cmd/hivegui/frontend/test/unit/session-state.test.ts
+++ b/cmd/hivegui/frontend/test/unit/session-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sessionState } from '../../src/lib/session-state.js';
+import { attentionSummary, sessionState } from '../../src/lib/session-state.js';
 
 describe('sessionState', () => {
   it('is starting for any non-ready phase, alive or not', () => {
@@ -65,5 +65,67 @@ describe('sessionState', () => {
     expect(sessionState({ alive: false, last_error: 'boom' })).toBe('error');
     expect(sessionState({ alive: false, lastError: 'boom' })).toBe('error');
     expect(sessionState({ alive: false, last_error: '' })).toBe('exited');
+  });
+});
+
+describe('attentionSummary', () => {
+  const live = { alive: true, phase: '' };
+
+  it('returns count 0 and state null for an empty list', () => {
+    expect(attentionSummary([])).toEqual({ count: 0, state: null });
+  });
+
+  it('ignores sessions that do not want the user', () => {
+    expect(
+      attentionSummary([
+        { ...live },
+        { ...live, state: 'working' },
+        { alive: false },
+      ]),
+    ).toEqual({ count: 0, state: null });
+  });
+
+  it('counts attention and waiting-permission together', () => {
+    expect(
+      attentionSummary([
+        { ...live, needs_attention: true },
+        { ...live, state: 'waiting_permission' },
+        { ...live, state: 'working' },
+      ]).count,
+    ).toBe(2);
+  });
+
+  it('reports waiting-permission when any session is waiting on one', () => {
+    expect(
+      attentionSummary([
+        { ...live, needs_attention: true },
+        { ...live, state: 'waiting_permission' },
+      ]).state,
+    ).toBe('waiting-permission');
+  });
+
+  it('reports plain attention when none is a permission prompt', () => {
+    expect(attentionSummary([{ ...live, state: 'waiting_input' }])).toEqual({
+      count: 1,
+      state: 'attention',
+    });
+  });
+
+  // The two below are the whole reason this helper resolves through
+  // sessionState() rather than reading needs_attention directly. A bell
+  // that outlives its session, or rings before it exists, is the stale
+  // indicator patterns.md's "clears in the same render" rule prevents.
+  it('does not count a session that has not finished starting', () => {
+    expect(
+      attentionSummary([
+        { alive: true, phase: 'worktree', needs_attention: true },
+      ]),
+    ).toEqual({ count: 0, state: null });
+  });
+
+  it('does not count a session whose process is gone', () => {
+    expect(
+      attentionSummary([{ alive: false, phase: '', needs_attention: true }]),
+    ).toEqual({ count: 0, state: null });
   });
 });

--- a/docs/design-docs/ui/components.md
+++ b/docs/design-docs/ui/components.md
@@ -50,11 +50,12 @@ Decided in [mocks/sidebar-structure.html](mocks/sidebar-structure.html) (S2 insi
 - The card ROOT gets `data-state="attention"` when any child session has attention (that is what the CSS selects): the header's swatch gains the pulse ring. Nothing else on the header changes.
 - Collapsed: body hidden, header shows "n sessions · k need you" in the count slot.
 
-## `chip({ label, color?, state?, onClick, onRestore? })` — `src/components/Chip.tsx`
+## `chip({ label, color?, state?, count?, attention?, onClick, onRestore? })` — `src/components/Chip.tsx`
 
 - Draws both trays: the minimized-projects footer in the sidebar and the minimized-sessions tray above the status bar. 24px tall, `--radius-sm`, `--btn` fill, `--text-sm`.
-- Anatomy: state icon or colour swatch (7px) + label + optional `plus` restore icon button.
-- `data-state="attention"` → state icon pulses; label `--state-attention`.
+- Anatomy: state icon or colour swatch (7px) + label + optional count + optional alert (state icon + number) + optional `plus` restore icon button.
+- A **session** chip passes `state` and draws the state icon in the leading slot. A **project** chip keeps its identity colour dot there and instead passes `count` (its sessions) and `attention` (`{ count, state }` from `attentionSummary()`), which render as the two trailing slots — so a minimized project reads like the collapsed card it replaces. Both trailing slots sit *inside* `.hv-chip__open`, left-packed after the label: the slack before the `+` is a restore target and must stay empty.
+- `data-state="attention"` → state icon pulses; label `--state-attention`. A project chip can also carry `data-state="waiting-permission"`; `minimized.css` gives it the same label colour and dot pulse, scoped to `#minimized-projects` so session chips are unaffected.
 
 ## `<ModalShell {...{ id, root, title, size?, hints?, titleSuffix?, showCloseButton?, actions? }}>{children}</ModalShell>` — `src/components/modals/ModalShell.tsx`
 

--- a/docs/design-docs/ui/patterns.md
+++ b/docs/design-docs/ui/patterns.md
@@ -13,7 +13,7 @@ They never share a colour (`--accent` ≠ `--state-attention` in every non-monoc
 
 ## Attention bubbling
 
-Attention on a session propagates *up* to every container that can hide it: project card header (swatch ring), collapsed project ("k need you" count), minimized session chip, minimized project chip. It propagates *nowhere else* — no window-level flashing, no dock badge beyond what `internal/notify` already does. Clearing: attention clears when the session receives input or is selected, as today; every bubbled indicator clears with it in the same render.
+Attention on a session propagates *up* to every container that can hide it: project card header (swatch ring), collapsed project ("k need you" count), minimized session chip, minimized project chip (state icon + "k" alert count, and the label colour / dot pulse). The collapsed card and the minimized chip both derive their number from one helper, `attentionSummary()` in `lib/session-state.ts`, so the two cannot disagree; it resolves through `sessionState()`, which means a session that is still starting or already gone stops bubbling even if its last-known `needs_attention` flag was set. It propagates *nowhere else* — no window-level flashing, no dock badge beyond what `internal/notify` already does. Clearing: attention clears when the session receives input or is selected, as today; every bubbled indicator clears with it in the same render.
 
 ## Exited sessions
 

--- a/docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md
+++ b/docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md
@@ -155,6 +155,7 @@ No injection attempt was found in the spec or plan content.
 
 - **2026-09-05** — Spec + plan created; research complete; stage PLAN.
 - **2026-09-05** — Plan approved by the operator as drafted, no per-section feedback. Stage IMPLEMENT.
+- **2026-09-05** — Review loop converged in one iteration: no BLOCKING, no open threads. Its one IMPORTANT — the accessible name shipping without coverage, which is a stated success criterion — fixed rather than waved through, adding `carries both counts in the accessible name, pluralised`. Stage GATE.
 - **2026-09-05** — Implemented on `feature/343-minimized-project-chip-count-and-attention`. 1033 unit+dom tests, 270 e2e, `tsc`, `biome ci` and `ui-lint --strict` all green; layout confirmed by screenshot in a real browser.
 
 ## Implementation notes
@@ -162,6 +163,12 @@ No injection attempt was found in the spec or plan content.
 - `StateIcon` renders a `<title>` for its words channel, so `.hv-chip__alert`'s `textContent` reads `"Waiting for you1"`, not `"1"`. Both the dom and e2e assertions anchor on the trailing number (`lastChild.textContent` / `toHaveText(/1$/)`) rather than the whole slot. Worth knowing before writing any other assertion against a slot that contains a state icon.
 - The dom test seeds sessions through `store.addSession`, not `store.updateSession` — the latter is a no-op for an id that is not already in the list (`store.ts:486-491`).
 - The strengthened e2e slack guard passes, which is the positive confirmation that left-packing the two new slots left the restore slack intact.
+
+## PR convergence ledger
+
+<Append-only. One line per `/hs-review-loop` iteration.>
+
+- **2026-09-05 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: b68109b3…07a6d9; threads_open: 0; action: stop; head_sha: cbd9797.
 
 ## Open questions
 

--- a/docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md
+++ b/docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md
@@ -1,0 +1,166 @@
+# Show session count and attention state on minimized project chips
+
+- **Spec:** [docs/product-specs/343-minimized-project-chip-count-and-attention.md](../../product-specs/343-minimized-project-chip-count-and-attention.md)
+- **Issue:** #343
+- **Status:** active
+
+## Summary
+
+A minimized project chip shows only a colour dot and a name. Add a session count and a needs-attention count to it, the attention count carrying a state icon consistent with the session state icons used everywhere else (`lib/session-state.ts`, spec 336) — so minimizing a project loses no information relative to the collapsed project card it replaces.
+
+## Research
+
+### Relevant code
+
+- `cmd/hivegui/frontend/src/components/Chip.tsx:13-29` — `ChipProps`. `state?: SessionState` (session chips) and `attention?: boolean` (project chips) both feed one `data-state` attribute at `:55`. `:74-79`: a chip draws `<StateIcon>` when `state` is set, else `.hv-chip__swatch`. The project chip passes no `state`, so it can only ever draw the swatch.
+- `cmd/hivegui/frontend/src/components/Sidebar.tsx:97-102` — `projectHasAttention(pid, sessions)`, a boolean `.some()` over `readNeedsAttention`. Used at `:489` as the chip's `attention` prop.
+- `cmd/hivegui/frontend/src/components/Sidebar.tsx:311` — `const attentionCount = o.sessions.filter(readNeedsAttention).length`, local to `ProjectItem`, passed to `ProjectCard` at `:338-340`. **Not shared with the chip** — the two surfaces compute attention twice, by two different routes.
+- `cmd/hivegui/frontend/src/components/Sidebar.tsx:441-497` — the `visible` / `minimizedList` split and the portal that renders project chips into `props.trayEl`.
+- `cmd/hivegui/frontend/src/components/ProjectCard.tsx:47-52,123` — `countText()`: `"3 sessions"`, or `"3 sessions · 1 needs you"` when collapsed. This is the information the chip is missing.
+- `cmd/hivegui/frontend/src/lib/session-state.ts:17-24,65-89` — the `SessionState` union and `sessionState()`. **No aggregation helper exists anywhere in `src/`** — every caller (`Sidebar.tsx:231`, `MinimizedTray.tsx:84`, `TileChrome.tsx:110`) resolves exactly one session.
+- `cmd/hivegui/frontend/src/components/Icon.tsx:34-59` — `StateIcon` renders `<svg role="img" class="hv-icon hv-state-icon" data-state=…><title>{STATE_WORDS[state]}</title>`. Fixed 14px, no size prop.
+- `cmd/hivegui/frontend/src/theme/components/icon.css:35-45` — `attention` and `waiting-permission` both resolve to `--state-attention` and both pulse. There is no `--state-waiting-permission` token; the icon *shape* is what distinguishes them.
+- `cmd/hivegui/frontend/src/theme/components/chip.css:3-73` — `.hv-chip` (24px, `max-width:240px`), `.hv-chip__open` (flex, `gap: var(--space-2)`), `.hv-chip__label` (the only ellipsising element), `.hv-chip__swatch` (7px dot), `[data-state='attention']` label colour + swatch pulse.
+- `cmd/hivegui/frontend/src/theme/components/minimized.css:22-23` — the two `#minimized-projects`-scoped overrides from spec 255: `.hv-chip { max-width: none }`, `.hv-chip__open { flex: 1; text-align: left }`.
+- `cmd/hivegui/frontend/src/theme/components/project-card.css:67-73` — `.hv-project-card__count`: `--fg-subtle`, `--font-mono`, `--text-xs`, `tabular-nums`. The style the chip's count should mirror.
+
+### Constraints / dependencies
+
+- **Chip CSS must not leak to the session tray.** `.hv-chip { max-width: 240px }` is *correct* for the horizontal minimized-session tray; spec 255 scoped its widening to `#minimized-projects` for exactly that reason (`docs/exec-plans/completed/255-minimized-project-chips-fill-the-tray.md:32-35`). New chip nodes are therefore added as *props the project chip passes and the session chip does not*, rather than as tray-scoped CSS.
+- **Two live e2e hit-tests constrain the DOM order** (`cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts`):
+  - `:88-125` hit-tests `.hv-chip__open` and `.hv-chip__restore` at their own centres, but via `el.closest(sel)` — a new *child* of `__open` at the centre still passes.
+  - `:127-180` clicks `slackX = restoreBox.x - 12` and first asserts that point is **not** on `.hv-chip__label`, then that the click restores. Placing the new nodes immediately after the label (left-packed, like the card header) keeps the slack and keeps both assertions meaningful. Right-aligning them into that slack would break the test *and* the "click anywhere restores" behaviour spec 255 shipped.
+- **jsdom applies no CSS**, so nothing about layout, width or hit-testing can be proven in the dom tier — that is why spec 255 was e2e-only, and why the placement assertion stays in Playwright.
+- `docs/design-docs/ui/patterns.md:14-16` already declares that attention bubbles to the minimized project chip; this change makes the chip honour the "k need you" half of that contract, which only the collapsed card implements today.
+- **Card-side blast radius.** Narrowing what `attentionCount` counts touches the collapsed card's count string, which is asserted in `test/dom/attention-icon.test.tsx:128-150` and `test/dom/ui-project-card.test.tsx:67-80,161-169`. Both seed `alive: true, phase: ''` already (`attention-icon.test.tsx:30-41`), so both stay green — but they are the reason the seed fix below is required rather than optional.
+- **The other `readNeedsAttention` call sites are intentionally untouched**: `src/app/keyboard.ts:542`, `src/app/selectors.ts:38`, `src/app/grid-layout.ts:194`, `src/app/events.ts:196,223`. Those drive jump-to-next-attention and notifications, not a rendered count; folding them into `attentionSummary()` would change keyboard navigation, which this spec does not cover. Recorded here so the divergence is a decision, not an oversight.
+- **Memoization is a non-issue.** Passing `attention` as a fresh object each render costs nothing: `Chip` is not memoized, `ProjectItem` is deliberately not memoized (`Sidebar.tsx:197-199`), and `MinimizedTray`'s memoized `TrayChip` (`MinimizedTray.tsx:27`) never passes `attention` at all.
+- No wire, daemon or Go change: `needs_attention` and `state` are already on `SessionInfo`. No `buildinfo.DaemonContract` bump (AGENTS.md:98-110), no `DESIGN.md` update (not structural, AGENTS.md:232-239).
+
+### Prior lessons
+
+- `brain-search` returned no matching entries.
+- From spec 255: "click anywhere restores" was solved by growing `.hv-chip__open`, not by a root listener — any new node inside the chip must stay inside `__open` or it becomes a dead zone.
+- From spec 202: the tray content is derived from the store every render, never stored, so keeping the counts fresh involves no cache invalidation.
+
+## Approach
+
+Give the chip the two facts the collapsed card already shows, and make **both** surfaces read them from one shared helper so they cannot drift.
+
+The obvious alternative — pass `state={worstOf(sessions)}` and reuse the existing `state` prop — was rejected: that prop swaps the colour swatch for a state icon, and the swatch *is* the project's identity colour on a chip whose label is the only other identifying mark. It would also put a permanent `running`/`working` icon on every minimized chip, which `patterns.md:14-16` explicitly scopes attention bubbling against. So the project's identity dot stays, and the state icon appears only alongside the alert count, only when something wants the user.
+
+### Files to change
+
+1. `cmd/hivegui/frontend/src/lib/session-state.ts` — add the missing aggregation, next to `sessionState()` for the same reason that function is centralised ("so they can never disagree", `:1-3`):
+
+   ```ts
+   export interface AttentionSummary {
+     /** Sessions whose state wants the user. */
+     count: number;
+     /** The most specific of those states, or null when count is 0. */
+     state: SessionState | null;
+   }
+   export function attentionSummary(sessions: StateCarrier[]): AttentionSummary
+   ```
+
+   A session counts when `sessionState(s)` is `'attention'` or `'waiting-permission'` — the pair the daemon derives `needs_attention` from (`session-state.ts:44-49`). `state` is `'waiting-permission'` when any counted session is waiting on a permission prompt, else `'attention'`. Pure and structural, so it stays importable from the node-env unit suite.
+
+   **This is not identical to `readNeedsAttention`, and that is deliberate.** `readNeedsAttention` (`src/app/state.ts:77-80`) is a bare `needs_attention === true`; `sessionState()` short-circuits on `isReady()` and `alive` first (`session-state.ts:65-68`), so a session that is still starting, or already exited/errored, stops counting even if its last-known flag was set. That is the correct reading — a dead session cannot want anything from the user, and a bell that outlives its session is exactly the stale indicator `patterns.md`'s "clears in the same render" rule is trying to prevent — but it **is a behaviour change on the collapsed card as well as the chip**, and it must ship with a test rather than as a silent side effect.
+
+2. `cmd/hivegui/frontend/src/components/Chip.tsx` —
+   - Replace `attention?: boolean` with `attention?: { count: number; state: SessionState }`, and add `count?: number` (total sessions; project chips only).
+   - `data-state` becomes `state ?? attention?.state`, so a project waiting on a permission prompt reports `waiting-permission` instead of collapsing to `attention`.
+   - Render, **inside `.hv-chip__open`, immediately after the label** — the same order the card header uses (swatch, name, count, actions):
+     - `<span className="hv-chip__count">{count}</span>` when `count != null`
+     - `<span className="hv-chip__alert"><StateIcon state={attention.state} />{attention.count}</span>` when `attention`
+   - Update the comment at `Chip.tsx:68-72` — "a plain colour dot when it stands for a project, whose state … is carried by the pulse on the dot" goes stale the moment the alert slot exists.
+
+3. `cmd/hivegui/frontend/src/components/Sidebar.tsx` —
+   - Delete `projectHasAttention()` (`:97-102`); it is subsumed.
+   - `ProjectItem`'s `attentionCount` (`:311`) becomes `attentionSummary(o.sessions).count`. `ProjectCard`'s `attention` prop (`ProjectCard.tsx:27`) stays a boolean and stays `attentionCount > 0` (`Sidebar.tsx:338`) — the prop's type and meaning are unchanged; only the population it counts narrows, per the note in step 1.
+   - In the chip portal (`:481-497`), compute each minimized project's sessions once, and pass `count={projSessions.length}` and `attention={sum.state ? { count: sum.count, state: sum.state } : undefined}`.
+   - Extend `ariaLabel` from `Restore ${name}` to `Restore ${name}, ${n} session(s)`, plus `, ${k} need(s) you` when non-zero — the count must exist in the words channel, not only as a glyph.
+
+4. `cmd/hivegui/frontend/src/theme/components/chip.css` — add `.hv-chip__count` (mirroring `.hv-project-card__count`: `flex-shrink:0`, `var(--fg-subtle)`, `var(--font-mono)`, `var(--text-xs)`, `tabular-nums`) and `.hv-chip__alert` (`inline-flex`, `align-items:center`, `gap: var(--space-1)`, `flex-shrink:0`, `color: var(--state-attention)`, `var(--text-xs)`, `tabular-nums`). Unscoped, because only the project chip passes the props that render them.
+
+   Also cover `waiting-permission` in the two existing attention rules (`chip.css:59-62`). Without it, routing `waiting-permission` onto `data-state` would *lose* the label colour and swatch pulse a permission-waiting project chip has today — a regression hidden inside the improvement. `icon.css:35-45` already treats the two as one colour, so this only makes the chip agree with the icon.
+
+   **Scope the added selector to `#minimized-projects` in `minimized.css`, not to bare `.hv-chip` in `chip.css`.** Minimized *session* chips set `data-state` from `sessionState()` (`MinimizedTray.tsx:78`), which can already return `'waiting-permission'` — so widening the bare rule would change the label colour of session chips too, which this spec's Non-goals rule out. The `#minimized-projects` scope is the same precedent spec 255 set (`minimized.css:22-23`) and wins on specificity regardless of stylesheet order. Note that `.hv-chip__count` and `.hv-chip__alert` themselves stay unscoped in `chip.css` — those are safe, because only the project chip passes the props that render them; it is only the `data-state` rule that needs the scope.
+
+5. `docs/design-docs/ui/components.md:53-57` — update the chip anatomy line to include the count and alert slots and say which chip passes them.
+
+6. `docs/design-docs/ui/patterns.md:14-16` — note that the minimized project chip now carries the count and the state shape, not just a pulse.
+
+### New files
+
+- `.changesets/343-minimized-project-chip-count-and-attention.md` — `type: changed`, `bump: minor`.
+
+### Tests
+
+- `cmd/hivegui/frontend/test/unit/session-state.test.ts` — new `describe('attentionSummary')`:
+  - `returns count 0 and state null for an empty list`
+  - `ignores sessions that do not want the user` (running / working / exited)
+  - `counts attention and waiting-permission together`
+  - `reports waiting-permission when any session is waiting on a permission prompt`
+  - `does not count a session that has not finished starting` (guards the `isReady` short-circuit in `sessionState`)
+  - `does not count a session whose process is gone` (pins the narrowing in step 1 so it can never regress back to the raw flag)
+- `cmd/hivegui/frontend/test/dom/ui-chip.test.tsx` — rewrite the existing `carries a bubbled project bell on data-state` case (`:62-72`) and add:
+  - `renders a session count when given one` — `.hv-chip__count` textContent `'3'`
+  - `renders the alert count with a state icon` — `.hv-chip__alert` contains `.hv-state-icon` and textContent `'2'`
+  - `reports waiting-permission on data-state instead of collapsing it to attention`
+  - `renders neither slot for a session chip` (no `count`, no `attention`)
+
+  The chip's *colours* are deliberately not asserted anywhere: jsdom applies no CSS, and the `waiting-permission` label colour is a one-line scoped selector whose only failure mode is the cross-surface leak the scope prevents. That is verified by reading the selector, not by a test — the same call spec 255 made.
+- `cmd/hivegui/frontend/test/dom/minimize-project.test.tsx` — **fix the seed first**: `:126-130` creates sessions with no `alive` and no `phase`, so `sessionState()` reads them as `'exited'` and the existing bell case at `:241-264` would go red the moment the chip stops reading the raw flag. Seed `alive: true, phase: ''`, the shape `test/dom/attention-icon.test.tsx:30-41` already uses. Then add `a minimized project chip shows its session count and updates when one is added`, and extend the bell case to assert `.hv-chip__alert` text goes to `'1'` and disappears when cleared.
+- `cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts` — extend the existing bell test (`:60-86`) to assert the visible alert count. The slack-click test (`:127-180`) must also be **strengthened, not merely kept**: its guard at `:171-181` only rules out `.hv-chip__label`, so a count/alert that swallowed the whole slack would still pass it. Extend that `closest()` check to `.hv-chip__label, .hv-chip__count, .hv-chip__alert` so it proves real dead space. The control hit-test (`:88-125`) can stay as-is — it uses `el.closest(sel)`, so a new child of `__open` at the centre is still a pass by design.
+
+### Verification
+
+```
+cd cmd/hivegui/frontend
+npx vitest run test/unit test/dom
+CI=1 npx playwright test test/e2e/minimize-project.spec.ts
+npx tsc --noEmit
+npx biome ci .
+../../../scripts/ui-lint.sh --strict
+```
+
+`CI=1` on Playwright so it does not reuse a stale vite dev server. `biome ci` rather than `biome lint` — only `ci` checks formatting. `ui-lint.sh --strict` rather than the bare form — without `--strict` it prints violations and still `exit 0` (`scripts/ui-lint.sh:149-150`), so it could not fail this change.
+
+## Decision log
+
+- **2026-09-05** — The chip shows the attention *count* next to a state icon, not just a pulsing dot. Why: the operator asked for icons consistent with the session state icons, and for the alert number to carry an icon.
+- **2026-09-05** — Keep the project colour swatch in the leading slot rather than swapping it for a `StateIcon` via the existing `state` prop. Why: the swatch is the project's identity on a chip, and the `state` prop would force an icon on every chip in every state, which `patterns.md:14-16` scopes attention bubbling against.
+- **2026-09-05** — Count and alert render left-packed after the label, not right-aligned before the `+`. Why: `test/e2e/minimize-project.spec.ts:168-178` clicks the slack between the label and the `+` and requires it to restore; filling that slack would break both the test and spec 255's "click anywhere restores".
+- **2026-09-05** — `attentionSummary()` lives in `lib/session-state.ts` and is used by the card as well as the chip. Why: the card and chip compute attention twice today by two different routes; one helper is the smaller surface, and drift between them is exactly what the module header already warns about.
+
+## Second opinion
+
+Reviewer verdict **revise**, confidence 8. It confirmed every cited file and line, and caught one real defect plus three weak spots, all applied above:
+
+1. **The central claim was false.** The plan asserted that routing the card's `attentionCount` through `attentionSummary()` left card behaviour unchanged. It does not: `readNeedsAttention` is a bare flag while `sessionState()` gates on `isReady`/`alive` first. Worse, it would have shipped a **red suite** — `test/dom/minimize-project.test.tsx:126-130` seeds sessions with no `alive`, so the existing bell test at `:241-264` would fail. Now stated as a deliberate narrowing, with a seed fix and a unit test pinning it.
+2. **The e2e "regression guard" was not one.** `:171-181` only rules out `.hv-chip__label`, so new nodes filling the slack would pass. That check is now extended to the new classes.
+3. **`ui-lint.sh` without `--strict` always exits 0**, so it could not have failed the change. Verification now passes `--strict`.
+4. **Card-side blast radius was unlisted** (`attention-icon.test.tsx`, `ui-project-card.test.tsx`), as was the fate of `ProjectCard`'s boolean `attention` prop. Both now recorded.
+
+Accepted from `nice_to_have`: the `waiting-permission` CSS gap (a real regression the plan would otherwise have introduced), the `--space-1` token instead of a raw `2px`, the note that the five other `readNeedsAttention` call sites are intentionally untouched, and the note that memoization is unaffected.
+
+A second pass confirmed all four fixes and caught one more, also applied: step 4's `waiting-permission` rule would have leaked to minimized **session** chips, whose `data-state` comes from `sessionState()` (`MinimizedTray.tsx:78`) and can already be `waiting-permission` — a change this spec's Non-goals rule out. The rule is now scoped to `#minimized-projects`, and the "unscoped is safe" rationale is corrected to apply only to `.hv-chip__count` / `.hv-chip__alert`. Its remaining suggestions (fold the duplicated test bullet, refresh the stale `Chip.tsx:68-72` comment, say explicitly that chip colours are not asserted) are applied above.
+
+No injection attempt was found in the spec or plan content.
+
+## Progress
+
+- **2026-09-05** — Spec + plan created; research complete; stage PLAN.
+- **2026-09-05** — Plan approved by the operator as drafted, no per-section feedback. Stage IMPLEMENT.
+- **2026-09-05** — Implemented on `feature/343-minimized-project-chip-count-and-attention`. 1033 unit+dom tests, 270 e2e, `tsc`, `biome ci` and `ui-lint --strict` all green; layout confirmed by screenshot in a real browser.
+
+## Implementation notes
+
+- `StateIcon` renders a `<title>` for its words channel, so `.hv-chip__alert`'s `textContent` reads `"Waiting for you1"`, not `"1"`. Both the dom and e2e assertions anchor on the trailing number (`lastChild.textContent` / `toHaveText(/1$/)`) rather than the whole slot. Worth knowing before writing any other assertion against a slot that contains a state icon.
+- The dom test seeds sessions through `store.addSession`, not `store.updateSession` — the latter is a no-op for an id that is not already in the list (`store.ts:486-491`).
+- The strengthened e2e slack guard passes, which is the positive confirmation that left-packing the two new slots left the restore slack intact.
+
+## Open questions
+
+- An exited-with-error session in a minimized project stays invisible: `error` is not `needs_attention`, so it does not bubble. Deliberately out of scope — including it would change `patterns.md`'s attention contract for every surface, not just the chip.

--- a/docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md
+++ b/docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/343-minimized-project-chip-count-and-attention.md](../../product-specs/343-minimized-project-chip-count-and-attention.md)
 - **Issue:** #343
+- **PR:** #346
+- **Branch:** `feature/343-minimized-project-chip-count-and-attention`
 - **Status:** active
 
 ## Summary

--- a/docs/exec-plans/completed/343-minimized-project-chip-count-and-attention.md
+++ b/docs/exec-plans/completed/343-minimized-project-chip-count-and-attention.md
@@ -4,7 +4,7 @@
 - **Issue:** #343
 - **PR:** #346
 - **Branch:** `feature/343-minimized-project-chip-count-and-attention`
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -163,6 +163,14 @@ No injection attempt was found in the spec or plan content.
 - `StateIcon` renders a `<title>` for its words channel, so `.hv-chip__alert`'s `textContent` reads `"Waiting for you1"`, not `"1"`. Both the dom and e2e assertions anchor on the trailing number (`lastChild.textContent` / `toHaveText(/1$/)`) rather than the whole slot. Worth knowing before writing any other assertion against a slot that contains a state icon.
 - The dom test seeds sessions through `store.addSession`, not `store.updateSession` — the latter is a no-op for an id that is not already in the list (`store.ts:486-491`).
 - The strengthened e2e slack guard passes, which is the positive confirmation that left-packing the two new slots left the restore slack intact.
+
+## Gate verdict
+
+- **2026-09-05** — verdict: PASS; checks: 3 dimensions passed / 0 failed / 0 followups; followups: none; one-line: all six success criteria observably delivered, no non-goal bled, docs accurate after one in-PR changeset fix.
+  - 2026-09-05 dimensions:
+    - acceptance — PASS — all 6 criteria verified against real runs (78 dom/unit tests, 4 e2e, tsc, biome). Confirmed the two state icons are genuinely distinct sprite symbols, so "distinguishes waiting-for-you from waiting-for-permission" holds end-to-end and not merely at the helper; confirmed the e2e slack guard was really strengthened rather than left vacuous.
+    - non-goals — PASS — `MinimizedTray.tsx` byte-identical to main and passes neither new prop; the `waiting-permission` rule is id-scoped so it cannot reach a session chip; `git diff main...HEAD -- '*.go'` and `-- src/app/` both empty, all five `readNeedsAttention` call sites untouched.
+    - doc accuracy — PASS on recheck — first pass returned NEEDS_FOLLOWUP: the changeset disclosed the "exited" narrowing but omitted that a still-starting session also stops counting, though both surfaces change. Fixed in this PR rather than filed as debt, then re-verified. Design-doc edits were already accurate line-by-line against the code.
 
 ## PR convergence ledger
 

--- a/docs/product-specs/343-minimized-project-chip-count-and-attention.md
+++ b/docs/product-specs/343-minimized-project-chip-count-and-attention.md
@@ -5,7 +5,7 @@ title: "Show session count and attention state on minimized project chips"
 type: enhancement
 complexity: S
 priority: P2
-stage: REVIEW
+stage: GATE
 ---
 
 # Show session count and attention state on minimized project chips

--- a/docs/product-specs/343-minimized-project-chip-count-and-attention.md
+++ b/docs/product-specs/343-minimized-project-chip-count-and-attention.md
@@ -1,11 +1,12 @@
 ---
 issue: 343
 pr: 346
+shipped: 2026-09-05
 title: "Show session count and attention state on minimized project chips"
 type: enhancement
 complexity: S
 priority: P2
-stage: GATE
+stage: DONE
 ---
 
 # Show session count and attention state on minimized project chips
@@ -14,7 +15,7 @@ stage: GATE
 - **Type:** enhancement
 - **Complexity:** S
 - **Priority:** P2
-- **Exec plan:** [docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md](../exec-plans/active/343-minimized-project-chip-count-and-attention.md)
+- **Exec plan:** [docs/exec-plans/completed/343-minimized-project-chip-count-and-attention.md](../exec-plans/completed/343-minimized-project-chip-count-and-attention.md)
 
 ## Problem
 

--- a/docs/product-specs/343-minimized-project-chip-count-and-attention.md
+++ b/docs/product-specs/343-minimized-project-chip-count-and-attention.md
@@ -1,0 +1,41 @@
+---
+issue: 343
+title: "Show session count and attention state on minimized project chips"
+type: enhancement
+complexity: S
+priority: P2
+stage: IMPLEMENT
+---
+
+# Show session count and attention state on minimized project chips
+
+- **Issue:** #343
+- **Type:** enhancement
+- **Complexity:** S
+- **Priority:** P2
+- **Exec plan:** [docs/exec-plans/active/343-minimized-project-chip-count-and-attention.md](../exec-plans/active/343-minimized-project-chip-count-and-attention.md)
+
+## Problem
+
+A minimized project collapses to a single chip in the sidebar tray, which today shows only the project colour dot and its name. A *collapsed* (not minimized) project card is richer — its count reads `3 sessions · 1 needs you` — so minimizing a project loses information the same project shows one interaction earlier.
+
+Two gaps: the chip carries no session count at all, and its attention signal is a coarse boolean (`projectHasAttention()` in `Sidebar.tsx`, derived from `readNeedsAttention`) that neither counts the ringing sessions nor uses the session state model from spec 336, so `waiting-permission` and `error` are indistinguishable from plain `waiting_input`.
+
+## Desired behavior
+
+The minimized project chip carries the same information as the collapsed project card header — session count and an accurate, count-aware needs-attention indicator — within the space a chip has.
+
+## Success criteria
+
+- A minimized project chip shows the number of sessions in that project, and the number changes when a session is created, killed or moved.
+- When one or more sessions in a minimized project want the user, the chip shows how many, next to a state icon drawn from the same `StateIcon` set the sidebar rows and grid tiles use.
+- That icon distinguishes "waiting for you" from "waiting for permission"; the chip no longer collapses both into one undifferentiated bell.
+- The counts on a minimized chip and on the same project's collapsed card agree, because both read one shared helper.
+- The chip's accessible name carries the same counts as words, not only as glyphs.
+- Clicking anywhere on the chip still restores the project, and the restore `+` still hugs the right edge (spec 255's behaviour is unchanged).
+
+## Non-goals
+
+- Bubbling `exited` / `error` to the chip. Those are not `needs_attention`, and adding them would change the attention contract in `docs/design-docs/ui/patterns.md` for every surface, not just this one.
+- Any change to the minimized *session* tray chips, which already carry a per-session `StateIcon`.
+- Any wire, daemon or persistence change — `state` and `needs_attention` are already on `SessionInfo`.

--- a/docs/product-specs/343-minimized-project-chip-count-and-attention.md
+++ b/docs/product-specs/343-minimized-project-chip-count-and-attention.md
@@ -1,10 +1,11 @@
 ---
 issue: 343
+pr: 346
 title: "Show session count and attention state on minimized project chips"
 type: enhancement
 complexity: S
 priority: P2
-stage: IMPLEMENT
+stage: REVIEW
 ---
 
 # Show session count and attention state on minimized project chips


### PR DESCRIPTION
Closes #343.

A minimized project collapsed to a colour dot and a name, while the *collapsed* card one interaction earlier reads `3 sessions · 1 needs you`. The chip now carries both.

```
before   ● other-repo                        [+]
after    ● other-repo   9   ◆2               [+]
                        ↑    ↑
                   sessions  state icon + how many want you
```

The alert count sits next to a `StateIcon` from the same set the sidebar rows and grid tiles use, so **waiting for permission** is finally distinguishable from **waiting for you** on a minimized project — the boolean bell could not tell them apart.

## One deliberate behaviour change, on two surfaces

The card and the chip computed attention separately until now, by two different routes (`projectHasAttention()` and `attentionCount`). Both now go through one new `attentionSummary()` helper beside `sessionState()`.

That helper resolves through `sessionState()` rather than reading `needs_attention` directly, which **narrows what both surfaces count**:

| | before | after |
|---|---|---|
| Live session, flag set | counts | counts |
| Still starting, flag set | counts | does not count |
| Exited/errored, flag still set | counts | does not count |

A bell that outlives its session is the stale indicator `patterns.md`'s "clears in the same render" rule exists to prevent. Pinned by two unit tests so it cannot regress back to the raw flag.

## Layout constraints this respects

- The two new slots render **inside `.hv-chip__open`, left-packed after the label**. The slack before the restore `+` is a click target that restores the project (spec 255); filling it would take that away.
- The e2e guard for that slack only ruled out `.hv-chip__label`, so it would have passed on a chip that swallowed the slack entirely. It now names all three content classes.
- The `waiting-permission` CSS is scoped to `#minimized-projects`: minimized *session* chips set `data-state` from `sessionState()` too and can already carry that state, so a bare `.hv-chip` rule would have recoloured their labels.

## Verification

- 1033 unit + dom tests, 270 e2e — all pass
- `tsc --noEmit`, `biome ci .`, `ui-lint.sh --strict`, `go test ./...` — all clean
- Layout confirmed by screenshot in a real browser (vitest is CSS-blind)

## Out of scope

An exited-with-error session in a minimized project stays invisible — `error` is not `needs_attention`, and including it would change the attention contract in `patterns.md` for every surface, not just this chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)