### PR TITLE
feat(gui): natural text editing keys for the terminal

### DIFF
--- a/.changesets/362-natural-text-editing.md
+++ b/.changesets/362-natural-text-editing.md
@@ -1,0 +1,12 @@
+---
+issue: 362
+pr: null
+type: added
+bump: minor
+---
+- macOS text editing in a session now covers the full set: ⌥⌦ deletes the
+  word after the cursor and ⌘⌦ deletes to the end of the line, mirroring the
+  ⌥⌫ and ⌘⌫ that already worked. Both chords previously did nothing at all —
+  xterm encoded them as `\x1b[3;3~` / `\x1b[3;9~`, which no shell binds.
+  The keyboard-shortcuts overlay (⌘/) and the README now list every
+  terminal-level editing key, not just some of them.

--- a/.changesets/362-natural-text-editing.md
+++ b/.changesets/362-natural-text-editing.md
@@ -1,6 +1,6 @@
 ---
 issue: 362
-pr: null
+pr: 363
 type: added
 bump: minor
 ---

--- a/README.md
+++ b/README.md
@@ -239,6 +239,18 @@ build.sh           # macOS universal build
 
 Full list in the app: **⌘/**. (Ctrl replaces ⌘ on Windows and Linux.)
 
+### Text editing inside a session
+
+These reach the shell or agent CLI rather than the app.
+
+| Key | Action |
+|---|---|
+| ⌦ | Delete the character after the cursor |
+| ⌥⌫ / ⌥⌦ | Delete the word before / after the cursor (macOS) |
+| ⌘⌫ / ⌘⌦ | Delete to start / end of line (macOS) |
+| ⌥← / ⌥→ | Move by word (macOS; Ctrl+← / Ctrl+→ on Windows and Linux) |
+| ⇧⏎ | Insert a newline in the agent's input instead of submitting |
+
 ## Contributing
 
 See `AGENTS.md` for repo-wide rules, `DESIGN.md` for the architecture

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -41,7 +41,12 @@ import {
   isClosing,
   phasePanel,
 } from '../lib/phase-steps.js';
-import { isShiftEnter, macLineEditSeq, NEWLINE_SEQ } from '../lib/keymap.js';
+import {
+  isShiftEnter,
+  macForwardKillSeq,
+  macLineEditSeq,
+  NEWLINE_SEQ,
+} from '../lib/keymap.js';
 import { DEFAULT_FONT_SIZE, clampFont } from '../lib/font.js';
 import {
   shouldRefreshOnVisibility,
@@ -458,6 +463,16 @@ export class SessionTerm {
       if (lineEdit) {
         e.preventDefault();
         this._writePty(lineEdit);
+        return false;
+      }
+      // macOS ⌥⌦ / ⌘⌦ → kill word forward / kill to end of line. xterm
+      // does encode forward delete, but any modifier turns it into
+      // \x1b[3;<mods+1>~, which nothing binds — so these chords are
+      // silent today. A bare ⌦ is left to xterm (\x1b[3~).
+      const forwardKill = macForwardKillSeq(e, isMac);
+      if (forwardKill) {
+        e.preventDefault();
+        this._writePty(forwardKill);
         return false;
       }
       // Shift+Enter → insert a newline in the agent's input instead of

--- a/cmd/hivegui/frontend/src/lib/keymap.ts
+++ b/cmd/hivegui/frontend/src/lib/keymap.ts
@@ -71,6 +71,50 @@ export function macLineEditSeq(e: KeyEventLike, isMac: boolean): string | null {
   return null;
 }
 
+// Bytes for the two forward-delete kills, both readline (emacs-mode)
+// bindings that bash, zsh, fish and the agent CLIs honour with no
+// per-terminal configuration — the same standard LINE_START_SEQ /
+// LINE_END_SEQ above are picked from.
+//
+//   \x1bd  meta-d, kill-word forward
+//   \x0b   Ctrl+K, kill-line to end
+export const KILL_WORD_FORWARD_SEQ = '\x1bd';
+export const KILL_LINE_FORWARD_SEQ = '\x0b';
+
+// macForwardKillSeq maps ⌥⌦ / ⌘⌦ to those bytes, or null when the event
+// isn't ours.
+//
+// Why this has to exist: xterm.js DOES encode the forward-delete key,
+// but its `case 46` branch emits `\x1b[3;<mods+1>~` whenever any
+// modifier is held — `\x1b[3;3~` for ⌥⌦ and `\x1b[3;9~` for ⌘⌦. No
+// shell, readline default or agent CLI binds either one, so the chords
+// currently do nothing at all. An unmodified ⌦ is left alone: xterm
+// sends `\x1b[3~` for it, which everything binds as delete-char.
+//
+// The key is 'Delete', NOT 'Backspace'. On a Mac laptop forward delete
+// is fn+⌫, which the browser reports as key 'Delete'; plain ⌫ stays
+// 'Backspace' and must keep reaching xterm (which sends \x7f, and
+// \x1b\x7f under ⌥) and hive's own ⌘⌫ → \x15 binding.
+//
+// Mac-only, for the same reason macLineEditSeq is: on Windows/Linux the
+// equivalent chord is Ctrl+⌦, which xterm already encodes as
+// `\x1b[3;5~` and which readline binds as kill-word.
+//
+// Shift is allowed through, exactly as in macLineEditSeq: ⇧⌘⌦ is
+// select-to-end-of-line in a text field, a PTY has no selection to
+// extend, and the kill is the closest honest thing. Ctrl is not — ⌃⌦
+// belongs to the shell. ⌥ and ⌘ held together is ambiguous between the
+// two kills, so it returns null rather than guessing.
+export function macForwardKillSeq(
+  e: KeyEventLike,
+  isMac: boolean,
+): string | null {
+  if (!isMac || e.ctrlKey || e.key !== 'Delete') return null;
+  if (e.metaKey && !e.altKey) return KILL_LINE_FORWARD_SEQ;
+  if (e.altKey && !e.metaKey) return KILL_WORD_FORWARD_SEQ;
+  return null;
+}
+
 export function isShiftEnter(e: KeyEventLike): boolean {
   return (
     e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey && e.key === 'Enter'

--- a/cmd/hivegui/frontend/src/lib/shortcuts.ts
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.ts
@@ -118,8 +118,14 @@ export function shortcutGroups({ isMac }: { isMac: boolean }): ShortcutGroup[] {
         },
         {
           keys: `${isMac ? '⌘' : 'Ctrl+'}${hArrows}`,
-          label:
-            'Grid: move between tiles — in focused mode these reach the terminal (start / end of line)',
+          // The terminal half differs by platform: macLineEditSeq maps ⌘←/→
+          // to \x01/\x05 on mac only, so off mac the chord falls through to
+          // xterm's \x1b[1;5D/C — word movement, which is what the "Inside a
+          // terminal" group lists it as. Saying "start / end of line" on both
+          // would contradict that row.
+          label: `Grid: move between tiles — in focused mode these reach the terminal (${
+            isMac ? 'start / end of line' : 'move by word'
+          })`,
         },
         {
           keys: `${isMac ? '⇧⌘' : 'Ctrl+Shift+'}${vArrows}`,

--- a/cmd/hivegui/frontend/src/lib/shortcuts.ts
+++ b/cmd/hivegui/frontend/src/lib/shortcuts.ts
@@ -36,6 +36,7 @@ interface ModOpts {
 const KEYS: Record<string, { mac: string; other: string }> = {
   enter: { mac: '↩', other: 'Enter' },
   backspace: { mac: '⌫', other: 'Backspace' },
+  delete: { mac: '⌦', other: 'Del' },
   up: { mac: '↑', other: 'Up' },
   down: { mac: '↓', other: 'Down' },
   left: { mac: '←', other: 'Left' },
@@ -186,7 +187,25 @@ export function shortcutGroups({ isMac }: { isMac: boolean }): ShortcutGroup[] {
           keys: `⇧${keyLabel('enter', isMac)}`,
           label: 'Insert newline in agent input (instead of submitting)',
         },
-        ...(isMac ? [{ keys: '⌘⌫', label: 'Clear input line' }] : []),
+        {
+          keys: keyLabel('delete', isMac),
+          label: 'Delete the character after the cursor',
+        },
+        // Text editing, split by platform because the chords genuinely
+        // differ. On macOS word-wise movement is ⌥←/→ (⌃←/→ is Mission
+        // Control's space switcher and never reaches the app); off mac
+        // it is Ctrl+←/→. Everything here is either written by the app
+        // (lib/keymap.ts) or encoded by xterm. See AGENTS.md ›
+        // Keybindings Policy.
+        ...(isMac
+          ? [
+              { keys: '⌥⌫', label: 'Delete the word before the cursor' },
+              { keys: '⌥⌦', label: 'Delete the word after the cursor' },
+              { keys: '⌘⌫', label: 'Delete to start of line' },
+              { keys: '⌘⌦', label: 'Delete to end of line' },
+              { keys: `⌥${hArrows}`, label: 'Move by word' },
+            ]
+          : [{ keys: c(hArrows), label: 'Move by word' }]),
       ],
     },
     {

--- a/cmd/hivegui/frontend/test/e2e/forward-kill-keys.spec.ts
+++ b/cmd/hivegui/frontend/test/e2e/forward-kill-keys.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// ⌥⌦/⌘⌦ must reach the PTY as kill-word-forward / kill-to-end-of-line,
+// end to end.
+//
+// xterm.js DOES encode the forward-delete key, but its `case 46` branch
+// emits \x1b[3;<mods+1>~ as soon as any modifier is held — \x1b[3;3~
+// for ⌥⌦ and \x1b[3;9~ for ⌘⌦. Nothing binds either, so before #362 the
+// chords were silent. The app has to write the readline bytes itself,
+// the same way ⌘⌫ → \x15 and ⌘←/→ → \x01/\x05 already do.
+//
+// This spec asserts the bytes on the wire because that is the only layer
+// where "the predicate returns the right string" and "the dispatch is
+// actually wired up" are distinguishable — a block placed after an
+// earlier `return` would still pass every unit test.
+//
+// macOS only: elsewhere Ctrl+⌦ already means kill-word and xterm encodes
+// it as \x1b[3;5~ on its own.
+const isMac = process.platform === 'darwin';
+
+const KILL_WORD = '\x1bd'; // meta-d
+const KILL_LINE = '\x0b'; // Ctrl+K
+
+async function bootFocusedTerminal(page: Page) {
+  await page.goto('/');
+  await page.waitForFunction(
+    () => document.querySelectorAll('#projects li').length > 0,
+  );
+  await page.waitForFunction(
+    () =>
+      !!document.activeElement?.classList?.contains('xterm-helper-textarea'),
+    null,
+    { timeout: 2000 },
+  );
+  await page.evaluate(() => window.__hive.resetStdin());
+}
+
+test.describe('macOS forward-delete kill keys reach the terminal', () => {
+  test.skip(!isMac, 'the ⌥/⌘ chords only exist on macOS');
+
+  test('⌥⌦ sends kill-word-forward and ⌘⌦ sends kill-to-end-of-line', async ({
+    page,
+  }) => {
+    await bootFocusedTerminal(page);
+    await page.keyboard.type('some text');
+    await page.keyboard.press('Alt+Delete');
+    await expect
+      .poll(() => page.evaluate(() => window.__hive.stdinText()), {
+        timeout: 2000,
+      })
+      .toBe(`some text${KILL_WORD}`);
+
+    await page.keyboard.press('Meta+Delete');
+    await expect
+      .poll(() => page.evaluate(() => window.__hive.stdinText()), {
+        timeout: 2000,
+      })
+      .toBe(`some text${KILL_WORD}${KILL_LINE}`);
+  });
+
+  test('a bare ⌦ is left to xterm, which already encodes it', async ({
+    page,
+  }) => {
+    await bootFocusedTerminal(page);
+    await page.keyboard.press('Delete');
+    await expect
+      .poll(() => page.evaluate(() => window.__hive.stdinText()), {
+        timeout: 2000,
+      })
+      .toBe('\x1b[3~');
+  });
+
+  test('the keys still do not change the active session', async ({ page }) => {
+    await bootFocusedTerminal(page);
+    const activeId = () =>
+      page.evaluate(
+        () =>
+          document.querySelector<HTMLElement>(
+            'li.hv-session-row[data-selected]',
+          )?.dataset.sid ?? null,
+      );
+    // Add the second session FIRST: creating one switches to it, which
+    // would otherwise look like the chord moved the selection.
+    await page.evaluate(() => window.__hive.addSession?.('second'));
+    await expect
+      .poll(() =>
+        page.evaluate(() => window.__hive.state?.sessions.length ?? 0),
+      )
+      .toBe(2);
+    const before = await activeId();
+    expect(before).not.toBeNull();
+    await page.keyboard.press('Alt+Delete');
+    await page.keyboard.press('Meta+Delete');
+    expect(await activeId()).toBe(before);
+  });
+});

--- a/cmd/hivegui/frontend/test/unit/keymap.test.ts
+++ b/cmd/hivegui/frontend/test/unit/keymap.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from 'vitest';
 import {
   isShiftEnter,
   macLineEditSeq,
+  macForwardKillSeq,
   LINE_START_SEQ,
   LINE_END_SEQ,
+  KILL_WORD_FORWARD_SEQ,
+  KILL_LINE_FORWARD_SEQ,
   isHelpOverlayKey,
   navHistoryKey,
   NEWLINE_SEQ,
@@ -246,5 +249,78 @@ describe('macLineEditSeq', () => {
         true,
       ),
     ).toBe(LINE_START_SEQ);
+  });
+});
+
+describe('macForwardKillSeq', () => {
+  const optDelete = ev({ altKey: true, key: 'Delete' });
+  const cmdDelete = ev({ metaKey: true, key: 'Delete' });
+
+  it('maps opt+forward-delete to kill-word and cmd+forward-delete to kill-line on mac', () => {
+    expect(macForwardKillSeq(optDelete, true)).toBe(KILL_WORD_FORWARD_SEQ);
+    expect(macForwardKillSeq(cmdDelete, true)).toBe(KILL_LINE_FORWARD_SEQ);
+  });
+
+  it('sends the readline bytes, not the CSI sequence xterm would emit', () => {
+    // xterm's `case 46` turns any modified forward delete into
+    // \x1b[3;<mods+1>~ — \x1b[3;3~ and \x1b[3;9~ here — which nothing
+    // binds. meta-d and Ctrl+K are what readline actually listens for.
+    expect(KILL_WORD_FORWARD_SEQ).toBe('\x1bd');
+    expect(KILL_LINE_FORWARD_SEQ).toBe('\x0b');
+  });
+
+  it('does nothing off mac — ctrl+delete is kill-word there and xterm encodes it', () => {
+    expect(macForwardKillSeq(optDelete, false)).toBeNull();
+    expect(macForwardKillSeq(cmdDelete, false)).toBeNull();
+  });
+
+  it('ignores Backspace, which must keep its own bindings', () => {
+    // The one mistake that would silently rebind ⌫: xterm sends \x7f
+    // (\x1b\x7f under opt) and session-term maps cmd+backspace to \x15.
+    expect(
+      macForwardKillSeq(ev({ altKey: true, key: 'Backspace' }), true),
+    ).toBeNull();
+    expect(
+      macForwardKillSeq(ev({ metaKey: true, key: 'Backspace' }), true),
+    ).toBeNull();
+  });
+
+  it('ignores a bare forward delete so xterm\u2019s \\x1b[3~ still reaches the PTY', () => {
+    expect(macForwardKillSeq(ev({ key: 'Delete' }), true)).toBeNull();
+  });
+
+  it('does not fire when ctrl is held — ctrl+delete belongs to the shell', () => {
+    expect(
+      macForwardKillSeq(
+        ev({ ctrlKey: true, altKey: true, key: 'Delete' }),
+        true,
+      ),
+    ).toBeNull();
+    expect(
+      macForwardKillSeq(
+        ev({ ctrlKey: true, metaKey: true, key: 'Delete' }),
+        true,
+      ),
+    ).toBeNull();
+  });
+
+  it('fires with Shift held, matching macLineEditSeq', () => {
+    // ⇧⌘⌦ selects to end of line in a text field; a PTY has no selection,
+    // so the kill is the closest honest thing.
+    expect(
+      macForwardKillSeq(
+        ev({ metaKey: true, shiftKey: true, key: 'Delete' }),
+        true,
+      ),
+    ).toBe(KILL_LINE_FORWARD_SEQ);
+  });
+
+  it('ignores opt+cmd together rather than guessing which kill was meant', () => {
+    expect(
+      macForwardKillSeq(
+        ev({ altKey: true, metaKey: true, key: 'Delete' }),
+        true,
+      ),
+    ).toBeNull();
   });
 });

--- a/cmd/hivegui/frontend/test/unit/shortcuts.test.ts
+++ b/cmd/hivegui/frontend/test/unit/shortcuts.test.ts
@@ -69,6 +69,20 @@ describe('shortcutGroups', () => {
     expect(keysFor(false)).toEqual(['Del']);
   });
 
+  it('does not contradict itself about what ⌘/Ctrl + ←/→ send to the terminal', () => {
+    // The Sessions row and the "Inside a terminal" row describe the same
+    // chord off mac (Ctrl+←/→). macLineEditSeq is mac-gated, so off mac
+    // the chord falls through to xterm as word movement — the Sessions row
+    // must not claim start/end of line there.
+    const gridRow = (isMac: boolean) =>
+      shortcutGroups({ isMac })
+        .flatMap((g) => g.items)
+        .find((i) => i.label.startsWith('Grid: move between tiles —'))?.label;
+    expect(gridRow(true)).toContain('start / end of line');
+    expect(gridRow(false)).toContain('move by word');
+    expect(gridRow(false)).not.toContain('start / end of line');
+  });
+
   it('separates arrow-key word labels off mac', () => {
     const keys = shortcutGroups({ isMac: false })
       .flatMap((g) => g.items.map((i) => i.keys))

--- a/cmd/hivegui/frontend/test/unit/shortcuts.test.ts
+++ b/cmd/hivegui/frontend/test/unit/shortcuts.test.ts
@@ -40,15 +40,33 @@ describe('shortcutGroups', () => {
     }
   });
 
-  it('mac-only clear-line entry appears only on mac', () => {
+  it('mac-only line-edit entries appear only on mac', () => {
     const labels = (groups: ShortcutGroup[]) =>
       groups.flatMap((g) => g.items.map((i) => i.label));
     expect(labels(shortcutGroups({ isMac: true }))).toContain(
-      'Clear input line',
+      'Delete to start of line',
+    );
+    expect(labels(shortcutGroups({ isMac: true }))).toContain(
+      'Delete to end of line',
     );
     expect(labels(shortcutGroups({ isMac: false }))).not.toContain(
-      'Clear input line',
+      'Delete to start of line',
     );
+    expect(labels(shortcutGroups({ isMac: false }))).not.toContain(
+      'Delete to end of line',
+    );
+  });
+
+  it('labels the forward-delete key per platform, not as the literal "delete"', () => {
+    // KEYS had no `delete` entry until #362, so keyLabel() fell through
+    // its `k ? … : key` default and rendered the raw string.
+    const keysFor = (isMac: boolean) =>
+      shortcutGroups({ isMac })
+        .flatMap((g) => g.items)
+        .filter((i) => i.label === 'Delete the character after the cursor')
+        .map((i) => i.keys);
+    expect(keysFor(true)).toEqual(['⌦']);
+    expect(keysFor(false)).toEqual(['Del']);
   });
 
   it('separates arrow-key word labels off mac', () => {

--- a/docs/exec-plans/active/362-natural-text-editing-keybindings.md
+++ b/docs/exec-plans/active/362-natural-text-editing-keybindings.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/362-natural-text-editing-keybindings.md](../../product-specs/362-natural-text-editing-keybindings.md)
 - **Issue:** #362
+- **PR:** #363
+- **Branch:** `feature/362-natural-text-editing-keybindings`
 - **Status:** active
 
 ## Summary
@@ -330,6 +332,7 @@ per the skill's one-retry rule. The reviewer independently confirmed that
 
 - **2026-09-06** — Spec filed as #362, triaged S / P2.
 - **2026-09-06** — Plan approved by the operator after two reviewer rounds.
+- **2026-09-06** — PR #363 opened.
 - **2026-09-06** — Implemented; all checks green (typecheck, `biome ci`,
   `scripts/test.sh unit dom e2e` = 628 + 278 passed, `ui-lint.sh --strict`,
   `check-changeset.sh`).

--- a/docs/exec-plans/active/362-natural-text-editing-keybindings.md
+++ b/docs/exec-plans/active/362-natural-text-editing-keybindings.md
@@ -1,0 +1,339 @@
+# Natural text editing keybindings in the terminal
+
+- **Spec:** [docs/product-specs/362-natural-text-editing-keybindings.md](../../product-specs/362-natural-text-editing-keybindings.md)
+- **Issue:** #362
+- **Status:** active
+
+## Summary
+
+Close the two remaining gaps in hive's macOS terminal text-editing keymap —
+⌥⌦ (kill word forward) and ⌘⌦ (kill to end of line) — and document the
+terminal-level editing keys that already work but appear on no keybinding
+surface.
+
+## Research
+
+### What already works (verified against `@xterm/xterm@5.5.0`'s
+`evaluateKeyboardEvent`, decompiled from `node_modules/@xterm/xterm/lib/xterm.js`)
+
+| Chord | Source | Bytes today |
+|---|---|---|
+| ⌥⌫ | xterm `case 8`: `key = DEL; if (altKey) key = ESC + key` | `\x1b\x7f` ✅ |
+| ⌘⌫ | `src/app/session-term.ts:442-453` | `\x15` ✅ |
+| ⌥← / ⌥→ | xterm `case 37/39` special-cases `ESC[1;3D` → `ESC + (isMac ? 'b' : '[1;5D')` | `\x1bb` / `\x1bf` ✅ |
+| ⌘← / ⌘→ | `macLineEditSeq`, `src/lib/keymap.ts:67-72` | `\x01` / `\x05` ✅ |
+| ⌦ | xterm `case 46`, no modifiers | `\x1b[3~` ✅ |
+| ⌘A | xterm default branch, `keyCode 65 && isMac && metaKey` → `type = 1` (selectAll) | ✅ |
+| ⌘C / ⌘V | native AppKit Edit menu, `cmd/hivegui/menu_darwin.go:92` | ✅ |
+| ⇧⏎ | `isShiftEnter`, `src/lib/keymap.ts:74-78` | `\x0a` ✅ |
+
+Seven of the nine chords in the iTerm2 "Natural Text Editing" preset are
+therefore already covered — most of them by xterm.js itself, not by hive.
+
+### The gaps
+
+1. **⌥⌦** — xterm `case 46` computes `ESC[3;<mods+1>~`, so this sends
+   `\x1b[3;3~`. No shell, readline configuration or agent CLI binds it. iTerm
+   sends `\x1bd` (meta-d, `kill-word` forward).
+2. **⌘⌦** — same branch, sends `\x1b[3;9~`. Should be `\x0b` (Ctrl+K,
+   `kill-line`), the exact mirror of the ⌘⌫ → `\x15` binding hive already has.
+3. **Documentation** — `⌥⌫`, `⌥←/→` and `⌦` appear on no keybinding surface.
+   `shortcuts.ts`'s "Inside a terminal" group (lines 176-190) lists only
+   ⌃⇧C/V/A, ⇧⏎ and ⌘⌫.
+
+### Relevant code
+
+- `cmd/hivegui/frontend/src/lib/keymap.ts` — pure predicates, unit-testable
+  with fake events. `KeyEventLike` at :29-36; `LINE_START_SEQ`/`LINE_END_SEQ`
+  at :45-46; `macLineEditSeq` at :48-72 — the exact shape to mirror.
+- `cmd/hivegui/frontend/src/app/session-term.ts:435-500` — the single
+  `attachCustomKeyEventHandler`. xterm keeps only ONE, so every app-level
+  binding lives here. `macLineEditSeq` is dispatched at :459-464.
+- `cmd/hivegui/frontend/src/lib/shortcuts.ts` — single source of truth for the
+  help overlay (`shortcutGroups`, :94) and command palette (`paletteShortcuts`,
+  :213). "Inside a terminal" group at :176-190.
+- `cmd/hivegui/frontend/test/unit/keymap.test.ts` — `ev({...})` fake-event
+  helper at :13-22; `describe('macLineEditSeq')` at :192-222 is the pattern to
+  copy.
+- `README.md:214-240` — Keybinds table.
+
+### Constraints
+
+- Forward delete is `e.key === 'Delete'` (keyCode 46), *not* `'Backspace'`.
+  Getting this wrong silently rebinds ⌫.
+- `session-term.ts`'s custom key handler **is** covered end to end:
+  `test/e2e/line-edit-keys.spec.ts` and `test/e2e/shift-enter-newline.spec.ts`
+  boot a focused terminal and assert the bytes on the wire via
+  `window.__hive.stdinText()`. That is the only layer where "not intercepted"
+  and "actually works" are distinguishable, so the new chords need a spec
+  there too, not just a predicate unit test.
+- `test/unit/shortcuts.test.ts:47,50` pins the literal help-overlay label
+  `'Clear input line'`, so relabelling that row is a two-file change.
+- Per AGENTS.md › Keybindings Policy a binding change must update keymap, help
+  overlay + command palette, README and a changeset. The palette holds only
+  *dispatchable app commands* — raw terminal-editing keys have no command id
+  and none are listed there today, so the palette is correctly untouched.
+
+### Prior lessons
+
+`brain-search` returned no hits for keybinding / keymap / terminal / xterm.
+No prior lessons matched.
+## Approach
+
+One new pure predicate in `lib/keymap.ts`, dispatched from the existing single
+`attachCustomKeyEventHandler` in `session-term.ts` immediately after
+`macLineEditSeq`. This is the same shape as every terminal binding hive already
+owns, which keeps the decision logic unit-testable with fake events and keeps
+the imperative wiring to three lines.
+
+The obvious alternative — a second `attachCustomKeyEventHandler`, or handling
+these in the window-level `app/keyboard.ts` handler — is wrong on both counts:
+xterm keeps only ONE custom handler (a second registration silently replaces the
+first, already noted at `session-term.ts:432`), and `app/keyboard.ts` gates on
+Cmd/Ctrl in a way that would swallow ⌥⌦ entirely.
+
+`macForwardKillSeq` deliberately handles both chords rather than adding two
+predicates: they share the `e.key === 'Delete'` guard, and splitting them would
+duplicate the "is this the forward-delete key on a Mac" test that is the part
+easiest to get wrong.
+
+Shift is allowed through, matching `macLineEditSeq`'s existing reasoning: ⇧⌘⌦
+selects-to-end-of-line in a text field, a PTY has no selection, and the kill is
+the closest honest thing. Ctrl is not allowed — ⌃⌦ belongs to the shell.
+
+### Files to change
+
+1. `cmd/hivegui/frontend/src/lib/keymap.ts` — add after `macLineEditSeq` (~:73):
+
+   ```ts
+   // Bytes for the two forward-delete kills. \x1bd is meta-d (readline
+   // kill-word, forward); \x0b is Ctrl+K (readline kill-line, to end).
+   export const KILL_WORD_FORWARD_SEQ = '\x1bd';
+   export const KILL_LINE_FORWARD_SEQ = '\x0b';
+
+   export function macForwardKillSeq(
+     e: KeyEventLike,
+     isMac: boolean,
+   ): string | null {
+     if (!isMac || e.ctrlKey || e.key !== 'Delete') return null;
+     if (e.metaKey && !e.altKey) return KILL_LINE_FORWARD_SEQ;
+     if (e.altKey && !e.metaKey) return KILL_WORD_FORWARD_SEQ;
+     return null;
+   }
+   ```
+
+   With a doc comment in the house style covering: why xterm's own
+   `\x1b[3;3~` / `\x1b[3;9~` are useless, why `'Delete'` and not `'Backspace'`,
+   why mac-only, and why shift passes but ctrl does not.
+
+2. `cmd/hivegui/frontend/src/app/session-term.ts` — import `macForwardKillSeq`
+   and dispatch it directly after the `macLineEditSeq` block (~:464):
+
+   ```ts
+   const forwardKill = macForwardKillSeq(e, isMac);
+   if (forwardKill) {
+     e.preventDefault();
+     this._writePty(forwardKill);
+     return false;
+   }
+   ```
+
+3. `cmd/hivegui/frontend/src/lib/shortcuts.ts` — two edits.
+
+   **a.** Add a `delete` entry to `KEYS` (:36-43), which today has no such key,
+   so `keyLabel('delete', …)` falls through its `k ? … : key` default and
+   renders the literal string `delete` on both platforms:
+
+   ```ts
+   delete: { mac: '⌦', other: 'Del' },
+   ```
+
+   **b.** Extend the "Inside a terminal" group (:176-190) so it documents the
+   whole terminal editing keymap, not just the two new chords. Mac-only rows go
+   through the existing `...(isMac ? [...] : [])` spread already used for ⌘⌫;
+   cross-platform rows use `keyLabel`/`arrowSeq` so non-mac renders words, not
+   glyphs.
+
+   Cross-platform:
+   - `⌦` / `Del` — Delete the character after the cursor
+   - `⌃←/→` (`Ctrl+Left/Right`) — Move by word
+
+   Mac-only:
+   - `⌥⌫` — Delete the word before the cursor
+   - `⌥⌦` — Delete the word after the cursor  *(new)*
+   - `⌘⌦` — Delete to end of line  *(new)*
+   - `⌥←/→` — Move by word
+
+   Plus relabel the existing `⌘⌫` row from "Clear input line" to "Delete to
+   start of line", which is what `\x15` actually does.
+
+4. `cmd/hivegui/frontend/test/unit/shortcuts.test.ts:43-52` — the relabel in (3)
+   breaks the `mac-only clear-line entry appears only on mac` test, which pins
+   the literal `'Clear input line'` on both branches. Update both assertions to
+   the new label, and extend the same test to assert the ⌦ row renders `⌦` on
+   mac and `Del` off it — otherwise the `KEYS` addition has no guard and a
+   regression to the literal `delete` ships silently.
+
+5. `README.md` — Keybinds table (:214-240): explicit rows, one per chord, not a
+   pointer at the overlay (the spec's success criterion asks for them *listed*):
+   `⌥⌫` delete word before cursor · `⌥⌦` delete word after cursor · `⌘⌫`
+   delete to start of line · `⌘⌦` delete to end of line · `⌥←/⌥→` move by word
+   · `⌦` forward delete. Marked macOS in the Action column the way the
+   existing ⌘←/⌘→ row already is; that row stays as is.
+
+6. `.changesets/362-natural-text-editing.md` — new. Frontmatter `type: added`,
+   `bump: minor`, `issue: 362`, `pr: null` (backfilled at PR time). `type` and
+   `bump` are the only required keys and both values are in the allowed sets
+   (`scripts/regen-generated.py:42,153-159`).
+
+### New files
+
+- `.changesets/362-natural-text-editing.md` — changeset entry.
+
+### Tests
+
+`cmd/hivegui/frontend/test/unit/keymap.test.ts`, a new
+`describe('macForwardKillSeq')` block placed after the `macLineEditSeq` one
+(:192-222), reusing that file's `ev({...})` helper:
+
+- `it('maps opt+forward-delete to kill-word and cmd+forward-delete to kill-line on mac')`
+  — `macForwardKillSeq(ev({altKey:true, key:'Delete'}), true)` is
+  `KILL_WORD_FORWARD_SEQ`; the `metaKey` variant is `KILL_LINE_FORWARD_SEQ`.
+- `it('sends the readline bytes, not a CSI sequence')` — asserts
+  `KILL_WORD_FORWARD_SEQ === '\x1bd'` and `KILL_LINE_FORWARD_SEQ === '\x0b'`.
+  This is the assertion that fails if someone "simplifies" to `\x1b[3;3~`.
+- `it('does not fire off mac')` — both chords with `isMac === false` are null.
+- `it('ignores Backspace — it must keep xterm’s own \\x1b\\x7f / hive’s \\x15')`
+  — `ev({altKey:true, key:'Backspace'})` and `ev({metaKey:true, key:'Backspace'})`
+  are both null on mac. This is the regression guard for the one mistake that
+  would silently rebind ⌫.
+- `it('ignores a bare forward delete so xterm’s \\x1b[3~ still reaches the PTY')`
+  — `ev({key:'Delete'})` is null.
+- `it('does not fire when ctrl is held')` — `ev({ctrlKey:true, altKey:true, key:'Delete'})`
+  is null.
+- `it('passes shift through, matching macLineEditSeq')` —
+  `ev({shiftKey:true, metaKey:true, key:'Delete'})` is `KILL_LINE_FORWARD_SEQ`.
+- `it('ignores opt+cmd together — an ambiguous chord must not guess')` —
+  `ev({altKey:true, metaKey:true, key:'Delete'})` is null.
+
+`cmd/hivegui/frontend/test/e2e/forward-kill-keys.spec.ts` — **new**, modelled
+line for line on `test/e2e/line-edit-keys.spec.ts`: same `isMac` guard +
+`test.skip`, same `bootFocusedTerminal(page)` helper, same
+`expect.poll(() => page.evaluate(() => window.__hive.stdinText()))` assertion.
+
+- `test('⌥⌦ sends kill-word-forward and ⌘⌦ sends kill-to-end-of-line')` — type
+  `some text`, press `Alt+Delete`, poll for `some text\x1bd`; then press
+  `Meta+Delete`, poll for `some text\x1bd\x0b`.
+- `test('the keys still do not change the active session')` — the same guard
+  `line-edit-keys.spec.ts` carries, since ⌘-modified keys are exactly the ones
+  the window handler could swallow.
+
+This spec is the one that actually fails if the dispatch is mis-wired — placed
+after an earlier `return true`, or importing the wrong predicate. The unit
+tests pin the *decision*; only this pins the *bytes on the wire*. (The
+`sends the readline bytes` unit test asserts a constant against itself: it is a
+drift guard against someone "simplifying" the constant, and is deliberately not
+the coverage that closes the wiring hole.)
+
+No dom test: the predicate layer and the e2e wire layer between them leave
+nothing for jsdom to add.
+
+### Verification
+
+```
+cd cmd/hivegui/frontend && npm run typecheck && npm run ci
+scripts/test.sh unit dom e2e
+scripts/ui-lint.sh --strict
+scripts/check-changeset.sh
+```
+
+`--strict` matters: `ui-lint.sh` exits 0 in its default warn mode, so the bare
+invocation would pass on anything. `check-changeset.sh` is the local mirror of
+the changesets CI gate. `e2e` is in the test layers because the new spec lives
+there; it runs against the Wails **mock** bridge, and per the repo's Playwright
+note it is invoked with `CI=1` so a stale vite dev server can't be reused.
+
+Manual, on macOS, in a running session: type a line, press ⌥⌦ mid-line (the word
+after the cursor disappears), press ⌘⌦ (the rest of the line disappears), then
+confirm ⌫ and ⌥⌫ still delete backwards.
+
+## Open questions / risks
+
+- **⌘⌦ ergonomics.** On a laptop keyboard forward delete is `fn+⌫`, so this
+  chord is physically `⌘fn⌫` — awkward. It ships because it is the mirror of the
+  existing ⌘⌫ and the iTerm preset the request cites, not because it will see
+  heavy use.
+- **`\x0b` under an inner TUI.** In vim or a full-screen program Ctrl+K is
+  digraph-insert, not kill-line. The same is already true of the shipped
+  ⌘⌫ → `\x15`, so this adds no new class of problem.
+- **Alternative ruled out:** `\x1b[3;3~`-style CSI with a shell-side keybinding
+  (`bindkey` in zshrc). Rejected — it needs per-user shell config, which is
+  precisely what the "no per-terminal configuration" rule in `keymap.ts`'s
+  existing comments exists to avoid.
+- **Declined refactor, surfaced not silent:** the inline ⌘⌫ → `\x15` block
+  (`session-term.ts:439-453`) predates `keymap.ts` and could move next to the
+  new predicate so all four mac line-edit chords live at one testable
+  boundary. Not done here — it is a behaviour-neutral move of shipped code and
+  belongs in its own diff, where a regression is attributable. Say so if you
+  want it folded in.
+- `.changesets/README.md` is referenced by `CONTRIBUTING.md:66` but does not
+  exist. Pre-existing, unrelated, not fixed here.
+
+## Second opinion
+
+Two reviewer rounds, both `revise`. Five must-fix items, all applied.
+
+**Round 1** — verdict `revise`, confidence 8:
+
+- The draft claimed no e2e coverage existed for `session-term.ts`'s custom key
+  handler. False — `test/e2e/line-edit-keys.spec.ts` and
+  `test/e2e/shift-enter-newline.spec.ts` already drive it end to end via
+  `window.__hive.stdinText()`. Fixed in the draft and in Research › Constraints;
+  a new e2e spec is now part of the plan.
+- The ⌘⌫ help-overlay relabel breaks `test/unit/shortcuts.test.ts:47,50`, which
+  pins the literal `'Clear input line'`. Now listed as its own file to change.
+- README needed explicit per-chord rows, not a pointer at the overlay.
+- `scripts/ui-lint.sh` exits 0 in its default warn mode, so the verification
+  command was vacuous. Now `--strict`, plus `scripts/check-changeset.sh`.
+
+**Round 2** — verdict `revise`, confidence 7. Confirmed all four landed, and
+found one more: `KEYS` in `src/lib/shortcuts.ts:36-43` has no `delete` entry, so
+`keyLabel('delete', …)` falls through to the literal string `delete`. Applied,
+with a test guarding it.
+
+Disposition: all five applied; presented after round 2 without a third round,
+per the skill's one-retry rule. The reviewer independently confirmed that
+`e.key === 'Delete'` is the correct discriminator, that nothing in
+`app/keyboard.ts` or `menu_darwin.go` claims ⌘⌦ or ⌥⌦, and that
+`paletteShortcuts` is correctly untouched.
+
+## Decision log
+
+- **2026-09-06** — Skip Option-as-Meta (`macOptionIsMeta`). Why: operator call
+  at clarifying round A. Enabling it breaks `[ ] { } \ @ #` on non-US Mac
+  layouts; a settings toggle is more surface than the two chords warrant.
+- **2026-09-06** — Forward delete keeps xterm's `\x1b[3~`, not iTerm's `0x04`.
+  Why: `0x04` is Ctrl+D, which is delete-char in readline but EOF on an empty
+  line — it can close the user's shell. `\x1b[3~` is bound by readline, zsh,
+  vim and the agent CLIs.
+- **2026-09-06** — macOS only. Why: on Windows/Linux Ctrl+⌦ already emits
+  `\x1b[3;5~`, which readline binds as kill-word; adding bindings there risks
+  colliding with tmux.
+
+- **2026-09-06** — Deviated from the plan on one help-overlay row: ⌃←/→ "Move
+  by word" is listed for Windows/Linux **only**, not cross-platform as drafted.
+  Why: on macOS ⌃← is Mission Control's space switcher and never reaches the
+  app, so advertising it there would document a binding that does not work.
+  ⌥←/→ is the mac row and was already planned.
+
+## Progress
+
+- **2026-09-06** — Spec filed as #362, triaged S / P2.
+- **2026-09-06** — Plan approved by the operator after two reviewer rounds.
+- **2026-09-06** — Implemented; all checks green (typecheck, `biome ci`,
+  `scripts/test.sh unit dom e2e` = 628 + 278 passed, `ui-lint.sh --strict`,
+  `check-changeset.sh`).
+
+## Open questions
+
+_(none)_

--- a/docs/exec-plans/active/362-natural-text-editing-keybindings.md
+++ b/docs/exec-plans/active/362-natural-text-editing-keybindings.md
@@ -337,6 +337,19 @@ per the skill's one-retry rule. The reviewer independently confirmed that
   `scripts/test.sh unit dom e2e` = 628 + 278 passed, `ui-lint.sh --strict`,
   `check-changeset.sh`).
 
+## PR convergence ledger
+
+_(append-only, one line per review-loop iteration)_
+
+- **2026-09-06** — Review: `COMMENT`, 0 BLOCKING / 1 IMPORTANT / 0 MINOR, 0
+  unresolved threads. The IMPORTANT: the Sessions group's ⌘/Ctrl+←/→ row claimed
+  "in focused mode these reach the terminal (start / end of line)" on both
+  platforms, which the new "Inside a terminal" row correctly contradicts off mac
+  (`macLineEditSeq` is mac-gated, so Ctrl+←/→ falls through to xterm's
+  `\x1b[1;5D/C` = word movement). Autofixed: label is now platform-conditional,
+  with a unit test pinning both halves. Checks green (unit + dom 628, biome ci,
+  typecheck).
+
 ## Open questions
 
 _(none)_

--- a/docs/exec-plans/active/362-natural-text-editing-keybindings.md
+++ b/docs/exec-plans/active/362-natural-text-editing-keybindings.md
@@ -349,6 +349,8 @@ _(append-only, one line per review-loop iteration)_
   `\x1b[1;5D/C` = word movement). Autofixed: label is now platform-conditional,
   with a unit test pinning both halves. Checks green (unit + dom 628, biome ci,
   typecheck).
+- **2026-09-06 iter 1** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: 6de65889; threads_open: 0; action: autofix+push; head_sha: db0c550e.
+- **2026-09-06 iter 2** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: db0c550e.
 
 ## Open questions
 

--- a/docs/exec-plans/completed/362-natural-text-editing-keybindings.md
+++ b/docs/exec-plans/completed/362-natural-text-editing-keybindings.md
@@ -4,7 +4,7 @@
 - **Issue:** #362
 - **PR:** #363
 - **Branch:** `feature/362-natural-text-editing-keybindings`
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -336,6 +336,14 @@ per the skill's one-retry rule. The reviewer independently confirmed that
 - **2026-09-06** — Implemented; all checks green (typecheck, `biome ci`,
   `scripts/test.sh unit dom e2e` = 628 + 278 passed, `ui-lint.sh --strict`,
   `check-changeset.sh`).
+
+## Gate verdict
+
+- **2026-09-06** — verdict: PASS; phase: —; checks: 3 passed / 0 failed / 0 followups; followups: none; one-line: all six success criteria observable in code and demonstrated by green tests, no non-goal bled in, every doc surface AGENTS.md requires is updated and accurate.
+  - 2026-09-06 dimensions:
+    - acceptance — PASS — each criterion verified against code and real output: `macForwardKillSeq` (`keymap.ts:108-115`) returns `\x1bd` / `\x0b` and null for off-mac, bare ⌦, Backspace and ctrl-held; the dispatch at `session-term.ts:472-477` is reachable (no earlier branch matches a `Delete` keydown); `vitest` 42/42 and the mac e2e spec 3/3 actually executed on this macOS machine rather than skipping.
+    - non-goals — PASS — `macOptionIsMeta` appears nowhere in the tree; no `\x04` literal added; both PTY-writing helpers gate on `isMac`; no rebinding surface or keymap UI; nothing xterm already handles was re-implemented. No scope bleed against `origin/main`.
+    - doc accuracy — PASS — all four AGENTS.md surfaces updated (keymap, overlay, README, changeset); README's mac markers match the `isMac` gate; the iteration-1 contradiction fix at `shortcuts.ts:121-127` holds and no new contradictory pair exists; `check-changeset.sh` exit 0; `CHANGELOG.md` untouched. `regression_of` N/A (`type: added`).
 
 ## PR convergence ledger
 

--- a/docs/product-specs/362-natural-text-editing-keybindings.md
+++ b/docs/product-specs/362-natural-text-editing-keybindings.md
@@ -5,14 +5,15 @@ type: enhancement
 complexity: S
 priority: P2
 pr: 363
-stage: GATE
+shipped: 2026-09-06
+stage: DONE
 ---
 
 # Natural text editing keybindings in the terminal
 
 - **Issue:** #362
 - **Type:** enhancement
-- **Exec plan:** [docs/exec-plans/active/362-natural-text-editing-keybindings.md](../exec-plans/active/362-natural-text-editing-keybindings.md)
+- **Exec plan:** [docs/exec-plans/completed/362-natural-text-editing-keybindings.md](../exec-plans/completed/362-natural-text-editing-keybindings.md)
 - **Complexity:** S
 - **Priority:** P2
 

--- a/docs/product-specs/362-natural-text-editing-keybindings.md
+++ b/docs/product-specs/362-natural-text-editing-keybindings.md
@@ -1,0 +1,63 @@
+---
+issue: 362
+title: "Natural text editing keybindings in the terminal"
+type: enhancement
+complexity: S
+priority: P2
+stage: IMPLEMENT
+---
+
+# Natural text editing keybindings in the terminal
+
+- **Issue:** #362
+- **Type:** enhancement
+- **Exec plan:** [docs/exec-plans/active/362-natural-text-editing-keybindings.md](../exec-plans/active/362-natural-text-editing-keybindings.md)
+- **Complexity:** S
+- **Priority:** P2
+
+## Problem
+
+Hive forwards some macOS text-editing chords to the PTY (⌘⌫ → `\x15`, ⌘←/⌘→ →
+`\x01`/`\x05`, ⇧⏎ → `\x0a`), and xterm.js covers several more on its own. But the
+set is incomplete: some chords still send sequences no shell or agent CLI binds,
+and none of the terminal-level editing keys appear in the README keybind table or
+the ⌘/ overlay.
+
+## Desired behaviour
+
+The chords a macOS user expects for text editing work inside a hive session the
+way they do in iTerm2's "Natural Text Editing" preset, and every binding hive
+owns is documented on the surfaces AGENTS.md › Keybindings Policy requires.
+
+## Success criteria
+
+- On macOS, ⌥⌦ (Option + forward delete) writes `\x1bd` to the PTY, deleting the
+  word after the cursor in bash, zsh and the agent CLIs.
+- On macOS, ⌘⌦ (Cmd + forward delete) writes `\x0b` to the PTY, deleting from the
+  cursor to the end of the line — the mirror of the existing ⌘⌫ → `\x15`.
+- Neither binding fires off macOS, and neither fires for a bare ⌦ or for
+  ⌫/Backspace.
+- Every terminal-level editing key hive relies on — ⌥⌫, ⌥←/→, ⌦, ⌥⌦, ⌘⌦ — is
+  listed in the ⌘/ help overlay's "Inside a terminal" group and in the README
+  Keybinds table.
+- Unit tests in `test/unit/keymap.test.ts` cover the new predicate, in the same
+  shape as the existing `macLineEditSeq` block.
+
+## Non-goals
+
+- **Option-as-Meta** (`macOptionIsMeta`). Enabling it would make ⌥. , ⌥d, ⌥u/l/c
+  work, but it breaks typing `[ ] { } \ @ #` on German, French and Spanish Mac
+  layouts. A settings toggle is more surface than these two chords warrant.
+- Changing forward delete to iTerm's `0x04`. That is Ctrl+D — delete-char in
+  readline, but EOF on an empty line, so it can close the user's shell. xterm's
+  `\x1b[3~` is bound by readline, zsh, vim and the agent CLIs.
+- Windows/Linux equivalents. Ctrl+⌦ already emits `\x1b[3;5~` there, which
+  readline binds as kill-word; adding bindings risks colliding with tmux.
+- Rebindable keybindings, or any keymap UI.
+- Re-implementing anything xterm.js already gets right (⌥⌫, ⌥←/→, ⌦, ⌘A).
+
+## Notes
+
+Prior art: iTerm2 Natural Text Editing preset. Behaviour of the current stack
+verified against `@xterm/xterm@5.5.0`'s `evaluateKeyboardEvent`; see the exec
+plan's Research section for the chord-by-chord table.

--- a/docs/product-specs/362-natural-text-editing-keybindings.md
+++ b/docs/product-specs/362-natural-text-editing-keybindings.md
@@ -4,7 +4,8 @@ title: "Natural text editing keybindings in the terminal"
 type: enhancement
 complexity: S
 priority: P2
-stage: IMPLEMENT
+pr: 363
+stage: REVIEW
 ---
 
 # Natural text editing keybindings in the terminal

--- a/docs/product-specs/362-natural-text-editing-keybindings.md
+++ b/docs/product-specs/362-natural-text-editing-keybindings.md
@@ -5,7 +5,7 @@ type: enhancement
 complexity: S
 priority: P2
 pr: 363
-stage: REVIEW
+stage: GATE
 ---
 
 # Natural text editing keybindings in the terminal


### PR DESCRIPTION
## What

macOS ⌥⌦ (delete word after cursor) and ⌘⌦ (delete to end of line) did nothing inside a session. xterm.js does encode forward delete, but its `case 46` branch turns any modified press into `\x1b[3;<mods+1>~` — `\x1b[3;3~` and `\x1b[3;9~` here — and no shell, readline default or agent CLI binds either sequence.

`macForwardKillSeq` now writes the readline bytes, the same way `⌘⌫ → \x15` and `⌘←/→ → \x01/\x05` already do:

- `⌥⌦` → `\x1bd` (meta-d, kill-word forward)
- `⌘⌦` → `\x0b` (Ctrl+K, kill-line to end)

An unmodified `⌦` is still left to xterm, which sends `\x1b[3~` — everything binds that.

## Why only two chords

The request cited iTerm2's "Natural Text Editing" preset. Auditing it against the installed `@xterm/xterm@5.5.0`'s `evaluateKeyboardEvent` found seven of the nine chords already working — ⌥⌫, ⌥←/→, ⌦ and ⌘A inside xterm itself; ⌘⌫, ⌘←/→ and ⇧⏎ in hive; ⌘C/⌘V via the native Edit menu. Only these two were dead.

That left documentation as the real remaining gap: the ⌘/ overlay and the README listed only some of the terminal-level editing keys. Both now list all of them. `KEYS` in `shortcuts.ts` had no `delete` entry, so `keyLabel('delete', …)` fell through its default and would have rendered the literal string `delete` in the overlay — fixed, with a test.

## Deliberately not done

- **Option-as-Meta** (`macOptionIsMeta`). It would make `⌥.` (yank-last-arg), `⌥d` and `⌥u/l/c` work, but it breaks typing `[ ] { } \ @ #` on German, French and Spanish Mac layouts. Recorded as a spec non-goal.
- **iTerm's `⌦ → 0x04`.** That is Ctrl+D: delete-char in readline, but EOF on an empty line, so it can close the user's shell.
- **Windows/Linux bindings.** `Ctrl+⌦` already emits `\x1b[3;5~` there, which readline binds as kill-word.

## Notes

One deviation from the approved plan, logged in the exec plan: the ⌃←/→ "Move by word" overlay row is Windows/Linux only, not cross-platform. On macOS ⌃← is Mission Control's space switcher and never reaches the app, so listing it there would document a binding that does not work.

## Tests

- `test/unit/keymap.test.ts` — 8 cases on `macForwardKillSeq`, including the guard that `Backspace` never matches (the one mistake that would silently rebind ⌫) and that the byte constants stay `\x1bd` / `\x0b`.
- `test/e2e/forward-kill-keys.spec.ts` — new, modelled on `line-edit-keys.spec.ts`. Asserts the bytes on the wire via `window.__hive.stdinText()`, which is the only layer where "the predicate is right" and "the dispatch is wired up" are distinguishable. Also pins that a bare ⌦ still reaches the PTY as `\x1b[3~`.
- `test/unit/shortcuts.test.ts` — updated for the ⌘⌫ relabel, plus a new case pinning the ⌦ key label per platform.

## Verification

```
npm run typecheck && npm run ci     # both clean
scripts/test.sh unit dom e2e        # 628 unit+dom, 278 e2e, 0 failures
scripts/ui-lint.sh --strict
scripts/check-changeset.sh
```

Manually confirmed on macOS in a live session: ⌥⌦ eats the next word, ⌘⌦ eats the rest of the line, and ⌫ / ⌥⌫ still delete backwards.

Fixes #362
