### PR TITLE
chore: THROWAWAY probe for actions/cache v6 + upload-artifact v7 (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,16 +362,6 @@ jobs:
           CI: 'true'
           TERM: dumb
 
-      - name: PROBE (throwaway) force artifact upload path
-        if: matrix.label == 'Linux'
-        working-directory: cmd/hivegui/frontend
-        run: |
-          mkdir -p test-results/probe-trace
-          head -c 200000 /dev/urandom > test-results/probe-trace/trace.bin
-          echo "probe" > test-results/probe-note.txt
-          ls -laR test-results
-          exit 1
-
       - name: Upload Playwright failure artifacts
         # Traces + scrolltrace attachments are the only way to debug a
         # CI-only e2e failure (retain-on-failure traces land in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,10 +213,10 @@ jobs:
         # unconditional install overwrites whatever was restored and the
         # cache buys nothing but its own latency. Keyed on the pinned
         # versions, so a bump misses exactly once.
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/go/bin
-          key: go-analysis-tools-${{ runner.os }}-staticcheck2026.2.1-govulncheck1.7.0
+          key: v6probe-go-analysis-tools-${{ runner.os }}-staticcheck2026.2.1-govulncheck1.7.0
 
       - name: Staticcheck (Go)
         if: matrix.biome
@@ -310,10 +310,10 @@ jobs:
         # when the browsers are present, and skipping it on cache-hit would
         # leave a leg with no browser if a cache were ever partial. On Linux
         # it also installs the apt deps, which are not cacheable.
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ github.workspace }}/.playwright-browsers
-          key: playwright-${{ runner.os }}-${{ hashFiles('cmd/hivegui/frontend/package-lock.json') }}
+          key: v6probe-playwright-${{ runner.os }}-${{ hashFiles('cmd/hivegui/frontend/package-lock.json') }}
           restore-keys: |
             playwright-${{ runner.os }}-
 
@@ -362,12 +362,22 @@ jobs:
           CI: 'true'
           TERM: dumb
 
+      - name: PROBE (throwaway) force artifact upload path
+        if: matrix.label == 'Linux'
+        working-directory: cmd/hivegui/frontend
+        run: |
+          mkdir -p test-results/probe-trace
+          head -c 200000 /dev/urandom > test-results/probe-trace/trace.bin
+          echo "probe" > test-results/probe-note.txt
+          ls -laR test-results
+          exit 1
+
       - name: Upload Playwright failure artifacts
         # Traces + scrolltrace attachments are the only way to debug a
         # CI-only e2e failure (retain-on-failure traces land in
         # test-results/). Without this step they die with the runner.
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-test-results-${{ matrix.label }}
           path: cmd/hivegui/frontend/test-results/


### PR DESCRIPTION
**Do not merge. Do not review.** This branch exists only to exercise two upgrade paths that #372 and #370 cannot reach in their own CI runs, then it gets deleted.

- `actions/cache` v6.1.0 with both cache keys prefixed `v6probe-`, forcing a primary-key miss so the **save** path runs. #372's CI hit every key, which proved restore-from-v4-written-cache only.
- `actions/upload-artifact` v7.0.1 plus a Linux-only step that writes files into `test-results/` and exits 1, so the `if: failure()` upload step actually uploads a real artifact.

The Linux leg is expected to be red. That is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)