### PR TITLE
fix(gui): stop Ctrl+Shift+V pasting twice

### DIFF
--- a/.changesets/paste-fires-twice.md
+++ b/.changesets/paste-fires-twice.md
@@ -1,0 +1,12 @@
+---
+type: fixed
+bump: patch
+pr: 387
+---
+
+`Ctrl+Shift+V` pastes once instead of twice. The terminal read the clipboard and
+wrote it to the session itself, but never cancelled the keypress, so the webview
+also ran its own paste on top — the same text arrived twice on every use. The
+paste now also goes through xterm's paste path, so multi-line clipboard content
+keeps its newline normalisation and bracketed-paste framing instead of being
+written raw, which had agents submitting once per pasted line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ navigation, ⌘1-9, the tray and the command palette now all follow the order th
 rows are actually painted in.
 
 ### Fixed
+`Ctrl+Shift+V` pastes once instead of twice. The terminal read the clipboard and
+wrote it to the session itself, but never cancelled the keypress, so the webview
+also ran its own paste on top — the same text arrived twice on every use. The
+paste now also goes through xterm's paste path, so multi-line clipboard content
+keeps its newline normalisation and bracketed-paste framing instead of being
+written raw, which had agents submitting once per pasted line.
+
 Confirmation dialogs now work on Windows. Deleting a project, killing a live
 session, restarting Hive and applying an update all go through a native
 confirmation, and every one of them silently did nothing on Windows: the dialog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,6 @@ navigation, ⌘1-9, the tray and the command palette now all follow the order th
 rows are actually painted in.
 
 ### Fixed
-`Ctrl+Shift+V` pastes once instead of twice. The terminal read the clipboard and
-wrote it to the session itself, but never cancelled the keypress, so the webview
-also ran its own paste on top — the same text arrived twice on every use. The
-paste now also goes through xterm's paste path, so multi-line clipboard content
-keeps its newline normalisation and bracketed-paste framing instead of being
-written raw, which had agents submitting once per pasted line.
-
 Confirmation dialogs now work on Windows. Deleting a project, killing a live
 session, restarting Hive and applying an update all go through a native
 confirmation, and every one of them silently did nothing on Windows: the dialog

