### PR TITLE
chore(337): reset to IMPLEMENT for phase 3

### DIFF
--- a/docs/exec-plans/active/337-idea-inbox.md
+++ b/docs/exec-plans/active/337-idea-inbox.md
@@ -3,10 +3,16 @@
 - **Spec:** [docs/product-specs/337-idea-inbox.md](../../product-specs/337-idea-inbox.md)
 - **Design:** [docs/design-docs/control-plane.md](../../design-docs/control-plane.md)
 - **Issue:** —
-- **Branch:** `cedar-light` (phase 1), `feature/337-idea-inbox-gui` (phase 2)
-- **PR:** [#352](https://github.com/lucascaro/hive/pull/352) (phase 1),
-  [#358](https://github.com/lucascaro/hive/pull/358) (phase 2)
-- **Phase:** 2 of 3 (see `### Phasing`)
+- **Branch:** —
+- **PR:** —
+- **Shipped:** phase 1 → [#352](https://github.com/lucascaro/hive/pull/352)
+  (branch `cedar-light`), phase 2 → [#358](https://github.com/lucascaro/hive/pull/358)
+  (branch `feature/337-idea-inbox-gui`). `Branch:` and `PR:` above are
+  cleared between phases on purpose: `/hs-merge-gate` and
+  `/hs-feature-implement` both resolve the plan's `PR:` field, and a
+  merged one left there short-circuits the next phase straight back to
+  `GATE` before it has built anything.
+- **Phase:** 3 of 3 (see `### Phasing`)
 - **Status:** active
 
 ## Summary
@@ -1003,6 +1009,17 @@ path instead.
   e2e suite (279 passed / 31 skipped, first attempt), `ui-lint.sh` and
   `ui-contrast.mjs` all clean. Phase 3 (`initial_prompt`, Start
   session, the `CreateSession` options struct) not started.
+- **2026-09-07** — Phase 2 merged as #358 (`4f53fbe6`). Reset for phase
+  3: spec `stage:` back to `IMPLEMENT`, plan `Phase:` to `3 of 3`,
+  `Branch:`/`PR:` cleared. Phase 3's scope is now four things — the
+  original `initial_prompt` + Start session + `CreateSession`
+  options-struct refactor, plus re-kind and re-project, added to the
+  spec on 2026-09-06 after the feature was exercised by hand. **Nothing
+  should be built before the Claude/Pi interactive check in `###
+  Initial prompt delivery` is run by hand**: the whole argv path
+  (`Def.PositionalPrompt`) rests on an assertion nothing in this tree
+  proves, and if either agent drops to one-shot print mode the design
+  changes rather than the implementation.
 
 ## Gate verdict
 

--- a/docs/product-specs/337-idea-inbox.md
+++ b/docs/product-specs/337-idea-inbox.md
@@ -5,7 +5,7 @@ title: "Idea inbox: capture ideas mid-session, start a session from one later"
 type: enhancement
 complexity: M
 priority: P1
-stage: GATE
+stage: IMPLEMENT
 ---
 
 # Idea inbox: capture ideas mid-session, start a session from one later


### PR DESCRIPTION
Bookkeeping only — no code. Phase 2 of the idea inbox merged as #358
(`4f53fbe6`); this hands the feature to phase 3.

## What changes

- Spec frontmatter `stage:` → `IMPLEMENT`.
- Plan header `Phase:` → `3 of 3`.
- Plan header `Branch:` and `PR:` cleared, with the shipped-phase
  record moved to a new `Shipped:` line so the history survives.

Clearing those two is load-bearing rather than tidiness: both
`/hs-merge-gate` (step 4) and `/hs-feature-implement` (cold-start
guard) resolve the plan's `PR:` field, and a merged PR left there
short-circuits the next phase straight back to `GATE` before it has
built anything.

## Phase 3's scope

Four things, one more than originally planned:

1. `initial_prompt` on `CreateSpec` + delivery — a bare positional argv
   for Claude and Pi, typed into the PTY at first idle for every other
   agent.
2. `CreateSession`'s 11 positional parameters → an options struct,
   which (1) forces.
3. Start session in the inbox, the `status=started` / `session_id`
   write, and the session-row idea glyph.
4. Re-kind and re-project — `UpdateIdeaReq{Kind, ProjectID}`, registry
   validation, and Edit becoming a small dialog. Added to the spec on
   2026-09-06 after phase 2 was exercised by hand against an isolated
   build: an idea's kind and project were fixed at capture time, and
   the capture sheet pre-fills the project from whatever session is
   focused, so mis-filing was correctable only by deleting and
   retyping the note.

## Before any of it is built

`### Initial prompt delivery` in the plan demands a manual check that
nothing in this tree proves: that `claude --session-id <uuid> "text"`
and `pi --session-id <id> "text"` start an *interactive* session seeded
with the text, rather than dropping into one-shot print mode. The whole
argv path (`Def.PositionalPrompt`) rests on it — if either drops, that
agent falls back to the typed path and `PositionalPrompt` may end up
with zero users, which changes the design rather than the
implementation.

Labelled `no-changeset`: docs-only, no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
