### PR TITLE
fix(update): match the upstream remote by host and path, not substring

### DIFF
--- a/.changesets/update-remote-exact-match.md
+++ b/.changesets/update-remote-exact-match.md
@@ -1,6 +1,6 @@
 ---
 issue: null
-pr: null
+pr: 365
 type: fixed
 bump: patch
 ---

--- a/.changesets/update-remote-exact-match.md
+++ b/.changesets/update-remote-exact-match.md
@@ -1,0 +1,9 @@
+---
+issue: null
+pr: null
+type: fixed
+bump: patch
+---
+- The "latest" update channel now checks that the source checkout's
+  remote is exactly github.com/lucascaro/hive before pulling and
+  building from it. A URL that merely contained that text used to pass.

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -364,12 +364,12 @@ func stageLatest(info UpdateInfo, progress func(string)) (string, error) {
 // verifyUpstreamRemote refuses a checkout whose tracked branch does not
 // come from this project's own repository.
 //
-// remoteIsUpstream matches host and path whole, so both SSH
-// (git@github.com:lucascaro/hive.git) and HTTPS spellings pass and a
-// trailing .git or slash is tolerated, while a host that merely
-// contains "github.com" does not. A fork would be rejected — that is
-// the intended trade: this button pulls and *executes*, so "close
-// enough" is not the bar.
+// The remote URL is matched on host and path whole (see
+// remoteIsUpstream), so both SSH (git@github.com:lucascaro/hive.git)
+// and HTTPS spellings pass and a trailing .git or slash is tolerated,
+// while a host that merely contains "github.com" does not. A fork
+// would be rejected — that is the intended trade: this button pulls
+// and *executes*, so "close enough" is not the bar.
 func verifyUpstreamRemote(repo string) error {
 	upstream, err := runGitFn(repo, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
 	if err != nil {

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -364,10 +364,11 @@ func stageLatest(info UpdateInfo, progress func(string)) (string, error) {
 // verifyUpstreamRemote refuses a checkout whose tracked branch does not
 // come from this project's own repository.
 //
-// Matching is on the "owner/repo" substring so both SSH
-// (git@github.com:lucascaro/hive.git) and HTTPS spellings pass, and a
-// trailing .git or slash is tolerated. A fork would be rejected — that
-// is the intended trade: this button pulls and *executes*, so "close
+// remoteIsUpstream matches host and path whole, so both SSH
+// (git@github.com:lucascaro/hive.git) and HTTPS spellings pass and a
+// trailing .git or slash is tolerated, while a host that merely
+// contains "github.com" does not. A fork would be rejected — that is
+// the intended trade: this button pulls and *executes*, so "close
 // enough" is not the bar.
 func verifyUpstreamRemote(repo string) error {
 	upstream, err := runGitFn(repo, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
@@ -378,12 +379,12 @@ func verifyUpstreamRemote(repo string) error {
 	if !found || remote == "" {
 		return fmt.Errorf("cannot tell which remote %q tracks", upstream)
 	}
-	url, err := runGitFn(repo, "remote", "get-url", remote)
+	remoteURL, err := runGitFn(repo, "remote", "get-url", remote)
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(url, updateRepo) {
-		return fmt.Errorf("refusing to build from %s: remote %q is %s, not %s", repo, remote, url, updateRepo)
+	if !remoteIsUpstream(remoteURL) {
+		return fmt.Errorf("refusing to build from %s: remote %q is %s, not %s", repo, remote, remoteURL, updateRepo)
 	}
 	return nil
 }

--- a/cmd/hivegui/update_remote.go
+++ b/cmd/hivegui/update_remote.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+// remoteIsUpstream reports whether a git remote URL names exactly
+// github.com/<updateRepo>: HTTPS, ssh://, or scp-like git@ spellings,
+// with an optional .git suffix or trailing slash. Host and path are
+// compared whole — a substring match let evil.example/lucascaro/hive
+// through, and this gate guards a pull that is then executed.
+//
+// It lives in a non-suffixed file, away from its only (darwin-only)
+// caller, so its table test runs on every platform CI builds.
+func remoteIsUpstream(remote string) bool {
+	remote = strings.TrimSpace(remote)
+	var host, path string
+	if strings.Contains(remote, "://") {
+		u, err := url.Parse(remote)
+		if err != nil {
+			return false
+		}
+		host, path = u.Hostname(), u.Path
+	} else if at := strings.Index(remote, "@"); at >= 0 {
+		// scp-like: git@github.com:owner/repo.git
+		h, p, ok := strings.Cut(remote[at+1:], ":")
+		if !ok {
+			return false
+		}
+		host, path = h, "/"+p
+	} else {
+		return false
+	}
+	path = strings.TrimSuffix(strings.TrimSuffix(path, "/"), ".git")
+	return strings.EqualFold(host, "github.com") && path == "/"+updateRepo
+}

--- a/cmd/hivegui/update_remote_test.go
+++ b/cmd/hivegui/update_remote_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestRemoteIsUpstream(t *testing.T) {
+	ok := []string{
+		"https://github.com/lucascaro/hive",
+		"https://github.com/lucascaro/hive.git",
+		"https://github.com/lucascaro/hive/",
+		"git@github.com:lucascaro/hive.git",
+		"ssh://git@github.com/lucascaro/hive.git",
+		"https://GitHub.com/lucascaro/hive",
+	}
+	bad := []string{
+		"https://evil.example/lucascaro/hive",
+		"https://github.com.evil.example/lucascaro/hive",
+		"https://github.com/lucascaro/hive-fork",
+		"https://github.com/someone/lucascaro/hive",
+		"git@gitlab.com:lucascaro/hive.git",
+		"",
+	}
+	for _, u := range ok {
+		if !remoteIsUpstream(u) {
+			t.Errorf("%q: want true", u)
+		}
+	}
+	for _, u := range bad {
+		if remoteIsUpstream(u) {
+			t.Errorf("%q: want false", u)
+		}
+	}
+}


### PR DESCRIPTION
Task 6 of the 2026-09-05 security-hardening plan.

## Problem

`verifyUpstreamRemote` gated the "latest" update channel's pull-and-build on
`strings.Contains(url, "lucascaro/hive")`. Any remote URL merely *containing*
that text passed — `https://evil.example/lucascaro/hive`,
`https://github.com.evil.example/lucascaro/hive`. The gate guards a `git pull`
whose result is then built and executed.

## Change

- New `cmd/hivegui/update_remote.go`: `remoteIsUpstream` parses HTTPS, `ssh://`
  and scp-like `git@host:owner/repo` remotes and compares **host and path
  whole**, tolerating a trailing slash or `.git` and matching the host
  case-insensitively.
- `verifyUpstreamRemote` calls it instead of the substring check. The local
  variable `url` shadowed the `net/url` package, so it is now `remoteURL`.
- Table test covering the accept and reject sets from the plan.

The function lives in a non-suffixed file, away from its darwin-only caller,
so its test runs on every platform CI builds rather than macOS alone.

No daemon-observable behaviour changes, so no `DaemonContract` bump.

## Test

- `go test ./cmd/hivegui/ -count=1` — pass (new test red before the fix,
  `undefined: remoteIsUpstream`).
- Note: `internal/registry` `TestTerminalQueriesAreNotWork` fails on a clean
  `origin/main` in this environment. Pre-existing and unrelated to this diff.