### PR TITLE
fix: accept Windows dialog labels in Confirm

### DIFF
--- a/.changesets/windows-confirm-dialog.md
+++ b/.changesets/windows-confirm-dialog.md
@@ -1,0 +1,13 @@
+---
+type: fixed
+bump: patch
+---
+
+Confirmation dialogs now work on Windows. Deleting a project, killing a live
+session, restarting Hive and applying an update all go through a native
+confirmation, and every one of them silently did nothing on Windows: the dialog
+appeared, but answering it always read as a refusal, so the action was abandoned
+before it reached the daemon — with no error to show why. Wails ignores our
+button labels on Windows and substitutes a native Yes/No, and Hive only
+recognised the macOS `OK` as consent. It now accepts the labels each platform
+actually reports.

--- a/cmd/hivegui/app_calls.go
+++ b/cmd/hivegui/app_calls.go
@@ -386,7 +386,24 @@ func (a *App) Confirm(title, message string) bool {
 	if err != nil {
 		return false
 	}
-	return res == "OK"
+	return confirmAccepted(res)
+}
+
+// confirmAccepted reports whether a MessageDialog result is the
+// affirmative answer. The label we get back is the backend's choice,
+// not ours: macOS honours the Buttons slice above and returns "OK", but
+// Wails' Windows backend ignores Buttons entirely — a QuestionDialog
+// becomes MB_YESNO, so the user sees native Yes/No and the Win32 code
+// is mapped through a fixed table whose affirmatives are "Yes" (IDYES)
+// and "Ok" (IDOK, lowercase k — "OK" never appears). Matching only
+// "OK" made Confirm return false forever on Windows, silently
+// no-opping every confirm-gated action. See TestConfirmAccepted.
+func confirmAccepted(res string) bool {
+	switch res {
+	case "OK", "Ok", "Yes":
+		return true
+	}
+	return false
 }
 
 // OpenNewWindow spawns a second Hive GUI process. Wails v2 does not

--- a/cmd/hivegui/app_calls_test.go
+++ b/cmd/hivegui/app_calls_test.go
@@ -404,3 +404,46 @@ func checkStrPtr(t *testing.T, name string, got, want *string) {
 		t.Errorf("%s = %q, want %q", name, *got, *want)
 	}
 }
