### PR TITLE
chore(337): gate pass and DONE bookkeeping after the merge

### DIFF
--- a/docs/exec-plans/active/337-idea-inbox.md
+++ b/docs/exec-plans/active/337-idea-inbox.md
@@ -1615,6 +1615,18 @@ path instead.
   permission classifier, twice. Per the skill it does not block the
   implementation, but this run had no prior-lesson pass over the files
   it touched.
+- **2026-09-07** — PR #377 was merged by the operator as `fbcbecca`
+  while the spec was still at `REVIEW`. Review never converged — ten
+  passes, each finding something real — so `/hs-review-loop` §4a never
+  advanced the stage, and `/hs-merge-gate` refused on that basis
+  earlier. The feature therefore shipped **ungated**: nothing has
+  validated it against the spec's `## Success criteria`, which were
+  amended twice during the work on the strength of measurements.
+  Advancing to `GATE` by hand so the gate can run its degraded
+  post-merge path over `fbcbecca~1..fbcbecca`. Recorded rather than
+  done quietly: this is a stage write the pipeline would not have made
+  on its own, and any failure it now finds becomes a follow-up issue
+  rather than a fix in the PR, because the code has shipped.
 
 ## Gate verdict
 

--- a/docs/exec-plans/completed/337-idea-inbox.md
+++ b/docs/exec-plans/completed/337-idea-inbox.md
@@ -13,7 +13,7 @@
   merged one left there short-circuits the next phase straight back to
   `GATE` before it has built anything.
 - **Phase:** 3 of 3 (see `### Phasing`)
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -1629,6 +1629,15 @@ path instead.
   rather than a fix in the PR, because the code has shipped.
 
 ## Gate verdict
+
+- **2026-09-07** — verdict: PASS; phase: 3/3; checks: 8 passed / 0 failed / 0 followups; followups: none; one-line: all eight success criteria verified against the SHIPPED code, including both 2026-09-07 amendments, by running the suites rather than reading comments.
+  - 2026-09-07 dimensions:
+    - acceptance — PASS — each criterion exercised, not inspected: 13 Playwright e2e, 126 vitest, and the Go registry/wire/daemon/`cmd/hived` suites were run. The two amended criteria (offer-instead-of-auto-type, and `started` only on actual delivery) are implemented by `deliveryFor`/`handedOverAtCreate`/`ResolvePrompt` and confirmed by the e2e cases that a typed-path agent is *offered* the prompt and that dismissing keeps the idea in the inbox.
+    - non-goals — PASS — all seven negative checks hold; `cmd/hived/idea.go` untouched, so `add`/`list` only. The one arguable scope call — guarding `cmdExeEscape` and `newWindowsCmd` for EVERY Windows caller rather than just this feature — was judged justified: a root-cause fix at the single choke point, with the decision recorded.
+    - doc accuracy — PASS — README, changeset, spec criteria and `site/features.json` each checked against the code rather than taken on trust, which mattered here: two documentation claims in this PR were false during the work and are now correct. `regression_of: declared-absent` (the changeset is `type: added`, so the field does not apply).
+  - **Gated after the merge, not before.** Review never converged (ten passes), so the stage never reached `GATE` and the gate refused while the PR was open; the operator merged on their own judgement and the gate ran over `fbcbecca~1..fbcbecca` afterwards. It passed, so nothing was lost — but the ordering meant a FAIL here would have become a follow-up issue against shipped code instead of a fix in the PR.
+  - Independently confirmed while gating: `TestTerminalQueriesAreNotWork` fails identically on `fbcbecca~1` in a throwaway worktree, and `state_test.go` was never touched by this diff. That closes out the pre-existing-failure claim this session made repeatedly, with evidence from outside the session.
+
 
 Append-only, one entry per `/hs-merge-gate` run.
 

--- a/docs/product-specs/337-idea-inbox.md
+++ b/docs/product-specs/337-idea-inbox.md
@@ -5,7 +5,7 @@ title: "Idea inbox: capture ideas mid-session, start a session from one later"
 type: enhancement
 complexity: M
 priority: P1