--- a/cmd/hivegui/frontend/src/app/session-term.ts
+++ b/cmd/hivegui/frontend/src/app/session-term.ts
@@ -507,7 +507,15 @@ export class SessionTerm {
       // Ctrl+Shift+V pastes from the system clipboard.
       if (!e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return true;
       const key = e.key.toLowerCase();
+      // Returning false only stops xterm's own keydown translation; it
+      // does NOT cancel the DOM default action. Each branch below fully
+      // owns its key, so it must preventDefault() as well (same as the
+      // Cmd+Backspace / Shift+Enter branches above). Ctrl+Shift+V is
+      // where this bit: the webview went on to run its native paste,
+      // xterm's helper-textarea 'paste' listener wrote the clipboard to
+      // the PTY a second time, and one keypress pasted twice.
       if (key === 'c') {
+        e.preventDefault();
         const sel = this.term.getSelection();
         // SetClipboardText (Go-side via atotto/clipboard) rather than
         // wails runtime.ClipboardSetText — the latter is broken on
@@ -516,14 +524,22 @@ export class SessionTerm {
         return false;
       }
       if (key === 'v') {
+        e.preventDefault();
         ClipboardGetText()
           .then((text) => {
-            if (text) this._writePty(text);
+            // term.paste() rather than a raw _writePty: it folds CRLF to
+            // CR and applies bracketed-paste framing when the running
+            // program asked for it (DECSET 2004). That framing used to
+            // arrive via the duplicate native paste we now suppress —
+            // writing the clipboard raw would make every multi-line
+            // paste submit once per line in Claude/Codex.
+            if (text) this.term.paste(text);
           })
           .catch(reportFailure('paste'));
         return false;
       }
       if (key === 'a') {
+        e.preventDefault();
         this.term.selectAll();
         return false;
       }

--- a/cmd/hivegui/frontend/test/dom/paste.test.ts
+++ b/cmd/hivegui/frontend/test/dom/paste.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+//
+// Regression test: Ctrl+Shift+V used to paste twice.
+//
+// The terminal's custom key handler (src/app/session-term.ts) owns
+// Ctrl+Shift+V: it reads the system clipboard over the Wails bridge and
+// writes the text to the PTY, then returns false. Returning false only
+// tells xterm.js to skip its own *keydown* translation — it does NOT
+// cancel the DOM default action. The webview therefore went on to
+// perform its native paste, which fires a `paste` event on xterm's
+// helper textarea, and xterm's own paste listener wrote the same
+// clipboard text to the PTY a second time. One keypress, two pastes.
+//
+// The fix is e.preventDefault() on the branch that consumes the key
+// (matching every other consuming branch in the same handler), plus
+// routing our own write through term.paste() so the single surviving
+// write keeps the newline normalisation and bracketed-paste framing
+// that xterm's suppressed native handler used to provide.
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as store from '../../src/store/store.js';
+import { clearTerms } from '../../src/store/terms.js';
+
+const writes: string[] = [];
+let clipboardText = 'CLIP';
+
+vi.mock('../../src/bridge.js', () => {
+  const fn = () => vi.fn(() => Promise.resolve());
+  return {
+    ConnectControl: fn(),
+    OpenSession: fn(),
+    CloseAttach: fn(),
+    WriteStdin: vi.fn((_id: string, b64: string) => {
+      writes.push(atob(b64));
+      return Promise.resolve();
+    }),
+    ResizeSession: fn(),
+    RequestScrollbackReplay: fn(),
+    CreateSession: fn(),
+    DuplicateSession: fn(),
+    KillSession: fn(),
+    RestartSession: fn(),
+    UpdateSession: fn(),
+    ListAgents: fn(),
+    ListCustomAgents: fn(),
+    SaveCustomAgents: fn(),
+    CreateProject: fn(),
+    KillProject: fn(),
+    UpdateProject: fn(),
+    LaunchDir: fn(),
+    PickDirectory: fn(),
+    OpenNewWindow: fn(),
+    CloseWindow: fn(),
+    IsGitRepo: fn(),
+    OpenURL: fn(),
+    OpenTerminalAt: fn(),
+    Notify: fn(),
+    Confirm: fn(),
+    RestartDaemon: fn(),
+    CheckForUpdate: fn(),
+    SetClipboardText: fn(),
+    LogFrontend: vi.fn(),
+    EventsOn: vi.fn(),
+    WindowSetTitle: vi.fn(),
+    ClipboardGetText: vi.fn(() => Promise.resolve(clipboardText)),
+  };
+});
+
+type SessionTermClass =
+  typeof import('../../src/app/session-term.js').SessionTerm;
+type Info = import('../../src/app/state.js').SessionInfo;
+
+let SessionTerm: SessionTermClass;
+
+beforeAll(async () => {
+  // Same jsdom shims as test/dom/session-phase.test.ts: view.ts installs
+  // a container ResizeObserver at module load, and xterm's DPR watcher
+  // needs matchMedia.
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+    onchange: null,
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  document.body.innerHTML =
+    '<div id="terms"></div><ul id="projects"></ul><div id="status"><span id="status-text"></span><span id="status-hint"></span></div>';
+  ({ SessionTerm } = await import('../../src/app/session-term.js'));
+});
+
+let seq = 0;
+
+beforeEach(() => {
+  writes.length = 0;
+  clipboardText = 'CLIP';
+  clearTerms();
+  store.resetStore();
+});
+
+function mount() {
+  seq += 1;
+  const info = { id: `paste-${seq}`, name: 'test', color: '#888' } as Info;
+  const st = new SessionTerm(info);
+  const textarea = st.body.querySelector('textarea');
+  if (!textarea) throw new Error('xterm helper textarea not mounted');
+  return { st, textarea };
+}
+
+// Let the ClipboardGetText promise chain settle.
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+function ctrlShiftKey(key: string) {
+  return new KeyboardEvent('keydown', {
+    key,
+    ctrlKey: true,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+describe('Ctrl+Shift+V paste', () => {
+  it('cancels the keydown default so the webview cannot paste a second time', async () => {
+    const { textarea } = mount();
+    const ev = ctrlShiftKey('V');
+    textarea.dispatchEvent(ev);
+    await settle();
+
+    // The whole bug in one assertion: an un-cancelled keydown lets the
+    // webview run its native paste on top of ours.
+    expect(ev.defaultPrevented).toBe(true);
+    expect(writes).toEqual(['CLIP']);
+  });
+
+  it('writes the clipboard exactly once', async () => {
+    const { textarea } = mount();
+    textarea.dispatchEvent(ctrlShiftKey('v'));
+    await settle();
+    expect(writes).toHaveLength(1);
+  });
+
+  it('normalises newlines instead of writing the clipboard raw', async () => {
+    clipboardText = 'one\r\ntwo';
+    const { textarea } = mount();
+    textarea.dispatchEvent(ctrlShiftKey('v'));
+    await settle();
+    // \r\n would submit twice in Claude/Codex; xterm's paste path folds
+    // it to a single \r, which is what the native paste used to deliver.
+    expect(writes).toEqual(['one\rtwo']);
+  });
+
+  it('brackets the paste when the running program enabled DECSET 2004', async () => {
+    clipboardText = 'hello';
+    const { st, textarea } = mount();
+    await new Promise<void>((r) => st.term.write('\x1b[?2004h', r));
+    textarea.dispatchEvent(ctrlShiftKey('v'));
+    await settle();
+    expect(writes).toEqual(['\x1b[200~hello\x1b[201~']);
+  });
+});
+
+describe('Ctrl+Shift+C / Ctrl+Shift+A', () => {
+  it('cancel their keydown default too', () => {
+    const { textarea } = mount();
+    const copy = ctrlShiftKey('C');
+    const selectAll = ctrlShiftKey('A');
+    textarea.dispatchEvent(copy);
+    textarea.dispatchEvent(selectAll);
+    expect(copy.defaultPrevented).toBe(true);
+    expect(selectAll.defaultPrevented).toBe(true);
+  });
+
+  it('leaves other Ctrl+Shift keys to xterm', () => {
+    const { textarea } = mount();
+    const other = ctrlShiftKey('Z');
+    textarea.dispatchEvent(other);
+    expect(other.defaultPrevented).toBe(false);
+  });
+});
+
+describe('xterm native paste path (evidence for the duplicate)', () => {
+  it('writes to the PTY on a bare paste event, with no keydown involved', () => {
+    const { textarea } = mount();
+    const ev = new Event('paste', {
+      bubbles: true,
+      cancelable: true,
+    }) as ClipboardEvent;
+    Object.defineProperty(ev, 'clipboardData', {
+      value: { getData: () => 'CLIP' },
+    });
+    textarea.dispatchEvent(ev);
+    // This is the second write the user saw. It is reachable only when
+    // the Ctrl+Shift+V keydown leaves its default action intact.
+    expect(writes).toEqual(['CLIP']);
+  });
+});


### PR DESCRIPTION
## The bug

`Ctrl+Shift+V` in a session terminal pastes the clipboard **twice**.

## Root cause

`SessionTerm`'s custom key handler (`cmd/hivegui/frontend/src/app/session-term.js`) owns `Ctrl+Shift+V`: it reads the system clipboard over the Wails bridge, writes the text to the PTY, and returns `false`.

Returning `false` from `attachCustomKeyEventHandler` only tells xterm.js to skip its own *keydown* translation — it does **not** cancel the DOM default action (xterm's keydown listener discards the return value of `_keyDown`, and the early `return false` happens before xterm's own `preventDefault()`).

So the webview went on to perform its native paste. That fires a `paste` event on xterm's helper textarea, where xterm registers its own listener (`handlePasteEvent` → `triggerDataEvent` → `onData` → `_writePty`). The same clipboard text reached the PTY a second time.

One keypress, two writes.

The two sibling branches in the same handler (Cmd+Backspace, Shift+Enter) already call `e.preventDefault()`; the `Ctrl+Shift` block was the odd one out.

## The fix

1. `e.preventDefault()` on the branches that consume the key, so the webview cannot run a native paste on top of ours.
2. The clipboard write now goes through `term.paste()` instead of a raw `_writePty()`.

(2) is part of the same fix, not a drive-by: suppressing the native path also removes the CRLF→CR normalisation and bracketed-paste framing (DECSET 2004) that xterm applied. Those arrived *via the duplicate*. Without this, killing the duplicate would leave only the raw write, and every multi-line paste would submit once per line in Claude/Codex.

## Tests

New `test/dom/paste.test.js` drives the real handler through a real xterm instance in jsdom:

- **`cancels the keydown default…`** — the bug in one assertion (`ev.defaultPrevented`). Fails before the fix.
- **`writes the clipboard exactly once`**
- **`normalises newlines…`** and **`brackets the paste when the running program enabled DECSET 2004`** — both fail before the fix.
- **`xterm native paste path (evidence for the duplicate)`** — dispatches a bare `paste` event with no keydown and shows it writes to the PTY on its own. This is the second write the user saw; it is reachable only while the keydown default is left intact.

Pre-fix: 3 failed / 2 passed. Post-fix: 5 passed.

Full frontend suite: **26 files, 203 tests, all passing.** `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SPt4Ra6ndrNVYG1jMhNRTB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `Ctrl+Shift+V` so clipboard content is pasted only once.
  - Preserved newline normalization and bracketed-paste behavior for multi-line text.
  - Prevented unintended browser actions for terminal copy, paste, and select-all shortcuts.
- **Tests**
  - Added coverage for single-paste behavior, clipboard handling, newline normalization, and bracketed paste.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->