### PR TITLE
fix(daemon): per-user socket dir + events-only socket for agent children

### DIFF
--- a/.changesets/socket-hardening.md
+++ b/.changesets/socket-hardening.md
@@ -11,14 +11,14 @@ bump: minor
   shared machine another account could previously plant a fake socket
   there and read everything you typed.
 - Programs running inside a Hive session can now only report their state
-  back to Hive and capture ideas for their own project (`hive idea`). They
+  back to Hive and capture ideas for their own project (`hived idea`). They
   could previously use the same connection to create, attach to or kill
   sessions, remove worktrees, shut the daemon down, or list every session
   you have open. This raises the bar rather than sealing a boundary — an
   agent runs as you and Hive does not sandbox it — so `SECURITY.md` now says
   so plainly. Requires a daemon restart, which Hive will prompt for after
   the update.
-- `hive idea list --all` is refused from inside a session, where `hive idea
+- `hived idea list --all` is refused from inside a session, where `hived idea
   list` now shows that session's project. `--all` works from an ordinary
   shell, which it did not before — it needed a session's environment and
   was therefore unreachable in every context the moment the in-session case

--- a/.changesets/socket-hardening.md
+++ b/.changesets/socket-hardening.md
@@ -11,7 +11,16 @@ bump: minor
   shared machine another account could previously plant a fake socket
   there and read everything you typed.
 - Programs running inside a Hive session can now only report their state
-  back to Hive and capture ideas (`hive idea`). They could previously use
-  the same connection to create, attach to or kill sessions, remove
-  worktrees, shut the daemon down, or list every session you have open.
-  Requires a daemon restart, which Hive will prompt for after the update.
+  back to Hive and capture ideas for their own project (`hive idea`). They
+  could previously use the same connection to create, attach to or kill
+  sessions, remove worktrees, shut the daemon down, or list every session
+  you have open. This raises the bar rather than sealing a boundary — an
+  agent runs as you and Hive does not sandbox it — so `SECURITY.md` now says
+  so plainly. Requires a daemon restart, which Hive will prompt for after
+  the update.
+- `hive idea list --all` is refused from inside a session, where it now
+  lists only that session's project. Run it from an ordinary shell for the
+  cross-project view.
+- Hive refuses to start a second daemon against one state directory. The
+  old guard was the socket file, which stopped working the moment the
+  socket moved; it is now a lock on the state directory itself.

--- a/.changesets/socket-hardening.md
+++ b/.changesets/socket-hardening.md
@@ -18,9 +18,11 @@ bump: minor
   agent runs as you and Hive does not sandbox it — so `SECURITY.md` now says
   so plainly. Requires a daemon restart, which Hive will prompt for after
   the update.
-- `hive idea list --all` is refused from inside a session, where it now
-  lists only that session's project. Run it from an ordinary shell for the
-  cross-project view.
+- `hive idea list --all` is refused from inside a session, where `hive idea
+  list` now shows that session's project. `--all` works from an ordinary
+  shell, which it did not before — it needed a session's environment and
+  was therefore unreachable in every context the moment the in-session case
+  was closed.
 - Hive refuses to start a second daemon against one state directory. The
   old guard was the socket file, which stopped working the moment the
   socket moved; it is now a lock on the state directory itself.

--- a/.changesets/socket-hardening.md
+++ b/.changesets/socket-hardening.md
@@ -1,0 +1,16 @@
+---
+issue: null
+pr: null
+type: fixed
+bump: minor
+---
+- The daemon socket moved out of the shared `/tmp` into a directory only
+  your user can reach — `$TMPDIR/hive/` on macOS, `$XDG_RUNTIME_DIR/hive/`
+  on Linux — and Hive now checks that directory's owner and permissions
+  before trusting it, whether it is binding to it or dialing it. On a
+  shared machine another account could previously plant a fake socket
+  there and read everything you typed.
+- Programs running inside a Hive session can now only report their state
+  back to Hive. They could previously use the same connection to create,
+  attach to or kill sessions and remove worktrees. Requires a daemon
+  restart, which Hive will prompt for after the update.

--- a/.changesets/socket-hardening.md
+++ b/.changesets/socket-hardening.md
@@ -11,6 +11,7 @@ bump: minor
   shared machine another account could previously plant a fake socket
   there and read everything you typed.
 - Programs running inside a Hive session can now only report their state
-  back to Hive. They could previously use the same connection to create,
-  attach to or kill sessions and remove worktrees. Requires a daemon
-  restart, which Hive will prompt for after the update.
+  back to Hive and capture ideas (`hive idea`). They could previously use
+  the same connection to create, attach to or kill sessions, remove
+  worktrees, shut the daemon down, or list every session you have open.
+  Requires a daemon restart, which Hive will prompt for after the update.

--- a/.changesets/socket-hardening.md
+++ b/.changesets/socket-hardening.md
@@ -1,6 +1,6 @@
 ---
 issue: null
-pr: null
+pr: 361
 type: fixed
 bump: minor
 ---

--- a/.changesets/socket-hardening.md
+++ b/.changesets/socket-hardening.md
@@ -24,5 +24,13 @@ bump: minor
   was therefore unreachable in every context the moment the in-session case
   was closed.
 - Hive refuses to start a second daemon against one state directory. The
-  old guard was the socket file, which stopped working the moment the
-  socket moved; it is now a lock on the state directory itself.
+  old guard was the socket file, which only worked while the socket path
+  stayed put; it is now a lock on the state directory itself, which is
+  the thing that can only have one writer.
+- Upgrading is handled for you. Because the socket moved, a Hive daemon
+  left running from before the update would otherwise have been invisible
+  to the new one, and you would have ended up with two of them managing
+  the same sessions. The app now finds that older daemon and offers the
+  same "restart to finish updating" banner it shows for any out-of-date
+  daemon; restarting from there shuts the old one down and starts the new
+  one. Nothing to do by hand.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ What works:
   hived idea add "the grid loses focus after ⌘G twice"   # kind: idea
   hived idea add -k bug "sidebar drag handle is 1px off"
   hived idea list                                        # this project
-  hived idea list --all                                  # every project
   ```
