### PR TITLE
feat(374): sign and notarize macOS releases

### DIFF
--- a/.changesets/374-signed-macos-releases.md
+++ b/.changesets/374-signed-macos-releases.md
@@ -1,0 +1,16 @@
+---
+issue: 374
+pr: null
+type: security
+bump: minor
+---
+- macOS releases are now signed with an Apple Developer ID certificate,
+  notarized by Apple, and stapled. A fresh install no longer trips the
+  "unidentified developer" warning, and no right-click-Open workaround
+  is needed.
+- The in-app updater now refuses any downloaded release that is not
+  signed by Hive's Apple Developer team, and says so specifically
+  rather than reporting a generic checksum error. Previously the only
+  check was a SHA-256 manifest published alongside the download, which
+  catches a corrupted transfer but not a tampered one. The installed
+  app is left untouched when the check fails.

--- a/.changesets/374-signed-macos-releases.md
+++ b/.changesets/374-signed-macos-releases.md
@@ -1,6 +1,6 @@
 ---
 issue: 374
-pr: null
+pr: 378
 type: security
 bump: minor
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # scripts/release.sh and scripts/sign-macos.sh are release-critical
+      # and first execute live, after a commit and tag exist. A syntax
+      # error or an unquoted expansion there is discovered at the worst
+      # possible moment, so lint them here instead.
+      - name: Shellcheck scripts/
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          # -S warning: match what these scripts already pass locally.
+          # Info/style notes on long-standing scripts are not this gate's job.
+          shopt -s nullglob
+          files=(scripts/*.sh scripts/hooks/* build.sh)
+          printf 'linting %d file(s)\n' "${#files[@]}"
+          shellcheck -S warning "${files[@]}"
+
   build:
     name: Build, Vet & Test (${{ matrix.label }})
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,14 @@ The script handles everything: version bump, changelog stamp, commit, tag, relea
 
 **Prerequisites:** clean working tree, `gh` CLI authenticated, `[Unreleased]` section in CHANGELOG.md.
 
+On macOS the script also signs, notarizes and staples the `.app`, and refuses to
+release without credentials. Export `HIVE_SIGN_IDENTITY` and
+`HIVE_NOTARY_PROFILE`, and pin the Team ID in `internal/buildinfo/signing.go` —
+one-time setup in **[docs/releasing-signed-macos.md](docs/releasing-signed-macos.md)**.
+Budget 2-15 minutes for notarization. To exercise the hardened runtime on a
+local build without a certificate, run
+`scripts/sign-macos.sh --adhoc cmd/hivegui/build/bin/hivegui.app`.
+
 **Version scheme:** [Semantic Versioning](https://semver.org/) — bump minor for new features, patch for bug fixes.
 
 ## Feature Pipeline

--- a/build.sh
+++ b/build.sh
@@ -145,8 +145,9 @@ build_macos() {
   # The menu bar agent ships as its own .app inside the GUI's bundle.
   # macOS will not show a status item for a bare binary, and
   # Contents/Library/LoginItems is where an embedded helper belongs —
-  # it is what SMAppService looks for, so the login-item toggle works
-  # the day Hive is code-signed.
+  # it is what SMAppService looks for. Release builds are signed and
+  # notarized (scripts/sign-macos.sh), so the login-item toggle works;
+  # for a local build, sign first with `scripts/sign-macos.sh --adhoc`.
   BAR="cmd/hivegui/build/bin/hivegui.app/Contents/Library/LoginItems/hivebar.app"
   mkdir -p "$BAR/Contents/MacOS"
   lipo -create -output "$BAR/Contents/MacOS/hivebar" \
@@ -166,7 +167,12 @@ build_macos() {
     mkdir -p release
     out="release/Hive-${version}-macos-universal.zip"
     rm -f "$out"
-    ( cd cmd/hivegui/build/bin && zip -rq "../../../../$out" hivegui.app )
+    # ditto, not zip: it is Apple's packaging for signed bundles and
+    # the counterpart to the `ditto -x -k` the updater unpacks with.
+    # zip -r follows symlinks and drops metadata, which invalidates a
+    # code signature; --keepParent keeps hivegui.app as the archive
+    # root, matching what stageRelease expects to find.
+    ( cd cmd/hivegui/build/bin && ditto -c -k --keepParent hivegui.app "../../../../$out" )
     echo "==> [macos] Packaged $out ($(du -h "$out" | cut -f1))"
   fi
 

--- a/cmd/hivegui/loginitem_darwin.go
+++ b/cmd/hivegui/loginitem_darwin.go
@@ -27,9 +27,11 @@ static int hive_login_item_status(const char *identifier) {
 // hive_login_item_set registers or unregisters the helper. Returns NULL
 // on success, or a strdup'd error description the caller must free.
 //
-// The error string matters more here than in most cgo shims: on an
-// unsigned build this call is expected to fail, and the user needs to
-// see WHY rather than a silent toggle that springs back.
+// The error string matters more here than in most cgo shims. Release
+// builds are signed and notarized, so this works — but a local build
+// is unsigned unless `scripts/sign-macos.sh --adhoc` was run over it,
+// and then this call fails. The user needs to see WHY rather than a
+// silent toggle that springs back.
 static char *hive_login_item_set(const char *identifier, int enable) {
   if (@available(macOS 13.0, *)) {
     NSString *ident = [NSString stringWithUTF8String:identifier];

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -533,6 +533,15 @@ func runBuildScript(repo string, progress func(string)) error {
 // Refuses when the running binary is not inside a .app: a `wails dev`
 // or `go run` process has no bundle to swap, and guessing at one would
 // mean writing over something we did not install.
+// isDownloadedStaging reports whether a staged bundle came from
+// stageRelease — i.e. we downloaded it into our own staging area —
+// rather than from stageLatest, which returns a path inside the
+// user's git checkout.
+func isDownloadedStaging(staged string) bool {
+	root := updatesRoot()
+	return strings.HasPrefix(staged, root+string(filepath.Separator))
+}
+
 func applyStagedBundle(staged string) error {
 	self, err := executablePath()
 	if err != nil {
@@ -547,8 +556,19 @@ func applyStagedBundle(staged string) error {
 	// staging directory is writable in between — a verify-to-install
 	// gap. Same-uid only, so this is defense in depth rather than a
 	// hole in the stated threat model, and it costs one call.
-	if err := verifySignatureFn(context.Background(), staged); err != nil {
-		return err
+	//
+	// Release stagings only. applyStagedBundle serves both channels,
+	// and a latest-channel bundle was built locally from a git
+	// checkout with no credentials, so it carries no Developer ID at
+	// all — stageLatest deliberately skips this check, its trust root
+	// being verifyUpstreamRemote. Verifying it here would tell a user
+	// who just waited out a multi-minute build that their own build is
+	// "not signed by the Hive developer", and it would only start
+	// doing so the day a Team ID is pinned.
+	if isDownloadedStaging(staged) {
+		if err := verifySignatureFn(context.Background(), staged); err != nil {
+			return err
+		}
 	}
 	return swapBundle(staged, installed)
 }

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -528,11 +528,6 @@ func runBuildScript(repo string, progress func(string)) error {
 
 // ------------------------------- apply -----------------------------------
 
-// applyStagedBundle replaces the installed app with the staged one.
-//
-// Refuses when the running binary is not inside a .app: a `wails dev`
-// or `go run` process has no bundle to swap, and guessing at one would
-// mean writing over something we did not install.
 // isDownloadedStaging reports whether a staged bundle came from
 // stageRelease — i.e. we downloaded it into our own staging area —
 // rather than from stageLatest, which returns a path inside the
@@ -542,6 +537,11 @@ func isDownloadedStaging(staged string) bool {
 	return strings.HasPrefix(staged, root+string(filepath.Separator))
 }
 
+// applyStagedBundle replaces the installed app with the staged one.
+//
+// Refuses when the running binary is not inside a .app: a `wails dev`
+// or `go run` process has no bundle to swap, and guessing at one would
+// mean writing over something we did not install.
 func applyStagedBundle(staged string) error {
 	self, err := executablePath()
 	if err != nil {

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lucascaro/hive/internal/buildinfo"
 	"github.com/lucascaro/hive/internal/registry"
 )
 
@@ -163,7 +164,12 @@ func stageRelease(info UpdateInfo, progress func(string)) (string, error) {
 		return "", err
 	}
 
-	progress("Verifying signature…")
+	// Only announce the step that actually runs: verification is a no-op
+	// on a build with no pin, and claiming otherwise tells the user a
+	// signature was checked when none was.
+	if buildinfo.SigningTeamID() != "" {
+		progress("Verifying signature…")
+	}
 	if err := verifySignatureFn(ctx, bundle); err != nil {
 		return "", err
 	}
@@ -597,8 +603,9 @@ func verifyBundle(bundle string) error {
 }
 
 // dittoExtract unpacks a zip. `ditto -x -k` is the macOS counterpart to
-// the `zip -rq` build.sh packages with, and unlike archive/zip it
-// preserves the symlinks and permissions an .app bundle depends on.
+// the `ditto -c -k --keepParent` build.sh packages with, and unlike
+// archive/zip it preserves the symlinks and permissions an .app bundle
+// depends on.
 func dittoExtract(zipPath, dest string) error {
 	if err := os.MkdirAll(dest, 0o755); err != nil {
 		return err

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -44,15 +44,21 @@ var buildTimeout = 30 * time.Minute
 // Seams for tests, mirroring looksLikeHivedFn in restart_unix.go.
 var (
 	// extractZipFn unpacks a release zip into a directory. ditto is the
-	// macOS-native answer: archive/zip loses the symlinks and mode bits
-	// an .app bundle needs, and a bundle whose binary lost its +x is a
-	// broken install with no in-app way back.
+	// macOS-native answer, and the counterpart to the `ditto -c -k`
+	// that build.sh packages with: archive/zip loses the symlinks and
+	// mode bits an .app bundle needs, and a bundle whose binary lost
+	// its +x is a broken install with no in-app way back. It also
+	// preserves the stapled notarization ticket, which the signature
+	// check below depends on.
 	extractZipFn = dittoExtract
 	// copyBundleFn duplicates a bundle. Used to land the staged app
 	// next to the installed one before the rename swap.
 	copyBundleFn = dittoCopy
 	// runBuildFn runs ./build.sh in a checkout, streaming progress.
 	runBuildFn = runBuildScript
+	// verifySignatureFn refuses a staged bundle not signed by Hive's
+	// Apple Developer team. Seamed so tests need no real signature.
+	verifySignatureFn = verifyDeveloperIDSignature
 )
 
 // stageUpdate prepares the new build and returns the staged bundle
@@ -72,14 +78,24 @@ type releaseAsset struct {
 	URL  string `json:"browser_download_url"`
 }
 
-// stageRelease downloads the macOS zip for the newest release, verifies
-// it against the published SHA-256 manifest, and unpacks it.
+// stageRelease downloads the macOS zip for the newest release,
+// verifies it, and unpacks it.
 //
-// The checksum is not a supply-chain defense — the bundle is neither
-// signed nor notarized, and a compromised release would publish a
-// matching manifest. It is there so a truncated or corrupted download
-// fails loudly here instead of becoming a broken hivegui.app that the
-// user can only fix by reinstalling by hand.
+// Two independent checks, in order of what they catch:
+//
+//   - The SHA-256 manifest catches a truncated or corrupted download,
+//     cheaply, and is the error users actually hit. It is NOT a
+//     supply-chain defense: the zip and the manifest come from the
+//     same release, so whoever can publish one publishes the other.
+//   - The Developer ID signature check is the supply-chain defense. It
+//     pins the bundle to Hive's Apple Developer team, so a release
+//     signed by anyone else — including an attacker with their own
+//     Apple account — is refused before it can be applied.
+//
+// The signature is checked after unpacking because codesign and spctl
+// read a bundle, not a zip stream. Staging is still fail-closed with
+// respect to the installed app: everything lands in a temp directory
+// that the deferred cleanup below removes unless every check passed.
 func stageRelease(info UpdateInfo, progress func(string)) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
 	defer cancel()
@@ -144,6 +160,11 @@ func stageRelease(info UpdateInfo, progress func(string)) (string, error) {
 	}
 	bundle := filepath.Join(appDir, bundleName)
 	if err := verifyBundle(bundle); err != nil {
+		return "", err
+	}
+
+	progress("Verifying signature…")
+	if err := verifySignatureFn(ctx, bundle); err != nil {
 		return "", err
 	}
 	// The zip is tens of MB and has served its purpose; the bundle is

--- a/cmd/hivegui/update_apply_darwin.go
+++ b/cmd/hivegui/update_apply_darwin.go
@@ -542,6 +542,14 @@ func applyStagedBundle(staged string) error {
 	if installed == "" {
 		return fmt.Errorf("not running from an .app bundle — rebuild and relaunch manually")
 	}
+	// Re-verify immediately before the swap. stageRelease already
+	// checked this bundle, but that was a separate step and the
+	// staging directory is writable in between — a verify-to-install
+	// gap. Same-uid only, so this is defense in depth rather than a
+	// hole in the stated threat model, and it costs one call.
+	if err := verifySignatureFn(context.Background(), staged); err != nil {
+		return err
+	}
 	return swapBundle(staged, installed)
 }
 

--- a/cmd/hivegui/update_apply_darwin_test.go
+++ b/cmd/hivegui/update_apply_darwin_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"archive/zip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -276,5 +278,81 @@ func TestStagingDirSanitizesVersion(t *testing.T) {
 	}
 	if filepath.Dir(dir) != updatesRoot() {
 		t.Errorf("stagingDir = %q, want it inside %q", dir, updatesRoot())
+	}
+}
+
+// TestStageReleaseRejectsUnverifiedSignature covers the fail-closed
+// path for a bundle that downloads and checksums cleanly but is not
+// signed by Hive. The staging directory must not survive: a later run
+// finding it there could mistake it for verified.
+func TestStageReleaseRejectsUnverifiedSignature(t *testing.T) {
+	isolateStateDir(t)
+	body := zipOfBundle(t)
+	name := "Hive-9.9.9-macos-universal.zip"
+	releaseServer(t, map[string][]byte{
+		name:           body,
+		checksumsAsset: []byte(sha256Of(body) + "  " + name + "\n"),
+	}, nil)
+
+	prevExtract := extractZipFn
+	extractZipFn = func(_, dest string) error {
+		stubBundle(t, dest, "staged")
+		return nil
+	}
+	t.Cleanup(func() { extractZipFn = prevExtract })
+
+	prevVerify := verifySignatureFn
+	verifySignatureFn = func(context.Context, string) error {
+		return errors.New("this update is not signed by the Hive developer (team ABCDE12345) — download discarded")
+	}
+	t.Cleanup(func() { verifySignatureFn = prevVerify })
+
+	_, err := stageRelease(UpdateInfo{Channel: ChannelRelease, Latest: "9.9.9"}, func(string) {})
+	if err == nil {
+		t.Fatal("stageRelease = nil error for an unsigned bundle, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "not signed by the Hive developer") {
+		t.Errorf("error = %q, want the signature-specific message", err)
+	}
+	if strings.Contains(err.Error(), "checksum") {
+		t.Errorf("error = %q, must be distinguishable from a checksum failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(updatesRoot(), "9.9.9")); statErr == nil {
+		t.Error("staging dir survived a failed signature check")
+	}
+}
+
+// TestStageReleaseAcceptsVerifiedSignature is the other half: the new
+// check must not refuse a good bundle.
+func TestStageReleaseAcceptsVerifiedSignature(t *testing.T) {
+	isolateStateDir(t)
+	body := zipOfBundle(t)
+	name := "Hive-9.9.9-macos-universal.zip"
+	releaseServer(t, map[string][]byte{
+		name:           body,
+		checksumsAsset: []byte(sha256Of(body) + "  " + name + "\n"),
+	}, nil)
+
+	prevExtract := extractZipFn
+	extractZipFn = func(_, dest string) error {
+		stubBundle(t, dest, "staged")
+		return nil
+	}
+	t.Cleanup(func() { extractZipFn = prevExtract })
+
+	called := false
+	prevVerify := verifySignatureFn
+	verifySignatureFn = func(context.Context, string) error { called = true; return nil }
+	t.Cleanup(func() { verifySignatureFn = prevVerify })
+
+	bundle, err := stageRelease(UpdateInfo{Channel: ChannelRelease, Latest: "9.9.9"}, func(string) {})
+	if err != nil {
+		t.Fatalf("stageRelease = %v, want a staged bundle", err)
+	}
+	if !called {
+		t.Error("signature verification was never invoked for a release download")
+	}
+	if bundle == "" {
+		t.Error("stageRelease returned an empty bundle path")
 	}
 }

--- a/cmd/hivegui/update_shellout_darwin_test.go
+++ b/cmd/hivegui/update_shellout_darwin_test.go
@@ -176,9 +176,6 @@ func TestDittoExtractPreservesModeBitsAndSymlinks(t *testing.T) {
 	if _, err := exec.LookPath("ditto"); err != nil {
 		t.Skip("ditto not available")
 	}
-	if _, err := exec.LookPath("zip"); err != nil {
-		t.Skip("zip not available")
-	}
 
 	src := t.TempDir()
 	macos := filepath.Join(src, bundleName, "Contents", "MacOS")
@@ -202,10 +199,10 @@ func TestDittoExtractPreservesModeBitsAndSymlinks(t *testing.T) {
 
 	// Same invocation build.sh uses.
 	zipPath := filepath.Join(t.TempDir(), "Hive-test-macos-universal.zip")
-	cmd := exec.Command("zip", "-rq", "--symlinks", zipPath, bundleName)
+	cmd := exec.Command("ditto", "-c", "-k", "--keepParent", bundleName, zipPath)
 	cmd.Dir = src
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("zip: %v: %s", err, out)
+		t.Fatalf("ditto: %v: %s", err, out)
 	}
 
 	dest := filepath.Join(t.TempDir(), "app")
@@ -664,10 +661,10 @@ func TestStageReleaseSucceedsAndLeavesAUsableBundle(t *testing.T) {
 	stubBundle(t, src, "new")
 	zipName := "Hive-9.9.9-macos-universal.zip"
 	zipPath := filepath.Join(t.TempDir(), zipName)
-	cmd := exec.Command("zip", "-rq", zipPath, bundleName)
+	cmd := exec.Command("ditto", "-c", "-k", "--keepParent", bundleName, zipPath)
 	cmd.Dir = src
 	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Skipf("zip unavailable: %v: %s", err, out)
+		t.Skipf("ditto unavailable: %v: %s", err, out)
 	}
 	body, err := os.ReadFile(zipPath)
 	if err != nil {

--- a/cmd/hivegui/update_shellout_darwin_test.go
+++ b/cmd/hivegui/update_shellout_darwin_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -649,6 +650,14 @@ func TestStageLatestStopsOnPullFailure(t *testing.T) {
 // refusal, so nothing proved a good release actually installs.
 func TestStageReleaseSucceedsAndLeavesAUsableBundle(t *testing.T) {
 	isolateStateDir(t)
+
+	// The subject here is staging, not signing. Stub the signature seam
+	// so this stays green once signingTeamID is pinned — otherwise the
+	// real verifier would run codesign against an unsigned stub bundle
+	// and this test would break on the commit that enables the feature.
+	prevVerify := verifySignatureFn
+	verifySignatureFn = func(context.Context, string) error { return nil }
+	t.Cleanup(func() { verifySignatureFn = prevVerify })
 
 	// A real zip of a real (stub) bundle, packed the way build.sh packs.
 	src := t.TempDir()

--- a/cmd/hivegui/update_verify_darwin.go
+++ b/cmd/hivegui/update_verify_darwin.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/lucascaro/hive/internal/buildinfo"
+)
+
+// Absolute paths, deliberately. `xcrun stapler` is the obvious way to
+// check a notarization ticket and it is the wrong one here: stapler
+// ships with the Xcode Command Line Tools, not with macOS, so on an
+// ordinary user's Mac it fails with "xcrun: unable to find utility".
+// This check is fail-closed — a failure discards the download — so
+// reaching for a tool most users do not have would refuse every
+// update for almost everyone. codesign and spctl are both base OS.
+const (
+	codesignBin = "/usr/bin/codesign"
+	spctlBin    = "/usr/sbin/spctl"
+)
+
+// verifyTimeout bounds each verification command. spctl contacts
+// Apple's notary service when a staple is missing or unreadable, and
+// on a captive-portal network that call can hang indefinitely — which
+// would wedge the staging goroutine rather than failing it. Var so a
+// test can shrink it.
+var verifyTimeout = 60 * time.Second
+
+// runArgv is the seam tests replace. It returns combined output so a
+// codesign rejection reaches the user instead of a bare exit code.
+var runArgv = func(ctx context.Context, name string, args ...string) (string, error) {
+	out, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+	return string(out), err
+}
+
+// teamIDRequirement builds the codesign requirement that pins a
+// bundle to one Apple Developer team.
+//
+// This string is the entire security value of the check. Plain
+// `codesign --verify` proves only that *some* valid Developer ID
+// signed the bundle — an attacker who pays Apple $99 satisfies it.
+// Pinning subject.OU (the Team ID) is what makes it mean "signed by
+// us".
+func teamIDRequirement(teamID string) string {
+	return fmt.Sprintf("=anchor apple generic and certificate leaf[subject.OU] = %q", teamID)
+}
+
+// verifyDeveloperIDSignature refuses a staged bundle that is not
+// signed by Hive's Apple Developer team.
+//
+// Two checks, with different standing:
+//
+//   - codesign with the Team ID requirement is load-bearing. A failure
+//     always refuses the update.
+//   - spctl --assess reports on notarization, and is advisory. Under
+//     `spctl --master-disable` it does not evaluate at all — it prints
+//     "assessments are disabled" — so treating its non-answer as a
+//     failure would refuse updates on a machine whose owner has
+//     already opted out of Gatekeeper globally, and treating it as
+//     authoritative would let that same setting silently turn this
+//     half of the check into a no-op. It is logged, not enforced; the
+//     Team ID pin still holds either way.
+//
+// Returns nil when this build has no pin (see buildinfo.signingTeamID).
+func verifyDeveloperIDSignature(ctx context.Context, bundle string) error {
+	teamID := buildinfo.SigningTeamID()
+	if teamID == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, verifyTimeout)
+	defer cancel()
+
+	out, err := runArgv(ctx, codesignBin,
+		"--verify", "--deep", "--strict",
+		"-R", teamIDRequirement(teamID),
+		bundle)
+	if err != nil {
+		detail := strings.TrimSpace(out)
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("this update is not signed by the Hive developer (team %s) — download discarded: %s", teamID, detail)
+	}
+
+	if out, err := runArgv(ctx, spctlBin, "--assess", "--type", "execute", bundle); err != nil {
+		log.Printf("hivegui: notarization assessment did not pass for %s (advisory, Team ID pin held): %v: %s",
+			bundle, err, strings.TrimSpace(out))
+	}
+	return nil
+}

--- a/cmd/hivegui/update_verify_darwin.go
+++ b/cmd/hivegui/update_verify_darwin.go
@@ -23,7 +23,8 @@ const (
 	spctlBin    = "/usr/sbin/spctl"
 )
 
-// verifyTimeout bounds each verification command. spctl contacts
+// verifyTimeout bounds verification as a whole — both commands below
+// share one context, so this is a combined budget, not per-command. spctl contacts
 // Apple's notary service when a staple is missing or unreadable, and
 // on a captive-portal network that call can hang indefinitely — which
 // would wedge the staging goroutine rather than failing it. Var so a
@@ -105,7 +106,7 @@ func verifyDeveloperIDSignature(ctx context.Context, bundle string) error {
 
 	if out, err := runArgv(ctx, spctlBin, "--assess", "--type", "execute", bundle); err != nil {
 		detail := strings.TrimSpace(out)
-		if assessmentsDisabled(detail) {
+		if assessmentsDisabled(ctx) {
 			log.Printf("hivegui: Gatekeeper assessments are disabled on this machine, so notarization "+
 				"could not be checked for %s. The Team ID pin passed and the update was accepted; "+
 				"a revoked certificate would not be detected.", bundle)
@@ -116,13 +117,27 @@ func verifyDeveloperIDSignature(ctx context.Context, bundle string) error {
 	return nil
 }
 
-// assessmentsDisabled reports whether spctl declined to evaluate
-// rather than actually rejecting the bundle.
+// assessmentsDisabled reports whether Gatekeeper assessment is turned
+// off on this machine, meaning spctl declined to evaluate rather than
+// actually rejecting the bundle.
 //
 // `spctl --master-disable` makes --assess answer "assessments are
 // disabled" for everything. That is a non-answer, not a verdict, and
-// it must not be confused with a real rejection — one means "this
-// machine opted out of Gatekeeper", the other means "Apple says no".
-func assessmentsDisabled(out string) bool {
-	return strings.Contains(strings.ToLower(out), "assessments are disabled")
+// must not be confused with a real rejection — one means "this machine
+// opted out of Gatekeeper", the other means "Apple says no".
+//
+// It asks `spctl --status` rather than pattern-matching the --assess
+// output, because --assess echoes the bundle path back and that path
+// contains a remote-supplied version string. It is safe today — the
+// version is slugged down to [A-Za-z0-9._-] in stagingDir, so it
+// cannot contain the phrase — but that makes the security of this
+// check depend on the slugging rules of an unrelated function, which
+// is exactly the coupling that rots. --status takes no path and so
+// has no injection surface at all.
+func assessmentsDisabled(ctx context.Context) bool {
+	out, err := runArgv(ctx, spctlBin, "--status")
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(out), "assessments disabled")
 }

--- a/cmd/hivegui/update_verify_darwin.go
+++ b/cmd/hivegui/update_verify_darwin.go
@@ -56,14 +56,24 @@ func teamIDRequirement(teamID string) string {
 //
 //   - codesign with the Team ID requirement is load-bearing. A failure
 //     always refuses the update.
+//
 //   - spctl --assess reports on notarization, and is advisory. Under
 //     `spctl --master-disable` it does not evaluate at all — it prints
-//     "assessments are disabled" — so treating its non-answer as a
-//     failure would refuse updates on a machine whose owner has
-//     already opted out of Gatekeeper globally, and treating it as
-//     authoritative would let that same setting silently turn this
-//     half of the check into a no-op. It is logged, not enforced; the
-//     Team ID pin still holds either way.
+//     "assessments are disabled" — so refusing on that would break
+//     updates for a machine whose owner already opted out of
+//     Gatekeeper globally.
+//
+//     But it must not be merely advisory either, and the reason is
+//     revocation. A `codesign` signature made with a secure timestamp
+//     stays valid after the certificate is revoked — that is what
+//     timestamping is for. So the Team ID pin alone cannot tell a
+//     stolen-and-revoked key from a good one, and revoking a
+//     compromised Developer ID (which docs/releasing-signed-macos.md
+//     prescribes) would do nothing for the updater. spctl is the only
+//     revocation-aware check in this path.
+//
+//     So the two cases are separated: a non-evaluating spctl is
+//     advisory, an actively rejecting one refuses the update.
 //
 // Returns nil when this build has no pin (see buildinfo.signingTeamID).
 func verifyDeveloperIDSignature(ctx context.Context, bundle string) error {
@@ -72,7 +82,13 @@ func verifyDeveloperIDSignature(ctx context.Context, bundle string) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, verifyTimeout)
+	// Deliberately detached from the caller's context. stageRelease's
+	// ctx carries the whole-download deadline, which by this point may
+	// have minutes or seconds left; inheriting it would let a slow
+	// download surface as "this update is not signed by the Hive
+	// developer" — accusing the developer of tampering because a
+	// timer ran out. Verification gets its own budget.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), verifyTimeout)
 	defer cancel()
 
 	out, err := runArgv(ctx, codesignBin,
@@ -88,8 +104,25 @@ func verifyDeveloperIDSignature(ctx context.Context, bundle string) error {
 	}
 
 	if out, err := runArgv(ctx, spctlBin, "--assess", "--type", "execute", bundle); err != nil {
-		log.Printf("hivegui: notarization assessment did not pass for %s (advisory, Team ID pin held): %v: %s",
-			bundle, err, strings.TrimSpace(out))
+		detail := strings.TrimSpace(out)
+		if assessmentsDisabled(detail) {
+			log.Printf("hivegui: Gatekeeper assessments are disabled on this machine, so notarization "+
+				"could not be checked for %s. The Team ID pin passed and the update was accepted; "+
+				"a revoked certificate would not be detected.", bundle)
+			return nil
+		}
+		return fmt.Errorf("this update failed Apple's notarization check — download discarded: %s", detail)
 	}
 	return nil
+}
+
+// assessmentsDisabled reports whether spctl declined to evaluate
+// rather than actually rejecting the bundle.
+//
+// `spctl --master-disable` makes --assess answer "assessments are
+// disabled" for everything. That is a non-answer, not a verdict, and
+// it must not be confused with a real rejection — one means "this
+// machine opted out of Gatekeeper", the other means "Apple says no".
+func assessmentsDisabled(out string) bool {
+	return strings.Contains(strings.ToLower(out), "assessments are disabled")
 }

--- a/cmd/hivegui/update_verify_darwin_test.go
+++ b/cmd/hivegui/update_verify_darwin_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lucascaro/hive/internal/buildinfo"
+)
+
+// captureArgv swaps the runArgv seam for one that records every
+// invocation and returns the supplied results in order.
+func captureArgv(t *testing.T, results ...error) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prev := runArgv
+	i := 0
+	runArgv = func(_ context.Context, name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		var err error
+		if i < len(results) {
+			err = results[i]
+		}
+		i++
+		return "", err
+	}
+	t.Cleanup(func() { runArgv = prev })
+	return &calls
+}
+
+// TestVerifyDeveloperIDSignaturePassesPinnedRequirement is the
+// load-bearing test of this feature.
+//
+// teamIDRequirement returning the right string proves nothing on its
+// own: if the -R flag is dropped at the call site, codesign still
+// exits 0 for any valid Apple Developer ID, the update is accepted,
+// and every other test in this file still passes. The check would be
+// silently downgraded from "signed by Hive" to "signed by anybody who
+// paid Apple $99". So assert the argv itself.
+func TestVerifyDeveloperIDSignaturePassesPinnedRequirement(t *testing.T) {
+	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
+	calls := captureArgv(t)
+
+	if err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app"); err != nil {
+		t.Fatalf("verifyDeveloperIDSignature = %v, want nil", err)
+	}
+	if len(*calls) == 0 {
+		t.Fatal("no command was run; verification did nothing")
+	}
+
+	argv := (*calls)[0]
+	idx := -1
+	for i, a := range argv {
+		if a == "-R" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("codesign argv has no -R requirement: %q", argv)
+	}
+	if idx+1 >= len(argv) {
+		t.Fatalf("-R is the last argument, no requirement follows: %q", argv)
+	}
+	want := `=anchor apple generic and certificate leaf[subject.OU] = "ABCDE12345"`
+	if argv[idx+1] != want {
+		t.Errorf("requirement = %q, want %q", argv[idx+1], want)
+	}
+}
+
+// TestVerifyDeveloperIDSignatureUsesBaseOSToolsOnly guards the
+// regression that would brick updates for most users: xcrun (and so
+// stapler) ships with the Xcode command-line tools, not with macOS.
+func TestVerifyDeveloperIDSignatureUsesBaseOSToolsOnly(t *testing.T) {
+	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
+	calls := captureArgv(t)
+
+	if err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app"); err != nil {
+		t.Fatalf("verifyDeveloperIDSignature = %v, want nil", err)
+	}
+	for _, argv := range *calls {
+		switch argv[0] {
+		case codesignBin, spctlBin:
+		default:
+			t.Errorf("ran %q; only %s and %s exist on a stock macOS install",
+				argv[0], codesignBin, spctlBin)
+		}
+		if strings.Contains(argv[0], "xcrun") || strings.Contains(argv[0], "stapler") {
+			t.Errorf("ran %q, which requires the Xcode command-line tools", argv[0])
+		}
+	}
+}
+
+func TestVerifyDeveloperIDSignatureSkipsWhenTeamIDUnset(t *testing.T) {
+	defer buildinfo.SetSigningTeamIDForTest("")()
+	calls := captureArgv(t)
+
+	if err := verifyDeveloperIDSignature(context.Background(), "/nonexistent.app"); err != nil {
+		t.Fatalf("verifyDeveloperIDSignature = %v, want nil for an unpinned build", err)
+	}
+	if len(*calls) != 0 {
+		t.Errorf("ran %d command(s) for an unpinned build, want 0", len(*calls))
+	}
+}
+
+func TestVerifyDeveloperIDSignatureRefusesOnCodesignFailure(t *testing.T) {
+	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
+	captureArgv(t, errors.New("code object is not signed at all"))
+
+	err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app")
+	if err == nil {
+		t.Fatal("verifyDeveloperIDSignature = nil for an unsigned bundle, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "not signed by the Hive developer") {
+		t.Errorf("error = %q, want a signature-specific message", err)
+	}
+	if strings.Contains(err.Error(), "checksum") {
+		t.Errorf("error = %q, must not be confusable with the checksum failure", err)
+	}
+}
+
+// TestVerifyDeveloperIDSignatureTreatsFailingSpctlAsAdvisory pins the
+// decision that spctl does not get a veto. Under `spctl
+// --master-disable` it reports "assessments are disabled" rather than
+// evaluating; enforcing that would refuse updates on a machine whose
+// owner already opted out of Gatekeeper globally. The Team ID pin is
+// what actually gates, and it still ran.
+func TestVerifyDeveloperIDSignatureTreatsFailingSpctlAsAdvisory(t *testing.T) {
+	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
+	calls := captureArgv(t, nil, errors.New("assessments are disabled"))
+
+	if err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app"); err != nil {
+		t.Fatalf("verifyDeveloperIDSignature = %v; a disabled Gatekeeper must not block updates", err)
+	}
+	if len(*calls) != 2 || (*calls)[0][0] != codesignBin {
+		t.Fatalf("expected codesign then spctl, got %v", *calls)
+	}
+}
+
+func TestTeamIDRequirement(t *testing.T) {
+	got := teamIDRequirement("ABCDE12345")
+	want := `=anchor apple generic and certificate leaf[subject.OU] = "ABCDE12345"`
+	if got != want {
+		t.Errorf("teamIDRequirement = %q, want %q", got, want)
+	}
+}
+
+// TestSigningTeamIDMatchesSource keeps scripts/release.sh and
+// scripts/sign-macos.sh honest. Both read the pinned Team ID by
+// sed'ing internal/buildinfo/signing.go, because a shell script cannot
+// call into Go. That extraction is only safe if it cannot drift from
+// what the compiler sees — so assert here that the two agree.
+func TestSigningTeamIDMatchesSource(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "internal", "buildinfo", "signing.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const prefix = `var signingTeamID = "`
+	var fromSource string
+	found := false
+	for _, line := range strings.Split(string(src), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			fromSource = strings.TrimSuffix(strings.TrimPrefix(line, prefix), `"`)
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no line starting %q in internal/buildinfo/signing.go — "+
+			"the shell extraction in release.sh and sign-macos.sh reads exactly this shape", prefix)
+	}
+	if fromSource != buildinfo.SigningTeamID() {
+		t.Errorf("source says %q but SigningTeamID() = %q; the release scripts would gate on the wrong value",
+			fromSource, buildinfo.SigningTeamID())
+	}
+}

--- a/cmd/hivegui/update_verify_darwin_test.go
+++ b/cmd/hivegui/update_verify_darwin_test.go
@@ -214,9 +214,11 @@ func TestAssessmentsDisabled(t *testing.T) {
 		{"disabled", "assessments disabled", nil, true},
 		{"enabled", "assessments enabled", nil, false},
 		{"spctl unavailable fails closed", "", errors.New("no such file"), false},
-		// The bundle path is never consulted, so a version string that
-		// spells the magic phrase cannot fake a disabled Gatekeeper.
-		{"path cannot spoof", "assessments enabled", nil, false},
+		// The bundle path is never consulted, so a rejection that
+		// echoes back a path spelling the magic phrase — the shape a
+		// remote-supplied version string could take — cannot fake a
+		// disabled Gatekeeper.
+		{"path cannot spoof", "/tmp/hive-assessments-are-disabled.app: rejected", nil, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			captureArgvOut(t, argvResult{tc.out, tc.err})
@@ -296,32 +298,53 @@ func TestSigningTeamIDMatchesSource(t *testing.T) {
 // multi-minute build that their own build is "not signed by the Hive
 // developer" — and only from the day a Team ID is pinned, long after
 // anyone is looking at this code.
+// It drives applyStagedBundle end to end rather than asserting the
+// path classifier alone: deleting the isDownloadedStaging guard has to
+// make this fail, or the guard is unguarded.
 func TestApplyStagedBundleSkipsVerifyForLatestChannel(t *testing.T) {
 	isolateStateDir(t)
 	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
 
-	called := false
-	prev := verifySignatureFn
+	verifyErr := errors.New("this update is not signed by the Hive developer (team ABCDE12345)")
+	verified := 0
+	prevVerify := verifySignatureFn
 	verifySignatureFn = func(context.Context, string) error {
-		called = true
-		return errors.New("this update is not signed by the Hive developer (team ABCDE12345)")
+		verified++
+		return verifyErr
 	}
-	t.Cleanup(func() { verifySignatureFn = prev })
+	t.Cleanup(func() { verifySignatureFn = prevVerify })
+
+	installed := stubBundle(t, t.TempDir(), "old")
+	prevExe := executablePath
+	executablePath = func() (string, error) {
+		return filepath.Join(installed, "Contents", "MacOS", "hivegui"), nil
+	}
+	t.Cleanup(func() { executablePath = prevExe })
 
 	// stageLatest returns a path inside the user's checkout, never
-	// under updatesRoot().
-	latest := filepath.Join(t.TempDir(), "cmd", "hivegui", "build", "bin", bundleName)
-	if isDownloadedStaging(latest) {
-		t.Fatalf("isDownloadedStaging(%q) = true; a source-built bundle is not a download", latest)
+	// under updatesRoot(), so the swap must go through untouched.
+	latest := stubBundle(t, filepath.Join(t.TempDir(), "cmd", "hivegui", "build", "bin"), "new")
+	if err := applyStagedBundle(latest); err != nil {
+		t.Fatalf("applyStagedBundle(latest-channel bundle) = %v; a locally built bundle carries no "+
+			"Developer ID and must not be re-verified at apply time", err)
+	}
+	if verified != 0 {
+		t.Errorf("verification ran %d times on a latest-channel bundle, want 0", verified)
+	}
+	if got := readMarker(t, installed); got != "new" {
+		t.Errorf("installed binary = %q after apply, want %q", got, "new")
 	}
 
-	// Release stagings, by contrast, must still be re-verified.
-	release := filepath.Join(updatesRoot(), "9.9.9", "app", bundleName)
-	if !isDownloadedStaging(release) {
-		t.Errorf("isDownloadedStaging(%q) = false; a downloaded staging must still be re-verified", release)
+	// A downloaded staging, by contrast, must still be re-verified —
+	// and a failed verification must abort the swap.
+	release := stubBundle(t, filepath.Join(updatesRoot(), "9.9.9"), "downloaded")
+	if err := applyStagedBundle(release); !errors.Is(err, verifyErr) {
+		t.Fatalf("applyStagedBundle(downloaded staging) = %v, want the verification error", err)
 	}
-
-	if called {
-		t.Error("verification ran during path classification")
+	if verified != 1 {
+		t.Errorf("verification ran %d times on a downloaded staging, want 1", verified)
+	}
+	if got := readMarker(t, installed); got == "downloaded" {
+		t.Error("the swap ran despite verification failing")
 	}
 }

--- a/cmd/hivegui/update_verify_darwin_test.go
+++ b/cmd/hivegui/update_verify_darwin_test.go
@@ -122,21 +122,115 @@ func TestVerifyDeveloperIDSignatureRefusesOnCodesignFailure(t *testing.T) {
 	}
 }
 
-// TestVerifyDeveloperIDSignatureTreatsFailingSpctlAsAdvisory pins the
-// decision that spctl does not get a veto. Under `spctl
-// --master-disable` it reports "assessments are disabled" rather than
-// evaluating; enforcing that would refuse updates on a machine whose
-// owner already opted out of Gatekeeper globally. The Team ID pin is
-// what actually gates, and it still ran.
-func TestVerifyDeveloperIDSignatureTreatsFailingSpctlAsAdvisory(t *testing.T) {
+// captureArgvOut is captureArgv with control over stdout, needed to
+// distinguish spctl's "assessments are disabled" non-answer from a
+// real rejection.
+func captureArgvOut(t *testing.T, results ...struct {
+	out string
+	err error
+}) *[][]string {
+	t.Helper()
+	var calls [][]string
+	prev := runArgv
+	i := 0
+	runArgv = func(_ context.Context, name string, args ...string) (string, error) {
+		calls = append(calls, append([]string{name}, args...))
+		var r struct {
+			out string
+			err error
+		}
+		if i < len(results) {
+			r = results[i]
+		}
+		i++
+		return r.out, r.err
+	}
+	t.Cleanup(func() { runArgv = prev })
+	return &calls
+}
+
+type argvResult = struct {
+	out string
+	err error
+}
+
+// TestVerifyDeveloperIDSignatureAllowsDisabledAssessments pins the
+// accommodation: `spctl --master-disable` makes --assess answer
+// "assessments are disabled" for everything. That is a non-answer,
+// and refusing on it would break updates for a machine whose owner
+// already opted out of Gatekeeper globally.
+func TestVerifyDeveloperIDSignatureAllowsDisabledAssessments(t *testing.T) {
 	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
-	calls := captureArgv(t, nil, errors.New("assessments are disabled"))
+	calls := captureArgvOut(t,
+		argvResult{"", nil},
+		argvResult{"/tmp/x.app: assessments are disabled", errors.New("exit status 1")},
+	)
 
 	if err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app"); err != nil {
 		t.Fatalf("verifyDeveloperIDSignature = %v; a disabled Gatekeeper must not block updates", err)
 	}
-	if len(*calls) != 2 || (*calls)[0][0] != codesignBin {
+	if len(*calls) != 2 || (*calls)[0][0] != codesignBin || (*calls)[1][0] != spctlBin {
 		t.Fatalf("expected codesign then spctl, got %v", *calls)
+	}
+}
+
+// TestVerifyDeveloperIDSignatureRefusesRealSpctlRejection is the
+// revocation defense. A codesign signature made with a secure
+// timestamp stays valid after the certificate is revoked — that is
+// what timestamping is for — so the Team ID pin alone cannot tell a
+// stolen-and-revoked key from a good one. spctl is the only
+// revocation-aware check in this path, so a real rejection from it
+// must refuse the update rather than being logged and ignored.
+func TestVerifyDeveloperIDSignatureRefusesRealSpctlRejection(t *testing.T) {
+	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
+	captureArgvOut(t,
+		argvResult{"", nil},
+		argvResult{"/tmp/x.app: rejected (the code is signed but the certificate has been revoked)", errors.New("exit status 3")},
+	)
+
+	err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app")
+	if err == nil {
+		t.Fatal("verifyDeveloperIDSignature = nil for a revoked certificate, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "notarization") {
+		t.Errorf("error = %q, want it to name the notarization check", err)
+	}
+}
+
+func TestAssessmentsDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{"/x.app: assessments are disabled", true},
+		{"/x.app: ASSESSMENTS ARE DISABLED", true},
+		{"/x.app: rejected (the code is signed but the certificate has been revoked)", false},
+		{"/x.app: rejected", false},
+		{"", false},
+	} {
+		if got := assessmentsDisabled(tc.out); got != tc.want {
+			t.Errorf("assessmentsDisabled(%q) = %v, want %v", tc.out, got, tc.want)
+		}
+	}
+}
+
+// TestVerifyDeveloperIDSignatureDoesNotInheritCallerDeadline guards
+// against a slow download surfacing as a tampering accusation: if
+// verification inherited stageRelease's nearly-spent whole-download
+// deadline, an expired timer would produce "this update is not signed
+// by the Hive developer" for a perfectly good build.
+func TestVerifyDeveloperIDSignatureDoesNotInheritCallerDeadline(t *testing.T) {
+	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
+	calls := captureArgv(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already dead, as an exhausted download budget would be
+
+	if err := verifyDeveloperIDSignature(ctx, "/tmp/x.app"); err != nil {
+		t.Fatalf("verifyDeveloperIDSignature = %v; a spent caller deadline must not read as tampering", err)
+	}
+	if len(*calls) == 0 {
+		t.Error("verification did not run under an already-cancelled caller context")
 	}
 }
 

--- a/cmd/hivegui/update_verify_darwin_test.go
+++ b/cmd/hivegui/update_verify_darwin_test.go
@@ -163,14 +163,20 @@ func TestVerifyDeveloperIDSignatureAllowsDisabledAssessments(t *testing.T) {
 	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
 	calls := captureArgvOut(t,
 		argvResult{"", nil},
-		argvResult{"/tmp/x.app: assessments are disabled", errors.New("exit status 1")},
+		argvResult{"/tmp/x.app: rejected", errors.New("exit status 3")},
+		argvResult{"assessments disabled", nil}, // spctl --status
 	)
 
 	if err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app"); err != nil {
 		t.Fatalf("verifyDeveloperIDSignature = %v; a disabled Gatekeeper must not block updates", err)
 	}
-	if len(*calls) != 2 || (*calls)[0][0] != codesignBin || (*calls)[1][0] != spctlBin {
-		t.Fatalf("expected codesign then spctl, got %v", *calls)
+	if len(*calls) != 3 {
+		t.Fatalf("expected codesign, spctl --assess, spctl --status; got %v", *calls)
+	}
+	last := (*calls)[2]
+	if last[0] != spctlBin || len(last) != 2 || last[1] != "--status" {
+		t.Errorf("disabled-detection ran %v; it must ask `spctl --status`, which takes no "+
+			"bundle path, rather than pattern-matching --assess output that echoes one back", last)
 	}
 }
 
@@ -186,6 +192,7 @@ func TestVerifyDeveloperIDSignatureRefusesRealSpctlRejection(t *testing.T) {
 	captureArgvOut(t,
 		argvResult{"", nil},
 		argvResult{"/tmp/x.app: rejected (the code is signed but the certificate has been revoked)", errors.New("exit status 3")},
+		argvResult{"assessments enabled", nil}, // spctl --status
 	)
 
 	err := verifyDeveloperIDSignature(context.Background(), "/tmp/x.app")
@@ -199,18 +206,24 @@ func TestVerifyDeveloperIDSignatureRefusesRealSpctlRejection(t *testing.T) {
 
 func TestAssessmentsDisabled(t *testing.T) {
 	for _, tc := range []struct {
+		name string
 		out  string
+		err  error
 		want bool
 	}{
-		{"/x.app: assessments are disabled", true},
-		{"/x.app: ASSESSMENTS ARE DISABLED", true},
-		{"/x.app: rejected (the code is signed but the certificate has been revoked)", false},
-		{"/x.app: rejected", false},
-		{"", false},
+		{"disabled", "assessments disabled", nil, true},
+		{"enabled", "assessments enabled", nil, false},
+		{"spctl unavailable fails closed", "", errors.New("no such file"), false},
+		// The bundle path is never consulted, so a version string that
+		// spells the magic phrase cannot fake a disabled Gatekeeper.
+		{"path cannot spoof", "assessments enabled", nil, false},
 	} {
-		if got := assessmentsDisabled(tc.out); got != tc.want {
-			t.Errorf("assessmentsDisabled(%q) = %v, want %v", tc.out, got, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			captureArgvOut(t, argvResult{tc.out, tc.err})
+			if got := assessmentsDisabled(context.Background()); got != tc.want {
+				t.Errorf("assessmentsDisabled = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -269,5 +282,46 @@ func TestSigningTeamIDMatchesSource(t *testing.T) {
 	if fromSource != buildinfo.SigningTeamID() {
 		t.Errorf("source says %q but SigningTeamID() = %q; the release scripts would gate on the wrong value",
 			fromSource, buildinfo.SigningTeamID())
+	}
+}
+
+// TestApplyStagedBundleSkipsVerifyForLatestChannel covers the branch
+// that would otherwise break in production and that nothing exercised.
+//
+// applyStagedBundle serves both update channels. A latest-channel
+// bundle is built locally from a git checkout with no credentials, so
+// it carries no Developer ID at all — stageLatest deliberately skips
+// verification, its trust root being verifyUpstreamRemote. Verifying
+// it at apply time would tell a user who just waited out a
+// multi-minute build that their own build is "not signed by the Hive
+// developer" — and only from the day a Team ID is pinned, long after
+// anyone is looking at this code.
+func TestApplyStagedBundleSkipsVerifyForLatestChannel(t *testing.T) {
+	isolateStateDir(t)
+	defer buildinfo.SetSigningTeamIDForTest("ABCDE12345")()
+
+	called := false
+	prev := verifySignatureFn
+	verifySignatureFn = func(context.Context, string) error {
+		called = true
+		return errors.New("this update is not signed by the Hive developer (team ABCDE12345)")
+	}
+	t.Cleanup(func() { verifySignatureFn = prev })
+
+	// stageLatest returns a path inside the user's checkout, never
+	// under updatesRoot().
+	latest := filepath.Join(t.TempDir(), "cmd", "hivegui", "build", "bin", bundleName)
+	if isDownloadedStaging(latest) {
+		t.Fatalf("isDownloadedStaging(%q) = true; a source-built bundle is not a download", latest)
+	}
+
+	// Release stagings, by contrast, must still be re-verified.
+	release := filepath.Join(updatesRoot(), "9.9.9", "app", bundleName)
+	if !isDownloadedStaging(release) {
+		t.Errorf("isDownloadedStaging(%q) = false; a downloaded staging must still be re-verified", release)
+	}
+
+	if called {
+		t.Error("verification ran during path classification")
 	}
 }

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -345,7 +345,7 @@ Manual, gated on the certificate existing (see `docs/releasing-signed-macos.md`)
 export HIVE_SIGN_IDENTITY="Developer ID Application: <Name> (<TEAMID>)"
 export HIVE_NOTARY_PROFILE=hive-notary
 ./build.sh --zip --version 0.0.0-signtest --platform macos
-scripts/sign-macos.sh cmd/hivegui/build/bin/hivegui.app release/Hive-0.0.0-signtest-macos-universal.zip
+scripts/sign-macos.sh release/Hive-0.0.0-signtest-macos-universal.zip
 
 ditto -x -k release/Hive-0.0.0-signtest-macos-universal.zip /tmp/signtest
 codesign --verify --deep --strict --verbose /tmp/signtest/hivegui.app
@@ -474,6 +474,13 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 - **2026-09-06** — Plan item 8 (README/CONTRIBUTING right-click-Open text)
   dropped: no such text exists in either file. It came from a reviewer's guess
   at the blast radius, not from the tree.
+
+## PR convergence ledger
+
+<Append-only. One line per `/hs-review-loop` iteration.>
+
+- **2026-09-06 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: cf0fbed9; threads_open: 0; action: autofix+push; head_sha: 08d4c378.
+- **2026-09-06 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0540e4ae; threads_open: 0; action: autofix+push, 6 RISKY surfaced for decision; head_sha: pending.
 
 ## Open questions
 

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -522,6 +522,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 - **2026-09-06 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: cf0fbed9; threads_open: 0; action: autofix+push; head_sha: 08d4c378.
 - **2026-09-06 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0540e4ae; threads_open: 0; action: autofix+push, 6 RISKY surfaced for decision; head_sha: 732127de.
 - **2026-09-06 iter 3** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: a3542f34; threads_open: 0; action: escalated:risky-fix-needs-human-decision (operator approved; fixed in 146eef91); head_sha: 876b70b6.
+- **2026-09-06 iter 4** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: f6a01f8d; threads_open: 0; action: autofix+push; head_sha: c6f725ab.
 
 ## Open questions
 

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -523,6 +523,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 - **2026-09-06 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0540e4ae; threads_open: 0; action: autofix+push, 6 RISKY surfaced for decision; head_sha: 732127de.
 - **2026-09-06 iter 3** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: a3542f34; threads_open: 0; action: escalated:risky-fix-needs-human-decision (operator approved; fixed in 146eef91); head_sha: 876b70b6.
 - **2026-09-06 iter 4** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: f6a01f8d; threads_open: 0; action: autofix+push; head_sha: c6f725ab.
+- **2026-09-06 iter 5** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty; threads_open: 0; action: stop; head_sha: c6f725ab.
 
 ## Open questions
 

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -460,6 +460,32 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 - **2026-09-06** — Signing pre-flight moved ahead of the commit/tag step. Why:
   failing after `git tag` leaves a local release commit and tag with no
   documented unwind.
+- **2026-09-06** — spctl is enforced on a real rejection and advisory only when
+  assessments are disabled. Why: review-loop iteration 2 found that a `codesign`
+  signature with a secure timestamp stays valid after the certificate is
+  revoked, so the Team ID pin alone cannot tell a stolen-and-revoked key from a
+  good one — making the revocation step this feature's own docs prescribe a
+  no-op. spctl is the only revocation-aware check in the path. The
+  master-disable accommodation is kept by distinguishing its non-answer
+  ("assessments are disabled") from a verdict.
+- **2026-09-06** — Verification runs on its own deadline
+  (`context.WithoutCancel`), not the caller's. Why: it inherited stageRelease's
+  whole-download budget, so a slow download could surface as "this update is not
+  signed by the Hive developer" — accusing the developer of tampering because a
+  timer expired.
+- **2026-09-06** — The staged bundle is re-verified in `applyStagedBundle`
+  before the swap. Why: it was verified once at stage time and installed later,
+  leaving a writable gap. Same-uid only, so defense in depth, and it costs one
+  call.
+- **2026-09-06** — `sign-macos.sh` resolves `signing.go` from the script's own
+  location rather than `cd`-ing to the repo root like sibling scripts. Why: a
+  `cd` would break the caller's relative zip/app path, and resolving against
+  `$PWD` breaks when run from outside the repo.
+- **2026-09-06** — Added a `shellcheck` CI job over `scripts/*.sh` + `build.sh`,
+  and fixed the two pre-existing warnings (SC2046 in `release.sh`, SC2164 in
+  `check-plan-lifecycle.sh`) that would have made it red on day one. Why:
+  operator asked for it; release-critical bash first executes live, after a
+  commit and tag already exist.
 
 ## Progress
 
@@ -471,6 +497,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
   left alone: `TestTerminalQueriesAreNotWork` (internal/registry) and
   `stateLockPoll is unused` (GOOS=windows staticcheck, internal/daemon).
 - **2026-09-06** — PR #378 opened.
+- **2026-09-06** — Review loop iter 1-2; operator approved 6 escalated RISKY items.
 - **2026-09-06** — Plan item 8 (README/CONTRIBUTING right-click-Open text)
   dropped: no such text exists in either file. It came from a reviewer's guess
   at the blast radius, not from the tree.
@@ -480,7 +507,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 <Append-only. One line per `/hs-review-loop` iteration.>
 
 - **2026-09-06 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: cf0fbed9; threads_open: 0; action: autofix+push; head_sha: 08d4c378.
-- **2026-09-06 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0540e4ae; threads_open: 0; action: autofix+push, 6 RISKY surfaced for decision; head_sha: pending.
+- **2026-09-06 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0540e4ae; threads_open: 0; action: autofix+push, 6 RISKY surfaced for decision; head_sha: 732127de.
 
 ## Open questions
 

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -486,6 +486,19 @@ Per the loop's one-retry rule the reviewer was not run a third time.
   `check-plan-lifecycle.sh`) that would have made it red on day one. Why:
   operator asked for it; release-critical bash first executes live, after a
   commit and tag already exist.
+- **2026-09-06** — The apply-time re-verify is scoped to release stagings
+  (`isDownloadedStaging`). Why: review-loop iteration 3 found that
+  `applyStagedBundle` serves both channels, and a latest-channel bundle is built
+  locally with no credentials and carries no Developer ID at all. Verifying it
+  would have told a user who just waited out a multi-minute build that their own
+  build was "not signed by the Hive developer" — and only from the day a Team ID
+  is pinned, long after anyone is reading this code.
+- **2026-09-06** — Disabled-Gatekeeper detection asks `spctl --status` rather
+  than pattern-matching `--assess` output. Why: `--assess` echoes the bundle
+  path, which embeds a remote-supplied version string. It is safe today because
+  `stagingDir` slugs that string to `[A-Za-z0-9._-]`, but that makes this
+  check's security depend on an unrelated function's slugging rules. `--status`
+  takes no path and has no injection surface.
 
 ## Progress
 
@@ -497,7 +510,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
   left alone: `TestTerminalQueriesAreNotWork` (internal/registry) and
   `stateLockPoll is unused` (GOOS=windows staticcheck, internal/daemon).
 - **2026-09-06** — PR #378 opened.
-- **2026-09-06** — Review loop iter 1-2; operator approved 6 escalated RISKY items.
+- **2026-09-06** — Review loop iter 1-3; operator approved 6 escalated RISKY items in iter 2, and iter 3 caught a latest-channel regression introduced by one of them.
 - **2026-09-06** — Plan item 8 (README/CONTRIBUTING right-click-Open text)
   dropped: no such text exists in either file. It came from a reviewer's guess
   at the blast radius, not from the tree.

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -521,6 +521,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 
 - **2026-09-06 iter 1** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: cf0fbed9; threads_open: 0; action: autofix+push; head_sha: 08d4c378.
 - **2026-09-06 iter 2** — verdict: COMMENT; mergeable: MERGEABLE; findings_hash: 0540e4ae; threads_open: 0; action: autofix+push, 6 RISKY surfaced for decision; head_sha: 732127de.
+- **2026-09-06 iter 3** — verdict: REQUEST_CHANGES; mergeable: MERGEABLE; findings_hash: a3542f34; threads_open: 0; action: escalated:risky-fix-needs-human-decision (operator approved; fixed in 146eef91); head_sha: 876b70b6.
 
 ## Open questions
 

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -1,0 +1,485 @@
+# Sign and notarize macOS releases
+
+- **Spec:** [docs/product-specs/374-sign-and-notarize-macos-releases.md](../../product-specs/374-sign-and-notarize-macos-releases.md)
+- **Issue:** #374
+- **Status:** active
+
+## Summary
+
+Add Apple Developer ID codesigning, notarization and stapling to the macOS
+release pipeline, and make the in-app updater refuse to stage a bundle whose
+signature does not verify against Hive's Team ID. The trust-root decision is
+already made in the spec; this plan is about where each step slots into
+`build.sh` / `scripts/release.sh` and what the updater actually checks.
+
+## Research
+
+### Release path
+
+- `scripts/release.sh` runs **locally, never in CI**. `.github/workflows/`
+  holds only `ci.yml`, `changesets.yml`, `pages.yml` — none package or upload.
+  The script needs a local authenticated `gh` (`scripts/release.sh:60`) and
+  pushes with `git push origin HEAD "$TAG"` (`scripts/release.sh:189`).
+- Flow: clean-tree/tag validation (`:60-68`) → pin `RELEASE_SHA` (`:73`) →
+  changelog bump (`:100-121`) → commit+tag (`:125-145`) →
+  `./build.sh --zip --version "$VERSION" --platform all` (`:156`) → assert both
+  zips exist (`:157-162`) → `shasum -a 256` into `release/checksums.txt`
+  (`:169-172`) → re-verify `origin/main` has not advanced (`:177-186`) → push →
+  `gh release create "$TAG" ... "${ARTIFACTS[@]}"` (`:195`).
+- **Signing seam:** after `build.sh --zip` (`:156-162`), before the checksum
+  step (`:171`). The checksum must be computed over the *final* signed,
+  notarized, stapled artifact or the manifest will not match what ships. Any
+  failure must `exit 1` before `gh release create`.
+- No credential convention exists yet. The script's existing style is plain
+  env vars with `${VAR:-default}` (`:23-39`); signing should follow it.
+
+### Bundle production
+
+- `build.sh` `build_macos()` (`:113-176`): `wails build -platform
+  darwin/universal -clean -ldflags …` (`:120-121`) builds the GUI; `hived` is
+  built separately per-arch and `lipo`'d (`:123-132`); `hivebar` (cgo/AppKit
+  menu-bar helper) is `lipo`'d into
+  `Contents/Library/LoginItems/hivebar.app` (`:134-155`). Zip at `:165-171`.
+- `cmd/hivegui/wails.json` is minimal — **no `mac.info`, no entitlements, no
+  hardened-runtime config**. No entitlements file exists anywhere in the repo.
+  Hardened runtime (`codesign --options runtime`), required by notarization,
+  must be added fresh.
+- Three Mach-O binaries need signing before the `.app` is sealed: `hivegui`,
+  `Contents/MacOS/hived`, and the nested `hivebar.app`. Inside-out order.
+
+### Updater path
+
+- `cmd/hivegui/update_apply_darwin.go`: `bundleName = "hivegui.app"`,
+  `checksumsAsset = "checksums.txt"` (`:24,28`).
+- `stageRelease` (`:83-154`): resolve asset URLs through `assetURL`, which
+  enforces the `updateURLPrefix` allowlist (`:183-194`) → download checksums →
+  download zip → SHA-256 verify (`:131-138`) → `extractZipFn` = `dittoExtract`
+  (`ditto -x -k`, `:578-586`) → `verifyBundle` checks `hivegui`/`hived` are
+  present and executable (`:564-576`).
+- The comment the spec wants deleted is at `:75-82` — it states outright that
+  the checksum is not a supply-chain defense.
+- **A signature cannot be checked before unpack.** `codesign`, `spctl` and
+  `stapler` all operate on an unpacked `.app`, not on a zip stream. The only
+  real seam is *after* `extractZipFn` and *before* the bundle is considered
+  staged — the existing `ok=false → os.RemoveAll(dir)` cleanup (`:108-113`)
+  already gives that path fail-closed semantics against the installed app.
+- `applyStagedBundle` / `swapBundle` (`:509-556`) copy the staged bundle to a
+  sibling `.new`, rename installed → `.old`, rename `.new` → installed, with
+  rollback. The stapled ticket must survive that copy; needs an explicit test.
+- `stageLatest` (`:313-362`) is a spec non-goal — its trust root is git plus
+  `verifyUpstreamRemote` (`:373-390`).
+- Existing seams to mirror: `extractZipFn` / `copyBundleFn` / `runBuildFn`
+  package vars (`:44-56`), so tests need no real Apple signature.
+
+### Hardened-runtime risk to the PTY host
+
+- `hived` is a separate binary spawned by the GUI (`cmd/hivegui/locate.go:18-43`
+  resolves it; `restart_unix.go:39-95` treats it as a distinct child, noting at
+  `:90-93` that it is never `Wait()`ed on). `update_restart_kind.go:32-61` runs
+  the **staged** `hived --version --json` as a probe — that exec is subject to
+  Gatekeeper on a freshly staged bundle.
+- PTY sessions: `internal/session/session.go:122-170` uses
+  `github.com/aymanbagabas/go-pty` and spawns ordinary child processes (login
+  shell, agent CLIs). No JIT, no `dlopen` of unsigned code, no in-memory object
+  images — so no `allow-unsigned-executable-memory` or debugger entitlement is
+  indicated.
+- cgo/ObjC files link **system frameworks only**:
+  `cmd/hivegui/loginitem_darwin.go` (ServiceManagement / SMAppService — already
+  notes it is expected to fail on an unsigned build),
+  `internal/notify/notify_darwin.go` (Cocoa),
+  `internal/activity/activity_darwin.go` (Foundation, App Nap).
+  Library validation should hold, but this needs a real smoke test.
+- App Sandbox is *not* required for Developer ID distribution and must not be
+  conflated with hardened runtime, which is.
+
+### Constraints / dependencies
+
+- **A paid Apple Developer account ($99/yr) is a hard external dependency.**
+  Nothing in the success criteria can be demonstrated without a `Developer ID
+  Application` certificate and `notarytool` credentials.
+- `xcrun stapler` staples `.app`, `.dmg` and `.pkg` **only** — never a bare
+  Mach-O. Hive ships a zipped `.app`, so this works, but the zip must be
+  rebuilt after stapling.
+- `xcrun notarytool submit --wait` blocks for roughly 2–15 minutes, adding that
+  to every release run.
+- `codesign --verify` alone accepts **any** valid Developer ID certificate. It
+  is not an authentication of *Hive* unless paired with a requirement that pins
+  the Team ID, e.g.
+  `-R '=anchor apple generic and certificate leaf[subject.OU] = "<TEAMID>"'`.
+  Without that pin the updater check is close to worthless against an attacker
+  who holds any Apple developer account.
+- No `.bats` or shell-test harness exists; `release.sh` has no test file.
+
+### Prior lessons
+
+`brain-search` returned no hits — nothing in the hive brain on codesigning,
+notarization or release signing yet.
+
+## Approach
+
+Sign inside-out, notarize the zip, staple the `.app`, then re-zip — never
+re-signing after stapling, because code-signing a bundle invalidates a ticket
+already stapled to it. The sequence lives in one new script,
+`scripts/sign-macos.sh`, called from `release.sh` after `build.sh` so the
+checksum manifest is computed over the final shipped artifact.
+
+**The Team ID is a committed source constant, not a build-time stamp.** It
+lives in `internal/buildinfo` as a `var` with a real default, and every build —
+release, local, CI, latest-channel — carries it.
+
+An earlier draft stamped it via ldflags from `HIVE_SIGN_IDENTITY` so that
+`release.sh` owned the value it gated on. That is wrong, and the failure is
+quiet. `stageLatest` (`update_apply_darwin.go:313-360`) builds from a git
+checkout by running `./build.sh` with no credentials, and any contributor or
+second machine builds the same way. Under stamping, all of those binaries get an
+*empty* pin — so they skip signature verification on every **release-channel**
+update they later download. The user would have built themselves out of the
+protection with no signal. A committed default means a credential-free build
+still verifies what it downloads, which is the only version of this that is
+safe by default.
+
+`release.sh` then asserts that the Team ID parsed out of `HIVE_SIGN_IDENTITY`
+(the `(TEAMID)` suffix of `Developer ID Application: Name (TEAMID)`) equals
+`buildinfo.SigningTeamID()`, reading it back from the built
+`hived --version --json`. Signing with one team while pinning another is still
+unrepresentable, and it costs no ldflags plumbing.
+
+**Only base-OS tools in the updater's critical path.** `xcrun stapler` ships
+with the Xcode Command Line Tools, not with macOS, so calling it from
+`verifyDeveloperIDSignature` would make `xcrun: unable to find utility` the
+normal outcome on an end user's Mac — and with the fail-closed
+`ok=false → os.RemoveAll` path (`update_apply_darwin.go:106-113`) that bricks
+updates for almost everyone. The updater therefore uses `/usr/bin/codesign` for
+the pinned signature check and `/usr/sbin/spctl --assess --type execute` for the
+notarization check, both present on a stock system. `stapler` is used only in
+`sign-macos.sh`, which runs on the maintainer's machine where Xcode CLT is
+already a prerequisite (`build.sh:114-117` already requires `lipo`).
+
+**The pin itself.** `codesign --verify --deep --strict -R '=anchor apple generic
+and certificate leaf[subject.OU] = "<TEAMID>"'`. Bare `--verify` only proves
+*some* valid Apple Developer ID signed the bundle, which an attacker with their
+own $99 account satisfies; the requirement is what authenticates Hive rather
+than Apple. `--deep` is correct here — Apple discourages it for *signing*, not
+for verification.
+
+**Where the check runs.** The spec asks for a check "before `ditto -x`", which
+is not achievable: `codesign` and `spctl` operate on an unpacked bundle, not a
+zip stream. The check runs on the extracted bundle in the temp staging
+directory before `stageRelease` returns; the existing deferred
+`os.RemoveAll(dir)` keeps it fail-closed with respect to the *installed* app,
+which is the property that matters. Spec wording is amended to match.
+
+**Fail before the release is half-made.** All signing pre-flight —
+`HIVE_SIGN_IDENTITY` set, the identity present in the keychain, its OU parsed,
+`HIVE_NOTARY_PROFILE` set, `stapler` available — happens next to the existing
+clean-tree and tag checks at `scripts/release.sh:60-68`, *before* the commit and
+tag at `:125-145`. Discovering a missing certificate or eating a 15-minute
+`notarytool` failure after the tag exists leaves the maintainer with a local
+release commit and tag and no documented unwind; the script only documents that
+recovery for the main-advanced case (`:184`).
+
+**Unconfigured builds stay buildable.** Unstamped, `buildinfo.SigningTeamID()`
+is empty and verification is skipped, so `go build`, `wails dev` and CI keep
+working. `release.sh`'s pre-flight refuses to publish without an identity, so an
+unpinned build cannot reach users. The gate is what keeps "skip when empty"
+honest rather than a hole.
+
+**Local builds can be self-signed, credential-free.** `sign-macos.sh --adhoc`
+signs with `-s -` and `--options runtime`, skipping notarization and stapling.
+Verified: ad-hoc signing carries the hardened-runtime flag
+(`flags=0x10002(adhoc,runtime)`), so this reproduces the runtime restrictions
+locally *without a certificate*. That is what makes the spec's third open
+question — whether hardened runtime breaks `hived` spawning PTY sessions —
+answerable before the $99 account is spent, rather than discovered on the first
+real release. It is also the right home for re-signing after `build.sh`'s
+`lipo -create` steps (`:130-132`, `:150-152`), which can drop a signature.
+It is a developer tool only: an ad-hoc signature has no Team ID, so it never
+satisfies the updater's pin and cannot be mistaken for a release.
+
+**No entitlements file.** Notarization requires hardened runtime
+(`--options runtime`), not entitlements. Hive's cgo links system frameworks only
+(`loginitem_darwin.go`, `notify_darwin.go`, `activity_darwin.go`), and PTY
+sessions `exec` ordinary child processes rather than loading code into their own
+address space — neither is restricted by hardened runtime. Ship without, and let
+the smoke test say otherwise; adding a plist later is a smaller change than
+justifying entitlements nobody proved were needed.
+
+### Files to change
+
+1. `build.sh` — package with `ditto -c -k --keepParent` instead of `zip -rq`
+   (`:165-171`). That is the whole change: no signing env var, no ldflags
+   splice, no allowlist. `build.sh` never needs credentials, so a
+   latest-channel rebuild and a contributor's checkout keep working untouched.
+2. `internal/buildinfo` — add `signingTeamID` (a `var`, not a `const`, so tests
+   can override it) holding the committed Team ID, and a `SigningTeamID()`
+   accessor beside `buildIDOverride` / `versionOverride`. `hived --version
+   --json` reports it, so `release.sh` can prove the built binary pins the ID it
+   is about to be signed with.
+3. `scripts/release.sh` — signing pre-flight beside the existing checks
+   (`:60-68`): require `HIVE_SIGN_IDENTITY` and `HIVE_NOTARY_PROFILE`, confirm
+   the identity exists via `security find-identity -v -p codesigning`, parse the
+   Team ID from it, and assert it equals `buildinfo.SigningTeamID()`. After the
+   build (`:156-162`) and before checksums (`:171`), call
+   `scripts/sign-macos.sh "release/Hive-${VERSION}-macos-universal.zip"`. Any
+   non-zero exit fails the release.
+4. `cmd/hivegui/update_apply_darwin.go` — delete the `:75-82` comment
+   disclaiming supply-chain defense and replace it with an accurate one; add
+   `verifySignatureFn` to the seam block (`:44-56`); call it in `stageRelease`
+   after `extractZipFn` and before `verifyBundle` (`:142-146`); update the
+   `dittoExtract` comment at `:578-580`, which cites the `zip -rq` that item 1
+   replaces.
+5. `cmd/hivegui/loginitem_darwin.go:30-32` — the comment says the call "is
+   expected to fail on an unsigned build"; no longer true.
+6. `build.sh:145-149` — comment says LoginItems is where the helper belongs "the
+   day Hive is code-signed"; that day is this PR.
+7. `AGENTS.md` "Releasing" (`:276-289`) — add signing prerequisites and a
+   pointer to the new doc.
+8. `README.md:75` / `CONTRIBUTING.md:24` — install text should say releases are
+   signed and notarized, and drop any right-click-Open workaround.
+9. `docs/product-specs/374-sign-and-notarize-macos-releases.md` — amend the
+   "fail-closed before unpack" wording in `## Desired behavior` to the staging
+   shape actually implemented; record the Team-ID pin.
+
+### New files
+
+- `scripts/sign-macos.sh <zip>` (or `--adhoc <app-dir>`) — signs, notarizes,
+  staples and re-packages one release zip **in place**. With `--adhoc` it signs
+  a locally built `.app` with `-s -` and `--options runtime` and stops there: no
+  credentials, no notarization, no network, no Team-ID assertions. Everything
+  below describes the release path. It takes the zip, not the `.app`: `release.sh:156`
+  runs `build.sh --platform all`, and `build_windows`'s `wails build -clean`
+  (`build.sh:180`) wipes `cmd/hivegui/build/bin` afterwards — the comment at
+  `build.sh:203-206` says so outright — so by the time `release.sh` could call
+  this, the `.app` directory is gone and only the zip remains. It therefore
+  round-trips: `ditto -x -k` to a temp dir, sign, notarize, staple, re-package.
+  Hard-fails on an empty or malformed Team ID, and asserts the
+  identity's OU equals the committed pin before doing anything, so a build signed by team A can
+  never pin team B. Writes to a temp path and `mv`s over `<zip>` only on full
+  success, so an aborted run never leaves an unsigned artifact at the publish
+  path. Before signing it also runs the extracted `hived --version --json` and
+  asserts the reported Team ID equals the OU of `HIVE_SIGN_IDENTITY` — proof
+  that the artifact about to be signed pins the key signing it.
+  Signs inside-out — `hivebar.app`, `Contents/MacOS/hived`,
+  `Contents/MacOS/hivegui`, then the outer `hivegui.app` — each with
+  `--options runtime --timestamp --force`. Then `ditto -c -k --keepParent` to a
+  temp zip, `notarytool submit --wait`, `stapler staple` the `.app`,
+  `stapler validate`, a `codesign --verify --deep --strict -R <pin>` self-check,
+  and a final `ditto -c -k --keepParent`. Any failure exits non-zero with the
+  failing command's output **and prints the same unwind recipe
+  `release.sh:184` gives for the main-advanced case** — a notarytool outage now
+  aborts after `git tag` (`:145`), and the maintainer needs the way back.
+- `cmd/hivegui/update_verify_darwin.go` — `teamIDRequirement(teamID string)
+  string`, and `verifyDeveloperIDSignature(bundle string) error` running
+  `/usr/bin/codesign` then `/usr/sbin/spctl` through a `runArgv` seam. Returns a
+  signature-specific error ("this update is not signed by the Hive developer …")
+  distinct from the checksum-mismatch text. Returns nil when
+  `buildinfo.SigningTeamID()` is empty.
+- `docs/releasing-signed-macos.md` — the setup walkthrough, written for an Apple
+  Developer account that has no certificate yet: CSR via Keychain Access →
+  Certificates page → download → install, finding the Team ID,
+  `xcrun notarytool store-credentials`, the two env vars, the notarytool retry
+  story (2–15 min, Apple-side outages, now on every release's critical path),
+  and the key-rotation procedure the spec asks to be documented but not
+  automated.
+- `.changesets/374-signed-macos-releases.md` — required by
+  `scripts/check-changeset.sh` and `.github/workflows/changesets.yml`, and this
+  is user-visible (no more Gatekeeper prompt).
+
+Not applicable: `scripts/check-daemon-contract.sh`. No `hived` protocol change,
+so no `buildinfo.DaemonContract` bump is needed.
+
+### Tests
+
+Go, beside source, following the `httptest` + `stubBundle` table pattern in
+`cmd/hivegui/update_apply_darwin_test.go`:
+
+- `TestVerifyDeveloperIDSignaturePassesPinnedRequirement` — the load-bearing
+  test. Stubs the `runArgv` seam, captures the argv actually handed to
+  `codesign`, and asserts `-R` is present with the correctly quoted Team ID.
+  `teamIDRequirement` returning the right string is worthless if the call site
+  drops the flag, and that failure silently degrades the check to "signed by any
+  Apple developer" while every other test still passes.
+- `TestVerifyDeveloperIDSignatureUsesAbsoluteBaseOSPaths` — asserts
+  `/usr/bin/codesign` and `/usr/sbin/spctl`, never `xcrun`. Guards the
+  regression that would brick updates on Macs without Xcode CLT.
+- `TestStageReleaseRejectsUnverifiedSignature` — `verifySignatureFn` stub
+  errors; asserts `stageRelease` fails, the message names the signature rather
+  than the checksum, and the staging directory was removed.
+- `TestVerifyDeveloperIDSignatureSkipsWhenTeamIDUnset` — with the Team ID
+  overridden to empty, returns nil without invoking the seam.
+- `TestBuildWithoutCredentialsStillPinsTeamID` — asserts `SigningTeamID()` is
+  non-empty in an ordinary `go build` with no signing environment, so a
+  latest-channel or contributor build still verifies downloaded releases.
+- `TestAdhocSignatureFailsTeamIDPin` — an ad-hoc signature has no OU, so
+  `verifyDeveloperIDSignature` must reject a self-signed bundle. Proves the
+  developer convenience cannot become a distribution hole.
+- `TestTeamIDRequirement` — exact requirement string including quoting.
+- `TestVerifyDeveloperIDSignatureTreatsDisabledSpctlAsPass` — stubbed `spctl`
+  returns the "assessments are disabled" output; asserts the update is still
+  accepted and that a `codesign` failure in the same run still refuses it.
+- `TestVerifyDeveloperIDSignatureRespectsContextCancellation` — asserts the
+  bounded timeout is plumbed through, so a hung `spctl` cannot wedge staging.
+
+`signingTeamID` is a package `var`, not a `const`, so the skip-when-unset test
+stays runnable after the real Team ID is committed.
+
+`scripts/sign-macos.sh` gets no automated test — the repo has no shell-test
+harness and a meaningful test needs real Apple credentials. `shellcheck` plus
+the manual verification below cover it.
+
+### Verification
+
+```bash
+scripts/test.sh go
+GOTOOLCHAIN=$(sed -n 's/^go //p' go.mod) go test ./cmd/hivegui/... -count=1
+for os in darwin linux windows; do GOOS=$os staticcheck ./... && GOOS=$os go vet ./...; done
+shellcheck scripts/sign-macos.sh scripts/release.sh && bash -n scripts/sign-macos.sh
+scripts/check-changeset.sh
+```
+
+Manual, gated on the certificate existing (see `docs/releasing-signed-macos.md`):
+
+```bash
+export HIVE_SIGN_IDENTITY="Developer ID Application: <Name> (<TEAMID>)"
+export HIVE_NOTARY_PROFILE=hive-notary
+./build.sh --zip --version 0.0.0-signtest --platform macos
+scripts/sign-macos.sh cmd/hivegui/build/bin/hivegui.app release/Hive-0.0.0-signtest-macos-universal.zip
+
+ditto -x -k release/Hive-0.0.0-signtest-macos-universal.zip /tmp/signtest
+codesign --verify --deep --strict --verbose /tmp/signtest/hivegui.app
+xcrun stapler validate /tmp/signtest/hivegui.app
+
+# Gatekeeper proof. A locally-extracted bundle carries no com.apple.quarantine
+# xattr, so spctl on it does NOT reproduce what a downloaded app faces — set the
+# xattr, and pull the network, so a pass proves the ticket is stapled rather
+# than fetched from Apple.
+xattr -w com.apple.quarantine "0083;00000000;Safari;" /tmp/signtest/hivegui.app
+networksetup -setairportpower en0 off
+spctl --assess --type execute --verbose /tmp/signtest/hivegui.app
+networksetup -setairportpower en0 on
+
+# Tamper proof: the updater must refuse this bundle with a signature-specific error.
+codesign --remove-signature /tmp/signtest/hivegui.app
+
+# The staple must survive the swap. copyBundleFn is a plain `ditto src dest`
+# (update_apply_darwin.go:588-590) and verification happens at stage time, never
+# after swapBundle (:530-556) — so confirm the ticket is still there afterwards.
+xcrun stapler validate "/Applications/Hive.app"
+```
+
+**Hardened-runtime smoke, runnable today without a certificate** — this is the
+step that retires the spec's open question #3:
+
+```bash
+./build.sh --platform macos
+scripts/sign-macos.sh --adhoc cmd/hivegui/build/bin/hivegui.app
+codesign -dv --verbose cmd/hivegui/build/bin/hivegui.app   # expect flags=…(adhoc,runtime)
+open cmd/hivegui/build/bin/hivegui.app
+# then: start a session, confirm the PTY spawns a real shell and hived stays up
+```
+
+Plus the same smoke on the real signed build once the cert exists: launch it, open a PTY session
+running a real shell, toggle the login item (which `loginitem_darwin.go` says
+only works signed), and confirm no entitlement denial in Console or
+`log stream --predicate 'subsystem == "com.apple.TCC"'`.
+
+## Second opinion
+
+Two rounds, both `revise`; all must-fix items applied.
+
+**Round 1 — `revise`, confidence 7.** Caught that `xcrun stapler` ships with the
+Xcode Command Line Tools rather than base macOS, so calling it from a
+fail-closed updater check would have refused every update on a stock Mac; that
+`release.sh` cannot read a Go `const`, so the Team-ID gate was hand-waved; that
+nothing tied the signing identity to the pinned ID; that signing failed only
+*after* `git tag`; that no changeset was planned; and that the planned tests
+would all pass if the `-R` flag were dropped at the call site. Applied: base-OS
+absolute paths, ldflags stamping derived from `HIVE_SIGN_IDENTITY`, an OU
+assertion in `sign-macos.sh`, pre-flight ahead of commit/tag, a changeset, an
+argv-capturing test, and a stale-comment sweep.
+
+**Round 2 — `revise`, confidence 8.** Confirmed round 1's fixes held, then found
+that the revision had introduced a seam that cannot exist: `release.sh:156` runs
+`build.sh --platform all`, and `build_windows`'s `wails build -clean`
+(`build.sh:180`) wipes `cmd/hivegui/build/bin` — `build.sh:203-206` says so in
+its own comment — so the `.app` the script was to be handed is gone by then.
+Verified directly and reverted `sign-macos.sh` to take the zip. Also applied:
+`exec.CommandContext` timeouts (an uncontexted `spctl` can hang staging on a
+captive-portal network), defined `spctl`-under-`--master-disable` semantics, a
+stamp-matches-signature assertion, a `^[A-Z0-9]{10}$` allowlist on the value
+spliced into `-ldflags`, a staple-survives-swap check, and the unwind recipe on
+a post-tag signing failure.
+
+Per the loop's one-retry rule the reviewer was not run a third time.
+
+## Decision log
+
+- **2026-09-06** — Trust root: Apple Developer ID + notarization. Why: settled
+  in the spec's Notes; covers install and update paths with one mechanism.
+- **2026-09-06** — Updater pins the Team ID via a `codesign -R` requirement.
+  Why: bare `--verify` accepts any valid Developer ID, including an attacker's
+  own, so it authenticates Apple rather than Hive.
+- **2026-09-06** — Signature is checked on the extracted bundle in the staging
+  directory, not on the zip. Why: `codesign`/`spctl`/`stapler` cannot read a zip
+  stream; the existing `os.RemoveAll` cleanup keeps it fail-closed against the
+  installed app. Spec wording amended to match.
+- **2026-09-06** — Releases stay local; credentials come from a `notarytool`
+  keychain profile. Why: operator decision — smallest change, no signing keys in
+  GitHub secrets.
+- **2026-09-06** — Team ID is read by the release scripts with a `sed` over the
+  single declaration in `internal/buildinfo/signing.go`, and
+  `TestSigningTeamIDMatchesSource` asserts that extraction agrees with what the
+  compiler sees. Why: a shell script cannot call into Go, and the reviewer's
+  objection that grepping source is brittle is answered by a test rather than by
+  care. The alternative — adding the ID to `buildinfo.Identity` — would put it on
+  the wire in `Welcome` and drag in the daemon contract for no benefit.
+- **2026-09-06** — Added `sign-macos.sh --adhoc` for credential-free local
+  signing. Why: operator asked for a self-sign path; verified that ad-hoc
+  signing carries the hardened-runtime flag, so it answers the spec's PTY /
+  hardened-runtime open question before the certificate exists. An ad-hoc
+  signature has no Team ID, so it can never pass the updater's pin.
+- **2026-09-06** — No entitlements plist in the first cut. Why: notarization
+  requires hardened runtime, not entitlements; Hive's cgo links system
+  frameworks only and PTY work is plain `exec`. Add one only if the smoke test
+  demands it.
+- **2026-09-06** — An empty Team ID (before the certificate exists) means skip
+  verification, and `release.sh` refuses to publish without a signing identity. Why: keeps a certless
+  checkout buildable without ever letting an unpinned build reach users.
+- **2026-09-06** — Team ID is a committed `var` in `internal/buildinfo`, not an
+  ldflags stamp. Why: operator flagged that the in-GUI latest-commit updater
+  must build without signing credentials. Under stamping, every
+  credential-free build (latest channel `stageLatest`, a second machine, a
+  contributor) would carry an empty pin and silently skip verification of the
+  release-channel updates it later downloads. A committed default verifies by
+  default; `release.sh` asserts the signing identity matches it.
+- **2026-09-06** — Updater uses `/usr/bin/codesign` + `/usr/sbin/spctl`, never
+  `xcrun stapler`. Why: `stapler` ships with Xcode CLT, not macOS, so a
+  fail-closed check calling it would refuse every update on a stock Mac.
+- **2026-09-06** — Signing pre-flight moved ahead of the commit/tag step. Why:
+  failing after `git tag` leaves a local release commit and tag with no
+  documented unwind.
+
+## Progress
+
+- **2026-09-06** — Spec advanced BACKLOG → RESEARCH; research recorded.
+- **2026-09-06** — Plan approved after two reviewer rounds and one operator
+  revision round (Team ID committed rather than stamped; `--adhoc` added).
+- **2026-09-06** — Implemented on `feature/374-sign-and-notarize-macos-releases`.
+  Two pre-existing failures confirmed against a clean `origin/main` checkout and
+  left alone: `TestTerminalQueriesAreNotWork` (internal/registry) and
+  `stateLockPoll is unused` (GOOS=windows staticcheck, internal/daemon).
+- **2026-09-06** — Plan item 8 (README/CONTRIBUTING right-click-Open text)
+  dropped: no such text exists in either file. It came from a reviewer's guess
+  at the blast radius, not from the tree.
+
+## Open questions
+
+- **Decide at the plan stop:** under `spctl --master-disable` the notarization
+  check does not evaluate. The plan treats that as pass and leans on the
+  `codesign -R` Team-ID pin, on the reasoning that a user who globally disabled
+  Gatekeeper has already made that call machine-wide. The stricter alternative
+  is to refuse updates outright on a Gatekeeper-disabled machine.
+- Not blocking. The Apple `Developer ID Application` certificate does not yet
+  exist (`security find-identity -v -p codesigning` reports 0 valid identities),
+  so the manual verification block and the `signingTeamID` value are deferred
+  until `docs/releasing-signed-macos.md` has been followed.

--- a/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/active/374-sign-and-notarize-macos-releases.md
@@ -2,6 +2,8 @@
 
 - **Spec:** [docs/product-specs/374-sign-and-notarize-macos-releases.md](../../product-specs/374-sign-and-notarize-macos-releases.md)
 - **Issue:** #374
+- **PR:** #378
+- **Branch:** `feature/374-sign-and-notarize-macos-releases`
 - **Status:** active
 
 ## Summary
@@ -468,6 +470,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
   Two pre-existing failures confirmed against a clean `origin/main` checkout and
   left alone: `TestTerminalQueriesAreNotWork` (internal/registry) and
   `stateLockPoll is unused` (GOOS=windows staticcheck, internal/daemon).
+- **2026-09-06** — PR #378 opened.
 - **2026-09-06** — Plan item 8 (README/CONTRIBUTING right-click-Open text)
   dropped: no such text exists in either file. It came from a reviewer's guess
   at the blast radius, not from the tree.

--- a/docs/exec-plans/completed/374-sign-and-notarize-macos-releases.md
+++ b/docs/exec-plans/completed/374-sign-and-notarize-macos-releases.md
@@ -4,7 +4,7 @@
 - **Issue:** #374
 - **PR:** #378
 - **Branch:** `feature/374-sign-and-notarize-macos-releases`
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -502,6 +502,7 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 
 ## Progress
 
+- **2026-09-06** — Gate NEEDS_FOLLOWUP; criteria 1 and 2 deferred to #380 pending the Apple certificate. Operator elected to advance to DONE.
 - **2026-09-06** — Spec advanced BACKLOG → RESEARCH; research recorded.
 - **2026-09-06** — Plan approved after two reviewer rounds and one operator
   revision round (Team ID committed rather than stamped; `--adhoc` added).
@@ -514,6 +515,16 @@ Per the loop's one-retry rule the reviewer was not run a third time.
 - **2026-09-06** — Plan item 8 (README/CONTRIBUTING right-click-Open text)
   dropped: no such text exists in either file. It came from a reviewer's guess
   at the blast radius, not from the tree.
+
+## Gate verdict
+
+- **2026-09-06** — verdict: NEEDS_FOLLOWUP; phase: —; checks: 3 passed / 0 failed / 2 followups; followups: #380; one-line: implementation and docs are complete and in scope, but two success criteria cannot be demonstrated until an Apple Developer ID certificate exists; operator elected to advance and track them.
+  - 2026-09-06 dimensions:
+    - acceptance — NEEDS_FOLLOWUP — criteria 3, 4, 5 PASS (release.sh aborts under `set -e` before any upload; `TestStageReleaseRejectsUnverifiedSignature` proves the refusal is signature-specific and not confusable with the checksum error; the `:75` supply-chain disclaimer is gone). Criteria 1 and 2 need a real certificate: `security find-identity -v -p codesigning` reports 0 valid identities, so `sign-macos.sh` refuses before reaching `stapler staple`. Mechanism verified read-only — an ad-hoc bundle fails the OU-pinned requirement with exit 3. Tracked in #380.
+    - non-goals — PASS — all six respected. Linux/Windows signing is `uname -s` gated; the SHA-256 manifest is kept and still verified; no reproducible-build or key-rotation tooling was added; the Gatekeeper-disabled path stays advisory with the Team ID pin load-bearing. The latest-channel exclusion was independently mutation-tested: deleting the `isDownloadedStaging` guard at its use site fails `TestApplyStagedBundleSkipsVerifyForLatestChannel`.
+    - doc accuracy — PASS — every claim in `docs/releasing-signed-macos.md` cross-checked against the code (env var names, the `signingTeamID` pin and the sed both scripts read it with, the password-free `store-credentials` invocation, the verification commands, and the Team-ID-stability rotation claim). `site/features.json` builds through both renderers (site/build.mjs, whats-new.ts 20/20). No stale `unsigned` / `zip -rq` / login-item claims outside historical completed plans. README and CONTRIBUTING carry no Gatekeeper install text to go stale.
+
+**Gate methodology note.** The three dimension validators ran in parallel against a single worktree, and two of them temporarily pinned a Team ID in `internal/buildinfo/signing.go` to exercise the verification paths. The doc-accuracy validator read that file mid-mutation and reported its tool output as tampered. It was not — this was a race introduced by dispatching parallel validators onto one checkout. Each validator restored the file, the final tree was clean at `var signingTeamID = ""`, and the doc validator confirmed ground truth independently via `git diff`. Future gate runs on a mutating dimension should give each validator its own worktree.
 
 ## PR convergence ledger
 

--- a/docs/product-specs/374-sign-and-notarize-macos-releases.md
+++ b/docs/product-specs/374-sign-and-notarize-macos-releases.md
@@ -1,11 +1,12 @@
 ---
 issue: 374
 pr: 378
+shipped: 2026-09-06
 title: "Sign and notarize macOS releases"
 type: enhancement
 complexity: M
 priority: P2
-stage: GATE
+stage: DONE
 ---
 
 # Sign and notarize macOS releases
@@ -14,7 +15,7 @@ stage: GATE
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** P2
-- **Exec plan:** [docs/exec-plans/active/374-sign-and-notarize-macos-releases.md](../exec-plans/active/374-sign-and-notarize-macos-releases.md)
+- **Exec plan:** [docs/exec-plans/completed/374-sign-and-notarize-macos-releases.md](../exec-plans/completed/374-sign-and-notarize-macos-releases.md)
 
 ## Problem
 

--- a/docs/product-specs/374-sign-and-notarize-macos-releases.md
+++ b/docs/product-specs/374-sign-and-notarize-macos-releases.md
@@ -1,11 +1,11 @@
 ---
 issue: 374
-pr: null
+pr: 378
 title: "Sign and notarize macOS releases"
 type: enhancement
 complexity: M
 priority: P2
-stage: IMPLEMENT
+stage: REVIEW
 ---
 
 # Sign and notarize macOS releases

--- a/docs/product-specs/374-sign-and-notarize-macos-releases.md
+++ b/docs/product-specs/374-sign-and-notarize-macos-releases.md
@@ -5,7 +5,7 @@ title: "Sign and notarize macOS releases"
 type: enhancement
 complexity: M
 priority: P2
-stage: BACKLOG
+stage: IMPLEMENT
 ---
 
 # Sign and notarize macOS releases
@@ -14,7 +14,7 @@ stage: BACKLOG
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** P2
-- **Exec plan:** —
+- **Exec plan:** [docs/exec-plans/active/374-sign-and-notarize-macos-releases.md](../exec-plans/active/374-sign-and-notarize-macos-releases.md)
 
 ## Problem
 
@@ -43,10 +43,18 @@ Gatekeeper warning and no right-click workaround. `spctl --assess` accepts the
 bundle offline, because the notarization ticket is stapled to it.
 
 **Update.** The in-app updater refuses to stage a build whose signature does not
-verify. A tampered or re-zipped bundle fails with a distinct, honest message
-("this update is not signed by the Hive developer") rather than the generic
-checksum-mismatch error, and the running app is left untouched — same
-fail-closed shape the current checksum path already has.
+verify against Hive's Apple **Team ID** — not merely against a valid Apple
+Developer ID, which anyone with a $99 account holds. A tampered or re-zipped
+bundle fails with a distinct, honest message ("this update is not signed by the
+Hive developer") rather than the generic checksum-mismatch error, and the
+running app is left untouched — same fail-closed shape the current checksum
+path already has.
+
+The check runs on the unpacked bundle in the temp staging directory, not on the
+zip: `codesign` and `spctl` read a bundle, not an archive stream, so a
+"before `ditto -x`" check is not achievable. Fail-closed is preserved where it
+matters — staging happens in a temp directory that is removed unless every
+check passes, so the *installed* app is never touched by an unverified build.
 
 **Release.** `scripts/release.sh` signs, notarizes, and staples as part of the
 normal release run, and refuses to publish if any of those steps fail. The
@@ -79,6 +87,11 @@ environment, never from the repo.
   download cheaply, and it is the error users see most.
 - **Key rotation automation.** Document the rotation procedure; do not build
   tooling for it until there is a second key.
+- **Gatekeeper-disabled machines.** Under `spctl --master-disable` the
+  notarization assessment does not evaluate. The Team ID pin remains
+  load-bearing and still refuses a bad signature; the advisory assessment is
+  logged, not enforced. Refusing updates outright on such a machine is not a
+  goal — its owner has already opted out of Gatekeeper globally.
 
 ## Notes
 

--- a/docs/product-specs/374-sign-and-notarize-macos-releases.md
+++ b/docs/product-specs/374-sign-and-notarize-macos-releases.md
@@ -5,7 +5,7 @@ title: "Sign and notarize macOS releases"
 type: enhancement
 complexity: M
 priority: P2
-stage: REVIEW
+stage: GATE
 ---
 
 # Sign and notarize macOS releases

--- a/docs/releasing-signed-macos.md
+++ b/docs/releasing-signed-macos.md
@@ -80,12 +80,15 @@ Security → App-Specific Passwords), then:
 ```bash
 xcrun notarytool store-credentials hive-notary \
     --apple-id you@example.com \
-    --team-id ABCDE12345 \
-    --password <app-specific-password>
+    --team-id ABCDE12345
 ```
 
-This writes to your login keychain. The password never appears in the repo or
-in a release command.
+`store-credentials` prompts for the app-specific password and reads it without
+echo. Do not pass it with `--password`: that puts the credential in your shell
+history and exposes it in `ps` output for the duration of the call.
+
+This writes to your login keychain. The password never appears in the repo, in
+your shell history, or in a release command.
 
 ### 4. Export the two variables
 

--- a/docs/releasing-signed-macos.md
+++ b/docs/releasing-signed-macos.md
@@ -67,6 +67,11 @@ silently skip signature verification on every release they later downloaded.
 
 `scripts/release.sh` refuses to publish while this is empty.
 
+Setting it also switches the updater's signature check on everywhere, tests
+included: any test that drives `stageRelease` end to end must stub
+`verifySignatureFn`, or it will shell out to `codesign` against an unsigned
+fixture bundle and fail.
+
 ### 3. Store notarization credentials
 
 Create an app-specific password at <https://appleid.apple.com> (Sign-In and

--- a/docs/releasing-signed-macos.md
+++ b/docs/releasing-signed-macos.md
@@ -1,0 +1,187 @@
+# Signing and notarizing macOS releases
+
+Hive's macOS releases are signed with an Apple Developer ID certificate,
+notarized by Apple, and stapled so the ticket travels with the download. The
+in-app updater refuses any release that is not signed by Hive's team.
+
+This document is the one-time setup, plus what to do when it breaks.
+
+## Why both halves matter
+
+Signing alone is not enough. `codesign --verify` proves that *some* valid
+Apple Developer ID signed a bundle — anyone who pays Apple $99 has one. What
+makes the check mean "signed by Hive" is pinning the **Team ID**, which the
+updater does in `cmd/hivegui/update_verify_darwin.go`.
+
+Notarization is the other half: Apple scans the build and issues a ticket.
+Stapling attaches that ticket to the bundle so Gatekeeper accepts it **offline**,
+which is what removes the "unidentified developer" prompt on a fresh install.
+
+## One-time setup
+
+### 1. Create the Developer ID Application certificate
+
+You need a paid Apple Developer account ($99/yr). The certificate is separate
+from the account and has to be created by hand.
+
+1. Open **Keychain Access** → menu **Certificate Assistant** → **Request a
+   Certificate From a Certificate Authority**.
+2. Enter your Apple ID email and name. Select **Saved to disk**, not "Emailed
+   to the CA". Leave "CA Email Address" blank. Save the `.certSigningRequest`
+   file.
+3. Go to <https://developer.apple.com/account/resources/certificates/list> and
+   click **+**.
+4. Choose **Developer ID Application** — *not* "Mac Development", *not* "Mac App
+   Distribution". Only Developer ID works for software distributed outside the
+   App Store.
+5. Upload the CSR from step 2, download the resulting `.cer`, and double-click
+   it to install into your login keychain.
+
+Confirm it landed:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+You want a line reading `Developer ID Application: Your Name (TEAMID)`. The
+10-character string in parentheses is your **Team ID**.
+
+> If this prints `0 valid identities found`, the certificate is not installed.
+> A common cause is downloading the `.cer` on a machine that does not hold the
+> private key from the CSR — the certificate is only usable on the Mac that
+> generated the request (or via an exported `.p12`).
+
+### 2. Pin the Team ID in the source
+
+Set it in `internal/buildinfo/signing.go`:
+
+```go
+var signingTeamID = "ABCDE12345"
+```
+
+This is a committed constant on purpose, not a build flag. Every build carries
+it — including a credential-free `./build.sh` on another machine, and the
+rebuild the GUI's latest-commit updater performs. If it arrived via `-ldflags`
+at release time, all of those builds would carry an empty pin and would
+silently skip signature verification on every release they later downloaded.
+
+`scripts/release.sh` refuses to publish while this is empty.
+
+### 3. Store notarization credentials
+
+Create an app-specific password at <https://appleid.apple.com> (Sign-In and
+Security → App-Specific Passwords), then:
+
+```bash
+xcrun notarytool store-credentials hive-notary \
+    --apple-id you@example.com \
+    --team-id ABCDE12345 \
+    --password <app-specific-password>
+```
+
+This writes to your login keychain. The password never appears in the repo or
+in a release command.
+
+### 4. Export the two variables
+
+```bash
+export HIVE_SIGN_IDENTITY="Developer ID Application: Your Name (ABCDE12345)"
+export HIVE_NOTARY_PROFILE=hive-notary
+```
+
+Put them in your shell profile. `scripts/release.sh` checks both before it
+commits or tags anything.
+
+## Releasing
+
+Nothing changes:
+
+```bash
+./scripts/release.sh 0.5.0
+```
+
+Signing pre-flight runs alongside the existing clean-tree and tag checks.
+After the build, `scripts/sign-macos.sh` signs, notarizes, staples, and
+rewrites the zip in place — so the SHA-256 manifest describes the artifact that
+actually ships.
+
+Budget **2–15 minutes** for notarization. It is a network round trip to Apple
+and it is now on the critical path of every release. Apple has occasional
+outages; check <https://developer.apple.com/system-status/> before assuming the
+build is at fault.
+
+## Testing hardened runtime without a certificate
+
+Notarization requires the hardened runtime, which restricts what a process may
+do at runtime and can break things like a PTY host or a login item. You do not
+need a certificate to find that out:
+
+```bash
+./build.sh --platform macos
+scripts/sign-macos.sh --adhoc cmd/hivegui/build/bin/hivegui.app
+open cmd/hivegui/build/bin/hivegui.app
+```
+
+An ad-hoc signature still sets the hardened-runtime flag
+(`codesign -dv` reports `flags=0x10002(adhoc,runtime)`), so the runtime
+restrictions are real. Start a session and confirm the PTY spawns a shell and
+`hived` stays up.
+
+An ad-hoc signature carries no Team ID, so a bundle signed this way can never
+pass the updater's pin. It is a development tool, not a distribution path.
+
+## Verifying a release
+
+```bash
+ditto -x -k Hive-0.5.0-macos-universal.zip /tmp/check
+codesign --verify --deep --strict --verbose /tmp/check/hivegui.app
+xcrun stapler validate /tmp/check/hivegui.app
+```
+
+To reproduce what a downloading user actually faces, add the quarantine
+attribute and pull the network — a locally extracted bundle has no quarantine
+flag, so `spctl` on it does **not** prove the ticket is stapled:
+
+```bash
+xattr -w com.apple.quarantine "0083;00000000;Safari;" /tmp/check/hivegui.app
+# disable networking, then:
+spctl --assess --type execute --verbose /tmp/check/hivegui.app
+```
+
+A pass with the network down is the real proof the ticket is stapled rather
+than fetched from Apple on demand.
+
+## Rotating the key
+
+Deliberately manual — there is one key, and automating rotation for a set of
+one is machinery with no second case to justify it.
+
+1. Create a new Developer ID Application certificate (steps above). Apple
+   allows more than one to exist at a time, so do this **before** revoking the
+   old one.
+2. Update `signingTeamID` in `internal/buildinfo/signing.go` **only if the Team
+   ID itself changed**. Rotating a certificate within the same account keeps
+   the Team ID, so usually no code change is needed — that is the main
+   advantage of pinning the team rather than a certificate fingerprint.
+3. Update `HIVE_SIGN_IDENTITY` to the new certificate's full name.
+4. Cut a release and verify it as above.
+5. Revoke the old certificate in the Apple developer console.
+
+Already-notarized releases keep working after a revocation: the notarization
+ticket is what Gatekeeper checks, and it is not invalidated by revoking the
+signing certificate.
+
+**If the Team ID does change** (a new Apple account, an org migration), every
+already-installed client pins the old one and will refuse the first update
+signed with the new team. Those users must reinstall by hand. Plan a release
+that warns first.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `0 valid identities found` | Certificate not installed, or installed on a Mac without the CSR's private key. |
+| `Team ID mismatch` from `release.sh` | `HIVE_SIGN_IDENTITY` and `signingTeamID` disagree. Fix whichever is wrong — publishing with a mismatch produces a release no client can install. |
+| `notarytool` returns `Invalid` | Run `xcrun notarytool log <submission-id> --keychain-profile hive-notary` for the per-file reason. Usually an unsigned nested binary or a missing hardened runtime. |
+| `The staple and validate action failed` | The bundle was re-signed after stapling. Signing invalidates a ticket — staple last, and never re-sign afterwards. |
+| Notarization fails after `git tag` | `sign-macos.sh` prints the unwind recipe. Reset the commit, delete the tag, fix, re-run. |

--- a/internal/buildinfo/signing.go
+++ b/internal/buildinfo/signing.go
@@ -1,0 +1,37 @@
+package buildinfo
+
+// signingTeamID is the Apple Developer Team ID that macOS release
+// builds are signed with. Unlike buildIDOverride and versionOverride
+// above, this is a committed constant rather than a link-time stamp,
+// and that difference is deliberate.
+//
+// The in-app updater refuses a downloaded release whose signature does
+// not chain to this team (see cmd/hivegui/update_verify_darwin.go). If
+// the value arrived via -ldflags from scripts/release.sh, then every
+// build made without those flags would carry an empty pin and silently
+// skip that check — and those builds are not rare. The GUI's
+// latest-commit updater rebuilds from a git checkout by running
+// ./build.sh with no credentials (stageLatest), and so does anyone
+// building on a second machine or from a fork. Baking the ID in means
+// a credential-free build still verifies the releases it downloads.
+//
+// Empty disables verification, which is the state of this repo until
+// the Developer ID certificate exists. scripts/release.sh refuses to
+// publish while it is empty, so an unpinned build cannot reach users.
+//
+// A var rather than a const so tests can override it; nothing else
+// writes to it.
+var signingTeamID = ""
+
+// SigningTeamID returns the Apple Developer Team ID that release
+// builds are signed with, or "" when this build has no pin.
+func SigningTeamID() string { return signingTeamID }
+
+// SetSigningTeamIDForTest overrides SigningTeamID() for the lifetime
+// of the caller's test. Use t.Cleanup with the returned restore
+// function. Tests that mutate this must not run with t.Parallel().
+func SetSigningTeamIDForTest(value string) (restore func()) {
+	prev := signingTeamID
+	signingTeamID = value
+	return func() { signingTeamID = prev }
+}

--- a/internal/buildinfo/signing.go
+++ b/internal/buildinfo/signing.go
@@ -28,8 +28,9 @@ var signingTeamID = ""
 func SigningTeamID() string { return signingTeamID }
 
 // SetSigningTeamIDForTest overrides SigningTeamID() for the lifetime
-// of the caller's test. Use t.Cleanup with the returned restore
-// function. Tests that mutate this must not run with t.Parallel().
+// of the caller's test. Defer the returned restore function (or pass
+// it to t.Cleanup). Tests that mutate this must not run with
+// t.Parallel().
 func SetSigningTeamIDForTest(value string) (restore func()) {
 	prev := signingTeamID
 	signingTeamID = value

--- a/scripts/check-plan-lifecycle.sh
+++ b/scripts/check-plan-lifecycle.sh
@@ -9,7 +9,7 @@
 # Needs `gh` authenticated. Not wired into CI on purpose — CI has no gh token
 # for this and the answer changes without the tree changing.
 set -uo pipefail
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 1
 
 drift=0
 # The PR header is written three ways across the plans in active/:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,6 +62,41 @@ command -v gh >/dev/null || { echo "Error: gh (GitHub CLI) required"; exit 1; }
 ! git rev-parse "$TAG" &>/dev/null || { echo "Error: tag $TAG already exists"; exit 1; }
 grep -q '## \[Unreleased\]' CHANGELOG.md || { echo "Error: CHANGELOG.md has no [Unreleased] section"; exit 1; }
 
+# macOS signing pre-flight. Deliberately here, next to the other refusals,
+# rather than next to the signing call further down: everything below the
+# commit/tag step is expensive to unwind, and a missing certificate or an
+# unset keychain profile is knowable now. Notarization itself can still fail
+# late (it is a network call to Apple); sign-macos.sh prints the unwind
+# recipe when it does.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    : "${HIVE_SIGN_IDENTITY:?set HIVE_SIGN_IDENTITY to your Developer ID (see docs/releasing-signed-macos.md)}"
+    : "${HIVE_NOTARY_PROFILE:?set HIVE_NOTARY_PROFILE to your notarytool keychain profile (see docs/releasing-signed-macos.md)}"
+
+    # Refuse to publish a build that pins no team: it would skip signature
+    # verification for every user who installs it, permanently.
+    pinned_team_id="$(sed -n 's/^var signingTeamID = "\(.*\)"$/\1/p' internal/buildinfo/signing.go)"
+    if [[ -z "$pinned_team_id" ]]; then
+        echo "Error: internal/buildinfo/signing.go pins no Team ID." >&2
+        echo "  A release built from it would skip update signature verification for" >&2
+        echo "  every user. Set signingTeamID — see docs/releasing-signed-macos.md." >&2
+        exit 1
+    fi
+
+    identity_team_id="$(sed -n 's/.*(\([A-Z0-9]\{10\}\))$/\1/p' <<<"$HIVE_SIGN_IDENTITY")"
+    [[ "$identity_team_id" == "$pinned_team_id" ]] || {
+        echo "Error: signing identity team ($identity_team_id) does not match the pinned team ($pinned_team_id)." >&2
+        echo "  No client could install this release." >&2
+        exit 1
+    }
+
+    security find-identity -v -p codesigning | grep -qF "$HIVE_SIGN_IDENTITY" || {
+        echo "Error: signing identity not in keychain: $HIVE_SIGN_IDENTITY" >&2
+        exit 1
+    }
+    command -v xcrun >/dev/null || { echo "Error: xcrun required for notarization"; exit 1; }
+    echo "Signing pre-flight OK (team ${pinned_team_id})."
+fi
+
 # Non-blocking reminder: shipped exec-plans should move active/ -> completed/
 # (PLANS.md lifecycle) at merge time. Surface any stragglers before a release.
 active_plans=$(find docs/exec-plans/active -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
@@ -160,6 +195,13 @@ for f in \
     [[ -f "$f" ]] || { echo "Error: expected artifact missing: $f"; exit 1; }
     ARTIFACTS+=("$f")
 done
+
+# Sign, notarize and staple before the manifest is written, so the checksums
+# describe the artifact that actually ships.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "Signing and notarizing the macOS artifact..."
+    ./scripts/sign-macos.sh "release/Hive-${VERSION}-macos-universal.zip"
+fi
 
 # SHA-256 manifest. The GUI's in-app updater downloads this alongside
 # the macOS zip and refuses to install on a mismatch — without it, a

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -210,7 +210,9 @@ fi
 # asset names GitHub serves.
 echo "Writing checksums..."
 SUMS="release/checksums.txt"
-( cd release && shasum -a 256 $(printf '%s\n' "${ARTIFACTS[@]}" | xargs -n1 basename) ) > "$SUMS"
+ARTIFACT_NAMES=()
+for f in "${ARTIFACTS[@]}"; do ARTIFACT_NAMES+=("$(basename "$f")"); done
+( cd release && shasum -a 256 "${ARTIFACT_NAMES[@]}" ) > "$SUMS"
 ARTIFACTS+=("$SUMS")
 
 # ---- PUSH ----------------------------------------------------------------

--- a/scripts/sign-macos.sh
+++ b/scripts/sign-macos.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Sign a macOS build.
+#
+# Two modes:
+#
+#   sign-macos.sh <release-zip>
+#       Release path. Signs with the Developer ID identity, notarizes,
+#       staples the ticket, and rewrites the zip in place. Requires
+#       credentials. Called by scripts/release.sh.
+#
+#   sign-macos.sh --adhoc <app-dir>
+#       Local path. Signs with an ad-hoc identity and the hardened
+#       runtime, then stops: no credentials, no network, no
+#       notarization. An ad-hoc signature carries no Team ID, so a
+#       bundle signed this way can never satisfy the updater's pin —
+#       it cannot be mistaken for a release.
+#
+#       Its purpose is that `codesign -s - -o runtime` still sets the
+#       hardened-runtime flag, so the runtime restrictions a notarized
+#       build will face can be reproduced — and a PTY host or login
+#       item broken by them found — without a $99 certificate.
+#
+# Environment (release mode only):
+#   HIVE_SIGN_IDENTITY   "Developer ID Application: Name (TEAMID)"
+#   HIVE_NOTARY_PROFILE  notarytool keychain profile name
+#
+# See docs/releasing-signed-macos.md for how to obtain both.
+set -euo pipefail
+
+BUNDLE_NAME="hivegui.app"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# sign_inside_out signs every Mach-O in the bundle before the bundle
+# itself. Order is not optional: signing the outer .app seals a hash of
+# its contents, so a nested binary signed afterwards invalidates the
+# seal.
+sign_inside_out() {
+    local app="$1" identity="$2"
+    local bar="$app/Contents/Library/LoginItems/hivebar.app"
+
+    # --force because build.sh's `lipo -create` output, and Go's own
+    # linker-signed binaries, may already carry a signature we are
+    # replacing. --timestamp is required for notarization; it is a
+    # network call, and the one in ad-hoc mode is harmless because
+    # codesign skips it for the ad-hoc identity.
+    local opts=(--force --options runtime --timestamp)
+    [[ "$identity" == "-" ]] && opts=(--force --options runtime)
+
+    if [[ -d "$bar" ]]; then
+        codesign "${opts[@]}" --sign "$identity" "$bar/Contents/MacOS/hivebar"
+        codesign "${opts[@]}" --sign "$identity" "$bar"
+    fi
+    codesign "${opts[@]}" --sign "$identity" "$app/Contents/MacOS/hived"
+    codesign "${opts[@]}" --sign "$identity" "$app/Contents/MacOS/hivegui"
+    codesign "${opts[@]}" --sign "$identity" "$app"
+}
+
+# ---- adhoc mode ----------------------------------------------------------
+
+if [[ "${1:-}" == "--adhoc" ]]; then
+    APP="${2:-}"
+    [[ -n "$APP" ]] || die "usage: $0 --adhoc <app-dir>"
+    [[ -d "$APP" ]] || die "not a directory: $APP"
+
+    echo "==> [adhoc] Signing $APP with the hardened runtime"
+    sign_inside_out "$APP" "-"
+    codesign --verify --deep --strict "$APP" \
+        || die "ad-hoc verification failed for $APP"
+
+    echo "==> [adhoc] Done. Flags below should include 'runtime':"
+    codesign --display --verbose "$APP" 2>&1 | grep -i 'flags' || true
+    echo
+    echo "This build is NOT distributable — an ad-hoc signature has no Team ID"
+    echo "and the updater's pin will reject it. It is for testing hardened-runtime"
+    echo "behavior (PTY sessions, login item) without a certificate."
+    exit 0
+fi
+
+# ---- release mode --------------------------------------------------------
+
+ZIP="${1:-}"
+[[ -n "$ZIP" ]] || die "usage: $0 <release-zip> | --adhoc <app-dir>"
+[[ -f "$ZIP" ]] || die "no such zip: $ZIP"
+
+: "${HIVE_SIGN_IDENTITY:?set HIVE_SIGN_IDENTITY (see docs/releasing-signed-macos.md)}"
+: "${HIVE_NOTARY_PROFILE:?set HIVE_NOTARY_PROFILE (see docs/releasing-signed-macos.md)}"
+
+command -v xcrun >/dev/null 2>&1 \
+    || die "xcrun not found — notarization needs the Xcode command-line tools"
+
+# The Team ID is the parenthesised suffix of the identity string.
+IDENTITY_TEAM_ID="$(sed -n 's/.*(\([A-Z0-9]\{10\}\))$/\1/p' <<<"$HIVE_SIGN_IDENTITY")"
+[[ -n "$IDENTITY_TEAM_ID" ]] \
+    || die "could not parse a 10-character Team ID from HIVE_SIGN_IDENTITY: $HIVE_SIGN_IDENTITY"
+
+# The pin the shipped binary will enforce, read from the single
+# declaration in internal/buildinfo/signing.go. If these two disagree
+# the release is unusable: every client would reject an update signed
+# by a team its binary does not trust. TestSigningTeamIDMatchesSource
+# asserts this extraction agrees with what the Go code sees.
+PINNED_TEAM_ID="$(sed -n 's/^var signingTeamID = "\(.*\)"$/\1/p' internal/buildinfo/signing.go)"
+[[ -n "$PINNED_TEAM_ID" ]] \
+    || die "internal/buildinfo/signing.go pins no Team ID — a release built from it would skip signature verification for every user. Set signingTeamID first."
+[[ "$PINNED_TEAM_ID" == "$IDENTITY_TEAM_ID" ]] \
+    || die "Team ID mismatch: signing with $IDENTITY_TEAM_ID but the binary pins $PINNED_TEAM_ID. No client could install this release."
+
+security find-identity -v -p codesigning | grep -qF "$HIVE_SIGN_IDENTITY" \
+    || die "identity not found in keychain: $HIVE_SIGN_IDENTITY"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> [sign] Unpacking $ZIP"
+ditto -x -k "$ZIP" "$WORK/app"
+APP="$WORK/app/$BUNDLE_NAME"
+[[ -d "$APP" ]] || die "zip did not contain $BUNDLE_NAME"
+
+echo "==> [sign] Signing as $HIVE_SIGN_IDENTITY"
+sign_inside_out "$APP" "$HIVE_SIGN_IDENTITY"
+
+echo "==> [sign] Submitting for notarization (typically 2-15 minutes)"
+ditto -c -k --keepParent "$APP" "$WORK/notarize.zip"
+if ! xcrun notarytool submit "$WORK/notarize.zip" \
+        --keychain-profile "$HIVE_NOTARY_PROFILE" --wait; then
+    cat >&2 <<UNWIND
+
+Notarization failed. This ran after the release commit and tag were
+created, so unwind before retrying:
+
+  git reset --hard HEAD~1 && git tag -d <tag> && git pull --ff-only
+
+Then re-run scripts/release.sh once the cause is fixed. If notarytool
+reported "Invalid", fetch the detail with:
+
+  xcrun notarytool log <submission-id> --keychain-profile $HIVE_NOTARY_PROFILE
+UNWIND
+    exit 1
+fi
+
+echo "==> [sign] Stapling the ticket"
+xcrun stapler staple "$APP"
+xcrun stapler validate "$APP"
+
+# Verify what we are about to ship the same way every client will. This
+# is the check that would catch signing with the wrong identity.
+echo "==> [sign] Verifying against the shipped pin"
+codesign --verify --deep --strict \
+    -R "=anchor apple generic and certificate leaf[subject.OU] = \"$PINNED_TEAM_ID\"" \
+    "$APP" || die "signed bundle does not satisfy the pin clients will enforce"
+
+# Repackage to a temp path and move into place, so an abort never
+# leaves an unsigned artifact sitting at the publish path.
+echo "==> [sign] Repackaging $ZIP"
+ditto -c -k --keepParent "$APP" "$WORK/signed.zip"
+mv "$WORK/signed.zip" "$ZIP"
+
+echo "==> [sign] $ZIP is signed, notarized and stapled"

--- a/scripts/sign-macos.sh
+++ b/scripts/sign-macos.sh
@@ -30,6 +30,15 @@ set -euo pipefail
 
 BUNDLE_NAME="hivegui.app"
 
+# The pinned Team ID is read from a repo file, but $ZIP and the --adhoc
+# app path belong to the caller and may be relative to wherever they
+# ran this from. So the repo file is resolved from this script's own
+# location rather than by cd'ing to the repo root like sibling scripts
+# do: a cd would silently break every relative path argument, and
+# resolving against $PWD would break when run from outside the repo.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIGNING_GO="$SCRIPT_DIR/../internal/buildinfo/signing.go"
+
 die() { echo "error: $*" >&2; exit 1; }
 
 # sign_inside_out signs every Mach-O in the bundle before the bundle
@@ -100,9 +109,10 @@ IDENTITY_TEAM_ID="$(sed -n 's/.*(\([A-Z0-9]\{10\}\))$/\1/p' <<<"$HIVE_SIGN_IDENT
 # the release is unusable: every client would reject an update signed
 # by a team its binary does not trust. TestSigningTeamIDMatchesSource
 # asserts this extraction agrees with what the Go code sees.
-PINNED_TEAM_ID="$(sed -n 's/^var signingTeamID = "\(.*\)"$/\1/p' internal/buildinfo/signing.go)"
+[[ -f "$SIGNING_GO" ]] || die "cannot find $SIGNING_GO — run this from inside the hive repo"
+PINNED_TEAM_ID="$(sed -n 's/^var signingTeamID = "\(.*\)"$/\1/p' "$SIGNING_GO")"
 [[ -n "$PINNED_TEAM_ID" ]] \
-    || die "internal/buildinfo/signing.go pins no Team ID — a release built from it would skip signature verification for every user. Set signingTeamID first."
+    || die "$SIGNING_GO pins no Team ID — a release built from it would skip signature verification for every user. Set signingTeamID first."
 [[ "$PINNED_TEAM_ID" == "$IDENTITY_TEAM_ID" ]] \
     || die "Team ID mismatch: signing with $IDENTITY_TEAM_ID but the binary pins $PINNED_TEAM_ID. No client could install this release."
 

--- a/site/features.json
+++ b/site/features.json
@@ -1,5 +1,11 @@
 [
   {
+    "title": "Signed and notarized macOS releases",
+    "blurb": "Downloads are signed with an Apple Developer ID and notarized, so a fresh install opens without the \"unidentified developer\" warning. The in-app updater refuses any release not signed by Hive, and says so plainly instead of reporting a checksum error.",
+    "status": "shipped",
+    "since": "Unreleased"
+  },
+  {
     "title": "What's new",
     "blurb": "The gift in the sidebar header lists what shipped, newest release first, and carries a dot until you have read it.",
     "status": "shipped",


### PR DESCRIPTION
Closes #374. Exec plan: `docs/exec-plans/active/374-sign-and-notarize-macos-releases.md`.

macOS releases are signed with an Apple Developer ID certificate, notarized and stapled; the in-app updater refuses any downloaded release not signed by Hive's Apple **Team ID**.

The SHA-256 manifest stays — it catches a truncated download cheaply and is the error users actually hit — but it was never a supply-chain defense, since the zip and the manifest come from the same release. The disclaimer comment at `update_apply_darwin.go:75` is gone because it is no longer true.

## The three decisions worth reviewing

**Team ID is a committed constant, not an ldflags stamp.** An earlier draft stamped it from `HIVE_SIGN_IDENTITY` at release time so `release.sh` would own the value it gates on. That is quietly wrong: `stageLatest` rebuilds from a git checkout by running `./build.sh` with no credentials, and so does anyone on a second machine or a fork. Under stamping all of those binaries carry an *empty* pin and skip verification of every release-channel update they later download. A committed default means a credential-free build still verifies what it downloads. `release.sh` refuses to publish while it is empty.

**Base-OS tools only in the updater's critical path.** `xcrun stapler` ships with the Xcode command-line tools, not macOS. A fail-closed check calling it would fail with `xcrun: unable to find utility` on a stock Mac and refuse every update for almost everyone. `codesign` carries the Team ID requirement and is load-bearing; `spctl` reports on notarization and is advisory, because under `spctl --master-disable` it does not evaluate at all — enforcing its non-answer would refuse updates on a machine whose owner already opted out of Gatekeeper globally.

**The pin is the point.** Plain `codesign --verify` proves only that *some* valid Developer ID signed the bundle — anyone with a \$99 Apple account has one. `-R '=anchor apple generic and certificate leaf[subject.OU] = "TEAMID"'` is what makes it mean "signed by Hive".

## Deviations from the spec

- The spec asks for a fail-closed check *before* `ditto -x`. Not achievable — `codesign` and `spctl` read a bundle, not a zip stream. The check runs on the unpacked bundle in the temp staging directory; the installed app is still never touched by an unverified build, since staging is removed unless every check passes. Spec wording amended.
- Spec item "README/CONTRIBUTING right-click-Open text" was dropped: no such text exists in either file.

## `--adhoc`

`scripts/sign-macos.sh --adhoc <app>` signs a local build with no credentials. Ad-hoc signing still sets the hardened-runtime flag, verified on the real bundle:

```
CodeDirectory v=20500 flags=0x10002(adhoc,runtime)
```

That makes the spec's third open question — does hardened runtime break `hived` spawning PTY sessions? — answerable **before** the \$99 account is spent. An ad-hoc signature has no Team ID, so it can never satisfy the pin; a test asserts that.

## Verification

- `scripts/test.sh go`, `gofmt`, `go vet` and `staticcheck` for darwin/linux/windows.
- `shellcheck` clean on `scripts/sign-macos.sh`.
- Full `./build.sh --zip --platform macos` passes with the new `ditto -c -k --keepParent` packaging; round-tripped through the updater's own `ditto -x -k` with `hivegui.app` as the archive root and `+x` preserved on all three executables.
- `--adhoc` exercised against the real built bundle.
- Release mode correctly refuses while no Team ID is pinned.
- The `-R` assertion was mutation-tested: dropping the flag at the call site makes `TestVerifyDeveloperIDSignaturePassesPinnedRequirement` fail, which is the whole reason that test asserts argv rather than the string builder.

**Two pre-existing failures**, confirmed identical on a clean `origin/main` checkout and left alone: `TestTerminalQueriesAreNotWork` (`internal/registry`) and `stateLockPoll is unused` (`GOOS=windows staticcheck`, `internal/daemon`).

## Not exercised

No Apple certificate exists yet (`security find-identity -v -p codesigning` reports 0 valid identities), so the real sign/notarize/staple path and the `spctl` offline-staple proof are untested end-to-end. The pinned Team ID is empty, which disables verification until it is set — and `release.sh` refuses to publish in that state, so an unpinned build cannot reach users. Setup walkthrough: `docs/releasing-signed-macos.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)