### PR TITLE
fix(gui): only open http/https/mailto links from terminals

### DIFF
--- a/.changesets/open-url-scheme-allowlist.md
+++ b/.changesets/open-url-scheme-allowlist.md
@@ -1,0 +1,10 @@
+---
+issue: null
+pr: null
+type: fixed
+bump: patch
+---
+- Clicking a link in a terminal now only opens http, https and mailto
+  URLs. A program could previously print a link labelled with one thing
+  that pointed at a local file or another app's URL scheme, and a click
+  would launch it.

--- a/cmd/hivegui/app_calls.go
+++ b/cmd/hivegui/app_calls.go
@@ -9,8 +9,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"log"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
@@ -428,13 +431,36 @@ func (a *App) IsGitRepo(path string) bool {
 	return worktree.IsGitRepo(path)
 }
 
-// OpenURL hands a URL to the OS default browser. Used by the
-// xterm web-links addon when the user cmd-clicks a URL in a session.
-func (a *App) OpenURL(url string) {
-	if url == "" {
+// OpenURL hands a URL to the OS default browser. Used by the xterm
+// web-links addon and the OSC 8 link handler when the user clicks a
+// URL in a session.
+//
+// Only web and mail schemes are forwarded. Terminal content is
+// attacker-influenced (agent output, a cat'd README), and OSC 8 lets
+// it label a file:// or custom-scheme URI with any visible text;
+// BrowserOpenURL would launch whatever handles that scheme.
+func (a *App) OpenURL(rawURL string) {
+	if !allowedURL(rawURL) {
+		log.Printf("hivegui: refusing to open URL with disallowed scheme: %q", rawURL)
 		return
 	}
-	wruntime.BrowserOpenURL(a.ctx, url)
+	wruntime.BrowserOpenURL(a.ctx, rawURL)
+}
+
+// allowedURL reports whether raw parses as an absolute URL whose
+// scheme is http, https or mailto.
+func allowedURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return u.Host != ""
+	case "mailto":
+		return u.Opaque != ""
+	}
+	return false
 }
 
 // UpdateSession patches name/color/order. Empty strings on name/color

--- a/cmd/hivegui/open_url_test.go
+++ b/cmd/hivegui/open_url_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestAllowedURL(t *testing.T) {
+	ok := []string{
+		"https://github.com/lucascaro/hive",
+		"http://localhost:5173/",
+		"HTTPS://Example.com",
+		"mailto:someone@example.com",
+	}
+	bad := []string{
+		"",
+		"file:///Applications/Utilities/Terminal.app",
+		"javascript:alert(1)",
+		"vscode://file/etc/passwd",
+		"x-apple.systempreferences:com.apple.preference.security",
+		"ssh://evil.example",
+		"github.com/no/scheme",
+		"https://\x00bad",
+	}
+	for _, u := range ok {
+		if !allowedURL(u) {
+			t.Errorf("allowedURL(%q) = false, want true", u)
+		}
+	}
+	for _, u := range bad {
+		if allowedURL(u) {
+			t.Errorf("allowedURL(%q) = true, want false", u)
+		}
+	}
+}


### PR DESCRIPTION
## What

Terminal content is attacker-influenced (agent output, a `cat`'d README), and OSC 8 lets it label a `file://` or custom-scheme URI with any visible text. `OpenURL` forwarded every scheme straight to `BrowserOpenURL`, so a click launched whatever handled it (`file://`, `vscode://`, `x-apple.systempreferences:`).

Now `OpenURL` passes the URL through `allowedURL`: `http`/`https` (host required) and `mailto` (opaque required) only; anything else is logged and dropped.

Task 1 of `.plans/2026-09-05-security-hardening.md` (audit finding #4, MED).

## Test

`cmd/hivegui/open_url_test.go` — table of allowed/denied URLs. `go test ./cmd/hivegui/ -run TestAllowedURL` passes.

Frontend unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)