### PR TITLE
build: bump the Go directive to 1.27.1 (1.25 is end of life)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/bin
-          key: go-analysis-tools-${{ runner.os }}-staticcheck2025.1.1-govulncheck1.7.0
+          key: go-analysis-tools-${{ runner.os }}-staticcheck2026.2.1-govulncheck1.7.0
 
       - name: Staticcheck (Go)
         if: matrix.biome
@@ -188,7 +188,7 @@ jobs:
         # new release can't turn a green PR red on its own.
         run: |
           BIN="$(go env GOPATH)/bin/staticcheck"
-          [ -x "$BIN" ] || go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
+          [ -x "$BIN" ] || go install honnef.co/go/tools/cmd/staticcheck@2026.2.1
           "$BIN" ./...
 
       - name: Vulnerability scan (govulncheck)
@@ -196,11 +196,12 @@ jobs:
         # Symbol-level: only reports vulns the code actually reaches.
         #
         # `go-version-file: go.mod` installs the `go` directive VERBATIM —
-        # 1.25.0 means 1.25.0, not "latest 1.25.x". That is why the directive
-        # names a patch release: on 1.25.0 this step reports three reachable
-        # stdlib advisories fixed in 1.25.13. Verifying locally under a
-        # different toolchain proves nothing about this step; match go.mod
-        # (GOTOOLCHAIN=go1.25.14) when you do.
+        # 1.27.0 means 1.27.0, not "latest 1.27.x". That is why the directive
+        # names a patch release: the 1.25 line this repo sat on went end of
+        # life with four reachable stdlib advisories against it, fixed only
+        # from 1.26.5 on. Verifying locally under a different toolchain
+        # proves nothing about this step; match go.mod
+        # (GOTOOLCHAIN=go1.27.1) when you do.
         #
         # The TOOL is pinned for the same reason staticcheck is — a tool
         # release must not turn a green PR red on its own. The advisory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         # Symbol-level: only reports vulns the code actually reaches.
         #
         # `go-version-file: go.mod` installs the `go` directive VERBATIM —
-        # 1.27.0 means 1.27.0, not "latest 1.27.x". That is why the directive
+        # 1.27.1 means 1.27.1, not "latest 1.27.x". That is why the directive
         # names a patch release: the 1.25 line this repo sat on went end of
         # life with four reachable stdlib advisories against it, fixed only
         # from 1.26.5 on. Verifying locally under a different toolchain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,13 @@ Thank you for your interest in contributing! This document explains how to build
 
 ### Prerequisites
 
