### PR TITLE
fix(gui): right-align session count on minimized project chips

### DIFF
--- a/.changesets/minimized-chip-count-alignment.md
+++ b/.changesets/minimized-chip-count-alignment.md
@@ -1,0 +1,9 @@
+---
+issue: null
+pr: null
+type: changed
+bump: patch
+---
+- On a minimized project chip in the sidebar, the session count is now
+  right-aligned instead of sitting next to the project name, with the
+  attention badge immediately to its left. Counts line up down the list.

--- a/cmd/hivegui/frontend/src/components/Chip.tsx
+++ b/cmd/hivegui/frontend/src/components/Chip.tsx
@@ -91,18 +91,17 @@ export function Chip({
         )}
         <span className="hv-chip__label">{label}</span>
         {sublabel ? <span className="hv-chip__sub">{sublabel}</span> : null}
-        {/* Count then alert, the order the project card header uses
-            (swatch, name, count, actions). Left-packed rather than
-            right-aligned on purpose: the slack between the label and the
-            restore + is a click target that restores the project, and
-            filling it would take that away (spec 255). */}
-        {count == null ? null : <span className="hv-chip__count">{count}</span>}
+        {/* Alert then count, right-aligned (the label takes the slack —
+            see minimized.css): the session count is the rightmost thing
+            so counts line up down the list, with the attention badge
+            immediately left of it. */}
         {attention ? (
           <span className="hv-chip__alert">
             <StateIcon state={attention.state} />
             {attention.count}
           </span>
         ) : null}
+        {count == null ? null : <span className="hv-chip__count">{count}</span>}
       </button>
       {onRestore ? (
         <IconButton

--- a/cmd/hivegui/frontend/src/theme/components/minimized.css
+++ b/cmd/hivegui/frontend/src/theme/components/minimized.css
@@ -21,6 +21,8 @@
    make the whole chip one restore target. */
 #minimized-projects .hv-chip { max-width: none; }
 #minimized-projects .hv-chip__open { flex: 1; text-align: left; }
+/* Label eats the slack so the count/alert pair sits flush right. */
+#minimized-projects .hv-chip__label { flex: 1; text-align: left; }
 
 /* A project chip reports waiting-permission on the same data-state channel
    as attention, so the label colour and the dot pulse have to cover both —

--- a/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/minimize-project.spec.ts
@@ -180,26 +180,41 @@ test('a project chip spans the tray, right-aligns +, and restores on any click',
     chipBox.x + chipBox.width - 12,
   );
 
-  // Click the slack between the label and the +. Assert first that the
-  // point really is dead space — with a long enough project name this
-  // would land on the label and pass without testing anything.
-  const slackX = restoreBox.x - 12;
-  const slackY = chipBox.y + chipBox.height / 2;
-  // Every node the chip can grow, not just the label: the count and alert
-  // slots sit between the label and the +, and a check that named only the
-  // label would keep passing on a chip that had swallowed the whole slack.
-  const onContent = await page.evaluate(
-    ({ x, y }) =>
-      !!document
-        .elementFromPoint(x, y)
-        ?.closest('.hv-chip__label, .hv-chip__count, .hv-chip__alert'),
-    { x: slackX, y: slackY },
-  );
-  expect(onContent, 'the click point is on chip content, not the slack').toBe(
-    false,
-  );
-  await page.mouse.click(slackX, slackY);
+  // The count is right-aligned now, so the strip left of the + is no
+  // longer guaranteed to be dead space — it is the count on a chip that
+  // has one. What spec 255 actually promised is that clicking there
+  // restores either way, since every node lives inside .hv-chip__open.
+  const nearRestoreX = restoreBox.x - 12;
+  const rowY = chipBox.y + chipBox.height / 2;
+  await page.mouse.click(nearRestoreX, rowY);
   await expect(listed).toHaveCount(before);
+});
+
+// The session count hugs the + rather than the label, so counts line up
+// down the list; the attention badge, when there is one, sits to its left.
+test('a project chip right-aligns its session count', async ({ page }) => {
+  await boot(page);
+  const first = page.locator('#projects > li.hv-project-card').first();
+  const pid = await first.getAttribute('data-pid');
+  await first.locator('.hv-project-card__header').hover();
+  await first
+    .locator('.hv-project-card__header [data-action="minimize"]')
+    .click();
+
+  const chip = page.locator(`#minimized-projects .hv-chip[data-pid="${pid}"]`);
+  const labelBox = (await chip.locator('.hv-chip__label').boundingBox())!;
+  const countBox = (await chip.locator('.hv-chip__count').boundingBox())!;
+  const restoreBox = (await chip.locator('.hv-chip__restore').boundingBox())!;
+
+  // Flush against the +, not trailing the name.
+  expect(countBox.x + countBox.width).toBeGreaterThan(restoreBox.x - 12);
+  expect(countBox.x).toBeGreaterThan(labelBox.x + labelBox.width - 1);
+
+  const alert = chip.locator('.hv-chip__alert');
+  if (await alert.count()) {
+    const alertBox = (await alert.boundingBox())!;
+    expect(alertBox.x + alertBox.width).toBeLessThanOrEqual(countBox.x + 1);
+  }
 });
 
 // Repro for #340: a minimized project must still be minimized after the


### PR DESCRIPTION
Session count on minimized project chips is now right-aligned, with the attention badge immediately to its left, so counts line up down the sidebar list.

- `Chip.tsx`: alert renders before count.
- `minimized.css`: `.hv-chip__label { flex: 1 }` inside `#minimized-projects` so the label eats the slack.

**Tradeoff:** the old comment cited spec 255 — the empty slack between label and restore `+` doubled as a project-restore click target. Right-aligning occupies most of it.

Verified: 46 chip/minimize DOM tests pass, `biome ci .` clean. Not visually checked in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)