### PR TITLE
ci(dependabot): drop the daemon-contract-override label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    labels: [no-changeset, daemon-contract-override]
+    labels: [no-changeset]


### PR DESCRIPTION
Follow-up to the MINOR finding on #366.

`.github/dependabot.yml` pre-applied `daemon-contract-override` to every Dependabot PR. `scripts/check-daemon-contract.sh` only fires on diffs under `internal/{wire,daemon,session,registry}` and `cmd/hived`; a `github-actions` Dependabot PR touches `.github/workflows/` only, so the gate already passes on its own. The label bought nothing and auto-attached a gate-bypass label to unreviewed bot PRs.

`no-changeset` stays — those PRs genuinely need it.

No changeset: CI-only.