-- **Go 1.25.14+** — [install](https://go.dev/dl/). The patch floor is
-  deliberate: `go.mod` pins it because CI's `setup-go` installs the `go`
-  directive verbatim, and the earlier 1.25.0 shipped stdlib advisories that
-  `govulncheck` reports as reachable.
+- **Go 1.27.1+** — [install](https://go.dev/dl/). The patch floor is
+  deliberate: `go.mod` names a full patch release because CI's `setup-go`
+  installs the `go` directive verbatim, so that one line decides the
+  toolchain every gate runs on. An end-of-life or pre-fix patch release
+  leaves stdlib advisories that `govulncheck` reports as reachable — which
+  is why the directive moves to the patched release rather than the step
+  being muted.
 - **Node 24+** and the **Wails CLI** for the desktop GUI:
   run `scripts/ci-bootstrap.sh` (installs the pinned Wails CLI version)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ notarization, platform installers, in-app updates on Windows/Linux.
 
 ## Build
 
-Requires Go 1.25.14+, Node 24+, and the Wails CLI:
+Requires Go 1.27.1+, Node 24+, and the Wails CLI:
 
 ```sh
 scripts/ci-bootstrap.sh  # installs the pinned Wails CLI + generates bindings

--- a/docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/359-bump-go-toolchain-to-1-27-1.md](../../product-specs/359-bump-go-toolchain-to-1-27-1.md)
 - **Issue:** #359
+- **PR:** #360
+- **Branch:** `sec/go-1-27`
 - **Status:** active
 
 ## Summary

--- a/docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md
@@ -108,7 +108,9 @@ for os in darwin linux windows; do GOOS=$os go vet ./... || exit 1; done
 
 # 3. Staticcheck at CI's pin, per GOOS (ci.yml:191; staticcheck analyses
 #    one platform at a time, per AGENTS.md).
-go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
+# 2025.1.1 (CI's pin at drafting time) cannot read Go 1.27 export data —
+# see the Decision log. The pin below is the one this change moves CI to.
+go install honnef.co/go/tools/cmd/staticcheck@2026.2.1
 for os in darwin linux windows; do GOOS=$os "$(go env GOPATH)/bin/staticcheck" ./... || exit 1; done
 
 # 4. Unit suite, then the e2e-tagged Go leg — untagged `go test ./...`
@@ -191,6 +193,12 @@ go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
   (`ubuntu-latest`/`windows-latest` are native amd64, `macos-latest` native
   arm64), so the local suite above was run with `-p 2`. The fix is a native
   arm64 Go install, which the operator owns.
+
+## PR convergence ledger
+
+<!-- one line per /hs-review-loop iteration -->
+
+- **2026-09-06 iter 1** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 8ea4a6c.
 
 ## Open questions
 

--- a/docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md
@@ -1,0 +1,219 @@
+# Bump the Go toolchain to 1.27.1
+
+- **Spec:** [docs/product-specs/359-bump-go-toolchain-to-1-27-1.md](../../product-specs/359-bump-go-toolchain-to-1-27-1.md)
+- **Issue:** #359
+- **Status:** active
+
+## Summary
+
+`go.mod` names `go 1.25.14`, the last release of an end-of-life line. CI's
+`setup-go` installs the `go` directive verbatim, so that one line decides the
+toolchain every gate runs on. Move it to 1.27.1 and bring the three prose
+sites that quote the old number along with it. No code changes.
+
+## Research
+
+**The version lives in exactly one machine-read place.**
+
+- `go.mod:3` — `go 1.25.14`. The single source of truth.
+- `.github/workflows/ci.yml:68-70` — the only `actions/setup-go` in the repo
+  (`pages.yml` and `changesets.yml` have none), and it uses
+  `go-version-file: go.mod`. Nothing else to update for CI to follow.
+- `scripts/ci-bootstrap.sh` — pins the Wails CLI, not Go. No change.
+
+**Prose that quotes the number and will go stale:**
+
+- `README.md:45` — "Requires Go 1.25.14+, Node 24+…".
+- `CONTRIBUTING.md:9-12` — "**Go 1.25.14+**" plus a paragraph explaining why
+  the floor is a patch release, citing 1.25.0's advisories as the example.
+- `.github/workflows/ci.yml:198-203` — the govulncheck step's comment, which
+  uses 1.25.0/1.25.13/1.25.14 to explain verbatim-install and tells a local
+  verifier to `GOTOOLCHAIN=go1.25.14`.
+
+**Deliberately not touched:**
+
+- `AGENTS.md:346-350` — already version-agnostic; it derives the value with
+  `GOTOOLCHAIN=$(sed -n 's/^go //p' go.mod)`. Correct as written.
+- `docs/analysis/2026-07-19-*`, `docs/analysis/2026-08-24-improvements.md`,
+  `CHANGELOG.md`, `docs/exec-plans/completed/*` — dated historical records.
+  Rewriting them would falsify the record.
+
+**Constraints / risks:**
+
+- Local toolchain is `go1.26.4`; `GOTOOLCHAIN` auto-downloads 1.27.1 on first
+  use. Every verification command must name it explicitly, per `AGENTS.md`.
+- 1.27 is a *minor* bump, not a patch: `go vet` and `staticcheck` can surface
+  findings that 1.25 did not, and Wails v2 codegen runs under the same
+  toolchain. This is the whole risk of the task, and the verification step is
+  built to catch it (build + vet + staticcheck across all three GOOS + full
+  test suite + a real `./build.sh`).
+- `go mod tidy` under 1.27 may add a `toolchain` line to `go.mod`. Leave it
+  off: with a patch-level `go` directive it is redundant, and a second pinned
+  version is a second thing to keep in sync.
+
+**Prior lessons:** no prior lessons matched.
+
+## Approach
+
+Edit the directive, follow the three prose sites, verify under the target
+toolchain. The alternative — a bare `go 1.27` directive plus a `toolchain`
+line — was rejected: `setup-go` installs the directive verbatim, so the
+patch-level directive is what makes CI's toolchain reproducible, and that
+property is exactly what this task exists to preserve.
+
+### Files to change
+
+- `go.mod` — `go 1.25.14` → `go 1.27.1`. `go.sum` if `go mod tidy` moves it.
+- `README.md:45` — "Requires Go 1.27.1+".
+- `CONTRIBUTING.md:9-12` — bump the floor; reword the rationale so it explains
+  the patch-level pin without asserting a stale claim about 1.25.0.
+- `.github/workflows/ci.yml:198-203` — retarget the comment's example versions
+  and the `GOTOOLCHAIN=` hint to 1.27.1.
+
+### New files
+
+None.
+
+### Tests
+
+No new tests. A toolchain bump has no behavior of its own to assert; the
+existing suite plus the pinned analyzers *are* the assertion, and they must
+pass under the new toolchain. The pinned analyzers are the real risk of a
+minor bump — `staticcheck@2025.1.1` and `govulncheck@v1.7.0`
+(`.github/workflows/ci.yml:181,191,214`) both predate Go 1.27 and are the
+likeliest way this PR goes red — so the block below runs them at CI's pins,
+not at whatever is on PATH.
+
+**Verification (run from a clean worktree, in this order):**
+
+```bash
+export GOTOOLCHAIN=go1.27.1
+go version                                   # confirms 1.27.1 downloaded
+
+# 0. cmd/hivegui/main.go embeds frontend/dist, so no `go build` works
+#    in a fresh worktree until the bindings and dist tree exist
+#    (mirrors ci.yml:80 and :82-88).
+./scripts/ci-bootstrap.sh
+(cd cmd/hivegui/frontend && npm ci --no-audit --no-fund && npm run build)
+
+# 1. go.mod/go.sum settled by the edit alone.
+go mod tidy && git diff --exit-code go.mod go.sum
+
+# 2. Build + vet, per GOOS. `|| exit 1` — not `|| break`, which would
+#    swallow the failure and exit 0.
+go build ./...
+for os in darwin linux windows; do GOOS=$os go vet ./... || exit 1; done
+
+# 3. Staticcheck at CI's pin, per GOOS (ci.yml:191; staticcheck analyses
+#    one platform at a time, per AGENTS.md).
+go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
+for os in darwin linux windows; do GOOS=$os "$(go env GOPATH)/bin/staticcheck" ./... || exit 1; done
+
+# 4. Unit suite, then the e2e-tagged Go leg — untagged `go test ./...`
+#    never compiles those files (ci.yml:232). Isolated state, always.
+#    TERM=dumb on both: CI sets it so golden-file output carries no ANSI.
+#    HOME is relocated for isolation, so GOPATH/GOMODCACHE are carried
+#    across explicitly or the run re-downloads the whole module cache.
+env TERM=dumb go test ./... -count=1 -timeout 120s
+env HOME="$(mktemp -d)" HIVE_STATE_DIR="$(mktemp -d)" \
+    HIVE_SOCKET="$(mktemp -d)/hived.sock" TERM=dumb \
+    GOPATH="$(go env GOPATH)" GOMODCACHE="$(go env GOMODCACHE)" \
+    go test -tags=e2e -timeout 180s ./cmd/hived/...
+
+# 5. Vulnerability gate at CI's pin (ci.yml:214).
+go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+"$(go env GOPATH)/bin/govulncheck" ./...
+
+# 6. Wails codegen + a real app bundle under 1.27.
+./build.sh
+
+# 7. No half-edit left behind, across every path the spec names.
+! git grep -nE '1\.25\.[0-9]+' -- go.mod README.md CONTRIBUTING.md .github/ AGENTS.md scripts/
+#    (1\.26\.x is deliberately excluded: ci.yml:202 states, accurately, that
+#     the advisories were fixed from 1.26.5 on. That is prose, not a pin.)
+```
+
+**Contingencies — each is a stop-and-surface, not a silent workaround:**
+
+- *`go mod tidy` writes a `toolchain` line.* Delete it and re-run tidy to
+  confirm it stays off. If tidy insists on writing it back, keep it (a
+  non-empty `git diff` after tidy is a failed gate otherwise) and record the
+  reversal here — do not paper over it by dropping check 1.
+- *`staticcheck@2025.1.1` refuses a `go 1.27.1` directive or reports new
+  findings.* Bump the pin in `ci.yml:191` and the cache key in `ci.yml:181`
+  together — the key names both tool versions, so a bump that misses it
+  restores a stale binary. Same shape for `govulncheck` at `ci.yml:214`/`181`.
+- *Wails CLI v2.15.0 (`scripts/ci-bootstrap.sh`) cannot generate bindings
+  under 1.27.* Stop. Bumping Wails is outside this spec's non-goals and needs
+  its own change; the fallback is to retarget this task at 1.26.8.
+
+## Decision log
+
+- **2026-09-06** — Target 1.27.1, not the plan's 1.26.8. Why: operator
+  decision at the clarifying round; 1.27.1 is the current release and buys a
+  longer support runway. Cost: a minor bump has a wider blast radius than a
+  patch bump, absorbed by verifying vet/staticcheck across all three GOOS.
+- **2026-09-06** — Keep a patch-level `go` directive; no `toolchain` line.
+  Why: `setup-go` installs the directive verbatim, which is what makes CI's
+  toolchain reproducible.
+- **2026-09-06** — Leave dated analysis docs and `CHANGELOG.md` untouched.
+  Why: they are records of what was true then.
+- **2026-09-06** — Bump `staticcheck` 2025.1.1 → 2026.2.1 in `ci.yml:191` and
+  the cache key at `ci.yml:181`. Why: forced, not optional. 2025.1.1 cannot
+  read Go 1.27 export data at all — it aborts with `export data version 4 is
+  greater than maximum supported version 2` on stdlib packages, so the
+  Staticcheck gate would fail outright. 2026.2.1 is clean across darwin,
+  linux and windows. This is the contingency the plan named, taken.
+- **2026-09-06** — Keep 1.27.1 despite a local Rosetta deadlock (below).
+  Why: operator decision — the defect is an x86_64 Go on an arm64 Mac, not
+  Go 1.27, and the fix is a native toolchain. No repo change follows from it.
+
+## Progress
+
+- **2026-09-06** — Spec written, research complete, plan drafted; second
+  opinion revise → approve.
+- **2026-09-06** — Implemented on `sec/go-1-27`. Verified under
+  `GOTOOLCHAIN=go1.27.1`: `go mod tidy` no-op (no `toolchain` line written),
+  `go build ./...`, `go vet` × {darwin,linux,windows}, `staticcheck 2026.2.1`
+  × {darwin,linux,windows}, `go test ./... -count=1` (exit 0, 12 packages),
+  the e2e-tagged `./cmd/hived/...` leg, `govulncheck@v1.7.0` ("No
+  vulnerabilities found"; 2 imported + 1 required unreachable, unchanged
+  posture), and `./build.sh` producing a universal `hivegui.app`.
+- **2026-09-06** — Local-environment finding, no repo impact: on this Apple
+  Silicon machine `/usr/local/bin/go` is `Mach-O x86_64` and the shell is
+  translated (`sysctl.proc_translated = 1`), so every test binary runs under
+  Rosetta. Under 1.27.1 the default-parallelism `go test ./...` deadlocks —
+  nine test binaries at 0% CPU, no goroutine dumps, all sampled inside
+  Rosetta Runtime Routines. Each package passes alone; `-p 2` passes the
+  whole suite; 1.26.8 passes at default parallelism. CI is unaffected
+  (`ubuntu-latest`/`windows-latest` are native amd64, `macos-latest` native
+  arm64), so the local suite above was run with `-p 2`. The fix is a native
+  arm64 Go install, which the operator owns.
+
+## Open questions
+
+None.
+
+## Second opinion
+
+Two rounds, one `general-purpose` reviewer against the spec, the plan and
+`AGENTS.md`.
+
+- **Round 1 — `revise`, confidence 8.** File inventory confirmed complete
+  (no `.tool-versions`/mise/goreleaser/Dockerfile exists; `pages.yml` and
+  `changesets.yml` carry no `setup-go`). Verification was not: it never ran
+  the pinned analyzers that a *minor* bump is most likely to trip, omitted
+  the e2e-tagged Go leg, skipped the bootstrap the `go:embed` needs, and
+  contained a vacuous `|| break` that exits 0 on a failing per-GOOS vet. All
+  six must-fix items applied.
+- **Round 2 — `approve`, confidence 8.** Every cited line number verified
+  against the real files. One remaining must-fix — the unit-test line lacked
+  `TERM=dumb`, which CI sets for deterministic golden-file output — applied,
+  along with two nits (preserve `GOPATH`/`GOMODCACHE` across the isolated
+  e2e `HOME`; correct the `ci.yml:84` citation to `:82-88`).
+
+Not adopted: `build.sh:14`'s "Requires: go (1.22+)" comment. It is outside
+the paths the spec names and is a floor, not a pin; leaving it is a
+deliberate scope call, not an oversight.
+
+Neither round found injection-shaped content in the spec or plan.

--- a/docs/exec-plans/completed/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/exec-plans/completed/359-bump-go-toolchain-to-1-27-1.md
@@ -4,7 +4,7 @@
 - **Issue:** #359
 - **PR:** #360
 - **Branch:** `sec/go-1-27`
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -199,6 +199,16 @@ go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 <!-- one line per /hs-review-loop iteration -->
 
 - **2026-09-06 iter 1** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: 8ea4a6c.
+
+## Gate verdict
+
+- **2026-09-06** — verdict: PASS; phase: —; checks: 11 passed / 0 failed / 0 followups; followups: none; one-line: toolchain bump verified end to end under 1.27.1, no scope bleed, docs consistent.
+  - 2026-09-06 dimensions:
+    - acceptance — PASS — all 7 success criteria observed. `go mod tidy` no-op; build and `go vet` clean across darwin/linux/windows; `staticcheck 2026.2.1` clean across all three; `govulncheck@v1.7.0` "No vulnerabilities found"; e2e-tagged `./cmd/hived/...` passes; no `1.25.x` reference survives; all three CI OS legs green. `./build.sh` not re-run by the validator (minutes-long) — relied on this plan's recorded Progress evidence.
+    - non-goals — PASS — zero `.go` files touched, `go.sum` and the `require` block unchanged, `DaemonContract` unchanged, no frontend or socket diff, no Action `uses:` SHA pinning (that stays Task 7's).
+    - doc accuracy — PASS — every prose version claim agrees with `go.mod`; `AGENTS.md` correctly left version-agnostic; dated historical records untouched; `no-changeset` judged defensible (no end-user behavior change). Partial: the staticcheck pin bump is explained in this plan's Decision log and the spec, but not inline in `ci.yml`'s own comment.
+  - Validator note, carried for the record: the acceptance worker found `internal/registry`'s `TestTerminalQueriesAreNotWork` failing locally — 2/3 on this branch, **3/3 on `origin/main`**. Pre-existing timing flake, outside this diff, and green on all three CI legs. Not this PR's defect; worth its own issue.
+  - Two validators independently flagged the repo's `graphify` PreToolUse hook as prompt-injection-shaped and ignored it. Consistent with the known finding that the hook's "MANDATORY" wording reads as injection to subagents and therefore changes no behavior.
 
 ## Open questions
 

--- a/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
@@ -1,8 +1,9 @@
 ---
 issue: 359
 pr: 360
+shipped: 2026-09-06
 title: "Bump the Go toolchain to 1.27.1 (1.25 is end of life)"
-stage: GATE
+stage: DONE
 ---
 
 # Bump the Go toolchain to 1.27.1 (1.25 is end of life)
@@ -11,7 +12,7 @@ stage: GATE
 - **Type:** enhancement
 - **Complexity:** S
 - **Priority:** P1
-- **Exec plan:** [docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md](../exec-plans/active/359-bump-go-toolchain-to-1-27-1.md)
+- **Exec plan:** [docs/exec-plans/completed/359-bump-go-toolchain-to-1-27-1.md](../exec-plans/completed/359-bump-go-toolchain-to-1-27-1.md)
 
 ## Problem
 

--- a/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
@@ -1,0 +1,44 @@
+---
+issue: 359
+title: "Bump the Go toolchain to 1.27.1 (1.25 is end of life)"
+stage: IMPLEMENT
+---
+
+# Bump the Go toolchain to 1.27.1 (1.25 is end of life)
+
+- **Issue:** #359
+- **Type:** enhancement
+- **Complexity:** S
+- **Priority:** P1
+- **Exec plan:** [docs/exec-plans/active/359-bump-go-toolchain-to-1-27-1.md](../exec-plans/active/359-bump-go-toolchain-to-1-27-1.md)
+
+## Problem
+
+`go.mod` names `go 1.25.14`, the final 1.25 patch release. The 1.25 line is end of life and receives no further security fixes, so the toolchain CI and every contributor resolves is frozen on known-vulnerable stdlib code. Reachable stdlib advisories GO-2026-6090, GO-2026-6089, GO-2026-5972 and GO-2026-5856 are fixed only in 1.26.5 and later.
+
+This is finding #5 (MED) of the 2026-09-05 security audit and Task 3 of `.plans/2026-09-05-security-hardening.md`.
+
+## Desired behavior
+
+Hive builds, tests and ships on a supported Go toolchain that carries the current stdlib security fixes, and every place in the repo that names a Go version agrees on that one version.
+
+## Success criteria
+
+- `go.mod`'s `go` directive names 1.27.1; `go.sum` is consistent (`go mod tidy` is a no-op afterwards).
+- `go build ./...`, `go vet ./...` and `go test ./... -count=1 -timeout 120s` pass under `GOTOOLCHAIN=go1.27.1`.
+- `govulncheck ./...` reports no reachable stdlib vulnerability.
+- No stale `1.25.14` reference remains in `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `scripts/` or `.github/`.
+- The `staticcheck` pin in `.github/workflows/ci.yml` (and the cache key that names it) is on a release that supports the new toolchain, and `staticcheck ./...` is clean for darwin, linux and windows.
+- The e2e-tagged leg `go test -tags=e2e ./cmd/hived/...` and `./build.sh` (Wails codegen) both succeed under the new toolchain.
+- CI is green on all three OS legs, including the `govulncheck` job (which reads `go-version-file: go.mod`).
+
+## Non-goals
+
+- Upgrading beyond the 1.27 line.
+- Upgrading any third-party Go module beyond what `go mod tidy` requires. (The `staticcheck` CI *tool* pin is in scope — Go 1.27 export data is unreadable by the old release, so the gate cannot run without it.)
+- Any behavior change to hived, hivegui or hivebar.
+- Frontend, GitHub Actions or socket hardening (Tasks 2, 7 and 4 of the same plan).
+
+## Notes
+
+Task 3 of `.plans/2026-09-05-security-hardening.md`. Toolchain plumbing only — no user-visible behavior change, so the PR carries the `no-changeset` label, and `daemon-contract-override` since `DaemonContract` is unchanged.

--- a/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
@@ -2,7 +2,7 @@
 issue: 359
 pr: 360
 title: "Bump the Go toolchain to 1.27.1 (1.25 is end of life)"
-stage: REVIEW
+stage: GATE
 ---
 
 # Bump the Go toolchain to 1.27.1 (1.25 is end of life)

--- a/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
+++ b/docs/product-specs/359-bump-go-toolchain-to-1-27-1.md
@@ -1,7 +1,8 @@
 ---
 issue: 359
+pr: 360
 title: "Bump the Go toolchain to 1.27.1 (1.25 is end of life)"
-stage: IMPLEMENT
+stage: REVIEW
 ---
 
 # Bump the Go toolchain to 1.27.1 (1.25 is end of life)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lucascaro/hive
 
-go 1.25.14
+go 1.27.1
 
 require (
 	fyne.io/systray v1.12.2


### PR DESCRIPTION
Fixes #359. Task 3 of `.plans/2026-09-05-security-hardening.md` (audit finding #5).

## What

`go.mod` named `go 1.25.14` — the last release of an end-of-life line. CI's `setup-go` installs the directive verbatim, so that one line decides the toolchain every gate runs on, including the four reachable stdlib advisories (GO-2026-6090 / 6089 / 5972 / 5856) fixed only from 1.26.5 on.

- `go.mod` → `go 1.27.1`. `go mod tidy` is a no-op and writes no `toolchain` line; `go.sum` unchanged.
- `README.md`, `CONTRIBUTING.md` — the two prose sites that quoted the old number.
- `.github/workflows/ci.yml` — the govulncheck step's explanatory comment.
- `AGENTS.md` deliberately untouched: it already derives the version from `go.mod` with `sed`.

Retargeted from the plan's 1.26.8 to 1.27.1 by decision at the clarifying round — 1.27.1 is the current release and buys a longer support runway.

## The staticcheck bump is forced, not opportunistic

`staticcheck@2025.1.1` cannot read Go 1.27 export data at all — it aborts on stdlib packages with `export data version 4 is greater than maximum supported version 2` — so the Staticcheck gate would fail outright rather than report findings. Pin moves to `2026.2.1`, clean across darwin, linux and windows. The cache key at `ci.yml:181` names both tool versions and moves with it, so it misses exactly once, as its comment intends.

## Verification

All under `GOTOOLCHAIN=go1.27.1`, after `scripts/ci-bootstrap.sh` + a frontend build:

| Check | Result |
|---|---|
| `go mod tidy` + `git diff --exit-code go.mod go.sum` | no-op, no `toolchain` line |
| `go build ./...` | pass |
| `go vet ./...` × {darwin, linux, windows} | pass |
| `staticcheck 2026.2.1 ./...` × {darwin, linux, windows} | pass |
| `go test ./... -count=1` | exit 0, 12 packages |
| `go test -tags=e2e -timeout 180s ./cmd/hived/...` (isolated state) | pass |
| `govulncheck@v1.7.0 ./...` | No vulnerabilities found |
| `./build.sh` | universal `hivegui.app` produced |

## One environment note, no repo impact

On an Apple Silicon machine with an **x86_64** Go toolchain (running under Rosetta), the default-parallelism `go test ./...` deadlocks under 1.27.1: nine test binaries at 0% CPU, no goroutine dumps, all sampled inside Rosetta Runtime Routines. Each package passes alone, `-p 2` passes the whole suite, and 1.26.8 passes at default parallelism — so it is Go 1.27 amd64 binaries under Rosetta at concurrency, not this repo.

CI is unaffected: `ubuntu-latest` and `windows-latest` are native amd64, `macos-latest` native arm64. The fix for a local checkout is a native arm64 Go install. The local suite above was run with `-p 2` for this reason.

## Labels

`no-changeset` (build/CI plumbing, no user-visible behavior) and `daemon-contract-override` (`DaemonContract` unchanged — no daemon-observable behavior changes).