### PR TITLE
docs(336): close the plan — every criterion has evidence

### DIFF
--- a/cmd/hivegui/frontend/src/app/events.ts
+++ b/cmd/hivegui/frontend/src/app/events.ts
@@ -183,7 +183,7 @@ export async function reconnectControl(
 // answer: every reader of that question (sidebar, tile, ⌘B, the pulse
 // class) reads session.needs_attention straight off the session list.
 // See the frozen transition table,
-// docs/exec-plans/active/336-session-state-model.md.
+// docs/exec-plans/completed/336-session-state-model.md.
 const attentionEdge = new Set<string>();
 let sawFirstSessionList = false;
 

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -585,7 +585,7 @@ export class SessionTerm {
     // needs_attention through the `attention` session event, which
     // drives the pulse class and the notification edge in
     // app/events.ts's syncAttentionClass. See the frozen transition
-    // table, docs/exec-plans/active/336-session-state-model.md.
+    // table, docs/exec-plans/completed/336-session-state-model.md.
 
     // Take over wheel handling. xterm's default wheel→lines math
     // honors raw deltaY, which on macOS trackpads with momentum

--- a/cmd/hivegui/frontend/src/lib/session-state.ts
+++ b/cmd/hivegui/frontend/src/lib/session-state.ts
@@ -47,7 +47,7 @@ export interface StateCarrier {
   // `state` (needs_attention = state ∈ {waiting_input,
   // waiting_permission}). The daemon and the session list are its only
   // writers; no client keeps a second copy (see the frozen transition
-  // table in docs/exec-plans/active/336-session-state-model.md).
+  // table in docs/exec-plans/completed/336-session-state-model.md).
   needs_attention?: boolean;
   // Which tier produced `state` (internal/wire/control.go StateSource*).
   // Absent = heuristic.

--- a/cmd/hivegui/frontend/src/store/store.ts
+++ b/cmd/hivegui/frontend/src/store/store.ts
@@ -662,7 +662,7 @@ export function forgetSession(id: string): void {
 // needs_attention is derived server-side and lives on SessionInfo
 // itself (session.needs_attention) — there is no local Set here. See
 // the frozen transition table in
-// docs/exec-plans/active/336-session-state-model.md. What stays is the
+// docs/exec-plans/completed/336-session-state-model.md. What stays is the
 // ⌘B/⇧⌘B round-tripping bookkeeping below, which is genuinely local UI
 // state (which sessions/projects a bell round pulled out of the tray).
 

--- a/cmd/hivegui/frontend/test/unit/store.test.ts
+++ b/cmd/hivegui/frontend/test/unit/store.test.ts
@@ -186,7 +186,7 @@ describe('projects', () => {
 // needs_attention is not store state any more — it lives on
 // SessionInfo, set by setSessions/updateSession like any other wire
 // field (see session-state.test.ts and the frozen transition table in
-// docs/exec-plans/active/336-session-state-model.md). There is nothing
+// docs/exec-plans/completed/336-session-state-model.md). There is nothing
 // left here to test in isolation.
 
 describe('minimize', () => {

--- a/docs/exec-plans/completed/336-session-state-model.md
+++ b/docs/exec-plans/completed/336-session-state-model.md
@@ -3,9 +3,10 @@
 - **Spec:** [docs/product-specs/336-session-state-model.md](../../product-specs/336-session-state-model.md)
 - **Design:** [docs/design-docs/control-plane.md](../../design-docs/control-plane.md)
 - **Issue:** —
-- **Branch:** `feature/336-phase4-hivebar-tooltip` (phases 1–2 shipped
-  from `feature/336-session-state-model`, phase 3 from
-  `feature/336-phase3-pi-extension`; both merged and dead)
+- **Branch:** one per phase, all merged and dead —
+  `feature/336-session-state-model` (phases 1–2),
+  `feature/336-phase3-pi-extension`, `feature/336-phase4-hivebar-tooltip`,
+  `feature/336-pi-probe`, `feature/336-close-out`
 - **Stage:** DONE
 - **PR:** #338 (phases 1–2) · #341 (phase 3) · #344 (phase 4) · #348
   (pi probe + smoke checklist) — all merged

--- a/docs/exec-plans/completed/336-session-state-model.md
+++ b/docs/exec-plans/completed/336-session-state-model.md
@@ -6,8 +6,10 @@
 - **Branch:** `feature/336-phase4-hivebar-tooltip` (phases 1–2 shipped
   from `feature/336-session-state-model`, phase 3 from
   `feature/336-phase3-pi-extension`; both merged and dead)
-- **PR:** #338 (phases 1–2, merged) · #341 (phase 3, merged) · #344 (phase 4)
-- **Status:** active
+- **Stage:** DONE
+- **PR:** #338 (phases 1–2) · #341 (phase 3) · #344 (phase 4) · #348
+  (pi probe + smoke checklist) — all merged
+- **Status:** completed
 
 ## Summary
 
@@ -1531,9 +1533,37 @@ decision-log entry with the log excerpt BEFORE any code changes.
   | 16 | PASS (both tiers) | heuristic: `"Idle\nguessed from terminal output"`. Hook tier, fired by the real `hived hook` binary over the real event socket with the repo's own fixtures: `"Idle\n“reply pong”\npong\nreported by the agent"` — state, quoted prompt, summary, provenance, identical on the sidebar row and the tile header |
 
   Criteria 6 and 7's tooltip half is therefore observed in a real
-  browser against a real daemon. What is still unobserved: the menu bar
-  (row 15), the desktop notification (row 2's second half), and the
-  extension tier (row 14, blocked above).
+  browser against a real daemon.
+
+- **2026-09-06 (rows 2 and 15 — the last two)** — both closed, so every
+  row of the checklist has now either passed or been superseded by a
+  probe.
+
+  - **Row 15 (hivebar):** PASS, confirmed by the user against a reloaded
+    hivebar built from the phase-4 tree. The menu bar is an
+    `NSStatusItem` and cannot be opened without screen control, so this
+    row stays a human row — noted in
+    `docs/verifying-the-gui-by-hand.md`.
+  - **Row 2 (desktop notification):** PASS. The notification is not
+    reachable from a headless browser *as a notification*, but the path
+    that fires it is: `events.ts:245` calls the Go binding `App.Notify`
+    (WKWebView has no HTML5 Notification API), and that binding is live
+    under `wails dev`. Wrapping it — calling through, so a real OS
+    notification still fired — recorded, for a bell:
+    `["main", "default", "Waiting for input — click to switch.", "<session id>"]`
+    and, after a `PermissionRequest` hook through the real `hived hook`
+    binary: `["main", "default", "Waiting for permission — click to switch.", "<session id>"]`.
+    Title, project subtitle, the two distinct bodies, and the session id
+    as the dedupe tag — all four fields, both wordings, one real
+    daemon.
+
+    One thing was faked and is worth naming: headless Chromium always
+    reports `document.hasFocus() === true`, so the row's precondition
+    ("the window is NOT focused") was stubbed. Everything downstream of
+    that branch is real. The unfaked half is covered too: with focus
+    reported true and the session active, no notification fired — which
+    is `syncAttentionClass`'s "a session you are already watching gets
+    no desktop notification" behaving correctly.
 
 ## Open questions
 
@@ -1550,6 +1580,19 @@ decision-log entry with the log excerpt BEFORE any code changes.
 - **2026-09-05 iter 5 (PR #341)** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 012bd1b0cb5b268652d7f421b16e0ddc5b99a330710aa60401cc653899411c66; threads_open: 0; action: converged (2 IMPORTANT fixed: boundary test + comment scope; reviewer re-derived iter 4's riskiest changes independently and found them correct); head_sha: d27c756.
 
 ## Gate verdict
+
+- **2026-09-06 (final)** — verdict: PASS; checks: 8 passed / 0 failed /
+  0 followups; one-line: every success criterion is now backed by
+  executed evidence, including the three that had never run against a
+  real binary or a running app. Criterion 2 (claude) by the recorded
+  manual transcript plus `TestClaudeProbe*`; criterion 3 (pi) by
+  `TestPiProbeReportsThroughTheExtension`, green against a real `pi` on
+  node v24.16.0; criteria 6 and 7 by the browser-driven checklist run
+  (glyphs, both tooltip tiers, both notification wordings) and the
+  user's own pass on the hivebar menu. Non-goals and doc accuracy were
+  PASS in the previous gate and nothing in #348 touched them — it adds
+  one opt-in test file and docs.
+
 
 - **2026-09-05 (re-gate after fixes)** — verdict: NEEDS_FOLLOWUP; checks: 6 passed / 0 failed / 2 followups; followups: none filed (manual verification only); one-line: every criterion is implemented, evidenced and now race-clean, and the prose defects are swept; what remains is that four criteria have never been exercised against a real binary or a running app.
   - 2026-09-05 dimensions (after `fc020de`):

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -5,7 +5,8 @@ title: "Session state model: know what every agent is doing"
 type: enhancement
 complexity: L
 priority: P1
-stage: GATE
+stage: DONE
+shipped: 2026-09-05
 ---
 
 # Session state model: know what every agent is doing

--- a/docs/product-specs/336-session-state-model.md
+++ b/docs/product-specs/336-session-state-model.md
@@ -14,7 +14,7 @@ stage: GATE
 - **Type:** enhancement
 - **Complexity:** L
 - **Priority:** P1
-- **Exec plan:** [docs/exec-plans/active/336-session-state-model.md](../exec-plans/active/336-session-state-model.md)
+- **Exec plan:** [docs/exec-plans/completed/336-session-state-model.md](../exec-plans/completed/336-session-state-model.md)
 - **Design:** [docs/design-docs/control-plane.md](../design-docs/control-plane.md)
 
 ## Problem

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -9,7 +9,6 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Priority | Issue | Title | Stage | Spec |
 |----------|-------|-------|-------|------|
 | P1 | — | Sidebar and grid repaints silently drop keyboard focus | REVIEW | [257-mock-e2e-worktree-glyph-loses-focus](257-mock-e2e-worktree-glyph-loses-focus.md) |
-| P1 | — | Session state model: know what every agent is doing | GATE | [336-session-state-model](336-session-state-model.md) |
 | P1 | — | Idea inbox: capture ideas mid-session, start a session from one later | PLAN | [337-idea-inbox](337-idea-inbox.md) |
 | P2 | — | A red CI check name should say which stage failed | TRIAGE | [256-ci-check-names-identify-the-failing-stage](256-ci-check-names-identify-the-failing-stage.md) |
 | P2 | — | Session messaging: hand a session a message, get told when it idles | PLAN | [338-session-messaging](338-session-messaging.md) |
@@ -24,6 +23,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 
 | Issue | Title | PR | Shipped | Spec |
 |-------|-------|----|---------|------|
+| — | Session state model: know what every agent is doing | #344 | 2026-09-05 | [336-session-state-model](336-session-state-model.md) |
 | #340 | Persist minimized projects across restarts | #342 | 2026-09-05 | [340-persist-minimized-projects-across-restarts](340-persist-minimized-projects-across-restarts.md) |
 | #343 | Show session count and attention state on minimized project chips | #346 | 2026-09-05 | [343-minimized-project-chip-count-and-attention](343-minimized-project-chip-count-and-attention.md) |
 | — | Add GUI-only reload and a daemon menu-bar agent | #333 | 2026-09-04 | [330-add-gui-only-reload-and-a-daemon-menu-bar-agent](330-add-gui-only-reload-and-a-daemon-menu-bar-agent.md) |

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -9,6 +9,7 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 | Priority | Issue | Title | Stage | Spec |
 |----------|-------|-------|-------|------|
 | P1 | — | Sidebar and grid repaints silently drop keyboard focus | REVIEW | [257-mock-e2e-worktree-glyph-loses-focus](257-mock-e2e-worktree-glyph-loses-focus.md) |
+| P1 | — | Session state model: know what every agent is doing | GATE | [336-session-state-model](336-session-state-model.md) |
 | P1 | — | Idea inbox: capture ideas mid-session, start a session from one later | PLAN | [337-idea-inbox](337-idea-inbox.md) |
 | P2 | — | A red CI check name should say which stage failed | TRIAGE | [256-ci-check-names-identify-the-failing-stage](256-ci-check-names-identify-the-failing-stage.md) |
 | P2 | — | Session messaging: hand a session a message, get told when it idles | PLAN | [338-session-messaging](338-session-messaging.md) |
@@ -23,7 +24,6 @@ The *what* and *why* of work this project plans to do. Each spec describes user 
 
 | Issue | Title | PR | Shipped | Spec |
 |-------|-------|----|---------|------|
-| — | Session state model: know what every agent is doing | #344 | 2026-09-05 | [336-session-state-model](336-session-state-model.md) |
 | #340 | Persist minimized projects across restarts | #342 | 2026-09-05 | [340-persist-minimized-projects-across-restarts](340-persist-minimized-projects-across-restarts.md) |
 | #343 | Show session count and attention state on minimized project chips | #346 | 2026-09-05 | [343-minimized-project-chip-count-and-attention](343-minimized-project-chip-count-and-attention.md) |
 | — | Add GUI-only reload and a daemon menu-bar agent | #333 | 2026-09-04 | [330-add-gui-only-reload-and-a-daemon-menu-bar-agent](330-add-gui-only-reload-and-a-daemon-menu-bar-agent.md) |

--- a/features/BACKLOG.md
+++ b/features/BACKLOG.md
@@ -7,10 +7,9 @@ See `features/templates/FEATURE.md` for the feature file template.
 
 | # | Issue | Title | Stage | Complexity |
 |---|-------|-------|-------|------------|
-| 1 | —     | [Session state model: know what every agent is doing](active/336-session-state-model.md) | IMPLEMENT | L |
-| 2 | —     | [Idea inbox: capture ideas mid-session, start a session from one later](active/337-idea-inbox.md) | PLAN | M |
-| 3 | —     | [Session messaging: hand a session a message, get told when it idles](active/338-session-messaging.md) | PLAN | M |
-| 4 | —     | [Resume conversations on daemon restart](active/resume-on-daemon-restart.md) | TRIAGE | M |
+| 1 | —     | [Idea inbox: capture ideas mid-session, start a session from one later](active/337-idea-inbox.md) | PLAN | M |
+| 2 | —     | [Session messaging: hand a session a message, get told when it idles](active/338-session-messaging.md) | PLAN | M |
+| 3 | —     | [Resume conversations on daemon restart](active/resume-on-daemon-restart.md) | TRIAGE | M |
 
 Shipped and rejected features are recorded in `CHANGELOG.md` and
 `docs/product-specs/` — not duplicated here.

--- a/features/completed/336-session-state-model.md
+++ b/features/completed/336-session-state-model.md
@@ -1,12 +1,12 @@
 # Feature: Session state model: know what every agent is doing
 
 - **GitHub Issue:** —
-- **Stage:** IMPLEMENT
+- **Stage:** DONE
 - **Type:** enhancement
 - **Complexity:** L
 - **Priority:** P1
-- **Branch:** —
-- **PR:** —
+- **Branch:** `feature/336-session-state-model` → `feature/336-phase3-pi-extension` → `feature/336-phase4-hivebar-tooltip` → `feature/336-pi-probe` → `feature/336-close-out`
+- **PR:** #338 · #341 · #344 · #348 · #350 (all merged)
 
 ## Description
 
@@ -20,7 +20,7 @@ Design: `docs/design-docs/control-plane.md`.
 ## Research
 
 See the exec plan's Research section:
-`docs/exec-plans/active/336-session-state-model.md`.
+`docs/exec-plans/completed/336-session-state-model.md`.
 
 ### Relevant Code
 - `internal/registry/registry.go` — `Entry`, `noteBell`, `SetAttention`, `broadcastLocked`

--- a/internal/session/state_fixture_test.go
+++ b/internal/session/state_fixture_test.go
@@ -282,7 +282,7 @@ func TestFixtureRecordsAreWellFormed(t *testing.T) {
 // is exactly the kind of guesswork this whole fixture suite exists to
 // replace with ground truth. That gap is filled by the hook tier
 // (agentstate.KindWaitingPermission), not the heuristic one; see
-// docs/exec-plans/active/336-session-state-model.md's frozen transition
+// docs/exec-plans/completed/336-session-state-model.md's frozen transition
 // table.
 func TestFixturePermissionSkipped(t *testing.T) {
 	t.Skip("no permission prompt appeared for `ls` via the Bash tool " +


### PR DESCRIPTION
Closes out spec 336. Docs only.

Rows 2 and 15 of the smoke checklist were the last two never run.

**Row 15 (hivebar menu)** — passed by hand against a hivebar reloaded from the phase-4 build. It is an `NSStatusItem`; no way to open it without screen control, so it stays a human row (noted in `docs/verifying-the-gui-by-hand.md`).

**Row 2 (desktop notification)** — closed through the path that actually fires it. `events.ts:245` calls the Go binding `App.Notify` (WKWebView has no HTML5 Notification API), and that binding is live under `wails dev`. Wrapping it — calling through, so a real OS notification still fired — recorded both wordings against one real daemon:

```
bell:       ["main", "default", "Waiting for input — click to switch.", "<session id>"]
permission: ["main", "default", "Waiting for permission — click to switch.", "<session id>"]
```

(the second after a real `PermissionRequest` hook through the `hived hook` binary). Title, project subtitle, both bodies, session id as dedupe tag.

One stub, named in the plan: headless Chromium always reports `document.hasFocus() === true`, so the row's "window is NOT focused" precondition was faked. Everything downstream is real, and the unfaked case is covered — active + focused fired nothing, which is `syncAttentionClass` behaving correctly.

**Gate → PASS**, plan moves to `completed/`, spec's exec-plan link follows it. `scripts/check-plan-lifecycle.sh`: no drift.

Docs only — no changeset (`no-changeset` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)