### PR TITLE
docs(337): the Claude/Pi interactive check passes — phase 3 unblocked

### DIFF
--- a/docs/exec-plans/active/337-idea-inbox.md
+++ b/docs/exec-plans/active/337-idea-inbox.md
@@ -859,6 +859,35 @@ path instead.
   matching success criterion; the work is assigned to phase 3 above.
   Recorded rather than fixed in phase 2 because it is a wire and
   registry change, and phase 2's PR had already gated.
+- **2026-09-07** — **The Claude/Pi interactive check is done, and both
+  pass.** `### Initial prompt delivery` asked for this before phase 3
+  was built, because the whole argv path rests on it and nothing in the
+  tree proved it. Measured under a real PTY (a throwaway probe using
+  the `go-pty` dependency `scripts/vtcapture` already pulls in; the
+  distinguishing signal is simply whether the process exits on its own):
+  - `claude --session-id <uuid> "text"` — **interactive, and it submits
+    the text as the first turn.** Alt screen (`\e[?1049h`), full clear,
+    mouse tracking, the Claude Code banner and status line; still
+    running after 25s. The capture shows `❯ reply with the single word
+    ok` → `⏺ ok` → an idle prompt, so the positional is not merely
+    seeded into the input box, it is dispatched.
+  - `pi --session-id <id> "text"` — **interactive, and it submits too.**
+    Same markers, still running after 25s, the prompt rendered into the
+    session and dispatched to the model. Its turn then failed with
+    `Error: Connection error.` — the probe machine had no backend for
+    pi's configured local MLX model. That is environmental and says
+    nothing about the mode question.
+  So `Def.PositionalPrompt` has its two users as the spec assumed, and
+  the typed-at-idle fallback is for the other agents only. Phase 3 is
+  unblocked on its own terms.
+- **2026-09-07** — Found while probing: `pi` prints a plain-text
+  warning **before** entering the alt screen when `--session-id` names
+  a session it has not seen — `Warning: No project session found with
+  id '<id>'; creating a new session with that id.` Hive passes a fresh
+  id for every new session, so this lands in the scrollback of every pi
+  session it starts. Harmless, but it is the first thing the user sees,
+  and it will be read as Hive having done something wrong. Worth a line
+  in phase 3's notes rather than a fix here.
 
 ## Review log
 


### PR DESCRIPTION
Docs only — a decision-log entry recording a measurement, no code.

## The question

Spec 337's plan has carried this since phase 1, in `### Initial prompt
delivery`, explicitly as *verify before implementing phase 3*:

> That `claude --session-id <uuid> "text"` starts an *interactive*
> session seeded with the text (rather than non-interactive print
> mode), and the same for `pi --session-id <id> "text"`, is asserted by
> the spec but proven by nothing in this tree.

The whole argv delivery path — `Def.PositionalPrompt`, and which agents
even use it — rests on the answer. If either agent had dropped to
one-shot print mode, that agent would fall back to the typed-at-idle
path and `PositionalPrompt` could have ended up with zero users, which
changes phase 3's design rather than its implementation.

## The answer: both pass

Measured under a real PTY, with a throwaway probe built on the `go-pty`
dependency `scripts/vtcapture` already pulls in. The distinguishing
signal needs no interpretation — a print-mode process exits on its own;
an interactive one does not.

- **`claude --session-id <uuid> "text"`** — interactive, and it submits
  the text as the first turn. Alt screen (`\e[?1049h`), full clear,
  mouse tracking, the Claude Code banner and status line; still running
  after 25s. The capture shows `❯ reply with the single word ok` → `⏺
  ok` → an idle prompt.
- **`pi --session-id <id> "text"`** — interactive, and it submits too.
  Same markers, still running after 25s, prompt rendered into the
  session and dispatched to the model. Its turn then failed with
  `Error: Connection error.` because the probe machine had no backend
  running for pi's configured local MLX model — environmental, and
  irrelevant to the mode question.

Both go slightly further than the spec assumed: the positional is not
merely *seeded into the input box*, it is dispatched. So
`PositionalPrompt` has its two users, typed-at-idle is the fallback for
the other agents only, and phase 3 needs no design change.

## Also found

`pi` prints a plain-text warning **before** entering the alt screen when
`--session-id` names a session it has not seen:

```
Warning: No project session found with id '<id>'; creating a new session with that id.
```

Hive passes a fresh id for every new session, so this will head the
scrollback of every pi session it starts. Harmless, but it is the first
thing the user sees and reads as Hive having done something wrong.
Recorded as a phase-3 note rather than fixed here.

The probe was deleted after use and left no agent processes running.

Labelled `no-changeset`: docs-only, no user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