-stage: REVIEW
+stage: GATE
 ---
 
 # Idea inbox: capture ideas mid-session, start a session from one later

--- a/docs/product-specs/337-idea-inbox.md
+++ b/docs/product-specs/337-idea-inbox.md
@@ -1,11 +1,12 @@
 ---
 issue: null
 pr: 377
+shipped: 2026-09-07
 title: "Idea inbox: capture ideas mid-session, start a session from one later"
 type: enhancement
 complexity: M
 priority: P1
-stage: GATE
+stage: DONE
 ---
 
 # Idea inbox: capture ideas mid-session, start a session from one later
@@ -14,7 +15,7 @@ stage: GATE
 - **Type:** enhancement
 - **Complexity:** M
 - **Priority:** P1
-- **Exec plan:** [docs/exec-plans/active/337-idea-inbox.md](../exec-plans/active/337-idea-inbox.md)
+- **Exec plan:** [docs/exec-plans/completed/337-idea-inbox.md](../exec-plans/completed/337-idea-inbox.md)
 - **Design:** [docs/design-docs/control-plane.md](../design-docs/control-plane.md)
 
 ## Problem


### PR DESCRIPTION
Post-merge bookkeeping for #377, plus the gate run that PR never got.

## Why this is a separate PR

`/hs-merge-gate` normally writes all of this into the feature branch, so
a feature ships in exactly one PR. It could not here: **#377 shipped
ungated.** Review never converged — ten passes, each finding something
real — so `/hs-review-loop` never advanced the spec to `GATE`, and the
gate correctly refused while the PR was open. The merge went ahead on
the operator's judgement, which left the gate to run afterwards over
`fbcbecca~1..fbcbecca` and the bookkeeping stranded.

## Gate verdict: PASS (3/3)

| Dimension | Verdict |
|---|---|
| acceptance criteria | PASS — 8/8 |
| non-goals | PASS — 7/7 |
| doc accuracy | PASS |

**acceptance** — each criterion was *exercised*, not inspected: 13
Playwright e2e, 126 vitest, and the Go registry / wire / daemon /
`cmd/hived` suites were run. Both criteria amended during the work —
the prompt is *offered* rather than auto-typed, and an idea flips to
`started` only on actual delivery — are implemented by
`deliveryFor` / `handedOverAtCreate` / `ResolvePrompt` and confirmed by
the e2e cases covering a typed-path agent and dismissal.

**non-goals** — all seven hold; `cmd/hived/idea.go` is untouched, so the
CLI is still `add`/`list` only. The one arguable scope call — guarding
`cmdExeEscape` and `newWindowsCmd` for *every* Windows caller rather
than this feature alone — was judged justified: a root-cause fix at the
single choke point, with the decision recorded in the plan.

**doc accuracy** — README, the changeset, the spec's success criteria and
`site/features.json` were each checked against the code rather than
taken on trust. That mattered: two documentation claims in this PR were
false during the work (a commit message and a ledger entry both claimed
the paste bar named its session before it did) and are now correct.

## What this changes

Only bookkeeping — no product code:

- plan `Status: active` → `completed`, moved to `docs/exec-plans/completed/`
- spec `Exec plan:` link repointed, `shipped: 2026-09-07`, `stage: DONE`
- the `## Gate verdict` entry and its per-dimension breakdown

`docs/product-specs/index.md` and `CHANGELOG.md` are deliberately
untouched — both are generated, and `regenerate-generated` rebuilds them
on push to `main`. `scripts/check-plan-lifecycle.sh` reports no drift.
Labelled `no-changeset` per AGENTS.md, since this is docs-only.

## One thing worth knowing

While gating, `TestTerminalQueriesAreNotWork` was confirmed to fail
identically on `fbcbecca~1` in a throwaway worktree, and `state_test.go`
was never touched by this diff. This session claimed that failure was
pre-existing many times; that is now verified from outside the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