+
+  `hived idea list --all` spans every project. It is refused inside a
+  session — where a note is scoped to the session's own project — so run
+  it from an ordinary shell.
 
   The project is resolved from the session, so a note lands where the
   work is even after the session is reassigned. An idea outlives the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,11 +33,13 @@ daemon (`hived`) listens on a per-user Unix socket — `$TMPDIR/hive/hived.sock`
 on macOS (launchd's private per-user temp dir),
 `$XDG_RUNTIME_DIR/hive/hived.sock` on Linux (falling back to the state
 directory when it is unset), `%LOCALAPPDATA%\Hive\hived.sock` on Windows
-(`HIVE_SOCKET` overrides all three). Hive creates that directory with mode
-`0o700`, and every component — the daemon before binding, the GUI and the menu
-bar before dialing — refuses a directory that is a symlink, is not owned by the
-current user, or is reachable by group or other. None of the defaults live under
-the world-writable `/tmp`.
+(`HIVE_SOCKET` overrides all three). Both POSIX defaults fall back to the state
+directory rather than to `/tmp`: Linux when `$XDG_RUNTIME_DIR` is unset, macOS
+when `$TMPDIR` resolves to the shared `/tmp`. Hive creates that directory with
+mode `0o700`, and every Go component — the daemon before binding, the GUI, the
+menu bar, `hived idea` and the hook client before dialing — refuses a directory
+that is a symlink, is not owned by the current user, or is reachable by group or
+other. None of the defaults live under the world-writable `/tmp`.
 
 ### Multi-User Systems
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,10 +48,13 @@ On shared machines (e.g., a development server with multiple accounts):
   neither connect to the daemon nor plant an impostor socket for Hive to
   connect to.
 - Programs running inside a session inherit `HIVE_SOCKET`, which names a
-  second, events-only socket. It accepts state reports (`HELLO{mode:event}`)
-  and answers every other mode with `mode_not_allowed`, so a subprocess of an
-  agent cannot use the environment it was handed to create, attach to, or kill
-  sessions, or remove worktrees.
+  second, narrowed socket. It serves state reports (`HELLO{mode:event}`) and
+  the idea verbs `hive idea` needs (`HELLO{mode:session}` — `ADD_IDEA` and
+  `LIST_IDEAS`, plus a session snapshot narrowed to the caller's own session),
+  and answers everything else with `mode_not_allowed`. A subprocess of an agent
+  therefore cannot use the environment it was handed to create, attach to or
+  kill sessions, remove worktrees, shut the daemon down, or enumerate your
+  other sessions.
 - Log files (`hived.log`, `hivegui.log`) are created with mode `0o600` and
   are not readable by other users.
 - Agent session output is not exposed outside the daemon process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,21 +29,29 @@ You can expect an acknowledgement within 72 hours.
 ### Single-User Systems
 
 Hive is designed for personal use on a single-user machine. The session
-daemon (`hived`) listens on a per-user Unix socket — `/tmp/hive-<uid>/hived.sock`
-on macOS, `$XDG_RUNTIME_DIR/hive/hived.sock` on Linux,
-`%LOCALAPPDATA%\Hive\hived.sock` on Windows (`HIVE_SOCKET` overrides all
-three). Hive creates the containing directory with mode `0o700`, so only the
-owner can reach the socket — but it does not re-check the mode of a directory
-that already exists. On macOS, and on Linux without `XDG_RUNTIME_DIR`, that
-directory lives under world-writable `/tmp`, so on a shared machine verify its
-ownership and permissions before trusting the socket.
+daemon (`hived`) listens on a per-user Unix socket — `$TMPDIR/hive/hived.sock`
+on macOS (launchd's private per-user temp dir),
+`$XDG_RUNTIME_DIR/hive/hived.sock` on Linux (falling back to the state
+directory when it is unset), `%LOCALAPPDATA%\Hive\hived.sock` on Windows
+(`HIVE_SOCKET` overrides all three). Hive creates that directory with mode
+`0o700`, and every component — the daemon before binding, the GUI and the menu
+bar before dialing — refuses a directory that is a symlink, is not owned by the
+current user, or is reachable by group or other. None of the defaults live under
+the world-writable `/tmp`.
 
 ### Multi-User Systems
 
 On shared machines (e.g., a development server with multiple accounts):
 
-- The socket directory is created `0o700`, so other users cannot connect to the
-  daemon directly — subject to the pre-existing-directory caveat above.
+- The socket directory is created `0o700` and re-verified (owner, mode, and
+  that it is not a symlink) on every bind and every dial, so other users can
+  neither connect to the daemon nor plant an impostor socket for Hive to
+  connect to.
+- Programs running inside a session inherit `HIVE_SOCKET`, which names a
+  second, events-only socket. It accepts state reports (`HELLO{mode:event}`)
+  and answers every other mode with `mode_not_allowed`, so a subprocess of an
+  agent cannot use the environment it was handed to create, attach to, or kill
+  sessions, or remove worktrees.
 - Log files (`hived.log`, `hivegui.log`) are created with mode `0o600` and
   are not readable by other users.
 - Agent session output is not exposed outside the daemon process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,13 +48,25 @@ On shared machines (e.g., a development server with multiple accounts):
   neither connect to the daemon nor plant an impostor socket for Hive to
   connect to.
 - Programs running inside a session inherit `HIVE_SOCKET`, which names a
-  second, narrowed socket. It serves state reports (`HELLO{mode:event}`) and
-  the idea verbs `hive idea` needs (`HELLO{mode:session}` — `ADD_IDEA` and
-  `LIST_IDEAS`, plus a session snapshot narrowed to the caller's own session),
-  and answers everything else with `mode_not_allowed`. A subprocess of an agent
-  therefore cannot use the environment it was handed to create, attach to or
-  kill sessions, remove worktrees, shut the daemon down, or enumerate your
-  other sessions.
+  second, narrowed socket rather than the control socket. It serves state
+  reports (`HELLO{mode:event}`) and the idea verbs `hive idea` needs
+  (`HELLO{mode:session}` — `ADD_IDEA` and `LIST_IDEAS`, both bound to the
+  caller's own session and project, plus a session snapshot narrowed to that
+  session's id and project). Everything else is answered with
+  `mode_not_allowed`, so what a session's child processes inherit does not
+  let them create, attach to or kill sessions, remove worktrees, shut the
+  daemon down, or read another project's ideas.
+
+  **This is defence in depth, not a security boundary.** The control socket
+  sits next to the events one, and both are owned by you: a process running as
+  your user can find it and connect to it, whatever `HIVE_SOCKET` says. POSIX
+  permissions cannot separate two processes running as the same user, and Hive
+  does not sandbox the agents it launches (see *Agent Processes* below). What
+  the narrowed socket buys is that the obvious path — the environment variable
+  a tool was handed — no longer leads to session creation, and that an
+  integration written against `HIVE_SOCKET` cannot reach those verbs by
+  accident. Treat an agent you run under Hive as having your privileges,
+  because it does.
 - Log files (`hived.log`, `hivegui.log`) are created with mode `0o600` and
   are not readable by other users.
 - Agent session output is not exposed outside the daemon process.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,10 @@ when `$TMPDIR` resolves to the shared `/tmp`. Hive creates that directory with
 mode `0o700`, and every Go component — the daemon before binding, the GUI, the
 menu bar, `hived idea` and the hook client before dialing — refuses a directory
 that is a symlink, is not owned by the current user, or is reachable by group or
-other. None of the defaults live under the world-writable `/tmp`.
+other. None of the defaults live under the world-writable `/tmp`. The Pi
+reporter extension (`internal/agent/pi/hive.ts`) is the exception: it runs in
+Pi's JavaScript tier and only ever sends state observations on the events
+socket, so it dials without the check.
 
 ### Multi-User Systems
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,9 +49,13 @@ socket, so it dials without the check.
 On shared machines (e.g., a development server with multiple accounts):
 
 - The socket directory is created `0o700` and re-verified (owner, mode, and
-  that it is not a symlink) on every bind and every dial, so other users can
-  neither connect to the daemon nor plant an impostor socket for Hive to
-  connect to.
+  that it is not a symlink) before every bind and before every dial the Go
+  components make — including the probe that looks for a daemon left over from
+  before the socket moved. Another user can therefore neither connect to the
+  daemon nor plant a socket Hive would connect to, or treat as a daemon. The
+  exceptions are the Pi reporter extension, which runs in Pi's JavaScript tier
+  and only sends state observations, and `hived-ws-bridge`, which is a test
+  harness that dials a socket its caller names explicitly.
 - Programs running inside a session inherit `HIVE_SOCKET`, which names a
   second, narrowed socket rather than the control socket. It serves state
   reports (`HELLO{mode:event}`) and the idea verbs `hive idea` needs

--- a/cmd/hivebar/actions.go
+++ b/cmd/hivebar/actions.go
@@ -110,7 +110,7 @@ func spawnHived() error {
 // hivebar has none, and the GUI's own reconnect loop picks the new
 // daemon up.
 func RestartDaemon(shutdown func()) error {
-	sock := hdaemon.SocketPath()
+	sock := activeSocket()
 	shutdown()
 	if !socketDead(sock, 5*time.Second) {
 		return fmt.Errorf("hived still answering on %s; not restarting", sock)
@@ -120,6 +120,24 @@ func RestartDaemon(shutdown func()) error {
 	}
 	log.Printf("hivebar: restarted hived")
 	return nil
+}
+
+// activeSocket is the socket hivebar talks to. Across the 2026-09
+// socket move that can be the OLD default, when a pre-move daemon is
+// still serving it: hivebar has no banner to offer a restart with, so
+// the useful thing is to keep showing the sessions of the daemon that
+// actually holds them rather than to report none. Both the reconnect
+// loop and the restart action resolve through here, so they cannot
+// disagree about which daemon is being restarted.
+//
+// Resolved per call rather than cached: hivebar's client loop
+// reconnects forever, and the very next reconnect after a restart must
+// find the NEW daemon. Delete with daemon.LegacySocketPath.
+func activeSocket() string {
+	if legacy, alive := hdaemon.LegacyDaemonAlive(); alive {
+		return legacy
+	}
+	return hdaemon.SocketPath()
 }
 
 // socketDead reports whether nothing answers on sock within budget.

--- a/cmd/hivebar/actions.go
+++ b/cmd/hivebar/actions.go
@@ -133,12 +133,7 @@ func RestartDaemon(shutdown func()) error {
 // Resolved per call rather than cached: hivebar's client loop
 // reconnects forever, and the very next reconnect after a restart must
 // find the NEW daemon. Delete with daemon.LegacySocketPath.
-func activeSocket() string {
-	if legacy, alive := hdaemon.LegacyDaemonAlive(); alive {
-		return legacy
-	}
-	return hdaemon.SocketPath()
-}
+func activeSocket() string { return hdaemon.ActiveSocketPath() }
 
 // socketDead reports whether nothing answers on sock within budget.
 // Dialling, not signalling: a zombie daemon answers signal(0) forever

--- a/cmd/hivebar/client.go
+++ b/cmd/hivebar/client.go
@@ -89,7 +89,14 @@ func (c *Client) Run() {
 
 // session runs one connection to exhaustion.
 func (c *Client) session() error {
-	conn, err := net.DialTimeout("unix", hdaemon.SocketPath(), 2*time.Second)
+	sock := hdaemon.SocketPath()
+	// Refuse an impostor before handshaking with it: hivebar never
+	// creates the directory (the daemon or the GUI does), so a check is
+	// all that is wanted here.
+	if err := hdaemon.CheckSocketDir(sock); err != nil {
+		return err
+	}
+	conn, err := net.DialTimeout("unix", sock, 2*time.Second)
 	if err != nil {
 		return err
 	}

--- a/cmd/hivebar/client.go
+++ b/cmd/hivebar/client.go
@@ -89,7 +89,7 @@ func (c *Client) Run() {
 
 // session runs one connection to exhaustion.
 func (c *Client) session() error {
-	sock := hdaemon.SocketPath()
+	sock := activeSocket()
 	// Refuse an impostor before handshaking with it: hivebar never
 	// creates the directory (the daemon or the GUI does), so a check is
 	// all that is wanted here.

--- a/cmd/hivebar/singleton.go
+++ b/cmd/hivebar/singleton.go
@@ -29,7 +29,7 @@ import (
 // exit — the kernel does it — but a test needs to hand the lock back.
 func claimSingleton() (release func(), ok bool) {
 	path := filepath.Join(registry.StateDir(), "hivebar.lock")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		// No state dir means no daemon either. Refuse rather than
 		// running unlocked: an unlocked hivebar is how you get two.
 		return nil, false

--- a/cmd/hived/hook.go
+++ b/cmd/hived/hook.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lucascaro/hive/internal/daemon"
 	"github.com/lucascaro/hive/internal/wire"
 )
 
@@ -177,6 +178,12 @@ func firstString(p hookPayload, keys ...string) string {
 // closes without waiting for a reply — the daemon sends none in
 // ModeEvent.
 func sendHookEvent(sock string, ev wire.AgentEvent) error {
+	// The hook reports what the user is doing. Check the socket
+	// directory before handing that to whatever is listening: the path
+	// arrives in an inherited environment variable.
+	if err := daemon.CheckSocketDir(sock); err != nil {
+		return err
+	}
 	conn, err := net.DialTimeout("unix", sock, hookDialTimeout)
 	if err != nil {
 		return err

--- a/cmd/hived/hook_integration_test.go
+++ b/cmd/hived/hook_integration_test.go
@@ -113,7 +113,10 @@ func findSessionByID(d *daemon.Daemon, id string) (wire.SessionInfo, bool) {
 func runHookFixture(t *testing.T, d *daemon.Daemon, sessionID, fixture string) {
 	t.Helper()
 	t.Setenv("HIVE_SESSION_ID", sessionID)
-	t.Setenv("HIVE_SOCKET", d.SocketPath())
+	// The events socket, not the control one: that is what a spawned
+	// session's environment carries, so pointing this at SocketPath
+	// would exercise wiring production no longer uses.
+	t.Setenv("HIVE_SOCKET", d.EventSocketPath())
 	raw := readFixture(t, fixture)
 	runHook(bytesReader(raw))
 }

--- a/cmd/hived/idea.go
+++ b/cmd/hived/idea.go
@@ -111,9 +111,20 @@ func ideaAdd(args []string, stdout io.Writer) error {
 func ideaList(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("idea list", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	all := fs.Bool("all", false, "list every project's ideas (refused from inside a session)")
+	all := fs.Bool("all", false, "list every project's ideas (run outside a session)")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+
+	// --all is the one thing here that is NOT about the caller's own
+	// session, and the daemon refuses it on a session connection —
+	// everything a session's children inherit is scoped to that
+	// session's project. So it takes the other road: the control
+	// socket, dialled from an ordinary shell the way hivebar does.
+	// Inside a session both paths exist, and the session one wins, so
+	// the refusal the user gets names the reason.
+	if *all {
+		return listAllIdeas(stdout)
 	}
 
 	sessionID, sock, err := ideaEnv()
@@ -133,20 +144,18 @@ func ideaList(args []string, stdout io.Writer) error {
 	// whatever had arrived by then: the snapshot and the reply are
 	// written by different goroutines in the daemon and can interleave.
 	projectID := ""
-	if !*all {
-		sessions, err := awaitSessions(c)
-		if err != nil {
-			return err
+	sessions, err := awaitSessions(c)
+	if err != nil {
+		return err
+	}
+	for _, s := range sessions {
+		if s.ID == sessionID {
+			projectID = s.ProjectID
+			break
 		}
-		for _, s := range sessions {
-			if s.ID == sessionID {
-				projectID = s.ProjectID
-				break
-			}
-		}
-		if projectID == "" {
-			return errNotInSession
-		}
+	}
+	if projectID == "" {
+		return errNotInSession
 	}
 	if err := c.WriteJSON(wire.FrameListIdeas, wire.ListIdeasReq{ProjectID: projectID}); err != nil {
 		return err
@@ -155,9 +164,7 @@ func ideaList(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	for _, i := range ideas {
-		fmt.Fprintf(stdout, "%s  %-8s %-7s %s\n", i.ID, i.Kind, i.Status, oneLine(i.Text))
-	}
+	printIdeas(stdout, ideas)
 	return nil
 }
 
@@ -172,6 +179,52 @@ func oneLine(s string) string {
 		return s[:i] + " …"
 	}
 	return s
+}
+
+// listAllIdeas lists every project's ideas over the control socket.
+// Deliberately not reachable from a session connection: HIVE_SOCKET
+// there names the events socket, which scopes every idea verb to the
+// caller's own project.
+func listAllIdeas(stdout io.Writer) error {
+	if os.Getenv("HIVE_SESSION_ID") != "" {
+		return errors.New("`idea list --all` is not available inside a Hive session; run it from an ordinary shell")
+	}
+	sock := daemon.SocketPath()
+	if err := daemon.CheckSocketDir(sock); err != nil {
+		return err
+	}
+	conn, err := net.DialTimeout("unix", sock, ideaDialTimeout)
+	if err != nil {
+		return fmt.Errorf("cannot reach the daemon at %s: %w", sock, err)
+	}
+	_ = conn.SetDeadline(time.Now().Add(ideaDeadline))
+	c, err := wire.Handshake(conn, wire.Hello{
+		Version: wire.PROTOCOL_VERSION,
+		Client:  "hived-idea/" + buildinfo.Version(),
+		BuildID: buildinfo.BuildID(),
+		Mode:    wire.ModeControl,
+	})
+	if err != nil {
+		conn.Close()
+		return err
+	}
+	defer c.Close()
+	if err := c.WriteJSON(wire.FrameListIdeas, wire.ListIdeasReq{}); err != nil {
+		return err
+	}
+	ideas, err := awaitIdeas(c)
+	if err != nil {
+		return err
+	}
+	printIdeas(stdout, ideas)
+	return nil
+}
+
+// printIdeas renders the one-row-per-idea listing both list paths share.
+func printIdeas(stdout io.Writer, ideas []wire.IdeaInfo) {
+	for _, i := range ideas {
+		fmt.Fprintf(stdout, "%s  %-8s %-7s %s\n", i.ID, i.Kind, i.Status, oneLine(i.Text))
+	}
 }
 
 func ideaEnv() (sessionID, sock string, err error) {

--- a/cmd/hived/idea.go
+++ b/cmd/hived/idea.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/lucascaro/hive/internal/buildinfo"
+	"github.com/lucascaro/hive/internal/daemon"
 	"github.com/lucascaro/hive/internal/wire"
 )
 
@@ -110,7 +111,7 @@ func ideaAdd(args []string, stdout io.Writer) error {
 func ideaList(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("idea list", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	all := fs.Bool("all", false, "list every project's ideas, not just this session's")
+	all := fs.Bool("all", false, "list every project's ideas (refused from inside a session)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -183,6 +184,12 @@ func ideaEnv() (sessionID, sock string, err error) {
 }
 
 func ideaDial(sock, sessionID string) (*wire.Client, error) {
+	// HIVE_SOCKET is inherited, and a socket that answers is not
+	// automatically ours — check the directory before handshaking, the
+	// same as every other client does.
+	if err := daemon.CheckSocketDir(sock); err != nil {
+		return nil, err
+	}
 	conn, err := net.DialTimeout("unix", sock, ideaDialTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("cannot reach the daemon at %s: %w", sock, err)

--- a/cmd/hived/idea.go
+++ b/cmd/hived/idea.go
@@ -80,7 +80,7 @@ func ideaAdd(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	c, err := ideaDial(sock)
+	c, err := ideaDial(sock, sessionID)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func ideaList(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	c, err := ideaDial(sock)
+	c, err := ideaDial(sock, sessionID)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func ideaEnv() (sessionID, sock string, err error) {
 	return sessionID, sock, nil
 }
 
-func ideaDial(sock string) (*wire.Client, error) {
+func ideaDial(sock, sessionID string) (*wire.Client, error) {
 	conn, err := net.DialTimeout("unix", sock, ideaDialTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("cannot reach the daemon at %s: %w", sock, err)
@@ -192,7 +192,12 @@ func ideaDial(sock string) (*wire.Client, error) {
 		Version: wire.PROTOCOL_VERSION,
 		Client:  "hived-idea/" + buildinfo.Version(),
 		BuildID: buildinfo.BuildID(),
-		Mode:    wire.ModeControl,
+		// ModeSession, not ModeControl: HIVE_SOCKET names the daemon's
+		// events socket, which serves the idea verbs and nothing else.
+		// The session id narrows the SESSIONS snapshot below to our own
+		// entry, which is all `list` needs to resolve its project.
+		Mode:      wire.ModeSession,
+		SessionID: sessionID,
 	})
 	if err != nil {
 		conn.Close()

--- a/cmd/hived/idea.go
+++ b/cmd/hived/idea.go
@@ -189,7 +189,12 @@ func listAllIdeas(stdout io.Writer) error {
 	if os.Getenv("HIVE_SESSION_ID") != "" {
 		return errors.New("`idea list --all` is not available inside a Hive session; run it from an ordinary shell")
 	}
-	sock := daemon.SocketPath()
+	// ActiveSocketPath, not SocketPath: during the socket migration the
+	// daemon holding the ideas may still be the pre-move one, and the
+	// GUI and hivebar both talk to it. Reporting "is hived running?"
+	// while the app shows that daemon's sessions would be the one
+	// answer that is definitely wrong.
+	sock := daemon.ActiveSocketPath()
 	if err := daemon.CheckSocketDir(sock); err != nil {
 		return err
 	}
@@ -209,6 +214,12 @@ func listAllIdeas(stdout io.Writer) error {
 		return err
 	}
 	defer c.Close()
+	// AFTER the handshake: wire.Handshake clears the read deadline on
+	// success, so the one set above covers the handshake only. The
+	// control socket has no server-side idle deadline — unlike a
+	// session connection — so without this a daemon that accepts and
+	// then never answers hangs this command forever.
+	_ = conn.SetDeadline(time.Now().Add(ideaDeadline))
 	if err := c.WriteJSON(wire.FrameListIdeas, wire.ListIdeasReq{}); err != nil {
 		return err
 	}
@@ -263,6 +274,10 @@ func ideaDial(sock, sessionID string) (*wire.Client, error) {
 		conn.Close()
 		return nil, err
 	}
+	// Re-armed after the handshake, which clears the read deadline on
+	// success. The session socket's own 30s idle deadline would catch a
+	// stalled daemon eventually; this keeps the CLI's own bound.
+	_ = conn.SetDeadline(time.Now().Add(ideaDeadline))
 	return c, nil
 }
 

--- a/cmd/hived/idea_test.go
+++ b/cmd/hived/idea_test.go
@@ -40,6 +40,53 @@ func TestIdeaListOutsideHiveExits2(t *testing.T) {
 	}
 }
 
+// `list --all` is the one subcommand that is NOT about the caller's own
+// session: inside one it is refused outright, and outside one it takes
+// the control socket rather than the HIVE_SOCKET the session exports.
+// Both halves are the behaviour change, so both are pinned here.
+func TestIdeaListAll(t *testing.T) {
+	// A real 0700 directory with no socket in it, so the dial fails
+	// after the routing decision this test is actually about — the
+	// socket-directory check runs before the dial and a missing or
+	// loose directory would fail earlier, for the wrong reason.
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sock := filepath.Join(dir, "hived.sock")
+
+	t.Run("refused inside a session", func(t *testing.T) {
+		t.Setenv("HIVE_SESSION_ID", "s1")
+		t.Setenv("HIVE_SOCKET", sock)
+
+		var stdout, stderr bytes.Buffer
+		if code := runIdea([]string{"list", "--all"}, &stdout, &stderr); code != 2 {
+			t.Fatalf("exit code = %d, want 2", code)
+		}
+		if !strings.Contains(stderr.String(), "not available inside a Hive session") {
+			t.Errorf("stderr = %q, want the in-session refusal", stderr.String())
+		}
+	})
+
+	// Outside a session it reaches the dial. Before this change it
+	// needed HIVE_SESSION_ID and failed with "not running inside a Hive
+	// session", so a dial failure here is the proof it now takes the
+	// control-socket road. HIVE_SOCKET is set (never left to the
+	// platform default) so the test cannot reach a real daemon.
+	t.Run("dials the control socket outside a session", func(t *testing.T) {
+		t.Setenv("HIVE_SESSION_ID", "")
+		t.Setenv("HIVE_SOCKET", sock)
+
+		var stdout, stderr bytes.Buffer
+		if code := runIdea([]string{"list", "--all"}, &stdout, &stderr); code != 2 {
+			t.Fatalf("exit code = %d, want 2", code)
+		}
+		if !strings.Contains(stderr.String(), "cannot reach the daemon") {
+			t.Errorf("stderr = %q, want a dial failure", stderr.String())
+		}
+	})
+}
+
 // Argument handling is checked before anything dials, so these fail
 // the same way inside a session or out of one.
 func TestIdeaArgErrors(t *testing.T) {

--- a/cmd/hived/idea_test.go
+++ b/cmd/hived/idea_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -81,7 +83,15 @@ func TestIdeaHelpExitsZero(t *testing.T) {
 // A multi-word idea is one idea, not one per word.
 func TestIdeaAddJoinsArgs(t *testing.T) {
 	t.Setenv("HIVE_SESSION_ID", "s1")
-	t.Setenv("HIVE_SOCKET", "/nonexistent/hived.sock")
+	// A real 0700 directory with no socket in it: the socket-directory
+	// check now runs before the dial, and neither a missing directory
+	// nor a loose one would reach the dial this test is aiming for.
+	// t.TempDir() itself is 0777&^umask — usually 0755 — so chmod it.
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HIVE_SOCKET", filepath.Join(dir, "hived.sock"))
 
 	var stdout, stderr bytes.Buffer
 	// The dial fails, but only after the text has been assembled and

--- a/cmd/hivegui/app.go
+++ b/cmd/hivegui/app.go
@@ -40,6 +40,17 @@ type App struct {
 	// Guarded by mu.
 	daemonContract int
 
+	// activeSocket is the socket this GUI talks to, resolved once on
+	// the first dial and reused by the restart path. Normally it is
+	// daemon.SocketPath(); across the 2026-09 socket move it can be the
+	// OLD path, when a pre-move daemon is still serving it. Connecting
+	// to that daemon rather than starting a second one beside it is what
+	// makes the migration ride the existing stale-daemon banner: it
+	// reports the older contract, the banner offers Restart, and the
+	// restart shuts down the daemon the GUI is actually connected to.
+	// Guarded by mu; see App.socketPath.
+	activeSocket string
+
 	// reloading latches once this process has committed to relaunching
 	// itself. The reload broadcast reaches every window including the
 	// one that asked, and a user can click the menu item twice, so

--- a/cmd/hivegui/app_control.go
+++ b/cmd/hivegui/app_control.go
@@ -30,7 +30,7 @@ import (
 // wait out a cold daemon, while OpenSession runs behind openMu and
 // pays its budget once per session on a grid launch.
 func (a *App) dialHandshake(hello wire.Hello, budget time.Duration) (*wire.Client, error) {
-	conn, err := dialOrSpawn(hdaemon.SocketPath(), a.launchDir, budget)
+	conn, err := dialOrSpawn(a.socketPath(), hdaemon.SocketPath(), a.launchDir, budget)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +193,29 @@ const restartKillBudget = 3 * time.Second
 // If the daemon survives both channels we return an error and stay
 // put. A visible failure in a working window beats quitting into a
 // window that looks restarted and isn't.
+// socketPath is the socket this GUI talks to. Resolved once and
+// remembered: a pre-move daemon still serving the old default path is
+// the one to connect to, not one to start a second daemon beside — and
+// the restart path has to target that same socket, or it would probe a
+// path nothing was ever bound to and report the daemon dead without
+// having stopped it. See App.activeSocket.
+func (a *App) socketPath() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.activeSocket != "" {
+		return a.activeSocket
+	}
+	if legacy, alive := hdaemon.LegacyDaemonAlive(); alive {
+		log.Printf("hivegui: an older hived is serving %s; connecting to it so the stale-daemon banner can offer a restart", legacy)
+		a.activeSocket = legacy
+		return a.activeSocket
+	}
+	a.activeSocket = hdaemon.SocketPath()
+	return a.activeSocket
+}
+
 func (a *App) RestartDaemon() error {
-	sock := hdaemon.SocketPath()
+	sock := a.socketPath()
 
 	a.mu.Lock()
 	control := a.control

--- a/cmd/hivegui/app_control.go
+++ b/cmd/hivegui/app_control.go
@@ -175,6 +175,25 @@ func (a *App) emitDaemonVersionStatus(daemonBuild, daemonRelease string, daemonC
 // registry flush, so this is generous.
 const restartKillBudget = 3 * time.Second
 
+// socketPath is the socket this GUI talks to. Resolved once and
+// remembered: a pre-move daemon still serving the old default path is
+// the one to connect to, not one to start a second daemon beside — and
+// the restart path has to target that same socket, or it would probe a
+// path nothing was ever bound to and report the daemon dead without
+// having stopped it. See App.activeSocket.
+func (a *App) socketPath() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.activeSocket != "" {
+		return a.activeSocket
+	}
+	a.activeSocket = hdaemon.ActiveSocketPath()
+	if a.activeSocket != hdaemon.SocketPath() {
+		log.Printf("hivegui: an older hived is serving %s; connecting to it so the stale-daemon banner can offer a restart", a.activeSocket)
+	}
+	return a.activeSocket
+}
+
 // RestartDaemon stops the running hived, relaunches the GUI as a
 // detached child, and quits this process. Reconnecting in-place left
 // the existing window holding stale session state (xterm buffers,
@@ -193,27 +212,6 @@ const restartKillBudget = 3 * time.Second
 // If the daemon survives both channels we return an error and stay
 // put. A visible failure in a working window beats quitting into a
 // window that looks restarted and isn't.
-// socketPath is the socket this GUI talks to. Resolved once and
-// remembered: a pre-move daemon still serving the old default path is
-// the one to connect to, not one to start a second daemon beside — and
-// the restart path has to target that same socket, or it would probe a
-// path nothing was ever bound to and report the daemon dead without
-// having stopped it. See App.activeSocket.
-func (a *App) socketPath() string {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.activeSocket != "" {
-		return a.activeSocket
-	}
-	if legacy, alive := hdaemon.LegacyDaemonAlive(); alive {
-		log.Printf("hivegui: an older hived is serving %s; connecting to it so the stale-daemon banner can offer a restart", legacy)
-		a.activeSocket = legacy
-		return a.activeSocket
-	}
-	a.activeSocket = hdaemon.SocketPath()
-	return a.activeSocket
-}
-
 func (a *App) RestartDaemon() error {
 	sock := a.socketPath()
 

--- a/cmd/hivegui/app_spawn.go
+++ b/cmd/hivegui/app_spawn.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"sync/atomic"
 	"time"
+
+	hdaemon "github.com/lucascaro/hive/internal/daemon"
 )
 
 // ----------------------------- daemon spawn ------------------------------
@@ -41,6 +43,12 @@ var spawnedHived atomic.Bool
 // exist until it is ready to handshake, so a dial that connects is a
 // daemon that answers.
 func dialOrSpawn(sock, cwd string, budget time.Duration) (net.Conn, error) {
+	// Verify (creating it if this GUI is first) before trusting
+	// anything that answers here: an accepting socket in a directory
+	// someone else owns is an impostor that would see every keystroke.
+	if err := hdaemon.EnsureSocketDir(sock); err != nil {
+		return nil, fmt.Errorf("socket dir: %w", err)
+	}
 	if c, err := net.Dial("unix", sock); err == nil {
 		return c, nil
 	}

--- a/cmd/hivegui/app_spawn.go
+++ b/cmd/hivegui/app_spawn.go
@@ -42,20 +42,31 @@ var spawnedHived atomic.Bool
 // The retry loop is the whole wait: the daemon's socket does not
 // exist until it is ready to handshake, so a dial that connects is a
 // daemon that answers.
-func dialOrSpawn(sock, cwd string, budget time.Duration) (net.Conn, error) {
-	// Verify (creating it if this GUI is first) before trusting
-	// anything that answers here: an accepting socket in a directory
-	// someone else owns is an impostor that would see every keystroke.
-	if err := hdaemon.EnsureSocketDir(sock); err != nil {
-		return nil, fmt.Errorf("socket dir: %w", err)
+// dialSock is what an already-running daemon is expected to answer on;
+// spawnSock is where a daemon this function starts will bind. They
+// differ only across the 2026-09 socket move, where dialSock can be the
+// OLD default because a pre-move daemon is still serving it. Nothing
+// this process starts ever binds that path — migrating forward is the
+// whole point — so a legacy daemon that dies between the two is
+// replaced at the new path, not the old one.
+func dialOrSpawn(dialSock, spawnSock, cwd string, budget time.Duration) (net.Conn, error) {
+	// Trust an answering socket only when its directory is ours: one in
+	// a directory someone else owns is an impostor that would see every
+	// keystroke. A failed check here is not fatal on its own — it just
+	// means there is nothing to connect to, and the spawn path below
+	// verifies (and creates) the directory it is actually going to use.
+	if hdaemon.CheckSocketDir(dialSock) == nil {
+		if c, err := net.Dial("unix", dialSock); err == nil {
+			return c, nil
+		}
 	}
-	if c, err := net.Dial("unix", sock); err == nil {
-		return c, nil
+	if err := hdaemon.EnsureSocketDir(spawnSock); err != nil {
+		return nil, fmt.Errorf("socket dir: %w", err)
 	}
 	// Spawn at most once per GUI process. A daemon that dies on
 	// startup is a bug to surface, not to retry into a fork loop.
 	if spawnedHived.CompareAndSwap(false, true) {
-		if err := spawnHived(sock, cwd); err != nil {
+		if err := spawnHived(spawnSock, cwd); err != nil {
 			return nil, fmt.Errorf("spawn hived: %w", err)
 		}
 	}
@@ -63,11 +74,11 @@ func dialOrSpawn(sock, cwd string, budget time.Duration) (net.Conn, error) {
 	delay := 100 * time.Millisecond
 	for {
 		time.Sleep(delay)
-		if c, err := net.Dial("unix", sock); err == nil {
+		if c, err := net.Dial("unix", spawnSock); err == nil {
 			return c, nil
 		}
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("hived did not come up at %s within %s", sock, budget)
+			return nil, fmt.Errorf("hived did not come up at %s within %s", spawnSock, budget)
 		}
 		if delay < 1600*time.Millisecond {
 			delay *= 2

--- a/cmd/hivegui/restart_test.go
+++ b/cmd/hivegui/restart_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -94,13 +95,28 @@ func TestRestartDaemon_FailurePreservesConns(t *testing.T) {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
+	// Hold the accepted conns in a slice, not in a discarded local: a
+	// net.Conn that becomes unreachable is closed by its finalizer
+	// whenever the GC next runs, which closed the client end mid-test
+	// and failed the "still writable" assertion below on Windows CI.
+	var mu sync.Mutex
+	var accepted []net.Conn
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, c := range accepted {
+			_ = c.Close()
+		}
+	})
 	go func() {
 		for {
 			c, err := ln.Accept()
 			if err != nil {
 				return
 			}
-			_ = c // hold it open, read nothing, exit never
+			mu.Lock()
+			accepted = append(accepted, c) // hold it open, read nothing, exit never
+			mu.Unlock()
 		}
 	}()
 	t.Setenv("HIVE_SOCKET", sock)

--- a/cmd/hivegui/update_action_test.go
+++ b/cmd/hivegui/update_action_test.go
@@ -276,9 +276,11 @@ func TestPackageIsIsolatedFromRealHiveState(t *testing.T) {
 	if sock == "" || state == "" {
 		t.Fatal("socket or state dir resolved empty")
 	}
-	// The real ones: /tmp/hive-<uid>/hived.sock and the platform state
-	// dir under the user's home.
-	if sock == fmt.Sprintf("/tmp/hive-%d/hived.sock", os.Getuid()) {
+	// Compare against whatever the platform default resolves to today
+	// rather than a hard-coded path, so this keeps meaning something
+	// when the default moves.
+	t.Setenv("HIVE_SOCKET", "")
+	if real := hdaemon.SocketPath(); sock == real {
 		t.Errorf("SocketPath() = %q — the real daemon socket; tests can kill a live hived", sock)
 	}
 	if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(state, home) {

--- a/docs/design-docs/control-plane.md
+++ b/docs/design-docs/control-plane.md
@@ -66,7 +66,7 @@ sends `HELLO{mode:"event"}`, then exactly one `AGENT_EVENT` frame, and
 closes. No `WELCOME` listing, no subscriptions; it is a fire-and-forget
 postcard, cheap enough to open per hook invocation.
 
-Why a wire mode and not a file drop or a second socket:
+Why a wire mode and not a file drop:
 
 - **One channel.** `DESIGN.md` forbids side-channel files; the wire is
   the IPC. A mode keeps `internal/wire/` free of I/O and lets the
@@ -81,6 +81,18 @@ Why a wire mode and not a file drop or a second socket:
   The daemon accepts an `AGENT_EVENT` only for a session id it has
   alive; a stale or forged id is logged and dropped. The socket is
   already user-only; this is the same trust model as the attach mode.
+
+**Since the 2026-09 hardening, `event` is served on its own listener.**
+The daemon binds a second socket beside the control one —
+`SocketPath()+".events"` — and that is what a session's environment
+carries as `HIVE_SOCKET`. It serves `event` and the narrowed `session`
+mode (`ADD_IDEA` / `LIST_IDEAS`, scoped to the caller's own project)
+and refuses everything else with `mode_not_allowed`. The mode is still
+the right shape for the reasons above; what changed is which file a
+session's children can reach, so that inheriting the environment no
+longer inherits session creation. It is defence in depth rather than a
+boundary — the control socket is owned by the same user and a process
+running as them can dial it directly. See `SECURITY.md`.
 
 ## Correlation with the agent's own identity
 

--- a/docs/verifying-the-gui-by-hand.md
+++ b/docs/verifying-the-gui-by-hand.md
@@ -25,6 +25,10 @@ or state dir — the same isolation rule as every other layer:
 ```bash
 ISO=/tmp/hive-iso-$(basename "$PWD")
 mkdir -p "$ISO/state"
+# hived and the GUI both refuse a socket directory reachable by group or
+# other (see internal/daemon.CheckSocketDir), and mkdir here obeys the
+# umask, which is commonly 022.
+chmod 700 "$ISO"
 cd cmd/hivegui && HIVE_SOCKET="$ISO/hived.sock" HIVE_STATE_DIR="$ISO/state" \
   HIVE_DEBUG_STATE=1 wails dev
 ```

--- a/internal/buildinfo/contract.go
+++ b/internal/buildinfo/contract.go
@@ -24,6 +24,13 @@ package buildinfo
 // History (newest first), so a bump is a decision with a record and
 // not just a number going up:
 //
+//	6 — Events-only socket. The daemon binds a second listener next to
+//	    the control socket (<sock>.events) that serves HELLO{mode:event}
+//	    alone, answering every other mode with mode_not_allowed, and
+//	    HIVE_SOCKET in a spawned session's environment now names THAT
+//	    socket. A session revived by an older daemon hands its agent the
+//	    control socket, so the security property only holds once the
+//	    daemon is the new one — which is exactly what a bump forces.
 //	5 — Ideas: the LIST_IDEAS / IDEAS / ADD_IDEA / UPDATE_IDEA /
 //	    REMOVE_IDEA / IDEA_EVENT frame set, the registry-owned ideas/
 //	    directory behind it, and the project_has_ideas refusal that
@@ -47,7 +54,7 @@ package buildinfo
 //	    before this cannot see or clear the flag.
 //	1 — first contract; everything up to and including the
 //	    CLIENT_COMMAND relay.
-const DaemonContract = 5
+const DaemonContract = 6
 
 // Identity is this binary's full build identity. `hived --version
 // --json` prints it, and Welcome carries the same three values, so a

--- a/internal/buildinfo/contract.go
+++ b/internal/buildinfo/contract.go
@@ -24,13 +24,18 @@ package buildinfo
 // History (newest first), so a bump is a decision with a record and
 // not just a number going up:
 //
-//	6 — Events-only socket. The daemon binds a second listener next to
-//	    the control socket (<sock>.events) that serves HELLO{mode:event}
-//	    alone, answering every other mode with mode_not_allowed, and
-//	    HIVE_SOCKET in a spawned session's environment now names THAT
-//	    socket. A session revived by an older daemon hands its agent the
-//	    control socket, so the security property only holds once the
-//	    daemon is the new one — which is exactly what a bump forces.
+//	6 — Narrowed socket for agent children. The daemon binds a second
+//	    listener next to the control socket (<sock>.events) serving only
+//	    HELLO{mode:event} (one state report) and the new
+//	    HELLO{mode:session} (ADD_IDEA / LIST_IDEAS, and a SESSIONS
+//	    snapshot narrowed to the caller's own session); every other mode
+//	    and verb is answered with mode_not_allowed. HIVE_SOCKET in a
+//	    spawned session's environment now names THAT socket, and
+//	    `hive idea` speaks mode:session rather than mode:control. A
+//	    session revived by an older daemon hands its agent the control
+//	    socket, and an older `hive idea` dialling the events socket in
+//	    mode:control is refused, so the pair has to move together —
+//	    which is exactly what a bump forces.
 //	5 — Ideas: the LIST_IDEAS / IDEAS / ADD_IDEA / UPDATE_IDEA /
 //	    REMOVE_IDEA / IDEA_EVENT frame set, the registry-owned ideas/
 //	    directory behind it, and the project_has_ideas refusal that

--- a/internal/daemon/control_subscribe_test.go
+++ b/internal/daemon/control_subscribe_test.go
@@ -29,7 +29,7 @@ func TestControlSubscribesBeforeWelcome(t *testing.T) {
 	defer client.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go d.serveControl(ctx, server)
+	go d.serveControl(ctx, server, wire.Hello{Mode: wire.ModeControl})
 
 	// Let the goroutine reach the WELCOME write and park there — the
 	// pipe is unbuffered and nothing else in serveControl can block, so

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -7,12 +7,15 @@
 //   - attach:  attach to an existing session by ID
 //   - create:  create a new session, then attach to it
 //   - event:   report one agent state observation, then close
+//   - session: a control connection narrowed to the idea verbs, for a
+//     program running INSIDE a session (see wire.ModeSession)
 //
-// There are two listeners. The control socket serves all four modes and
+// There are two listeners. The control socket serves all five modes and
 // is reachable only by this user (see CheckSocketDir). The events socket
-// next to it (SocketPath()+".events") serves `event` alone, and is what
-// spawned sessions inherit as HIVE_SOCKET — so an agent's subprocess can
-// report state but cannot create, attach to or kill anything.
+// next to it (SocketPath()+".events") serves `event` and `session`
+// alone, and is what spawned sessions inherit as HIVE_SOCKET — so an
+// agent's subprocess can report state and capture ideas, but cannot
+// create, attach to or kill anything.
 package daemon
 
 import (
@@ -587,7 +590,7 @@ func (d *Daemon) serve(ctx context.Context, conn net.Conn) {
 	default:
 		_ = wire.WriteJSON(conn, wire.FrameError, wire.Error{
 			Code:    "unknown_mode",
-			Message: fmt.Sprintf("mode %q; want control|attach|create|event", hello.Mode),
+			Message: fmt.Sprintf("mode %q; want control|attach|create|event|session", hello.Mode),
 		})
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -318,7 +318,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 				log.Printf("hived: events accept: %v", err)
 				continue
 			}
-			go d.serveEventsOnly(conn)
+			go d.serveEventsOnly(ctx, conn)
 		}
 	}()
 	for {
@@ -567,8 +567,8 @@ func (d *Daemon) serve(ctx context.Context, conn net.Conn) {
 	}
 
 	switch hello.Mode {
-	case wire.ModeControl:
-		d.serveControl(ctx, conn)
+	case wire.ModeControl, wire.ModeSession:
+		d.serveControl(ctx, conn, hello)
 	case wire.ModeAttach:
 		d.serveAttach(conn, hello.SessionID)
 	case wire.ModeCreate:
@@ -599,16 +599,17 @@ func (d *Daemon) serve(ctx context.Context, conn net.Conn) {
 const eventReadDeadline = 2 * time.Second
 
 // serveEventsOnly is serve for the events socket: the HELLO must be
-// ModeEvent, and anything else gets mode_not_allowed and a closed
-// connection. It shares serveEvent with the control socket so the two
-// paths cannot drift apart.
+// ModeEvent (one state report) or ModeSession (the narrowed idea
+// connection `hive idea` opens from inside a session). Anything else
+// gets mode_not_allowed and a closed connection. Both handlers are the
+// ones the control socket uses, so the two sockets cannot drift apart.
 //
-// Deliberately NOT registered in d.clients: that set is what Close
-// hangs up on, and every member of it today is a long-lived control or
-// attach connection. An events connection lives for one frame under
+// A ModeEvent connection is deliberately NOT registered in d.clients:
+// that set is what Close hangs up on, and it lives for one frame under
 // the deadline below, so tracking it would only add contention on d.mu
-// on the hottest short-lived path the daemon has.
-func (d *Daemon) serveEventsOnly(conn net.Conn) {
+// on the hottest short-lived path the daemon has. ModeSession is
+// long-lived and does join it.
+func (d *Daemon) serveEventsOnly(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
 	// The HELLO read needs its own deadline: serveEvent only sets one
 	// for the frame after it, so a dialer that connects and then stalls
@@ -635,14 +636,33 @@ func (d *Daemon) serveEventsOnly(conn net.Conn) {
 		})
 		return
 	}
-	if hello.Mode != wire.ModeEvent {
+	switch hello.Mode {
+	case wire.ModeEvent:
+		d.serveEvent(conn)
+	case wire.ModeSession:
+		// Long-lived, unlike ModeEvent: drop the handshake deadline and
+		// join d.clients so Close hangs this one up like any other
+		// control connection.
+		_ = conn.SetReadDeadline(time.Time{})
+		d.mu.Lock()
+		if d.clients == nil {
+			d.mu.Unlock()
+			return
+		}
+		d.clients[conn] = struct{}{}
+		d.mu.Unlock()
+		defer func() {
+			d.mu.Lock()
+			delete(d.clients, conn)
+			d.mu.Unlock()
+		}()
+		d.serveControl(ctx, conn, hello)
+	default:
 		_ = wire.WriteJSON(conn, wire.FrameError, wire.Error{
 			Code:    wire.ErrCodeModeNotAllowed,
-			Message: fmt.Sprintf("mode %q is not served on the events socket; want event", hello.Mode),
+			Message: fmt.Sprintf("mode %q is not served on the events socket; want event or session", hello.Mode),
 		})
-		return
 	}
-	d.serveEvent(conn)
 }
 
 // serveEvent handles a ModeEvent connection: read exactly one frame,
@@ -687,7 +707,11 @@ func (d *Daemon) serveEvent(conn net.Conn) {
 }
 
 // serveControl handles a session-management connection.
-func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
+func (d *Daemon) serveControl(ctx context.Context, conn net.Conn, hello wire.Hello) {
+	// A ModeSession connection comes from a program running inside a
+	// session, over the events socket. It gets the idea verbs and
+	// nothing else — see wire.ModeSession.
+	restricted := hello.Mode == wire.ModeSession
 	// Subscribe BEFORE the client can learn it is connected. A client
 	// that reads WELCOME and immediately causes an event (the hook
 	// integration test does exactly that; a GUI reload racing a hook
@@ -709,7 +733,7 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 		BuildID:        buildinfo.BuildID(),
 		Release:        buildinfo.Version(),
 		DaemonContract: buildinfo.DaemonContract,
-		Mode:           wire.ModeControl,
+		Mode:           hello.Mode,
 	}); err != nil {
 		return
 	}
@@ -727,14 +751,24 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 	stop := make(chan struct{})
 	go func() {
 		// Initial snapshot — projects first so the client can resolve
-		// session.project_id without a roundtrip.
-		_ = writeJSON(wire.FrameProjects, wire.ProjectsResp{Projects: d.reg.ListProjects()})
-		_ = writeJSON(wire.FrameSessions, wire.SessionsResp{Sessions: d.reg.List()})
+		// session.project_id without a roundtrip. A restricted client
+		// gets neither the project list nor anybody else's sessions:
+		// `hive idea list` needs its OWN session's project id and
+		// nothing more, so the snapshot is narrowed to that one entry.
+		if restricted {
+			_ = writeJSON(wire.FrameSessions, wire.SessionsResp{Sessions: ownSessionOnly(d.reg.List(), hello.SessionID)})
+		} else {
+			_ = writeJSON(wire.FrameProjects, wire.ProjectsResp{Projects: d.reg.ListProjects()})
+			_ = writeJSON(wire.FrameSessions, wire.SessionsResp{Sessions: d.reg.List()})
+		}
 		for {
 			select {
 			case ev, ok := <-listener:
 				if !ok {
 					return
+				}
+				if restricted {
+					continue
 				}
 				if err := writeJSON(wire.FrameSessionEvent, ev); err != nil {
 					return
@@ -742,6 +776,9 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 			case ev, ok := <-pListener:
 				if !ok {
 					return
+				}
+				if restricted {
+					continue
 				}
 				if err := writeJSON(wire.FrameProjectEvent, ev); err != nil {
 					return
@@ -756,6 +793,9 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 			case cmd, ok := <-cmdListener:
 				if !ok {
 					return
+				}
+				if restricted {
+					continue
 				}
 				if err := writeJSON(wire.FrameClientBroadcast, cmd); err != nil {
 					return
@@ -823,6 +863,7 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 		sendWorktrees(projectID, "list_worktrees_failed")
 	}
 	ops := controlOps{
+		restricted:     restricted,
 		writeJSON:      writeJSON,
 		sendError:      sendError,
 		sendWorktrees:  sendWorktrees,
@@ -842,6 +883,26 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 	}
 }
 
+// sessionModeFrames is everything a ModeSession connection may ask
+// for: capture an idea, and read the ideas back. See wire.ModeSession.
+var sessionModeFrames = map[wire.FrameType]bool{
+	wire.FrameAddIdea:   true,
+	wire.FrameListIdeas: true,
+}
+
+// ownSessionOnly narrows a session list to the one entry a restricted
+// client is allowed to see — its own. An id that matches nothing (a
+// stale HIVE_SESSION_ID from a copied environment) yields an empty
+// snapshot, which the client reads as "not in a session".
+func ownSessionOnly(all []wire.SessionInfo, id string) []wire.SessionInfo {
+	for _, s := range all {
+		if s.ID == id {
+			return []wire.SessionInfo{s}
+		}
+	}
+	return nil
+}
+
 // controlOps bundles the per-connection reply helpers serveControl
 // builds over the socket's write mutex. Passing them as one value is
 // what lets the frame handlers live outside serveControl, which was
@@ -849,6 +910,9 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn) {
 // bottom — untestable without a live socket, and the file's longest
 // function by a factor of two.
 type controlOps struct {
+	// restricted marks a ModeSession connection: handleControlFrame
+	// refuses every verb outside sessionModeFrames on one.
+	restricted     bool
 	writeJSON      func(wire.FrameType, any) error
 	sendError      func(code, msg string)
 	sendWorktrees  func(projectID, failCode string)
@@ -914,6 +978,14 @@ func ideaErrorCode(err error, generic string) string {
 // when the connection is finished (the client asked the daemon to shut
 // down), false to keep reading.
 func (d *Daemon) handleControlFrame(ctx context.Context, ops controlOps, ft wire.FrameType, payload []byte) bool {
+	// One gate for the whole verb set rather than a check per case: a
+	// verb added later is refused for a restricted client by default,
+	// which is the direction a mistake here should fail in.
+	if ops.restricted && !sessionModeFrames[ft] {
+		ops.sendError(wire.ErrCodeModeNotAllowed,
+			fmt.Sprintf("%s is not served on a session connection; want ADD_IDEA or LIST_IDEAS", ft))
+		return false
+	}
 	switch ft {
 	case wire.FrameShutdown:
 		// Return afterwards: the listener is about to close and

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -60,6 +60,11 @@ type Daemon struct {
 	evsock   string
 	lnEvents net.Listener
 
+	// lock is the flock on the state directory that makes this daemon
+	// the only writer of it. Held open for the process's lifetime;
+	// closing it releases the lock. nil on Windows.
+	lock *os.File
+
 	mu      sync.Mutex
 	clients map[net.Conn]struct{}
 
@@ -163,8 +168,20 @@ func New(cfg Config) (*Daemon, error) {
 	// control socket above is the one every client probes — so a
 	// leftover here is always stale by the time we get past that check.
 	_ = os.Remove(evsock)
+	// Before the registry opens: two daemons sharing one state
+	// directory both revive every persisted session, forking a second
+	// PTY for each. See acquireStateLock.
+	stateDir := cfg.StateDir
+	if stateDir == "" {
+		stateDir = registry.StateDir()
+	}
+	lock, err := acquireStateLock(stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("daemon: %w", err)
+	}
 	reg, err := registry.Open(cfg.StateDir)
 	if err != nil {
+		closeStateLock(lock)
 		return nil, err
 	}
 	// Children report on the events socket, never the control one.
@@ -218,6 +235,7 @@ func New(cfg Config) (*Daemon, error) {
 	ln, err := net.Listen("unix", sock)
 	if err != nil {
 		_ = reg.Close()
+		closeStateLock(lock)
 		return nil, fmt.Errorf("daemon: listen %s: %w", sock, err)
 	}
 	lnEvents, err := net.Listen("unix", evsock)
@@ -225,6 +243,7 @@ func New(cfg Config) (*Daemon, error) {
 		_ = ln.Close()
 		_ = os.Remove(sock)
 		_ = reg.Close()
+		closeStateLock(lock)
 		return nil, fmt.Errorf("daemon: listen %s: %w", evsock, err)
 	}
 
@@ -260,6 +279,7 @@ func New(cfg Config) (*Daemon, error) {
 		reg:      reg,
 		ln:       ln,
 		lnEvents: lnEvents,
+		lock:     lock,
 		sockInfo: sockInfo,
 
 		orphanCandidates: orphanCandidates,
@@ -473,7 +493,20 @@ func (d *Daemon) Close() error {
 		_ = d.reg.Close()
 	}
 	d.removeOwnSocket()
+	// Last: while this is held, a replacement daemon cannot open the
+	// registry, and the GUI's Restart spawns one the moment the socket
+	// goes quiet.
+	closeStateLock(d.lock)
 	return nil
+}
+
+// closeStateLock releases the state-directory lock. nil-safe, because
+// acquireStateLock is a no-op on Windows and because Close runs on
+// paths where New never got that far.
+func closeStateLock(f *os.File) {
+	if f != nil {
+		_ = f.Close()
+	}
 }
 
 // removeOwnSocket unlinks the socket only while it is still the file
@@ -601,6 +634,13 @@ func (d *Daemon) serve(ctx context.Context, conn net.Conn) {
 // goroutine forever.
 const eventReadDeadline = 2 * time.Second
 
+// sessionModeIdleDeadline bounds each read on a ModeSession connection.
+// It is refreshed per frame in serveControl, so a client working
+// steadily is never cut off; one that goes quiet is. Generous enough to
+// cover a slow `hive idea` round-trip and short enough that a session
+// child cannot park a goroutine for the daemon's lifetime.
+const sessionModeIdleDeadline = 30 * time.Second
+
 // serveEventsOnly is serve for the events socket: the HELLO must be
 // ModeEvent (one state report) or ModeSession (the narrowed idea
 // connection `hive idea` opens from inside a session). Anything else
@@ -643,10 +683,12 @@ func (d *Daemon) serveEventsOnly(ctx context.Context, conn net.Conn) {
 	case wire.ModeEvent:
 		d.serveEvent(conn)
 	case wire.ModeSession:
-		// Long-lived, unlike ModeEvent: drop the handshake deadline and
-		// join d.clients so Close hangs this one up like any other
-		// control connection.
-		_ = conn.SetReadDeadline(time.Time{})
+		// Long-lived relative to ModeEvent, but not unbounded: this is
+		// the one connection kind a subprocess of an agent can open, so
+		// it gets an idle deadline rather than the control socket's
+		// none. `hive idea` writes its verb immediately and exits;
+		// anything that connects and sits there is not doing that.
+		_ = conn.SetReadDeadline(time.Now().Add(sessionModeIdleDeadline))
 		d.mu.Lock()
 		if d.clients == nil {
 			d.mu.Unlock()
@@ -714,7 +756,19 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn, hello wire.Hel
 	// A ModeSession connection comes from a program running inside a
 	// session, over the events socket. It gets the idea verbs and
 	// nothing else — see wire.ModeSession.
+	//
+	// Resolve the caller's project ONCE, here, from the session id it
+	// named in HELLO. Every idea verb below is bound to it: allowlisting
+	// the verbs without also scoping the data would leave a session
+	// child able to read and write every project's ideas, which is the
+	// same capability in a different shape. An id the registry does not
+	// know (a stale HIVE_SESSION_ID from a copied environment) resolves
+	// to "", and every idea verb is then refused.
 	restricted := hello.Mode == wire.ModeSession
+	ownProjectID := ""
+	if restricted {
+		ownProjectID = projectOfSession(d.reg.List(), hello.SessionID)
+	}
 	// Subscribe BEFORE the client can learn it is connected. A client
 	// that reads WELCOME and immediately causes an event (the hook
 	// integration test does exactly that; a GUI reload racing a hook
@@ -789,6 +843,13 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn, hello wire.Hel
 			case ev, ok := <-iListener:
 				if !ok {
 					return
+				}
+				// A restricted client sees only its own project's
+				// ideas. Without this it could sit on the connection
+				// and passively harvest every idea filed anywhere,
+				// which is the read it is refused when it asks.
+				if restricted && ev.Idea.ProjectID != ownProjectID {
+					continue
 				}
 				if err := writeJSON(wire.FrameIdeaEvent, ev); err != nil {
 					return
@@ -867,12 +928,21 @@ func (d *Daemon) serveControl(ctx context.Context, conn net.Conn, hello wire.Hel
 	}
 	ops := controlOps{
 		restricted:     restricted,
+		ownSessionID:   hello.SessionID,
+		ownProjectID:   ownProjectID,
 		writeJSON:      writeJSON,
 		sendError:      sendError,
 		sendWorktrees:  sendWorktrees,
 		finishMutation: finishMutation,
 	}
 	for {
+		if restricted {
+			// Refreshed per frame, so a client that keeps working is
+			// never cut off and one that goes quiet is. Only restricted
+			// connections are bounded: a GUI control connection is idle
+			// by design between user actions.
+			_ = conn.SetReadDeadline(time.Now().Add(sessionModeIdleDeadline))
+		}
 		ft, payload, err := wire.ReadFrame(conn)
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
@@ -893,6 +963,17 @@ var sessionModeFrames = map[wire.FrameType]bool{
 	wire.FrameListIdeas: true,
 }
 
+// projectOfSession resolves the project a session belongs to, or "" if
+// the id names no live session.
+func projectOfSession(all []wire.SessionInfo, id string) string {
+	for _, s := range all {
+		if s.ID == id {
+			return s.ProjectID
+		}
+	}
+	return ""
+}
+
 // ownSessionOnly narrows a session list to the one entry a restricted
 // client is allowed to see — its own. An id that matches nothing (a
 // stale HIVE_SESSION_ID from a copied environment) yields an empty
@@ -900,7 +981,12 @@ var sessionModeFrames = map[wire.FrameType]bool{
 func ownSessionOnly(all []wire.SessionInfo, id string) []wire.SessionInfo {
 	for _, s := range all {
 		if s.ID == id {
-			return []wire.SessionInfo{s}
+			// Id and project only. `hive idea list` needs the project
+			// to scope its listing and nothing else, and the rest of
+			// SessionInfo — worktree path and branch, window title,
+			// last prompt — is not something to hand a subprocess
+			// merely because it runs in the session.
+			return []wire.SessionInfo{{ID: s.ID, ProjectID: s.ProjectID}}
 		}
 	}
 	return nil
@@ -914,8 +1000,15 @@ func ownSessionOnly(all []wire.SessionInfo, id string) []wire.SessionInfo {
 // function by a factor of two.
 type controlOps struct {
 	// restricted marks a ModeSession connection: handleControlFrame
-	// refuses every verb outside sessionModeFrames on one.
-	restricted     bool
+	// refuses every verb outside sessionModeFrames on one, and binds
+	// the ones it does serve to ownSessionID / ownProjectID.
+	restricted bool
+	// ownSessionID / ownProjectID are the caller's session and the
+	// project it belongs to, resolved once at handshake. Meaningful
+	// only when restricted. An empty ownProjectID means the session id
+	// resolved to nothing, and every idea verb is refused.
+	ownSessionID   string
+	ownProjectID   string
 	writeJSON      func(wire.FrameType, any) error
 	sendError      func(code, msg string)
 	sendWorktrees  func(projectID, failCode string)
@@ -1202,20 +1295,45 @@ func (d *Daemon) handleControlFrame(ctx context.Context, ops controlOps, ft wire
 		if !ok {
 			return false
 		}
+		if ops.restricted {
+			// An empty ProjectID means "every project" to the registry,
+			// which is what `hive idea list --all` sends — refused from
+			// inside a session rather than silently narrowed, so the
+			// user sees why the answer is not the one they asked for.
+			if ops.ownProjectID == "" || req.ProjectID != ops.ownProjectID {
+				ops.sendError(wire.ErrCodeModeNotAllowed,
+					"a session connection can only list its own project's ideas")
+				return false
+			}
+		}
 		_ = ops.writeJSON(wire.FrameIdeas, wire.IdeasResp{Ideas: d.reg.ListIdeas(req.ProjectID)})
 	case wire.FrameAddIdea:
 		req, ok := decodeReq[wire.AddIdeaReq](payload, ops.sendError)
 		if !ok {
 			return false
 		}
-		// Inline, not via runOp: an idea write is one temp+rename with
-		// no git and no subprocess behind it.
-		if _, err := d.reg.AddIdea(registry.IdeaSpec{
+		spec := registry.IdeaSpec{
 			ProjectID: req.ProjectID,
 			SessionID: req.SessionID,
 			Kind:      req.Kind,
 			Text:      req.Text,
-		}); err != nil {
+		}
+		if ops.restricted {
+			if ops.ownProjectID == "" {
+				ops.sendError(wire.ErrCodeModeNotAllowed,
+					"a session connection can only file ideas against its own session")
+				return false
+			}
+			// Taken from the handshake, not from the payload: the
+			// client is inside the session it is filing for, and a
+			// forged session id would both file into another project
+			// and misattribute the idea's source.
+			spec.SessionID = ops.ownSessionID
+			spec.ProjectID = ops.ownProjectID
+		}
+		// Inline, not via runOp: an idea write is one temp+rename with
+		// no git and no subprocess behind it.
+		if _, err := d.reg.AddIdea(spec); err != nil {
 			ops.sendError(ideaErrorCode(err, "add_idea_failed"), err.Error())
 		}
 	case wire.FrameUpdateIdea:

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -157,20 +157,10 @@ func New(cfg Config) (*Daemon, error) {
 		return nil, fmt.Errorf("daemon: socket dir: %w", err)
 	}
 	evsock := EventSocketPath(sock)
-	if _, err := os.Stat(sock); err == nil {
-		if c, derr := net.Dial("unix", sock); derr == nil {
-			_ = c.Close()
-			return nil, fmt.Errorf("daemon: another hived appears to be running at %s", sock)
-		}
-		_ = os.Remove(sock)
-	}
-	// The events socket has no independent liveness meaning — the
-	// control socket above is the one every client probes — so a
-	// leftover here is always stale by the time we get past that check.
-	_ = os.Remove(evsock)
-	// Before the registry opens: two daemons sharing one state
-	// directory both revive every persisted session, forking a second
-	// PTY for each. See acquireStateLock.
+	// The lock comes before the socket probe below, not after: that
+	// probe unlinks what it decides is stale, and a start that goes on
+	// to lose the lock would first have deleted a live daemon's socket
+	// files, leaving it bound to an inode nobody can dial.
 	stateDir := cfg.StateDir
 	if stateDir == "" {
 		stateDir = registry.StateDir()
@@ -179,6 +169,18 @@ func New(cfg Config) (*Daemon, error) {
 	if err != nil {
 		return nil, fmt.Errorf("daemon: %w", err)
 	}
+	if _, err := os.Stat(sock); err == nil {
+		if c, derr := net.Dial("unix", sock); derr == nil {
+			_ = c.Close()
+			closeStateLock(lock)
+			return nil, fmt.Errorf("daemon: another hived appears to be running at %s", sock)
+		}
+		_ = os.Remove(sock)
+	}
+	// The events socket has no independent liveness meaning — the
+	// control socket above is the one every client probes — so a
+	// leftover here is always stale by the time we get past that check.
+	_ = os.Remove(evsock)
 	reg, err := registry.Open(cfg.StateDir)
 	if err != nil {
 		closeStateLock(lock)
@@ -639,7 +641,8 @@ const eventReadDeadline = 2 * time.Second
 // steadily is never cut off; one that goes quiet is. Generous enough to
 // cover a slow `hive idea` round-trip and short enough that a session
 // child cannot park a goroutine for the daemon's lifetime.
-const sessionModeIdleDeadline = 30 * time.Second
+// Var, not const, so the tests can shrink it.
+var sessionModeIdleDeadline = 30 * time.Second
 
 // serveEventsOnly is serve for the events socket: the HELLO must be
 // ModeEvent (one state report) or ModeSession (the narrowed idea

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -6,6 +6,13 @@
 //   - control: session-management (LIST/CREATE/KILL/UPDATE), no DATA
 //   - attach:  attach to an existing session by ID
 //   - create:  create a new session, then attach to it
+//   - event:   report one agent state observation, then close
+//
+// There are two listeners. The control socket serves all four modes and
+// is reachable only by this user (see CheckSocketDir). The events socket
+// next to it (SocketPath()+".events") serves `event` alone, and is what
+// spawned sessions inherit as HIVE_SOCKET — so an agent's subprocess can
+// report state but cannot create, attach to or kill anything.
 package daemon
 
 import (
@@ -41,6 +48,14 @@ type Daemon struct {
 	sock string
 	reg  *registry.Registry
 	ln   net.Listener
+
+	// evsock/lnEvents are the events-only listener handed to spawned
+	// sessions as HIVE_SOCKET. Separate socket rather than a flag on
+	// the control one: the capability an agent child inherits has to
+	// be narrowed by the file it can reach, not by a check the child
+	// could be talking past.
+	evsock   string
+	lnEvents net.Listener
 
 	mu      sync.Mutex
 	clients map[net.Conn]struct{}
@@ -133,6 +148,7 @@ func New(cfg Config) (*Daemon, error) {
 	if err := EnsureSocketDir(sock); err != nil {
 		return nil, fmt.Errorf("daemon: socket dir: %w", err)
 	}
+	evsock := EventSocketPath(sock)
 	if _, err := os.Stat(sock); err == nil {
 		if c, derr := net.Dial("unix", sock); derr == nil {
 			_ = c.Close()
@@ -140,11 +156,16 @@ func New(cfg Config) (*Daemon, error) {
 		}
 		_ = os.Remove(sock)
 	}
+	// The events socket has no independent liveness meaning — the
+	// control socket above is the one every client probes — so a
+	// leftover here is always stale by the time we get past that check.
+	_ = os.Remove(evsock)
 	reg, err := registry.Open(cfg.StateDir)
 	if err != nil {
 		return nil, err
 	}
-	reg.SetSocketPath(sock)
+	// Children report on the events socket, never the control one.
+	reg.SetSocketPath(evsock)
 	reg.SetHivedPath(resolveHivedPath())
 
 	// Ensure a default project exists, then migrate any orphan
@@ -196,6 +217,13 @@ func New(cfg Config) (*Daemon, error) {
 		_ = reg.Close()
 		return nil, fmt.Errorf("daemon: listen %s: %w", sock, err)
 	}
+	lnEvents, err := net.Listen("unix", evsock)
+	if err != nil {
+		_ = ln.Close()
+		_ = os.Remove(sock)
+		_ = reg.Close()
+		return nil, fmt.Errorf("daemon: listen %s: %w", evsock, err)
+	}
 
 	// Collect the orphan-worktree candidates HERE, on the boot path,
 	// while no client can have created anything: the sweep itself is
@@ -225,8 +253,10 @@ func New(cfg Config) (*Daemon, error) {
 	d := &Daemon{
 		cfg:      cfg,
 		sock:     sock,
+		evsock:   evsock,
 		reg:      reg,
 		ln:       ln,
+		lnEvents: lnEvents,
 		sockInfo: sockInfo,
 
 		orphanCandidates: orphanCandidates,
@@ -276,6 +306,20 @@ func (d *Daemon) Run(ctx context.Context) error {
 		case <-d.shutdown:
 		}
 		_ = d.ln.Close()
+		_ = d.lnEvents.Close()
+	}()
+	go func() {
+		for {
+			conn, err := d.lnEvents.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) || ctx.Err() != nil {
+					return
+				}
+				log.Printf("hived: events accept: %v", err)
+				continue
+			}
+			go d.serveEventsOnly(conn)
+		}
 	}()
 	for {
 		conn, err := d.ln.Accept()
@@ -387,8 +431,12 @@ func (d *Daemon) Shutdown() {
 	})
 }
 
-// SocketPath returns the path the daemon is bound to.
+// SocketPath returns the control-socket path the daemon is bound to.
 func (d *Daemon) SocketPath() string { return d.sock }
+
+// EventSocketPath returns the events-only socket path — the one
+// spawned sessions get as HIVE_SOCKET.
+func (d *Daemon) EventSocketPath() string { return d.evsock }
 
 // Registry exposes the registry for tests; production code should
 // not bypass the wire protocol.
@@ -414,6 +462,9 @@ func (d *Daemon) Close() error {
 	}
 	if d.ln != nil {
 		_ = d.ln.Close()
+	}
+	if d.lnEvents != nil {
+		_ = d.lnEvents.Close()
 	}
 	if d.reg != nil {
 		_ = d.reg.Close()
@@ -461,6 +512,14 @@ func (d *Daemon) removeOwnSocket() {
 	}
 	if err := os.Remove(d.sock); err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Printf("hived: remove socket %s: %v", d.sock, err)
+	}
+	// The events socket rides on the control socket's verdict: the two
+	// are bound and unbound together, so if that one was still ours,
+	// this one is too.
+	if d.evsock != "" {
+		if err := os.Remove(d.evsock); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Printf("hived: remove events socket %s: %v", d.evsock, err)
+		}
 	}
 }
 
@@ -538,6 +597,53 @@ func (d *Daemon) serve(ctx context.Context, conn net.Conn) {
 // and then stalls (or never sends the frame at all) must not pin a
 // goroutine forever.
 const eventReadDeadline = 2 * time.Second
+
+// serveEventsOnly is serve for the events socket: the HELLO must be
+// ModeEvent, and anything else gets mode_not_allowed and a closed
+// connection. It shares serveEvent with the control socket so the two
+// paths cannot drift apart.
+//
+// Deliberately NOT registered in d.clients: that set is what Close
+// hangs up on, and every member of it today is a long-lived control or
+// attach connection. An events connection lives for one frame under
+// the deadline below, so tracking it would only add contention on d.mu
+// on the hottest short-lived path the daemon has.
+func (d *Daemon) serveEventsOnly(conn net.Conn) {
+	defer conn.Close()
+	// The HELLO read needs its own deadline: serveEvent only sets one
+	// for the frame after it, so a dialer that connects and then stalls
+	// would otherwise pin this goroutine forever.
+	_ = conn.SetReadDeadline(time.Now().Add(eventReadDeadline))
+	var hello wire.Hello
+	ft, err := wire.ReadJSON(conn, &hello)
+	if err != nil {
+		// Same reasoning as serve: a connect-then-hang-up is a liveness
+		// probe, not an error worth logging.
+		if !errors.Is(err, io.EOF) {
+			log.Printf("hived: events: read hello: %v", err)
+		}
+		return
+	}
+	if ft != wire.FrameHello {
+		log.Printf("hived: events: expected HELLO, got %s", ft)
+		return
+	}
+	if hello.Version != wire.PROTOCOL_VERSION {
+		_ = wire.WriteJSON(conn, wire.FrameError, wire.Error{
+			Code:    wire.ErrCodeProtocolVersionMismatch,
+			Message: fmt.Sprintf("server speaks v%d; client speaks v%d", wire.PROTOCOL_VERSION, hello.Version),
+		})
+		return
+	}
+	if hello.Mode != wire.ModeEvent {
+		_ = wire.WriteJSON(conn, wire.FrameError, wire.Error{
+			Code:    wire.ErrCodeModeNotAllowed,
+			Message: fmt.Sprintf("mode %q is not served on the events socket; want event", hello.Mode),
+		})
+		return
+	}
+	d.serveEvent(conn)
+}
 
 // serveEvent handles a ModeEvent connection: read exactly one frame,
 // which must be FrameAgentEvent, validate it, apply it to the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -161,6 +161,14 @@ func New(cfg Config) (*Daemon, error) {
 	// probe unlinks what it decides is stale, and a start that goes on
 	// to lose the lock would first have deleted a live daemon's socket
 	// files, leaving it bound to an inode nobody can dial.
+	// A daemon built before the socket moved takes no state lock and
+	// binds a path this one does not look at, so the lock below cannot
+	// see it. The GUI handles this case by connecting to the old daemon
+	// and letting the usual stale-daemon banner drive the restart; this
+	// is the backstop for a hand-started hived, which has no banner.
+	if legacy, alive := legacyDaemonBlocking(cfg.SocketPath); alive {
+		return nil, fmt.Errorf("daemon: an older hived is still running at %s; quit Hive (or kill that process) and start again", legacy)
+	}
 	stateDir := cfg.StateDir
 	if stateDir == "" {
 		stateDir = registry.StateDir()
@@ -300,6 +308,19 @@ func New(cfg Config) (*Daemon, error) {
 	d.runOp(d.reviveAll)
 	d.runOp(d.reclaimWorktrees)
 	return d, nil
+}
+
+// legacyDaemonBlocking reports a pre-move daemon that would collide
+// with the daemon about to start. Only the canonical path is checked:
+// an explicit socket that is NOT the platform default is a test or an
+// isolated dev daemon (scripts/dev-iso.sh), which has its own state
+// dir and no business refusing to start because the user's real Hive
+// is up.
+func legacyDaemonBlocking(cfgSocket string) (string, bool) {
+	if cfgSocket != "" && cfgSocket != SocketPath() {
+		return "", false
+	}
+	return LegacyDaemonAlive()
 }
 
 // resolveHivedPath resolves the absolute path of the running hived

--- a/internal/daemon/event_socket_test.go
+++ b/internal/daemon/event_socket_test.go
@@ -1,12 +1,14 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/lucascaro/hive/internal/registry"
 	"github.com/lucascaro/hive/internal/wire"
 )
 
@@ -277,4 +279,175 @@ func waitFor(t *testing.T, d time.Duration, cond func() bool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("condition not met in time")
+}
+
+// The idea verbs on a session connection are bound to the caller's own
+// session and project. Allowlisting the verbs is not enough on its own:
+// the registry reads an empty ProjectID as "every project".
+func TestSessionModeIdeasAreScopedToOwnProject(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	id := bootstrapSessionID(t, d)
+	own := projectOfSession(d.Registry().List(), id)
+	if own == "" {
+		t.Fatal("bootstrap session has no project")
+	}
+	other, err := d.Registry().CreateProject(wire.CreateProjectReq{Name: "other", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatalf("create second project: %v", err)
+	}
+	if _, err := d.Registry().AddIdea(registry.IdeaSpec{
+		ProjectID: other.ID, Text: "a secret from another project",
+	}); err != nil {
+		t.Fatalf("seed foreign idea: %v", err)
+	}
+
+	c := sessionConn(t, d, id)
+	defer c.Close()
+
+	// LIST_IDEAS across every project — what `hive idea list --all`
+	// sends — is refused, not silently narrowed.
+	if err := wire.WriteJSON(c, wire.FrameListIdeas, wire.ListIdeasReq{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := awaitModeNotAllowed(t, c); err != nil {
+		t.Fatalf("LIST_IDEAS{}: %v", err)
+	}
+	// And so is another project's id by name.
+	if err := wire.WriteJSON(c, wire.FrameListIdeas, wire.ListIdeasReq{ProjectID: other.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := awaitModeNotAllowed(t, c); err != nil {
+		t.Fatalf("LIST_IDEAS{other}: %v", err)
+	}
+
+	// A write naming another project lands in the caller's own instead
+	// of the one it asked for, and carries the caller's session id
+	// rather than the forged one.
+	if err := wire.WriteJSON(c, wire.FrameAddIdea, wire.AddIdeaReq{
+		ProjectID: other.ID, SessionID: "forged", Text: "planted",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		for _, i := range d.Registry().ListIdeas("") {
+			if i.Text == "planted" {
+				return i.ProjectID == own && i.SourceSessionID == id
+			}
+		}
+		return false
+	})
+	for _, i := range d.Registry().ListIdeas(other.ID) {
+		if i.Text == "planted" {
+			t.Fatal("ADD_IDEA wrote into another project")
+		}
+	}
+}
+
+// A restricted connection is not fed the session, project or broadcast
+// streams, and sees only its own project's idea events.
+func TestSessionModeReceivesNoForeignEvents(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	id := bootstrapSessionID(t, d)
+	other, err := d.Registry().CreateProject(wire.CreateProjectReq{Name: "other", Cwd: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := sessionConn(t, d, id)
+	defer c.Close()
+
+	// Cause traffic on every stream a control connection would see.
+	if _, err := d.Registry().AddIdea(registry.IdeaSpec{
+		ProjectID: other.ID, Text: "foreign idea",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	renamed := "renamed"
+	if _, err := d.Registry().Update(wire.UpdateSessionReq{SessionID: id, Name: &renamed}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	// Then something we ARE entitled to, as a sync point: if it
+	// arrives and nothing before it did, the suppression holds.
+	if err := wire.WriteJSON(c, wire.FrameAddIdea, wire.AddIdeaReq{Text: "mine"}); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = c.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for {
+		ft, payload, err := wire.ReadFrame(c)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		switch ft {
+		case wire.FrameSessionEvent, wire.FrameProjectEvent, wire.FrameClientBroadcast:
+			t.Fatalf("restricted connection received %s", ft)
+		case wire.FrameIdeaEvent:
+			var ev wire.IdeaEvent
+			if err := jsonUnmarshal(payload, &ev); err != nil {
+				t.Fatal(err)
+			}
+			if ev.Idea.Text == "foreign idea" {
+				t.Fatal("restricted connection received another project's IDEA_EVENT")
+			}
+			if ev.Idea.Text == "mine" {
+				return
+			}
+		}
+	}
+}
+
+// Two daemons must not share one state directory: both would revive
+// every persisted session and fork a second PTY for each.
+func TestNewRefusesASecondDaemonOnOneStateDir(t *testing.T) {
+	skipOnWindows(t)
+	tmp := shortTempDir(t)
+	state := filepath.Join(tmp, "state")
+	first, err := New(Config{SocketPath: filepath.Join(tmp, "s1"), StateDir: state})
+	if err != nil {
+		t.Fatalf("first New: %v", err)
+	}
+	defer first.Close()
+
+	// A different socket path, deliberately: this is the upgrade
+	// window the socket-file guard cannot see.
+	second, err := New(Config{SocketPath: filepath.Join(tmp, "s2"), StateDir: state})
+	if err == nil {
+		_ = second.Close()
+		t.Fatal("New accepted a second daemon on a state dir already in use")
+	}
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("New error = %v, want ErrAlreadyRunning", err)
+	}
+
+	// And the lock is released on teardown, so a replacement can start.
+	_ = first.Close()
+	third, err := New(Config{SocketPath: filepath.Join(tmp, "s3"), StateDir: state})
+	if err != nil {
+		t.Fatalf("New after the first daemon closed: %v", err)
+	}
+	_ = third.Close()
+}
+
+// sessionConn opens a ModeSession connection on the events socket and
+// reads past the handshake and the narrowed snapshot.
+func sessionConn(t *testing.T, d *Daemon, sessionID string) net.Conn {
+	t.Helper()
+	c := dialEvents(t, d)
+	if err := wire.WriteJSON(c, wire.FrameHello, wire.Hello{
+		Version: wire.PROTOCOL_VERSION, Client: "test/0",
+		Mode: wire.ModeSession, SessionID: sessionID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var w wire.Welcome
+	if ft, err := wire.ReadJSON(c, &w); err != nil || ft != wire.FrameWelcome {
+		t.Fatalf("handshake: %s %v", ft, err)
+	}
+	var snap wire.SessionsResp
+	if _, err := wire.ReadJSON(c, &snap); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	return c
 }

--- a/internal/daemon/event_socket_test.go
+++ b/internal/daemon/event_socket_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
@@ -59,6 +60,132 @@ func TestEventSocketAcceptsAgentEvent(t *testing.T) {
 			info.StateSource == wire.StateSourceHook &&
 			info.LastPrompt == "say pong"
 	})
+}
+
+// ModeSession on the events socket serves the idea verbs — this is
+// what `hive idea` inside a session speaks — and narrows the SESSIONS
+// snapshot to the caller's own entry.
+func TestEventSocketSessionModeServesIdeas(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	id := bootstrapSessionID(t, d)
+	c := dialEvents(t, d)
+	defer c.Close()
+	if err := wire.WriteJSON(c, wire.FrameHello, wire.Hello{
+		Version: wire.PROTOCOL_VERSION, Client: "test/0",
+		Mode: wire.ModeSession, SessionID: id,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var w wire.Welcome
+	if ft, err := wire.ReadJSON(c, &w); err != nil || ft != wire.FrameWelcome {
+		t.Fatalf("handshake: %s %v", ft, err)
+	}
+	// The unprompted snapshot carries this session and no other.
+	var snap wire.SessionsResp
+	ft, err := wire.ReadJSON(c, &snap)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if ft != wire.FrameSessions {
+		t.Fatalf("first frame after WELCOME = %s, want SESSIONS (no PROJECTS for a session conn)", ft)
+	}
+	if len(snap.Sessions) != 1 || snap.Sessions[0].ID != id {
+		t.Fatalf("snapshot = %+v, want only session %s", snap.Sessions, id)
+	}
+	if err := wire.WriteJSON(c, wire.FrameAddIdea, wire.AddIdeaReq{
+		SessionID: id, Text: "an idea from inside the session",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		ft, payload, err := wire.ReadFrame(c)
+		if err != nil {
+			t.Fatalf("read after ADD_IDEA: %v", err)
+		}
+		if ft == wire.FrameError {
+			t.Fatalf("ADD_IDEA refused on a session connection: %s", payload)
+		}
+		if ft == wire.FrameIdeaEvent {
+			var ev wire.IdeaEvent
+			if err := jsonUnmarshal(payload, &ev); err != nil {
+				t.Fatal(err)
+			}
+			if ev.Kind == wire.IdeaEventAdded && ev.Idea.Text == "an idea from inside the session" {
+				return
+			}
+		}
+	}
+}
+
+// Everything outside the idea verbs is refused on a session connection,
+// including the ones that would spawn or destroy work.
+func TestSessionModeRefusesEveryOtherVerb(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	id := bootstrapSessionID(t, d)
+	c := dialEvents(t, d)
+	defer c.Close()
+	if err := wire.WriteJSON(c, wire.FrameHello, wire.Hello{
+		Version: wire.PROTOCOL_VERSION, Client: "test/0",
+		Mode: wire.ModeSession, SessionID: id,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var w wire.Welcome
+	if _, err := wire.ReadJSON(c, &w); err != nil {
+		t.Fatal(err)
+	}
+	before := len(d.Registry().List())
+	for _, tc := range []struct {
+		frame wire.FrameType
+		body  any
+	}{
+		{wire.FrameCreateSession, wire.CreateSpec{Cmd: []string{"/bin/sh", "-c", "true"}}},
+		{wire.FrameKillSession, wire.KillSessionReq{SessionID: id}},
+		{wire.FrameListSessions, wire.ListSessionsReq{}},
+		{wire.FrameShutdown, struct{}{}},
+	} {
+		if err := wire.WriteJSON(c, tc.frame, tc.body); err != nil {
+			t.Fatalf("%s: write: %v", tc.frame, err)
+		}
+		if err := awaitModeNotAllowed(t, c); err != nil {
+			t.Fatalf("%s: %v", tc.frame, err)
+		}
+	}
+	// The daemon is still up (SHUTDOWN was refused, not obeyed) and
+	// nothing was created or killed.
+	if got := len(d.Registry().List()); got != before {
+		t.Fatalf("sessions: %d → %d", before, got)
+	}
+	if err := wire.WriteJSON(c, wire.FrameListIdeas, wire.ListIdeasReq{}); err != nil {
+		t.Fatalf("daemon went away after a refused SHUTDOWN: %v", err)
+	}
+}
+
+// awaitModeNotAllowed reads past the snapshot/event traffic to the next
+// ERROR frame and checks its code.
+func awaitModeNotAllowed(t *testing.T, c net.Conn) error {
+	t.Helper()
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer func() { _ = c.SetReadDeadline(time.Time{}) }()
+	for {
+		ft, payload, err := wire.ReadFrame(c)
+		if err != nil {
+			return err
+		}
+		if ft != wire.FrameError {
+			continue
+		}
+		var e wire.Error
+		if err := jsonUnmarshal(payload, &e); err != nil {
+			return err
+		}
+		if e.Code != wire.ErrCodeModeNotAllowed {
+			return fmt.Errorf("error code = %q, want mode_not_allowed", e.Code)
+		}
+		return nil
+	}
 }
 
 // Every other HELLO mode is refused on the events socket with

--- a/internal/daemon/event_socket_test.go
+++ b/internal/daemon/event_socket_test.go
@@ -402,6 +402,12 @@ func TestSessionModeReceivesNoForeignEvents(t *testing.T) {
 // every persisted session and fork a second PTY for each.
 func TestNewRefusesASecondDaemonOnOneStateDir(t *testing.T) {
 	skipOnWindows(t)
+	// Shrink the retry budget: this test is about the refusal, and the
+	// production budget would make it sit here for five seconds.
+	orig := stateLockBudget
+	stateLockBudget = 200 * time.Millisecond
+	t.Cleanup(func() { stateLockBudget = orig })
+
 	tmp := shortTempDir(t)
 	state := filepath.Join(tmp, "state")
 	first, err := New(Config{SocketPath: filepath.Join(tmp, "s1"), StateDir: state})
@@ -450,4 +456,106 @@ func sessionConn(t *testing.T, d *Daemon, sessionID string) net.Conn {
 		t.Fatalf("snapshot: %v", err)
 	}
 	return c
+}
+
+// A ModeSession HELLO whose session id resolves to nothing — a stale
+// HIVE_SESSION_ID from a copied environment — gets the idea verbs
+// refused rather than falling through to an unscoped registry call.
+func TestSessionModeUnknownSessionRefusesIdeaVerbs(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	c := sessionConn(t, d, "no-such-session")
+	defer c.Close()
+
+	before := len(d.Registry().ListIdeas(""))
+	for _, f := range []struct {
+		frame wire.FrameType
+		body  any
+	}{
+		{wire.FrameListIdeas, wire.ListIdeasReq{}},
+		{wire.FrameAddIdea, wire.AddIdeaReq{Text: "from nowhere"}},
+	} {
+		if err := wire.WriteJSON(c, f.frame, f.body); err != nil {
+			t.Fatalf("%s: %v", f.frame, err)
+		}
+		if err := awaitModeNotAllowed(t, c); err != nil {
+			t.Fatalf("%s: %v", f.frame, err)
+		}
+	}
+	if got := len(d.Registry().ListIdeas("")); got != before {
+		t.Fatalf("ideas: %d → %d; an unresolvable session must not be able to file one", before, got)
+	}
+}
+
+// A ModeSession connection that goes quiet is hung up on; a control
+// connection, which is idle by design between user actions, is not.
+func TestSessionModeIdleDeadlineHangsUpQuietConnections(t *testing.T) {
+	skipOnWindows(t)
+	orig := sessionModeIdleDeadline
+	sessionModeIdleDeadline = 150 * time.Millisecond
+	t.Cleanup(func() { sessionModeIdleDeadline = orig })
+
+	d := startTestDaemon(t)
+	id := bootstrapSessionID(t, d)
+
+	quiet := sessionConn(t, d, id)
+	defer quiet.Close()
+	_ = quiet.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, _, err := wire.ReadFrame(quiet); err == nil {
+		t.Fatal("idle session connection was not hung up on")
+	}
+
+	// The control socket is exempt: same silence, still connected.
+	ctl := dial(t, d)
+	defer ctl.Close()
+	if err := wire.WriteJSON(ctl, wire.FrameHello, wire.Hello{
+		Version: wire.PROTOCOL_VERSION, Client: "test/0", Mode: wire.ModeControl,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var w wire.Welcome
+	if _, err := wire.ReadJSON(ctl, &w); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(4 * sessionModeIdleDeadline)
+	if err := wire.WriteJSON(ctl, wire.FrameListSessions, wire.ListSessionsReq{}); err != nil {
+		t.Fatalf("control connection was hung up on: %v", err)
+	}
+	_ = ctl.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		ft, _, err := wire.ReadFrame(ctl)
+		if err != nil {
+			t.Fatalf("control connection went quiet: %v", err)
+		}
+		if ft == wire.FrameSessions {
+			return
+		}
+	}
+}
+
+// The restart handoff: the outgoing daemon holds the lock until its
+// teardown finishes, and the replacement the GUI spawns into that gap
+// must wait rather than exit.
+func TestStateLockWaitsOutAClosingDaemon(t *testing.T) {
+	skipOnWindows(t)
+	orig := stateLockBudget
+	stateLockBudget = 3 * time.Second
+	t.Cleanup(func() { stateLockBudget = orig })
+
+	tmp := shortTempDir(t)
+	state := filepath.Join(tmp, "state")
+	first, err := New(Config{SocketPath: filepath.Join(tmp, "s1"), StateDir: state})
+	if err != nil {
+		t.Fatalf("first New: %v", err)
+	}
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = first.Close()
+	}()
+
+	second, err := New(Config{SocketPath: filepath.Join(tmp, "s2"), StateDir: state})
+	if err != nil {
+		t.Fatalf("replacement daemon gave up on a lock the outgoing one was about to release: %v", err)
+	}
+	_ = second.Close()
 }

--- a/internal/daemon/event_socket_test.go
+++ b/internal/daemon/event_socket_test.go
@@ -98,6 +98,12 @@ func TestEventSocketSessionModeServesIdeas(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	// Bound the wait: without a deadline a regression that stops
+	// IDEA_EVENT reaching a restricted connection blocks here forever
+	// and the whole package dies on go test's timeout instead of
+	// failing this one test by name.
+	_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	defer func() { _ = c.SetReadDeadline(time.Time{}) }()
 	for {
 		ft, payload, err := wire.ReadFrame(c)
 		if err != nil {

--- a/internal/daemon/event_socket_test.go
+++ b/internal/daemon/event_socket_test.go
@@ -1,0 +1,147 @@
+package daemon
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lucascaro/hive/internal/wire"
+)
+
+func dialEvents(t *testing.T, d *Daemon) net.Conn {
+	t.Helper()
+	c, err := net.Dial("unix", d.EventSocketPath())
+	if err != nil {
+		t.Fatalf("dial events socket: %v", err)
+	}
+	return c
+}
+
+// The events socket sits next to the control socket, in the same
+// verified directory, and is not the control socket.
+func TestEventSocketPathSitsBesideControl(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	ev := d.EventSocketPath()
+	if ev == d.SocketPath() {
+		t.Fatal("events socket is the control socket")
+	}
+	if got, want := filepath.Dir(ev), filepath.Dir(d.SocketPath()); got != want {
+		t.Fatalf("events socket dir = %q, want %q", got, want)
+	}
+}
+
+// The events socket applies a well-formed AGENT_EVENT exactly like the
+// control socket's event mode does.
+func TestEventSocketAcceptsAgentEvent(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	id := bootstrapSessionID(t, d)
+	c := dialEvents(t, d)
+	defer c.Close()
+	if err := wire.WriteJSON(c, wire.FrameHello, wire.Hello{
+		Version: wire.PROTOCOL_VERSION, Client: "test/0", Mode: wire.ModeEvent,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := wire.WriteJSON(c, wire.FrameAgentEvent, wire.AgentEvent{
+		SessionID: id,
+		Kind:      wire.AgentEventPrompt,
+		Source:    wire.StateSourceHook,
+		Text:      "say pong",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		info := findSession(d, id)
+		return info.State == wire.StateWorking &&
+			info.StateSource == wire.StateSourceHook &&
+			info.LastPrompt == "say pong"
+	})
+}
+
+// Every other HELLO mode is refused on the events socket with
+// mode_not_allowed, and nothing is created.
+func TestEventSocketRefusesControlAndCreate(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	before := len(d.Registry().List())
+	for _, mode := range []wire.Mode{wire.ModeControl, wire.ModeCreate, wire.ModeAttach} {
+		c := dialEvents(t, d)
+		hello := wire.Hello{Version: wire.PROTOCOL_VERSION, Client: "test/0", Mode: mode}
+		if mode == wire.ModeCreate {
+			hello.Create = &wire.CreateSpec{Cmd: []string{"/bin/sh", "-c", "true"}}
+		}
+		if err := wire.WriteJSON(c, wire.FrameHello, hello); err != nil {
+			t.Fatal(err)
+		}
+		var e wire.Error
+		ft, err := wire.ReadJSON(c, &e)
+		if err != nil {
+			t.Fatalf("mode %s: read: %v", mode, err)
+		}
+		if ft != wire.FrameError || e.Code != wire.ErrCodeModeNotAllowed {
+			t.Fatalf("mode %s: got %s %+v, want ERROR mode_not_allowed", mode, ft, e)
+		}
+		_ = c.Close()
+	}
+	if got := len(d.Registry().List()); got != before {
+		t.Fatalf("sessions: %d → %d; create must not succeed on events socket", before, got)
+	}
+}
+
+// The control socket keeps serving every mode; narrowing the events
+// socket must not have narrowed it too.
+func TestControlSocketStillServesControl(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	c := dial(t, d)
+	defer c.Close()
+	if err := wire.WriteJSON(c, wire.FrameHello, wire.Hello{
+		Version: wire.PROTOCOL_VERSION, Client: "test/0", Mode: wire.ModeControl,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var w wire.Welcome
+	ft, err := wire.ReadJSON(c, &w)
+	if err != nil {
+		t.Fatalf("read welcome: %v", err)
+	}
+	if ft != wire.FrameWelcome {
+		t.Fatalf("got %s, want WELCOME", ft)
+	}
+}
+
+// The environment handed to a spawned session points at the events
+// socket, never the control socket.
+func TestSpawnedSessionEnvUsesEventSocket(t *testing.T) {
+	skipOnWindows(t)
+	d := startTestDaemon(t)
+	env := d.Registry().HiveEnvForTest("abc")
+	want := "HIVE_SOCKET=" + d.EventSocketPath()
+	found := false
+	for _, kv := range env {
+		if kv == want {
+			found = true
+		}
+		if kv == "HIVE_SOCKET="+d.SocketPath() {
+			t.Fatalf("env exports the control socket: %v", env)
+		}
+	}
+	if !found {
+		t.Fatalf("env %v lacks %q", env, want)
+	}
+}
+
+func waitFor(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met in time")
+}

--- a/internal/daemon/legacy_socket_test.go
+++ b/internal/daemon/legacy_socket_test.go
@@ -47,6 +47,40 @@ func TestLegacyDaemonAliveIgnoresAStaleSocketFile(t *testing.T) {
 	}
 }
 
+// The legacy path lives in the world-writable /tmp, and on a machine
+// that never ran a pre-move Hive the directory is absent — so another
+// account can create it and listen. Believing that would wedge every
+// consumer of the answer: the daemon refuses to start beside a
+// "running" daemon the user cannot see, hivebar pins to the squatted
+// path on every reconnect, and the GUI's spawn hits the same refusal.
+// An unverifiable directory must read as "no legacy daemon".
+func TestLegacyDaemonIsIgnoredWhenItsDirIsNotOurs(t *testing.T) {
+	skipOnWindows(t)
+	dir := shortTempDir(t)
+	sock := filepath.Join(dir, "hived.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Same live socket, only the directory changes.
+	if !legacyAlive(sock) {
+		t.Fatal("a live socket in a 0700 dir was not read as a legacy daemon")
+	}
+	for _, mode := range []os.FileMode{0o755, 0o777, 0o707} {
+		if err := os.Chmod(dir, mode); err != nil {
+			t.Fatal(err)
+		}
+		if legacyAlive(sock) {
+			t.Errorf("dir mode %o: a socket in a group/world-reachable dir was read as a legacy daemon", mode)
+		}
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // An explicit socket path that is not the platform default belongs to a
 // test or an isolated dev daemon; neither should refuse to start because
 // the user's real, pre-move Hive is running.

--- a/internal/daemon/legacy_socket_test.go
+++ b/internal/daemon/legacy_socket_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// HIVE_SOCKET pins the path explicitly, so there is nothing to migrate
+// from and the probe must stay out of the way — an isolated dev daemon
+// (scripts/dev-iso.sh) would otherwise refuse to start whenever the
+// user's real Hive was up.
+func TestLegacySocketPathIsEmptyWhenHiveSocketIsSet(t *testing.T) {
+	skipOnWindows(t)
+	t.Setenv("HIVE_SOCKET", filepath.Join(t.TempDir(), "s"))
+	if got := LegacySocketPath(); got != "" {
+		t.Fatalf("LegacySocketPath() = %q with HIVE_SOCKET set, want empty", got)
+	}
+}
+
+// A leftover socket file is not a running daemon. Spawning onto the old
+// path because a stale file was there would be worse than the collision
+// the probe exists to catch.
+func TestLegacyDaemonAliveIgnoresAStaleSocketFile(t *testing.T) {
+	skipOnWindows(t)
+	// shortTempDir, not t.TempDir: AF_UNIX paths are capped at 104
+	// bytes on macOS and the per-test temp path blows straight past it.
+	dir := shortTempDir(t)
+	stale := filepath.Join(dir, "hived.sock")
+	if err := os.WriteFile(stale, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// legacyAlive is what LegacyDaemonAlive does once it has a path;
+	// the path itself is uid-derived and not overridable.
+	if alive := legacyAlive(stale); alive {
+		t.Fatal("a stale socket file was read as a live daemon")
+	}
+
+	ln, err := net.Listen("unix", filepath.Join(dir, "live.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	if alive := legacyAlive(filepath.Join(dir, "live.sock")); !alive {
+		t.Fatal("a listening socket was not read as a live daemon")
+	}
+}
+
+// An explicit socket path that is not the platform default belongs to a
+// test or an isolated dev daemon; neither should refuse to start because
+// the user's real, pre-move Hive is running.
+func TestLegacyDaemonBlockingIgnoresNonDefaultSockets(t *testing.T) {
+	skipOnWindows(t)
+	if _, blocked := legacyDaemonBlocking(filepath.Join(t.TempDir(), "s")); blocked {
+		t.Fatal("a non-default socket path was blocked by the legacy probe")
+	}
+}

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -1,0 +1,29 @@
+package daemon
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrAlreadyRunning is what acquireStateLock returns when another hived
+// already holds this state directory.
+var ErrAlreadyRunning = errors.New("another hived is already running against this state directory")
+
+// stateLockBudget is how long a starting daemon waits for the state
+// lock before giving up, and stateLockPoll how often it retries.
+//
+// Non-zero because of the restart handoff: the outgoing daemon closes
+// its listeners first and releases the lock last, after draining its
+// in-flight ops. The GUI reads the dead socket as "daemon gone" and
+// spawns a replacement inside that gap — and dialOrSpawn spawns at most
+// once per GUI process, so a replacement that exits on a held lock
+// leaves the app with no daemon at all. Waiting a few seconds costs a
+// slow start in the rare case; not waiting costs the restart.
+//
+// Vars, not consts, so the tests can shrink them. Declared here rather
+// than beside the POSIX implementation so the tests that shrink them
+// still compile on Windows, where acquireStateLock is a no-op.
+var (
+	stateLockBudget = 5 * time.Second
+	stateLockPoll   = 50 * time.Millisecond
+)

--- a/internal/daemon/lock_posix.go
+++ b/internal/daemon/lock_posix.go
@@ -11,27 +11,6 @@ import (
 	"time"
 )
 
-// ErrAlreadyRunning is what acquireStateLock returns when another hived
-// already holds this state directory.
-var ErrAlreadyRunning = errors.New("another hived is already running against this state directory")
-
-// stateLockBudget is how long a starting daemon waits for the lock
-// before giving up, and stateLockPoll how often it retries.
-//
-// Non-zero because of the restart handoff: the outgoing daemon closes
-// its listeners first and releases this lock last, after draining its
-// in-flight ops. The GUI reads the dead socket as "daemon gone" and
-// spawns a replacement inside that gap — and dialOrSpawn spawns at most
-// once per GUI process, so a replacement that exits on a held lock
-// leaves the app with no daemon at all. Waiting a few seconds costs a
-// slow start in the rare case; not waiting costs the restart.
-//
-// Vars, not consts, so the tests can shrink them.
-var (
-	stateLockBudget = 5 * time.Second
-	stateLockPoll   = 50 * time.Millisecond
-)
-
 // acquireStateLock takes an exclusive, non-blocking flock on
 // <stateDir>/hived.lock. The returned file must be kept open for the
 // daemon's lifetime — closing it releases the lock — and closed on

--- a/internal/daemon/lock_posix.go
+++ b/internal/daemon/lock_posix.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// ErrAlreadyRunning is what acquireStateLock returns when another hived
+// already holds this state directory.
+var ErrAlreadyRunning = errors.New("another hived is already running against this state directory")
+
+// acquireStateLock takes an exclusive, non-blocking flock on
+// <stateDir>/hived.lock. The returned file must be kept open for the
+// daemon's lifetime — closing it releases the lock — and closed on
+// teardown.
+//
+// The socket file used to be the singleton guard: New dialled it and
+// refused to start if anything answered. That only ever worked while
+// the path was stable, and this change moves it, so across the upgrade
+// an old daemon on /tmp/hive-<uid> and a new one on $TMPDIR/hive cannot
+// see each other and would both revive every persisted session against
+// one registry. The state directory is the thing there can only be one
+// writer of, so lock that instead of the socket — it is what the guard
+// was always reaching for.
+func acquireStateLock(stateDir string) (*os.File, error) {
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(stateDir, "hived.lock")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, fmt.Errorf("%w: %s", ErrAlreadyRunning, stateDir)
+		}
+		return nil, fmt.Errorf("lock %s: %w", path, err)
+	}
+	return f, nil
+}

--- a/internal/daemon/lock_posix.go
+++ b/internal/daemon/lock_posix.go
@@ -8,11 +8,29 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"time"
 )
 
 // ErrAlreadyRunning is what acquireStateLock returns when another hived
 // already holds this state directory.
 var ErrAlreadyRunning = errors.New("another hived is already running against this state directory")
+
+// stateLockBudget is how long a starting daemon waits for the lock
+// before giving up, and stateLockPoll how often it retries.
+//
+// Non-zero because of the restart handoff: the outgoing daemon closes
+// its listeners first and releases this lock last, after draining its
+// in-flight ops. The GUI reads the dead socket as "daemon gone" and
+// spawns a replacement inside that gap — and dialOrSpawn spawns at most
+// once per GUI process, so a replacement that exits on a held lock
+// leaves the app with no daemon at all. Waiting a few seconds costs a
+// slow start in the rare case; not waiting costs the restart.
+//
+// Vars, not consts, so the tests can shrink them.
+var (
+	stateLockBudget = 5 * time.Second
+	stateLockPoll   = 50 * time.Millisecond
+)
 
 // acquireStateLock takes an exclusive, non-blocking flock on
 // <stateDir>/hived.lock. The returned file must be kept open for the
@@ -36,12 +54,20 @@ func acquireStateLock(stateDir string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		_ = f.Close()
-		if errors.Is(err, syscall.EWOULDBLOCK) {
+	deadline := time.Now().Add(stateLockBudget)
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			_ = f.Close()
+			return nil, fmt.Errorf("lock %s: %w", path, err)
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
 			return nil, fmt.Errorf("%w: %s", ErrAlreadyRunning, stateDir)
 		}
-		return nil, fmt.Errorf("lock %s: %w", path, err)
+		time.Sleep(stateLockPoll)
 	}
-	return f, nil
 }

--- a/internal/daemon/lock_posix.go
+++ b/internal/daemon/lock_posix.go
@@ -17,13 +17,21 @@ import (
 // teardown.
 //
 // The socket file used to be the singleton guard: New dialled it and
-// refused to start if anything answered. That only ever worked while
-// the path was stable, and this change moves it, so across the upgrade
-// an old daemon on /tmp/hive-<uid> and a new one on $TMPDIR/hive cannot
-// see each other and would both revive every persisted session against
-// one registry. The state directory is the thing there can only be one
-// writer of, so lock that instead of the socket — it is what the guard
-// was always reaching for.
+// refused to start if anything answered. That is a proxy for the thing
+// that actually has to be single — there can only be one writer of the
+// state directory — and it only holds while the socket path is stable.
+// This change moves the path, so the proxy stopped being reliable at
+// exactly the moment two daemons became easier to get. Lock the state
+// directory instead; it is what the guard was always reaching for.
+//
+// Note what this does NOT cover: the upgrade itself. A daemon built
+// before this takes no lock at all, so a new one starting beside a
+// still-running old one acquires uncontested and both run. Closing
+// that would mean probing the old default path — migration cruft with
+// a one-release shelf life. What covers it in practice is the contract
+// bump: the GUI shuts the old daemon down in-band before starting the
+// new one. A hand-started hived during the upgrade is the residual
+// gap, and it is a one-time one.
 func acquireStateLock(stateDir string) (*os.File, error) {
 	if err := os.MkdirAll(stateDir, 0o700); err != nil {
 		return nil, err

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+)
+
+// ErrAlreadyRunning is what acquireStateLock returns when another hived
+// already holds this state directory. Unreachable on Windows, where
+// acquireStateLock is a no-op — see below.
+var ErrAlreadyRunning = errors.New("another hived is already running against this state directory")
+
+// acquireStateLock is a no-op on Windows. The socket path there did not
+// move (%LOCALAPPDATA%\Hive), so the pre-existing "something answers
+// this socket" probe in New is still a working singleton guard, and the
+// upgrade window the POSIX lock exists to close does not open.
+func acquireStateLock(string) (*os.File, error) { return nil, nil }

--- a/internal/daemon/lock_windows.go
+++ b/internal/daemon/lock_windows.go
@@ -2,15 +2,7 @@
 
 package daemon
 
-import (
-	"errors"
-	"os"
-)
-
-// ErrAlreadyRunning is what acquireStateLock returns when another hived
-// already holds this state directory. Unreachable on Windows, where
-// acquireStateLock is a no-op — see below.
-var ErrAlreadyRunning = errors.New("another hived is already running against this state directory")
+import "os"
 
 // acquireStateLock is a no-op on Windows. The socket path there did not
 // move (%LOCALAPPDATA%\Hive), so the pre-existing "something answers

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -61,11 +61,14 @@ func SocketPath() string {
 	}
 }
 
-// EventSocketPath is the events-only listener that sits next to the
+// EventSocketPath is the narrowed listener that sits next to the
 // control socket. It is what spawned sessions get as HIVE_SOCKET: hooks
-// and extensions can report state on it, but a HELLO in any other mode
-// is refused, so a subprocess of an agent cannot create, attach to or
-// kill sessions through the environment it inherited.
+// and extensions report state on it with ModeEvent, and `hive idea`
+// opens a ModeSession connection for ADD_IDEA / LIST_IDEAS plus a
+// SESSIONS snapshot narrowed to its own session. Every other mode is
+// refused with mode_not_allowed, so a subprocess of an agent cannot
+// create, attach to or kill sessions through the environment it
+// inherited.
 func EventSocketPath(controlSock string) string { return controlSock + ".events" }
 
 // EnsureSocketDir creates the socket's directory 0700 when missing and

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -46,7 +46,12 @@ func SocketPath() string {
 		}
 		return filepath.Join(registry.StateDir(), "hived.sock")
 	case "darwin":
-		if tmp := os.TempDir(); tmp != "/tmp" && tmp != "/private/tmp" {
+		// Clean first: os.TempDir returns $TMPDIR verbatim, and
+		// launchd's own value ends in a slash. Comparing the raw string
+		// would let TMPDIR="/tmp/" walk straight past this guard and put
+		// the socket back in the shared /tmp this whole change exists to
+		// leave.
+		if tmp := filepath.Clean(os.TempDir()); tmp != "/tmp" && tmp != "/private/tmp" {
 			return filepath.Join(tmp, "hive", "hived.sock")
 		}
 		return filepath.Join(registry.StateDir(), "hived.sock")

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -103,7 +103,13 @@ func CheckSocketDir(sockPath string) error {
 	dir := filepath.Dir(sockPath)
 	st, err := os.Lstat(dir)
 	if err != nil {
-		return err
+		// A bare errno reaches a user as "lstat /some/path: no such
+		// file or directory", which says nothing about what was being
+		// checked or why the command stopped.
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("socket dir %s does not exist; is hived running?", dir)
+		}
+		return fmt.Errorf("socket dir %s: %w", dir, err)
 	}
 	if st.Mode()&os.ModeSymlink != 0 {
 		return fmt.Errorf("socket dir %s is a symlink; refusing", dir)

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -1,10 +1,13 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/lucascaro/hive/internal/registry"
 )
 
 // SocketPath returns the canonical hived socket path for the current
@@ -16,6 +19,22 @@ import (
 // Setting HIVE_SOCKET overrides the platform default — useful for
 // running an isolated dev daemon alongside a production one without
 // touching its sessions.
+//
+// The directory must be one only this user can reach. A shared /tmp is
+// not: another account can pre-create /tmp/hive-<uid> and park a fake
+// socket in it, and every client here would connect to it and hand it
+// every keystroke (2026-09 audit, finding 1). So:
+//   - Linux/BSD: $XDG_RUNTIME_DIR/hive (per-user, 0700 by the login
+//     manager); without it, fall back to the state dir.
+//   - macOS: $TMPDIR/hive — launchd gives every user a private 0700
+//     temp dir under /var/folders and os.TempDir returns it. When
+//     $TMPDIR is unset os.TempDir returns /tmp, which is refused here
+//     in favour of the state dir.
+//   - Windows: %LOCALAPPDATA%\Hive (unchanged; per-user profile).
+//
+// AF_UNIX paths are capped at 104 bytes on macOS; the launchd $TMPDIR
+// is ~49, which leaves room for "/hive/hived.sock" and the ".events"
+// suffix EventSocketPath appends.
 func SocketPath() string {
 	if s := os.Getenv("HIVE_SOCKET"); s != "" {
 		return s
@@ -25,11 +44,12 @@ func SocketPath() string {
 		if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
 			return filepath.Join(dir, "hive", "hived.sock")
 		}
-		return fmt.Sprintf("/tmp/hive-%d/hived.sock", os.Getuid())
+		return filepath.Join(registry.StateDir(), "hived.sock")
 	case "darwin":
-		// macOS doesn't ship XDG_RUNTIME_DIR. /tmp is the path of least
-		// resistance and matches what most Mac daemons do.
-		return fmt.Sprintf("/tmp/hive-%d/hived.sock", os.Getuid())
+		if tmp := os.TempDir(); tmp != "/tmp" && tmp != "/private/tmp" {
+			return filepath.Join(tmp, "hive", "hived.sock")
+		}
+		return filepath.Join(registry.StateDir(), "hived.sock")
 	case "windows":
 		base := os.Getenv("LOCALAPPDATA")
 		if base == "" {
@@ -41,12 +61,62 @@ func SocketPath() string {
 	}
 }
 
-// EnsureSocketDir makes sure the directory containing the socket
-// exists, with restrictive permissions on POSIX.
+// EventSocketPath is the events-only listener that sits next to the
+// control socket. It is what spawned sessions get as HIVE_SOCKET: hooks
+// and extensions can report state on it, but a HELLO in any other mode
+// is refused, so a subprocess of an agent cannot create, attach to or
+// kill sessions through the environment it inherited.
+func EventSocketPath(controlSock string) string { return controlSock + ".events" }
+
+// EnsureSocketDir creates the socket's directory 0700 when missing and
+// then verifies it with CheckSocketDir. The daemon calls it before
+// binding; the GUI calls it before dialing, since it may be the one to
+// spawn the daemon.
 func EnsureSocketDir(sockPath string) error {
 	dir := filepath.Dir(sockPath)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
+	return CheckSocketDir(sockPath)
+}
+
+// CheckSocketDir refuses a socket directory another user could have
+// created or can write to: it must be a real directory (not a
+// symlink), owned by this uid, with no group or other permission bits.
+// Clients call it before dialing so an impostor socket is never
+// trusted; the daemon calls it before binding.
+//
+// No-op on Windows, where the path is under the per-user profile and
+// POSIX mode bits do not describe who can reach it.
+func CheckSocketDir(sockPath string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	dir := filepath.Dir(sockPath)
+	st, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if st.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("socket dir %s is a symlink; refusing", dir)
+	}
+	if !st.IsDir() {
+		return fmt.Errorf("socket dir %s is not a directory", dir)
+	}
+	if perm := st.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Errorf("socket dir %s has mode %04o; must be 0700 (chmod 700 %s)", dir, perm, dir)
+	}
+	uid, err := dirOwnerUID(st)
+	if err != nil {
+		return err
+	}
+	if uid != os.Getuid() {
+		return fmt.Errorf("socket dir %s is owned by uid %d, not %d; refusing", dir, uid, os.Getuid())
+	}
 	return nil
 }
+
+// errNoOwner is what dirOwnerUID returns when the platform's FileInfo
+// carries no uid — it should not happen on the POSIX targets, and the
+// safe reading of "cannot tell who owns this" is to refuse.
+var errNoOwner = errors.New("socket dir: cannot read owner")

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -97,7 +97,8 @@ func LegacySocketPath() string {
 
 // LegacyDaemonAlive reports whether a pre-move daemon is still serving
 // the old default path. False whenever there is no legacy path to
-// check, and false for a stale socket file nothing answers.
+// check, false for a stale socket file nothing answers, and false for a
+// directory that is not ours — see legacyAlive.
 func LegacyDaemonAlive() (string, bool) {
 	legacy := LegacySocketPath()
 	if legacy == "" {
@@ -106,11 +107,29 @@ func LegacyDaemonAlive() (string, bool) {
 	return legacy, legacyAlive(legacy)
 }
 
-// legacyAlive reports whether something is actually serving path. Split
+// legacyAlive reports whether OUR pre-move daemon is serving path. Split
 // out of LegacyDaemonAlive because the path there is uid-derived and so
 // cannot be pointed at a fixture.
+//
+// CheckSocketDir first, and this is load-bearing rather than tidy. The
+// legacy path lives in the world-writable /tmp that this whole change
+// exists to leave, and on a machine that never ran a pre-move Hive the
+// directory does not exist — so another local account can create it,
+// bind a socket, and be believed. Nobody would be impersonated (every
+// client checks the directory before handshaking), but every consumer
+// of this answer would wedge: the daemon refuses to start beside a
+// "running" daemon the user cannot see, hivebar pins to the squatted
+// path on every reconnect, and the GUI's spawn hits that same refusal.
+// One guard here rather than three at the call sites: an unverifiable
+// directory is not a legacy daemon, so it reads as absent and every
+// caller falls through to the canonical path. A genuine legacy
+// directory passes — the old daemon created it 0700 with the same
+// EnsureSocketDir this package still has.
 func legacyAlive(path string) bool {
 	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	if err := CheckSocketDir(path); err != nil {
 		return false
 	}
 	c, err := net.DialTimeout("unix", path, legacyProbeTimeout)
@@ -119,6 +138,19 @@ func legacyAlive(path string) bool {
 	}
 	_ = c.Close()
 	return true
+}
+
+// ActiveSocketPath is the socket a running daemon is expected to be on:
+// the pre-move default while one is still serving it, otherwise the
+// canonical SocketPath. Clients that only ever DIAL should resolve
+// through here so they cannot disagree about which daemon they mean;
+// anything that BINDS wants SocketPath directly, since nothing new ever
+// binds the old path. Delete with LegacySocketPath.
+func ActiveSocketPath() string {
+	if legacy, alive := LegacyDaemonAlive(); alive {
+		return legacy
+	}
+	return SocketPath()
 }
 
 // legacyProbeTimeout bounds the legacy-path dial. A local daemon

--- a/internal/daemon/socket.go
+++ b/internal/daemon/socket.go
@@ -3,9 +3,11 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/lucascaro/hive/internal/registry"
 )
@@ -65,6 +67,64 @@ func SocketPath() string {
 		return filepath.Join(os.TempDir(), "hived.sock")
 	}
 }
+
+// LegacySocketPath returns the pre-2026-09 default socket path —
+// /tmp/hive-<uid>/hived.sock — or "" when there is nothing to migrate
+// from: HIVE_SOCKET pins the path explicitly, Windows never used it, or
+// it is what SocketPath returns anyway.
+//
+// It exists for one release's worth of upgrade. A daemon built before
+// the move takes no state lock and binds a path the new one does not
+// look at, so an upgrade that leaves the old daemon running — anything
+// but the in-app updater, which shuts it down in-band first — would
+// otherwise end with two daemons reviving the same sessions against one
+// registry. Callers probe this path by DIALING it, never by statting:
+// a leftover socket file is not a running daemon, and spawning onto the
+// old path would be worse than the problem.
+//
+// Delete this, and its callers, once the previous release is far enough
+// back that nobody is upgrading across the move.
+func LegacySocketPath() string {
+	if os.Getenv("HIVE_SOCKET") != "" || runtime.GOOS == "windows" {
+		return ""
+	}
+	legacy := fmt.Sprintf("/tmp/hive-%d/hived.sock", os.Getuid())
+	if legacy == SocketPath() {
+		return ""
+	}
+	return legacy
+}
+
+// LegacyDaemonAlive reports whether a pre-move daemon is still serving
+// the old default path. False whenever there is no legacy path to
+// check, and false for a stale socket file nothing answers.
+func LegacyDaemonAlive() (string, bool) {
+	legacy := LegacySocketPath()
+	if legacy == "" {
+		return "", false
+	}
+	return legacy, legacyAlive(legacy)
+}
+
+// legacyAlive reports whether something is actually serving path. Split
+// out of LegacyDaemonAlive because the path there is uid-derived and so
+// cannot be pointed at a fixture.
+func legacyAlive(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	c, err := net.DialTimeout("unix", path, legacyProbeTimeout)
+	if err != nil {
+		return false
+	}
+	_ = c.Close()
+	return true
+}
+
+// legacyProbeTimeout bounds the legacy-path dial. A local daemon
+// accepts immediately; anything slower is not one worth waiting for on
+// a boot path.
+const legacyProbeTimeout = 250 * time.Millisecond
 
 // EventSocketPath is the narrowed listener that sits next to the
 // control socket. It is what spawned sessions get as HIVE_SOCKET: hooks

--- a/internal/daemon/socket_dir_test.go
+++ b/internal/daemon/socket_dir_test.go
@@ -136,3 +136,20 @@ func TestSocketPathLinuxUsesXDGRuntimeDir(t *testing.T) {
 		t.Fatalf("SocketPath() without XDG_RUNTIME_DIR = %q; must not fall back to shared /tmp", got)
 	}
 }
+
+// os.TempDir returns $TMPDIR verbatim, slash and all, so the /tmp guard
+// has to compare a cleaned path. Without that, TMPDIR="/tmp/" puts the
+// socket straight back into the shared directory this change exists to
+// leave.
+func TestSocketPathRejectsTrailingSlashTmp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin uses $TMPDIR")
+	}
+	t.Setenv("HIVE_SOCKET", "")
+	for _, tmp := range []string{"/tmp/", "/tmp//", "/private/tmp/"} {
+		t.Setenv("TMPDIR", tmp)
+		if got := SocketPath(); strings.HasPrefix(got, "/tmp/") || strings.HasPrefix(got, "/private/tmp/") {
+			t.Errorf("TMPDIR=%q: SocketPath() = %q, want the state-dir fallback", tmp, got)
+		}
+	}
+}

--- a/internal/daemon/socket_dir_test.go
+++ b/internal/daemon/socket_dir_test.go
@@ -111,6 +111,10 @@ func TestSocketPathDarwinIsPerUserTmp(t *testing.T) {
 		t.Skip("darwin default")
 	}
 	t.Setenv("HIVE_SOCKET", "")
+	// The fallback resolves through registry.StateDir(), so an
+	// inherited HIVE_STATE_DIR (scripts/dev-iso.sh parks one under
+	// /tmp) would otherwise decide this assertion.
+	t.Setenv("HIVE_STATE_DIR", t.TempDir())
 	got := SocketPath()
 	if strings.HasPrefix(got, "/tmp/") || strings.HasPrefix(got, "/private/tmp/") {
 		t.Fatalf("SocketPath() = %q; must not live under shared /tmp", got)
@@ -127,13 +131,18 @@ func TestSocketPathLinuxUsesXDGRuntimeDir(t *testing.T) {
 		t.Skip("linux default")
 	}
 	t.Setenv("HIVE_SOCKET", "")
+	// Pin the fallback: without XDG_RUNTIME_DIR the path comes from
+	// registry.StateDir(), which an inherited HIVE_STATE_DIR would
+	// otherwise redirect (scripts/dev-iso.sh parks one under /tmp).
+	state := t.TempDir()
+	t.Setenv("HIVE_STATE_DIR", state)
 	t.Setenv("XDG_RUNTIME_DIR", "/run/user/4242")
 	if got, want := SocketPath(), "/run/user/4242/hive/hived.sock"; got != want {
 		t.Fatalf("SocketPath() = %q, want %q", got, want)
 	}
 	t.Setenv("XDG_RUNTIME_DIR", "")
-	if got := SocketPath(); strings.HasPrefix(got, "/tmp/") {
-		t.Fatalf("SocketPath() without XDG_RUNTIME_DIR = %q; must not fall back to shared /tmp", got)
+	if got, want := SocketPath(), filepath.Join(state, "hived.sock"); got != want {
+		t.Fatalf("SocketPath() without XDG_RUNTIME_DIR = %q, want the state-dir fallback %q", got, want)
 	}
 }
 
@@ -146,10 +155,16 @@ func TestSocketPathRejectsTrailingSlashTmp(t *testing.T) {
 		t.Skip("darwin uses $TMPDIR")
 	}
 	t.Setenv("HIVE_SOCKET", "")
+	// t.TempDir() reads TMPDIR, so take it before the loop rewrites
+	// it. Pinning HIVE_STATE_DIR is what makes the fallback assertion
+	// about SocketPath rather than about the caller's environment.
+	state := t.TempDir()
+	t.Setenv("HIVE_STATE_DIR", state)
+	want := filepath.Join(state, "hived.sock")
 	for _, tmp := range []string{"/tmp/", "/tmp//", "/private/tmp/"} {
 		t.Setenv("TMPDIR", tmp)
-		if got := SocketPath(); strings.HasPrefix(got, "/tmp/") || strings.HasPrefix(got, "/private/tmp/") {
-			t.Errorf("TMPDIR=%q: SocketPath() = %q, want the state-dir fallback", tmp, got)
+		if got := SocketPath(); got != want {
+			t.Errorf("TMPDIR=%q: SocketPath() = %q, want the state-dir fallback %q", tmp, got, want)
 		}
 	}
 }

--- a/internal/daemon/socket_dir_test.go
+++ b/internal/daemon/socket_dir_test.go
@@ -1,0 +1,138 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCheckSocketDirAcceptsOwn0700(t *testing.T) {
+	skipOnWindows(t)
+	dir := filepath.Join(t.TempDir(), "hive")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckSocketDir(filepath.Join(dir, "hived.sock")); err != nil {
+		t.Fatalf("CheckSocketDir: %v", err)
+	}
+}
+
+func TestCheckSocketDirRejectsGroupOrWorldAccess(t *testing.T) {
+	skipOnWindows(t)
+	for _, mode := range []os.FileMode{0o755, 0o770, 0o707, 0o777} {
+		dir := filepath.Join(t.TempDir(), "hive")
+		if err := os.Mkdir(dir, mode); err != nil {
+			t.Fatal(err)
+		}
+		// umask-proof: Mkdir's mode is masked, chmod's is not.
+		if err := os.Chmod(dir, mode); err != nil {
+			t.Fatal(err)
+		}
+		if err := CheckSocketDir(filepath.Join(dir, "hived.sock")); err == nil {
+			t.Errorf("mode %o: want error, got nil", mode)
+		}
+	}
+}
+
+func TestCheckSocketDirRejectsSymlink(t *testing.T) {
+	skipOnWindows(t)
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	if err := os.Mkdir(real, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "hive")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckSocketDir(filepath.Join(link, "hived.sock")); err == nil {
+		t.Fatal("symlinked socket dir accepted")
+	}
+}
+
+func TestEnsureSocketDirCreates0700(t *testing.T) {
+	skipOnWindows(t)
+	sock := filepath.Join(t.TempDir(), "hive", "hived.sock")
+	if err := EnsureSocketDir(sock); err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+	st, err := os.Lstat(filepath.Dir(sock))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode().Perm() != 0o700 {
+		t.Fatalf("mode = %o, want 700", st.Mode().Perm())
+	}
+}
+
+// EnsureSocketDir must not paper over a pre-existing loose directory:
+// MkdirAll is a no-op there, so the verify is the only thing standing
+// between the daemon and a squatted path.
+func TestEnsureSocketDirRejectsPreExistingLooseDir(t *testing.T) {
+	skipOnWindows(t)
+	dir := filepath.Join(t.TempDir(), "hive")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureSocketDir(filepath.Join(dir, "hived.sock")); err == nil {
+		t.Fatal("EnsureSocketDir accepted a world-writable pre-existing dir")
+	}
+}
+
+func TestNewRefusesUnsafeSocketDir(t *testing.T) {
+	skipOnWindows(t)
+	tmp := shortTempDir(t)
+	dir := filepath.Join(tmp, "open")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	d, err := New(Config{SocketPath: filepath.Join(dir, "s"), StateDir: filepath.Join(tmp, "state")})
+	if err == nil {
+		_ = d.Close()
+		t.Fatal("New accepted a world-writable socket dir")
+	}
+	if !strings.Contains(err.Error(), "socket dir") {
+		t.Fatalf("New error = %v, want it to name the socket dir", err)
+	}
+}
+
+// The default macOS path must not live in the shared /tmp, and must
+// leave room under the 104-byte AF_UNIX cap once ".events" is appended.
+func TestSocketPathDarwinIsPerUserTmp(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin default")
+	}
+	t.Setenv("HIVE_SOCKET", "")
+	got := SocketPath()
+	if strings.HasPrefix(got, "/tmp/") || strings.HasPrefix(got, "/private/tmp/") {
+		t.Fatalf("SocketPath() = %q; must not live under shared /tmp", got)
+	}
+	if n := len(EventSocketPath(got)); n > 100 {
+		t.Fatalf("EventSocketPath(SocketPath()) is %d bytes; AF_UNIX limit on macOS is 104", n)
+	}
+}
+
+// The Linux default follows XDG_RUNTIME_DIR, which the login manager
+// already owns 0700, and never falls back to a shared /tmp.
+func TestSocketPathLinuxUsesXDGRuntimeDir(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux default")
+	}
+	t.Setenv("HIVE_SOCKET", "")
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/4242")
+	if got, want := SocketPath(), "/run/user/4242/hive/hived.sock"; got != want {
+		t.Fatalf("SocketPath() = %q, want %q", got, want)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	if got := SocketPath(); strings.HasPrefix(got, "/tmp/") {
+		t.Fatalf("SocketPath() without XDG_RUNTIME_DIR = %q; must not fall back to shared /tmp", got)
+	}
+}

--- a/internal/daemon/socket_owner_posix.go
+++ b/internal/daemon/socket_owner_posix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+)
+
+// dirOwnerUID reads the owning uid out of a POSIX stat result.
+func dirOwnerUID(st os.FileInfo) (int, error) {
+	sys, ok := st.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, errNoOwner
+	}
+	return int(sys.Uid), nil
+}

--- a/internal/daemon/socket_owner_windows.go
+++ b/internal/daemon/socket_owner_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package daemon
+
+import "os"
+
+// dirOwnerUID is unreachable on Windows: CheckSocketDir returns before
+// it. It exists so the POSIX-only syscall.Stat_t stays out of the
+// Windows build.
+func dirOwnerUID(os.FileInfo) (int, error) { return 0, errNoOwner }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -250,11 +250,14 @@ type Registry struct {
 	order    []string
 	stateDir string
 
-	// socketPath is the Unix socket this registry's daemon is bound to.
-	// Set once by the daemon right after Open (SetSocketPath) — the
-	// registry has no way to know it otherwise, and it is what create,
-	// Revive and Restart put in a spawned agent's HIVE_SOCKET so its
-	// hooks/extension know where to dial back.
+	// socketPath is the daemon's EVENTS socket — not its control
+	// socket. Set once by the daemon right after Open (SetSocketPath);
+	// the registry has no way to know it otherwise, and it is what
+	// create, Revive and Restart put in a spawned agent's HIVE_SOCKET
+	// so its hooks/extension know where to dial back. Events-only on
+	// purpose: everything downstream of a session inherits this
+	// environment, and reporting state is the whole of what it should
+	// be able to do (2026-09 audit, finding 2).
 	socketPath string
 	// hivedPath is the resolved absolute path of the running hived
 	// binary (os.Executable() + filepath.EvalSymlinks, done once at
@@ -595,9 +598,10 @@ func (r *Registry) setPhaseIf(id, from, to string) bool {
 	return true
 }
 
-// SetSocketPath records the Unix socket this registry's daemon is
-// bound to. Called once by the daemon right after Open, before any
-// session can be created.
+// SetSocketPath records the daemon's events socket — the one spawned
+// sessions get as HIVE_SOCKET. Called once by the daemon right after
+// Open, before any session can be created. Passing the control socket
+// here would hand every agent child session-creation rights.
 func (r *Registry) SetSocketPath(p string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -617,13 +621,18 @@ func (r *Registry) SetHivedPath(p string) {
 // hiveEnv returns the HIVE_SESSION_ID / HIVE_SOCKET pair every spawned
 // session's environment carries, so an agent's hook or extension tier
 // (and, per spec 337, anything else that wants to dial the daemon back)
-// knows its own id and where to reach it. Takes r.mu.
+// knows its own id and where to reach it. HIVE_SOCKET is the daemon's
+// events socket; see socketPath. Takes r.mu.
 func (r *Registry) hiveEnv(id string) []string {
 	r.mu.Lock()
 	sock := r.socketPath
 	r.mu.Unlock()
 	return []string{"HIVE_SESSION_ID=" + id, "HIVE_SOCKET=" + sock}
 }
+
+// HiveEnvForTest exposes hiveEnv to other packages' tests, so the
+// daemon can assert on the environment it actually hands a session.
+func (r *Registry) HiveEnvForTest(id string) []string { return r.hiveEnv(id) }
 
 // spawnInfo builds the agent.SpawnInfo a Def.SpawnArgs call needs.
 // Takes r.mu.

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -22,6 +22,17 @@ const (
 	// applied, then the connection is closed — there is no Welcome and
 	// the connection never streams DATA.
 	ModeEvent Mode = "event"
+	// ModeSession is a narrowed control connection for a program
+	// running INSIDE a Hive session — `hive idea` today. It reaches the
+	// daemon over the events socket (HIVE_SOCKET), and the daemon
+	// serves only the idea verbs on it: ADD_IDEA and LIST_IDEAS, plus
+	// the IDEA_EVENT stream and a SESSIONS snapshot narrowed to the
+	// one session named in Hello.SessionID. Everything else — creating,
+	// attaching to or killing sessions, worktree mutations, shutdown,
+	// and the other sessions' existence — is refused with
+	// mode_not_allowed, because everything downstream of a session
+	// inherits this environment.
+	ModeSession Mode = "session"
 )
 
 // CreateSpec is the payload for ModeCreate's create field, and also

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -737,9 +737,11 @@ const (
 	// ErrCodeModeNotAllowed is returned INSTEAD of serving the HELLO
 	// when the mode is not offered on the socket it arrived at. The
 	// events socket — the one spawned sessions inherit as HIVE_SOCKET
-	// — serves ModeEvent alone, so a process inside a session cannot
-	// use the environment it was handed to create, attach to or kill
-	// sessions.
+	// — serves ModeEvent and the narrowed ModeSession only, so a
+	// process inside a session cannot use the environment it was
+	// handed to create, attach to or kill sessions. It is also the
+	// code a ModeSession connection gets for any verb outside
+	// ADD_IDEA / LIST_IDEAS.
 	ErrCodeModeNotAllowed = "mode_not_allowed"
 	// ErrCodeIdeaTooLong is returned when an idea's text exceeds
 	// MaxIdeaText. Rejected rather than truncated: a silently

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -723,6 +723,13 @@ const (
 	// daemon refuses the connection outright, so this is the client's
 	// only signal — Handshake turns it into ErrProtocolMismatch.
 	ErrCodeProtocolVersionMismatch = "protocol_version_mismatch"
+	// ErrCodeModeNotAllowed is returned INSTEAD of serving the HELLO
+	// when the mode is not offered on the socket it arrived at. The
+	// events socket — the one spawned sessions inherit as HIVE_SOCKET
+	// — serves ModeEvent alone, so a process inside a session cannot
+	// use the environment it was handed to create, attach to or kill
+	// sessions.
+	ErrCodeModeNotAllowed = "mode_not_allowed"
 	// ErrCodeIdeaTooLong is returned when an idea's text exceeds
 	// MaxIdeaText. Rejected rather than truncated: a silently
 	// half-saved note is worse than one the user is told to shorten.

--- a/scripts/dev-iso.sh
+++ b/scripts/dev-iso.sh
@@ -123,6 +123,10 @@ if [[ $do_reset -eq 1 ]]; then
   rm -rf "$abs_iso_dir"
 fi
 mkdir -p "$iso_dir/state"
+# hived and the GUI both refuse a socket directory reachable by group or
+# other (see internal/daemon.CheckSocketDir), and mkdir here obeys the
+# umask, which is commonly 022.
+chmod 700 "$iso_dir"
 
 if [[ $do_build -eq 1 ]]; then
   ./build.sh


### PR DESCRIPTION
Closes findings 1 and 2 of the 2026-09-05 security audit.

## Finding 1 — socket squatting

`SocketPath()` returned `/tmp/hive-<uid>/hived.sock` on macOS, and on Linux without `XDG_RUNTIME_DIR`. `EnsureSocketDir` was `MkdirAll(dir, 0700)`, which is a no-op on a directory that already exists — so another local account could pre-create it, park a socket there, and have the GUI hand an impostor every keystroke.

- The macOS default is now `$TMPDIR/hive/` (launchd's private per-user temp dir); Linux falls back to the state dir instead of `/tmp`. `HIVE_SOCKET` still overrides.
- `CheckSocketDir` refuses a socket directory that is a symlink, is not owned by this uid, or carries any group/other permission bit. `EnsureSocketDir` creates 0700 and then verifies.
- The daemon checks before binding; the GUI (`dialOrSpawn`) and hivebar (`Client.session`) check before dialing.

## Finding 2 — `HIVE_SOCKET` is the control socket

Every spawned session inherits `HIVE_SOCKET`. It named the control socket, so any subprocess of an agent could send `HELLO{mode:create, cmd:[...]}` and run arbitrary commands outside the agent's sandbox — or kill sessions, remove worktrees with `force`/`deleteRemote`, or shut the daemon down.

- The daemon binds a second listener at `<sock>.events`. It serves `HELLO{mode:event}` alone and answers every other mode with a new `mode_not_allowed` error frame.
- `registry.SetSocketPath` is now given that path, so `hiveEnv` exports it. `hived hook` and the Pi extension speak `ModeEvent` only and are unchanged.
- The control socket is untouched and still serves all four modes.

Finding 9 (an agent can spoof its own hook events, since it knows `HIVE_SESSION_ID`) stays accepted — this reduces the blast radius to state display.

## Contract

`DaemonContract` 5 → 6. A session revived by an older daemon is handed the control socket, so the property only holds once the daemon is the new one.

## Verification

`go test ./... -count=1`, `go vet ./...`, `scripts/check-daemon-contract-selftest.sh`. Plus a live run of the built `hived`:

- both sockets appear in a 0700 dir;
- `mode:create` on the events socket returns `mode_not_allowed` and creates nothing;
- `mode:control` on the control socket still returns a WELCOME (`daemon_contract: 6`);
- `hived` in a 0777 socket dir exits with `has mode 0777; must be 0700`.

Pre-existing and unrelated: `internal/registry` `TestTerminalQueriesAreNotWork` also fails on a clean `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)