### PR TITLE
fix: stop sessions inheriting NO_COLOR from the daemon

### DIFF
--- a/.changesets/session-strips-no-color.md
+++ b/.changesets/session-strips-no-color.md
@@ -1,0 +1,13 @@
+---
+type: fixed
+bump: patch
+---
+
+Sessions no longer render monochrome when the GUI happened to be launched from
+a shell with `NO_COLOR` set. Hive built every session's environment from the
+daemon's own, overriding only `TERM`, so a `NO_COLOR` that reached `hivegui` by
+inheritance was handed down to every agent and shell in every tile and stayed
+there for the life of the daemon — with no setting anywhere to explain it. A
+tile is a colour-capable xterm.js terminal whatever the GUI was started under,
+so the variable is now dropped when a session's environment is built, for the
+same reason `TERM` is already forced.

--- a/.changesets/session-strips-no-color.md
+++ b/.changesets/session-strips-no-color.md
@@ -1,6 +1,7 @@
 ---
 type: fixed
 bump: patch
+pr: 388
 ---
 
 Sessions no longer render monochrome when the GUI happened to be launched from

--- a/internal/session/env.go
+++ b/internal/session/env.go
@@ -1,0 +1,22 @@
+package session
+
+import "strings"
+
+// sessionEnv builds the environment a spawned session runs with, from
+// base — the daemon's own environment.
+//
+// TERM is forced because a tile is an xterm.js terminal whatever the
+// daemon itself was started under. NO_COLOR is dropped for the same
+// reason: it reaches hived only by inheritance from whichever shell
+// happened to launch the GUI, it says nothing about the tile, and while
+// it is set every agent and shell Hive spawns renders monochrome.
+func sessionEnv(base []string) []string {
+	env := make([]string, 0, len(base)+1)
+	for _, kv := range base {
+		if strings.HasPrefix(kv, "NO_COLOR=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env, "TERM=xterm-256color")
+}

--- a/internal/session/env_test.go
+++ b/internal/session/env_test.go
@@ -1,0 +1,42 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// envValue returns the value exec would resolve for key: last assignment
+// wins, matching how os/exec dedups a Cmd.Env with repeated names.
+func envValue(env []string, key string) (string, bool) {
+	value, found := "", false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, key+"=") {
+			value, found = strings.TrimPrefix(kv, key+"="), true
+		}
+	}
+	return value, found
+}
+
+func TestSessionEnvForcesTERM(t *testing.T) {
+	got, ok := envValue(sessionEnv([]string{"TERM=dumb", "PATH=/usr/bin"}), "TERM")
+	if !ok || got != "xterm-256color" {
+		t.Errorf("TERM = %q (present=%v), want %q", got, ok, "xterm-256color")
+	}
+}
+
+func TestSessionEnvDropsNoColor(t *testing.T) {
+	// NO_COLOR inherited from whatever shell happened to launch the GUI
+	// must not reach the session. A tile is a colour-capable xterm.js
+	// terminal, so the daemon's ambient value says nothing about it, and
+	// every agent spawned into one renders monochrome while it is set.
+	if got, ok := envValue(sessionEnv([]string{"NO_COLOR=1", "PATH=/usr/bin"}), "NO_COLOR"); ok {
+		t.Errorf("NO_COLOR = %q, want it dropped from the session environment", got)
+	}
+}
+
+func TestSessionEnvKeepsUnrelatedVars(t *testing.T) {
+	got, ok := envValue(sessionEnv([]string{"PATH=/usr/bin", "HOME=/home/q"}), "HOME")
+	if !ok || got != "/home/q" {
+		t.Errorf("HOME = %q (present=%v), want %q", got, ok, "/home/q")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -180,7 +180,7 @@ func Start(opts Options) (*Session, error) {
 		cmd = ptmx.Command(shell)
 		log.Printf("session: spawn %s (cwd=%s)", shell, opts.Cwd)
 	}
-	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
+	cmd.Env = sessionEnv(os.Environ())
 	if len(opts.Env) > 0 {
 		cmd.Env = append(cmd.Env, opts.Env...)
 	}


### PR DESCRIPTION
## Problem

Every session Hive spawns gets the daemon's environment verbatim, with only `TERM` overridden:

```go
cmd.Env = append(os.Environ(), "TERM=xterm-256color")
```

That makes `NO_COLOR` contagious. If whatever shell launched `hivegui` had it set, `hived` inherits it, and from then on every agent and every plain shell in every tile renders monochrome — for the life of the daemon, with nothing in Hive's own settings to explain it.

I hit this on Windows: a Claude session with no colour at all, while `TERM` was correctly `xterm-256color`. `NO_COLOR` was in neither the User nor Machine registry environment, no shell profile set it, and the string does not appear in Hive's source or in the `hived` binary. Reading the process environment blocks up the tree showed `NO_COLOR=1` present from `hivegui` down through `hived` to the session — inherited once at GUI launch and propagated from there.

## Fix

Extract the environment construction into `sessionEnv()` and drop `NO_COLOR` there. The justification is the one that already applies to `TERM`: a tile is a colour-capable xterm.js terminal whatever the GUI itself was started under, so a value the daemon picked up by inheritance says nothing about it. An explicit `Options.Env` still wins, since it is appended afterwards.

## Testing

Unit tests in `internal/session/env_test.go` cover `TERM` being forced, `NO_COLOR` being dropped, and unrelated variables surviving.

End-to-end, spawning a real session via `session.Start` from a parent holding `NO_COLOR=1` and echoing both variables inside the session:

```
before (main):  MARK_NO_COLOR=[1]  MARK_TERM=[xterm-256color]
after  (this):  MARK_NO_COLOR=[]   MARK_TERM=[xterm-256color]
```

`scripts/test.sh go` is green apart from `TestManagedPath`, which fails identically on unmodified `main` on this machine — it needs the Windows symlink privilege.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rBWb7d5MqmBcUvySKwMCh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed monochrome session rendering when the application is launched from a shell with `NO_COLOR` enabled.
  - Sessions now consistently use color-capable terminal settings while preserving other environment variables.

- **Tests**
  - Added coverage for terminal color handling, forced terminal settings, and preservation of unrelated environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->