+
+// TestConfirmAccepted pins the affirmative answers Confirm has to
+// recognise. The set is not ours to choose: each platform's Wails
+// backend decides both the buttons and the string it hands back, and
+// Windows ignores our Buttons slice entirely.
+//
+// On Windows (internal/frontend/desktop/windows/dialog.go)
+// calculateMessageDialogFlags never reads options.Buttons — a
+// QuestionDialog becomes MB_YESNO, so the user sees native Yes/No and
+// the Win32 code is mapped through a fixed table:
+//
+//	[]string{"", "Ok", "Cancel", "Abort", "Retry", "Ignore", "Yes", "No", ...}
+//
+// MB_YESNO can only return IDYES(6) or IDNO(7), so the answer is "Yes"
+// or "No" and never the "OK" we asked for. Note index 1 is "Ok", not
+// "OK" — no Windows dialog type can produce "OK" at all.
+//
+// Getting this wrong is silent: Confirm returns false forever, every
+// confirm-gated action (delete project, kill a live session, restart,
+// apply an update) no-ops with no error and nothing reaches the daemon.
+func TestConfirmAccepted(t *testing.T) {
+	for _, tc := range []struct {
+		res  string
+		want bool
+		why  string
+	}{
+		{"OK", true, "macOS honours our Buttons slice"},
+		{"Yes", true, "Windows MB_YESNO IDYES"},
+		{"Ok", true, "Windows responses table index 1"},
+		{"No", false, "Windows MB_YESNO IDNO"},
+		{"Cancel", false, "macOS cancel button"},
+		{"", false, "dialog dismissed without a choice"},
+		{"Error", false, "Windows out-of-range button code"},
+		{"ok", false, "not a string any backend returns"},
+	} {
+		t.Run(tc.res, func(t *testing.T) {
+			if got := confirmAccepted(tc.res); got != tc.want {
+				t.Errorf("confirmAccepted(%q) = %v, want %v (%s)",
+					tc.res, got, tc.want, tc.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Every confirm-gated action in the GUI silently does nothing on Windows: **deleting a project**, **killing a live session**, **restarting Hive**, and **applying an update**. The dialog appears, you answer it, and nothing happens — no error, no toast, nothing in `hived.log`.

Deleting a project was how I found it. The symptom is total silence: `projects/index.json` was never rewritten and the project directory stayed on disk, because the request never left the GUI.

## Cause

`App.Confirm` (`cmd/hivegui/app_calls.go`) asks for custom buttons and tests for one by name:

```go
Type:    wruntime.QuestionDialog,
Buttons: []string{"OK", "Cancel"},
...
return res == "OK"
```

Wails' Windows backend (`internal/frontend/desktop/windows/dialog.go`) does two things that break this:

1. **`options.Buttons` is ignored entirely.** `calculateMessageDialogFlags` only switches on `Type`; `QuestionDialog` becomes `MB_YESNO`, so the user sees native **Yes/No**.
2. **The result is mapped from the Win32 code through a fixed table:**
   ```go
   responses := []string{"", "Ok", "Cancel", "Abort", "Retry", "Ignore", "Yes", "No", ...}
   ```
   `MB_YESNO` can only return `IDYES` (6) or `IDNO` (7), so the answer is `"Yes"` or `"No"`.

`res` is therefore never `"OK"`, and `Confirm` returns `false` unconditionally on Windows. `confirmAndDeleteProject` (`app/keyboard.ts`) hits `if (!ok) return` and abandons before calling `KillProject`.

Note the sharper edge: table index 1 is `"Ok"`, not `"OK"`. **No** Windows dialog type can produce the string this code tested for.

macOS honours the `Buttons` slice and does return `"OK"`, which is why this went unnoticed.

## Fix

Extract the decision into `confirmAccepted` and accept the labels each backend actually reports:

```go
func confirmAccepted(res string) bool {
	switch res {
	case "OK", "Ok", "Yes":
		return true
	}
	return false
}
```

macOS behaviour is unchanged.

## Why no layer caught it

`Confirm` had no test, and the e2e bridge mock (`test/e2e/wails-mock.ts`) returns `true` unconditionally — so neither the Go suite nor the frontend suites could observe the real mapping. `TestConfirmAccepted` closes that gap: it pins all eight responses the backends actually return, with the Windows table documented inline so the affirmative set can't be narrowed back to `"OK"` without a red test.

I confirmed the test fails first for the right reason — exactly the `"Yes"` and `"Ok"` cases, with the other six passing — then passes after the change.

## Verification

- `TestConfirmAccepted` — red before, green after (8/8 subtests)
- `go vet ./...` clean
- `scripts/test.sh unit dom` — 501 + 712 tests pass
- `scripts/test.sh e2e` — 290 pass
- Manually verified in a real Windows build: deleting a project now shows the Yes/No dialog, and answering Yes removes it. `projects/index.json` went 23 → 22 entries and the project directory was removed — the first time that file had been rewritten since Sep 2.

Two pre-existing failures on this Windows machine, unrelated and identical on clean `main`:

- `TestPackageIsIsolatedFromRealHiveState` — asserts `StateDir()` is not under the user's home, but `%TEMP%` lives under `%LOCALAPPDATA%` on Windows, so the guard always trips.
- `internal/registry TestManagedPath` — `os.Symlink` needs elevation or Developer Mode ("A required privilege is not held by the client").

Happy to open a separate issue for those two if they're not already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018voaTrthm2eszNWkSbkvq6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Confirmation dialogs now work correctly on Windows.
  * Deleting projects, stopping live sessions, restarting Hive, and applying updates now respond properly to affirmative confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->