### PR TITLE
fix(session): restore DEC private modes on reattach and replay

### DIFF
--- a/.changesets/reattach-keeps-terminal-modes.md
+++ b/.changesets/reattach-keeps-terminal-modes.md
@@ -13,4 +13,7 @@ for the life of that tile. Bracketed paste was the visible casualty: without it
 agents guess where a paste starts and ends, and anything over about 1 KiB
 arrived as several separate pastes, because that is where the operating system
 splits a write to the terminal. The daemon now tracks those modes and re-asserts
-whatever was live, both in the reattach snapshot and in the resize replay.
+whatever was live, both in the reattach snapshot and in the resize replay — and
+turns off the ones the program switched off while nobody was attached, so a
+finished TUI no longer leaves mouse tracking on and spraying click codes into
+the shell that follows it.

--- a/.changesets/reattach-keeps-terminal-modes.md
+++ b/.changesets/reattach-keeps-terminal-modes.md
@@ -1,7 +1,7 @@
 ---
 type: fixed
 bump: patch
-pr: TBD
+pr: 391
 ---
 
 Pasting, mouse tracking and arrow keys keep working after a session is

--- a/.changesets/reattach-keeps-terminal-modes.md
+++ b/.changesets/reattach-keeps-terminal-modes.md
@@ -1,0 +1,16 @@
+---
+type: fixed
+bump: patch
+pr: TBD
+---
+
+Pasting, mouse tracking and arrow keys keep working after a session is
+reattached or the layout changes width. Repainting a tile begins with a soft
+reset, which clears the DEC private modes the running program set — and the
+program never sends them again, because it has no idea a new client attached.
+Only the cursor and alt-screen were being restored, so everything else was lost
+for the life of that tile. Bracketed paste was the visible casualty: without it
+agents guess where a paste starts and ends, and anything over about 1 KiB
+arrived as several separate pastes, because that is where the operating system
+splits a write to the terminal. The daemon now tracks those modes and re-asserts
+whatever was live, both in the reattach snapshot and in the resize replay.

--- a/cmd/hivegui/app_attach.go
+++ b/cmd/hivegui/app_attach.go
@@ -180,7 +180,10 @@ func (a *App) ResizeSession(id string, cols, rows int) error {
 //
 // Distinct from RenderSnapshot / SubscribeAtomicSnapshot — the bytes
 // streamed back are the raw PTY ring, not the vt10x-synthesized
-// repaint.
+// repaint. The one synthesized part is the tail: the DEC private modes
+// still in force are re-asserted after the ring, because the client
+// resets its terminal first and the ring may have trimmed the original
+// set sequences away.
 func (a *App) RequestScrollbackReplay(id string) error {
 	cs, err := a.attachFor(id)
 	if err != nil {

--- a/cmd/hivegui/frontend/test/dom/paste.test.ts
+++ b/cmd/hivegui/frontend/test/dom/paste.test.ts
@@ -166,6 +166,47 @@ describe('Ctrl+Shift+V paste', () => {
   });
 });
 
+// Reattach / width-changing replay repaints a tile from the daemon's
+// snapshot, which opens with DECSTR (\x1b[!p). DECSTR clears DEC private
+// modes, including bracketed paste — and the running program never
+// re-sends them, because it has no idea a new client attached. Unless
+// the snapshot re-asserts them, the tile pastes unframed for the rest of
+// the session, and a >1 KiB paste then splits at the macOS PTY
+// input-buffer boundary into several "pasted text" chunks in the agent.
+//
+// These two tests are the receiving end of internal/session/decmodes.go:
+// that one proves the daemon emits the restore bytes, this one proves
+// xterm actually honours them.
+describe('DEC private modes across a snapshot repaint', () => {
+  // The shape of what the daemon sends on reattach: soft reset, erase,
+  // home, then (with the fix) the restore of whatever was set.
+  const SNAPSHOT_PREAMBLE = '\x1b[!p\x1b[3J\x1b[2J\x1b[H';
+
+  it('loses bracketed paste when the snapshot does not re-assert it', async () => {
+    clipboardText = 'hello';
+    const { st, textarea } = mount();
+    await new Promise<void>((r) => st.term.write('\x1b[?2004h', r));
+    // A repaint with no mode restore — the pre-fix daemon behaviour.
+    await new Promise<void>((r) => st.term.write(SNAPSHOT_PREAMBLE, r));
+    textarea.dispatchEvent(ctrlShiftKey('v'));
+    await settle();
+    // Unframed. This is the bug, pinned so the mechanism stays visible.
+    expect(writes).toEqual(['hello']);
+  });
+
+  it('keeps bracketed paste when the snapshot re-asserts it', async () => {
+    clipboardText = 'hello';
+    const { st, textarea } = mount();
+    await new Promise<void>((r) => st.term.write('\x1b[?2004h', r));
+    await new Promise<void>((r) =>
+      st.term.write(SNAPSHOT_PREAMBLE + '\x1b[?2004h', r),
+    );
+    textarea.dispatchEvent(ctrlShiftKey('v'));
+    await settle();
+    expect(writes).toEqual(['\x1b[200~hello\x1b[201~']);
+  });
+});
+
 describe('Ctrl+Shift+C / Ctrl+Shift+A', () => {
   it('cancel their keydown default too', () => {
     const { textarea } = mount();

--- a/internal/buildinfo/contract.go
+++ b/internal/buildinfo/contract.go
@@ -26,7 +26,7 @@ package buildinfo
 //
 //	8 — DEC private modes survive a reattach. The snapshot and the
 //	    resize replay now end by re-asserting whatever the program had
-//	    set — bracketed paste (2004), mouse tracking (1000/1002/1003),
+//	    set — bracketed paste (2004), mouse tracking (9/1000/1002/1003),
 //	    mouse encoding (1005/1006/1015), app-cursor keys (1) and focus
 //	    reporting (1004). The snapshot's DECSTR had been clearing all of
 //	    them while only alt-screen and cursor visibility were restored,

--- a/internal/buildinfo/contract.go
+++ b/internal/buildinfo/contract.go
@@ -24,6 +24,19 @@ package buildinfo
 // History (newest first), so a bump is a decision with a record and
 // not just a number going up:
 //
+//	8 — DEC private modes survive a reattach. The snapshot and the
+//	    resize replay now end by re-asserting whatever the program had
+//	    set — bracketed paste (2004), mouse tracking (1000/1002/1003),
+//	    mouse encoding (1005/1006/1015), app-cursor keys (1) and focus
+//	    reporting (1004). The snapshot's DECSTR had been clearing all of
+//	    them while only alt-screen and cursor visibility were restored,
+//	    so a reattached tile lost them for the life of the session. No
+//	    frame or field changed, and that is exactly why it needs the
+//	    bump: the fix lives entirely in the daemon, so without one the
+//	    GUI offers its cheap reload, the user keeps the hived they
+//	    already had, and a >1 KiB paste still arrives split in three
+//	    while they believe they have the fix. The bump forces the
+//	    daemon restart that actually delivers it.
 //	7 — Starting a session from an idea. CreateSpec gained
 //	    initial_prompt (delivered as an argv positional to Claude and
 //	    Pi, typed into the PTY on the first idle edge for the agents
@@ -70,7 +83,7 @@ package buildinfo
 //	    before this cannot see or clear the flag.
 //	1 — first contract; everything up to and including the
 //	    CLIENT_COMMAND relay.
-const DaemonContract = 7
+const DaemonContract = 8
 
 // Identity is this binary's full build identity. `hived --version
 // --json` prints it, and Welcome carries the same three values, so a

--- a/internal/session/decmodes.go
+++ b/internal/session/decmodes.go
@@ -111,6 +111,19 @@ type decModeTracker struct {
 	// (see decModeGroup) is ever present; set order is kept only so the
 	// restore bytes are deterministic.
 	enabled []int
+	// seen holds one entry per mode SLOT the program has ever touched —
+	// set OR reset — carrying the member that touched it last. Ungrouped
+	// modes are their own slot; each exclusive group is one slot, so it
+	// gets one entry and therefore one sequence in the restore.
+	//
+	// enabled alone cannot drive the restore: the reattach path does not
+	// term.reset() the tile, and xterm's softReset() leaves
+	// CoreMouseService alone, so a mode the program turned OFF while the
+	// sink was unregistered stays ON in the client unless the snapshot
+	// says otherwise. seen is what lets restoreBytes answer "off"
+	// explicitly for exactly the modes that need an answer, while a
+	// session that never touched a mode still emits nothing at all.
+	seen []int
 }
 
 // feed scans p for private mode changes, recording the latest state of
@@ -128,7 +141,9 @@ func (t *decModeTracker) feed(p []byte) {
 			case '[':
 				t.state = decCSI
 			case 'c':
-				// RIS — the terminal drops everything.
+				// RIS — the terminal drops everything. `seen` survives:
+				// it records which modes still need an explicit answer in
+				// the snapshot, and after a RIS that answer is `l`.
 				t.enabled = t.enabled[:0]
 				t.state = decGround
 			case 0x1b:
@@ -201,6 +216,10 @@ func (t *decModeTracker) feed(p []byte) {
 // replay path would re-assert it — a reattach would silently kill mouse
 // reporting for the life of that tile, which is the same class of bug
 // this file was written to fix.
+//
+// Only `enabled` is touched; `seen` survives both resets. A mode the
+// program used at all still needs an explicit statement in the snapshot,
+// and after a reset that statement is `l`.
 func (t *decModeTracker) softReset() {
 	t.enabled = slices.DeleteFunc(t.enabled, func(m int) bool {
 		return decModeGroup[m] == decGroupNone
@@ -219,34 +238,49 @@ func (t *decModeTracker) set(params []byte, enabled bool) {
 			continue
 		}
 		group := decModeGroup[n]
-		t.enabled = slices.DeleteFunc(t.enabled, func(m int) bool {
+		sameSlot := func(m int) bool {
 			return m == n || (group != decGroupNone && decModeGroup[m] == group)
-		})
+		}
+		t.enabled = slices.DeleteFunc(t.enabled, sameSlot)
 		if enabled {
 			t.enabled = append(t.enabled, n)
 		}
+		// One seen entry per slot, holding the member that touched it
+		// last — that is the member whose h/l the restore must speak.
+		t.seen = append(slices.DeleteFunc(t.seen, sameSlot), n)
 	}
 }
 
-// restoreBytes returns the sequences needed to re-assert every sticky
-// mode currently enabled, in the order the program set them — which
-// makes the output deterministic (tests compare it byte-for-byte).
-// Order carries no meaning beyond that: at most one member of each
-// exclusive group is ever enabled, so no replay order can land the
-// terminal in a mode the program did not ask for.
+// restoreBytes states the CURRENT value of every mode slot the program
+// has ever touched: `h` if it is on, `l` if it is off. Slots the program
+// never touched emit nothing, so a session that used no sticky mode
+// replays byte-identical to the ring.
 //
-// Disabled modes emit nothing: a snapshot's DECSTR has already cleared
-// them in the receiving terminal, so an explicit reset would be bytes
-// spent to reach the state we are already in.
+// The `l` half is not redundant. The ordinary reattach path reuses the
+// existing xterm rather than term.reset()ing it, and xterm's softReset()
+// — all a snapshot's DECSTR preamble reaches — never touches
+// CoreMouseService. So a program that sets 1002, then exits and sends
+// 1002l while no sink is attached, leaves a tile with mouse tracking
+// still on: the next plain shell gets `\x1b[<0;12;5M` typed into it on
+// every click. Only an explicit reset in the snapshot closes that.
+//
+// Output order is the slots' last-touched order, which makes the bytes
+// deterministic (tests compare them byte-for-byte). Order carries no
+// meaning beyond that: one sequence per slot, so no replay order can
+// land the terminal in a state the program did not ask for.
 func (t *decModeTracker) restoreBytes() []byte {
-	if len(t.enabled) == 0 {
+	if len(t.seen) == 0 {
 		return nil
 	}
 	var buf bytes.Buffer
-	for _, mode := range t.enabled {
+	for _, mode := range t.seen {
 		buf.WriteString("\x1b[?")
 		buf.WriteString(strconv.Itoa(mode))
-		buf.WriteString("h")
+		if slices.Contains(t.enabled, mode) {
+			buf.WriteString("h")
+		} else {
+			buf.WriteString("l")
+		}
 	}
 	return buf.Bytes()
 }

--- a/internal/session/decmodes.go
+++ b/internal/session/decmodes.go
@@ -2,7 +2,7 @@ package session
 
 import (
 	"bytes"
-	"sort"
+	"slices"
 	"strconv"
 )
 
@@ -59,6 +59,7 @@ const (
 	decEsc                        // saw ESC
 	decCSI                        // saw ESC [
 	decPriv                       // saw ESC [ ?, collecting params
+	decBang                       // saw ESC [ !, expecting p (DECSTR)
 )
 
 // decModeTracker is a streaming scanner for DEC private mode set/reset
@@ -72,11 +73,20 @@ const (
 type decModeTracker struct {
 	state  decScanState
 	params []byte
-	on     map[int]bool
+	// enabled holds the sticky modes currently on, in the order the
+	// program turned them on. Order is the state, not decoration:
+	// 1000/1002/1003 (and the 1005/1006/1015 encodings) are mutually
+	// exclusive groups where the last one set wins, so replaying them in
+	// any other order can leave the terminal in a mode the program never
+	// asked for.
+	enabled []int
 }
 
 // feed scans p for private mode changes, recording the latest state of
-// every mode in stickyDECModes.
+// every mode in stickyDECModes. A soft reset (DECSTR, \x1b[!p) or a full
+// reset (RIS, \x1bc) from the program clears the tracked state: the
+// receiving terminal drops every private mode on those, so re-asserting
+// afterwards would push modes the program had abandoned.
 func (t *decModeTracker) feed(p []byte) {
 	for _, b := range p {
 		switch t.state {
@@ -88,6 +98,10 @@ func (t *decModeTracker) feed(p []byte) {
 			switch b {
 			case '[':
 				t.state = decCSI
+			case 'c':
+				// RIS — the terminal drops everything.
+				t.enabled = t.enabled[:0]
+				t.state = decGround
 			case 0x1b:
 				// Another ESC restarts the sequence.
 			default:
@@ -98,6 +112,8 @@ func (t *decModeTracker) feed(p []byte) {
 			case b == '?':
 				t.state = decPriv
 				t.params = t.params[:0]
+			case b == '!':
+				t.state = decBang
 			case b == 0x1b:
 				t.state = decEsc
 			default:
@@ -122,48 +138,53 @@ func (t *decModeTracker) feed(p []byte) {
 				// handle (e.g. \x1b[?25$p, a mode query). Not ours.
 				t.state = decGround
 			}
+		case decBang:
+			switch b {
+			case 'p':
+				// DECSTR — soft reset clears every private mode.
+				t.enabled = t.enabled[:0]
+				t.state = decGround
+			case 0x1b:
+				t.state = decEsc
+			default:
+				t.state = decGround
+			}
 		}
 	}
 }
 
 // set records each sticky mode named in a ";"-separated parameter list.
+// Re-setting a mode that is already on moves it to the end: within an
+// exclusive group the terminal honours whichever was set last, so the
+// tracker has to remember which that was.
 func (t *decModeTracker) set(params []byte, enabled bool) {
 	for _, field := range bytes.Split(params, []byte(";")) {
 		n, err := strconv.Atoi(string(field))
 		if err != nil || !stickyDECModes[n] {
 			continue
 		}
-		if t.on == nil {
-			t.on = make(map[int]bool, len(stickyDECModes))
+		t.enabled = slices.DeleteFunc(t.enabled, func(m int) bool { return m == n })
+		if enabled {
+			t.enabled = append(t.enabled, n)
 		}
-		t.on[n] = enabled
 	}
 }
 
 // restoreBytes returns the sequences needed to re-assert every sticky
-// mode currently enabled, in ascending mode order so the output is
-// deterministic (tests compare it byte-for-byte).
+// mode currently enabled, in the order the program set them — which is
+// both deterministic (tests compare it byte-for-byte) and the only
+// ordering that reproduces the program's intent across the exclusive
+// mode groups.
 //
 // Disabled modes emit nothing: a snapshot's DECSTR has already cleared
 // them in the receiving terminal, so an explicit reset would be bytes
 // spent to reach the state we are already in.
 func (t *decModeTracker) restoreBytes() []byte {
-	if len(t.on) == 0 {
+	if len(t.enabled) == 0 {
 		return nil
 	}
-	modes := make([]int, 0, len(t.on))
-	for mode, enabled := range t.on {
-		if enabled {
-			modes = append(modes, mode)
-		}
-	}
-	if len(modes) == 0 {
-		return nil
-	}
-	sort.Ints(modes)
-
 	var buf bytes.Buffer
-	for _, mode := range modes {
+	for _, mode := range t.enabled {
 		buf.WriteString("\x1b[?")
 		buf.WriteString(strconv.Itoa(mode))
 		buf.WriteString("h")

--- a/internal/session/decmodes.go
+++ b/internal/session/decmodes.go
@@ -1,0 +1,172 @@
+package session
+
+import (
+	"bytes"
+	"sort"
+	"strconv"
+)
+
+// DEC private modes that a program sets once, early, and then relies on
+// for the life of the session.
+//
+// This matters because our reattach path is not a byte replay of the
+// session's whole history: RenderSnapshot opens with DECSTR (\x1b[!p),
+// which clears these in the receiving terminal, and EmitAtomicReplay
+// streams a ring that may have trimmed the original set sequences (and
+// the client term.reset()s before consuming it). The program never
+// re-sends them — it has no idea a new client attached — so whatever
+// the snapshot does not re-assert is lost for the life of that tile.
+//
+// Bracketed paste is the one that bites hardest: with 2004 lost, xterm
+// writes a paste unframed, the agent falls back to guessing paste
+// boundaries from read sizes, and a >1 KiB paste splits at the macOS
+// PTY input-buffer boundary (1022 bytes) into several "pasted text"
+// chunks. Mouse tracking and app-cursor keys fail the same way, just
+// more visibly.
+//
+// vt10x models none of these (see VT.Write), so we sniff them off the
+// byte stream ourselves.
+//
+// Deliberately NOT here:
+//   - 25 (DECTCEM) and 1049 (alt screen), which RenderSnapshot already
+//     emits explicitly from emulator state; listing them here would
+//     double-emit and could fight that logic.
+//   - 7 (DECAWM), whose DECSTR default is already "on" — the common case
+//     needs no restore, and a program that turns wrap off mid-session is
+//     rare enough not to pay for.
+var stickyDECModes = map[int]bool{
+	1:    true, // DECCKM — application cursor keys
+	1000: true, // mouse: normal tracking (press/release)
+	1002: true, // mouse: button-event tracking (drag)
+	1003: true, // mouse: any-event tracking (motion)
+	1004: true, // focus in/out reporting
+	1005: true, // mouse encoding: UTF-8
+	1006: true, // mouse encoding: SGR
+	1015: true, // mouse encoding: urxvt
+	2004: true, // bracketed paste
+}
+
+// maxDECParams caps the parameter bytes we buffer for one sequence. A
+// real "\x1b[?1002;1006h" is a handful of bytes; anything longer is
+// garbage or a binary stream that happens to contain ESC [ ?, and we
+// drop back to ground rather than grow a buffer on it.
+const maxDECParams = 64
+
+type decScanState uint8
+
+const (
+	decGround decScanState = iota // scanning for ESC
+	decEsc                        // saw ESC
+	decCSI                        // saw ESC [
+	decPriv                       // saw ESC [ ?, collecting params
+)
+
+// decModeTracker is a streaming scanner for DEC private mode set/reset
+// (`\x1b[?<params>h` / `...l`). It is a scanner, not a parser: it looks
+// only for the private-mode form and ignores every other sequence, so
+// it cannot be confused by SGR, CUP, OSC payloads and the like.
+//
+// State persists across calls because PTY reads split wherever the
+// kernel happens to cut — a mode sequence can and does arrive in two
+// chunks.
+type decModeTracker struct {
+	state  decScanState
+	params []byte
+	on     map[int]bool
+}
+
+// feed scans p for private mode changes, recording the latest state of
+// every mode in stickyDECModes.
+func (t *decModeTracker) feed(p []byte) {
+	for _, b := range p {
+		switch t.state {
+		case decGround:
+			if b == 0x1b {
+				t.state = decEsc
+			}
+		case decEsc:
+			switch b {
+			case '[':
+				t.state = decCSI
+			case 0x1b:
+				// Another ESC restarts the sequence.
+			default:
+				t.state = decGround
+			}
+		case decCSI:
+			switch {
+			case b == '?':
+				t.state = decPriv
+				t.params = t.params[:0]
+			case b == 0x1b:
+				t.state = decEsc
+			default:
+				// Some other CSI (SGR, CUP, …). Not ours.
+				t.state = decGround
+			}
+		case decPriv:
+			switch {
+			case b >= '0' && b <= '9', b == ';':
+				if len(t.params) >= maxDECParams {
+					t.state = decGround
+					continue
+				}
+				t.params = append(t.params, b)
+			case b == 'h' || b == 'l':
+				t.set(t.params, b == 'h')
+				t.state = decGround
+			case b == 0x1b:
+				t.state = decEsc
+			default:
+				// A private-mode sequence with a final byte we don't
+				// handle (e.g. \x1b[?25$p, a mode query). Not ours.
+				t.state = decGround
+			}
+		}
+	}
+}
+
+// set records each sticky mode named in a ";"-separated parameter list.
+func (t *decModeTracker) set(params []byte, enabled bool) {
+	for _, field := range bytes.Split(params, []byte(";")) {
+		n, err := strconv.Atoi(string(field))
+		if err != nil || !stickyDECModes[n] {
+			continue
+		}
+		if t.on == nil {
+			t.on = make(map[int]bool, len(stickyDECModes))
+		}
+		t.on[n] = enabled
+	}
+}
+
+// restoreBytes returns the sequences needed to re-assert every sticky
+// mode currently enabled, in ascending mode order so the output is
+// deterministic (tests compare it byte-for-byte).
+//
+// Disabled modes emit nothing: a snapshot's DECSTR has already cleared
+// them in the receiving terminal, so an explicit reset would be bytes
+// spent to reach the state we are already in.
+func (t *decModeTracker) restoreBytes() []byte {
+	if len(t.on) == 0 {
+		return nil
+	}
+	modes := make([]int, 0, len(t.on))
+	for mode, enabled := range t.on {
+		if enabled {
+			modes = append(modes, mode)
+		}
+	}
+	if len(modes) == 0 {
+		return nil
+	}
+	sort.Ints(modes)
+
+	var buf bytes.Buffer
+	for _, mode := range modes {
+		buf.WriteString("\x1b[?")
+		buf.WriteString(strconv.Itoa(mode))
+		buf.WriteString("h")
+	}
+	return buf.Bytes()
+}

--- a/internal/session/decmodes.go
+++ b/internal/session/decmodes.go
@@ -114,17 +114,8 @@ type decModeTracker struct {
 }
 
 // feed scans p for private mode changes, recording the latest state of
-// every mode in stickyDECModes. A soft reset (DECSTR, \x1b[!p) or a full
-// reset (RIS, \x1bc) from the program clears the tracked state.
-//
-// That is deliberately more than the receiving terminal does: xterm.js's
-// softReset() resets coreService.decPrivateModes (1, 1004, 2004) but
-// leaves the mouse protocol and encoding alone, and only a full reset
-// clears those too. We drop everything on either, because a program that
-// resets its terminal has abandoned the modes it set, and re-asserting
-// them on the next attach would push modes onto a program that never
-// asked — the failure mode that is actually visible to the user (a plain
-// shell receiving \x1b[200~-wrapped pastes and mouse escapes).
+// every mode in stickyDECModes. A reset from the program clears tracked
+// state, but the two resets clear different amounts — see softReset.
 func (t *decModeTracker) feed(p []byte) {
 	for _, b := range p {
 		switch t.state {
@@ -179,8 +170,9 @@ func (t *decModeTracker) feed(p []byte) {
 		case decBang:
 			switch b {
 			case 'p':
-				// DECSTR — soft reset clears every private mode.
-				t.enabled = t.enabled[:0]
+				// DECSTR — soft reset clears only the ungrouped modes;
+				// see softReset for why the mouse slots survive.
+				t.softReset()
 				t.state = decGround
 			case 0x1b:
 				t.state = decEsc
@@ -189,6 +181,30 @@ func (t *decModeTracker) feed(p []byte) {
 			}
 		}
 	}
+}
+
+// softReset drops the modes a program-issued DECSTR (\x1b[!p) actually
+// clears in the receiving terminal, and only those.
+//
+// The tracker exists to mirror the real client, so it has to split the
+// two resets the way xterm.js 5.5.0 does. softReset() (InputHandler.ts)
+// calls _coreService.reset(), which restores DEFAULT_DEC_PRIVATE_MODES —
+// applicationCursorKeys (1), sendFocus (1004), bracketedPasteMode (2004),
+// i.e. exactly our decGroupNone members. It never touches
+// CoreMouseService, so activeProtocol (9/1000/1002/1003) and
+// activeEncoding (1005/1006/1015) survive a DECSTR. Only RIS clears
+// those: ESC c -> fullReset() -> CoreTerminal.reset(), which calls
+// coreMouseService.reset() as well.
+//
+// Clearing the mouse slots here too would leave the tracker believing
+// mouse reporting is off while the program still has it on, and no
+// replay path would re-assert it — a reattach would silently kill mouse
+// reporting for the life of that tile, which is the same class of bug
+// this file was written to fix.
+func (t *decModeTracker) softReset() {
+	t.enabled = slices.DeleteFunc(t.enabled, func(m int) bool {
+		return decModeGroup[m] == decGroupNone
+	})
 }
 
 // set records each sticky mode named in a ";"-separated parameter list.

--- a/internal/session/decmodes.go
+++ b/internal/session/decmodes.go
@@ -24,8 +24,12 @@ import (
 // chunks. Mouse tracking and app-cursor keys fail the same way, just
 // more visibly.
 //
-// vt10x models none of these (see VT.Write), so we sniff them off the
-// byte stream ourselves.
+// vt10x models some of these (1, 1000/1002/1003, 1004, 1006 all reach
+// its setMode) but not the one that bites — 2004 falls through to
+// "unknown private set/reset mode", as do 1005 and 1015 — and it exposes
+// only a coarse ModeFlag bitmask, not the mode numbers to replay. So we
+// sniff the whole set off the byte stream ourselves rather than stitch
+// two sources of truth together.
 //
 // Deliberately NOT here:
 //   - 25 (DECTCEM) and 1049 (alt screen), which RenderSnapshot already
@@ -36,6 +40,7 @@ import (
 //     rare enough not to pay for.
 var stickyDECModes = map[int]bool{
 	1:    true, // DECCKM — application cursor keys
+	9:    true, // mouse: X10 compatibility
 	1000: true, // mouse: normal tracking (press/release)
 	1002: true, // mouse: button-event tracking (drag)
 	1003: true, // mouse: any-event tracking (motion)
@@ -44,6 +49,34 @@ var stickyDECModes = map[int]bool{
 	1006: true, // mouse encoding: SGR
 	1015: true, // mouse encoding: urxvt
 	2004: true, // bracketed paste
+}
+
+// Exclusive groups. The receiving terminal keeps ONE slot per group, not
+// a flag per mode: xterm.js parks 9/1000/1002/1003 in
+// coreMouseService.activeProtocol and 1005/1006/1015 in activeEncoding.
+// So setting any member supersedes whichever member was on, and
+// resetting ANY member clears the slot outright — `\x1b[?1002l` sets the
+// protocol to NONE even if 1000 was set earlier and never reset.
+//
+// Tracking the group rather than the individual modes is what keeps the
+// restore honest in the reset direction: without it, a program that
+// downgrades 1000 -> 1002 -> 1002l leaves 1000 marked on, and the
+// reattach snapshot turns mouse reporting back on for a program that
+// switched it off — the client then feeds it mouse escapes as input.
+const (
+	decGroupNone = iota
+	decGroupMouseProtocol
+	decGroupMouseEncoding
+)
+
+var decModeGroup = map[int]int{
+	9:    decGroupMouseProtocol,
+	1000: decGroupMouseProtocol,
+	1002: decGroupMouseProtocol,
+	1003: decGroupMouseProtocol,
+	1005: decGroupMouseEncoding,
+	1006: decGroupMouseEncoding,
+	1015: decGroupMouseEncoding,
 }
 
 // maxDECParams caps the parameter bytes we buffer for one sequence. A
@@ -74,19 +107,24 @@ type decModeTracker struct {
 	state  decScanState
 	params []byte
 	// enabled holds the sticky modes currently on, in the order the
-	// program turned them on. Order is the state, not decoration:
-	// 1000/1002/1003 (and the 1005/1006/1015 encodings) are mutually
-	// exclusive groups where the last one set wins, so replaying them in
-	// any other order can leave the terminal in a mode the program never
-	// asked for.
+	// program turned them on. At most one member of each exclusive group
+	// (see decModeGroup) is ever present; set order is kept only so the
+	// restore bytes are deterministic.
 	enabled []int
 }
 
 // feed scans p for private mode changes, recording the latest state of
 // every mode in stickyDECModes. A soft reset (DECSTR, \x1b[!p) or a full
-// reset (RIS, \x1bc) from the program clears the tracked state: the
-// receiving terminal drops every private mode on those, so re-asserting
-// afterwards would push modes the program had abandoned.
+// reset (RIS, \x1bc) from the program clears the tracked state.
+//
+// That is deliberately more than the receiving terminal does: xterm.js's
+// softReset() resets coreService.decPrivateModes (1, 1004, 2004) but
+// leaves the mouse protocol and encoding alone, and only a full reset
+// clears those too. We drop everything on either, because a program that
+// resets its terminal has abandoned the modes it set, and re-asserting
+// them on the next attach would push modes onto a program that never
+// asked — the failure mode that is actually visible to the user (a plain
+// shell receiving \x1b[200~-wrapped pastes and mouse escapes).
 func (t *decModeTracker) feed(p []byte) {
 	for _, b := range p {
 		switch t.state {
@@ -154,16 +192,20 @@ func (t *decModeTracker) feed(p []byte) {
 }
 
 // set records each sticky mode named in a ";"-separated parameter list.
-// Re-setting a mode that is already on moves it to the end: within an
-// exclusive group the terminal honours whichever was set last, so the
-// tracker has to remember which that was.
+// A mode in an exclusive group takes its group's slot: setting it evicts
+// whichever member held the slot, and resetting any member empties the
+// slot rather than uncovering the previous occupant — see decModeGroup
+// for why the terminal behaves that way.
 func (t *decModeTracker) set(params []byte, enabled bool) {
 	for _, field := range bytes.Split(params, []byte(";")) {
 		n, err := strconv.Atoi(string(field))
 		if err != nil || !stickyDECModes[n] {
 			continue
 		}
-		t.enabled = slices.DeleteFunc(t.enabled, func(m int) bool { return m == n })
+		group := decModeGroup[n]
+		t.enabled = slices.DeleteFunc(t.enabled, func(m int) bool {
+			return m == n || (group != decGroupNone && decModeGroup[m] == group)
+		})
 		if enabled {
 			t.enabled = append(t.enabled, n)
 		}
@@ -171,10 +213,11 @@ func (t *decModeTracker) set(params []byte, enabled bool) {
 }
 
 // restoreBytes returns the sequences needed to re-assert every sticky
-// mode currently enabled, in the order the program set them — which is
-// both deterministic (tests compare it byte-for-byte) and the only
-// ordering that reproduces the program's intent across the exclusive
-// mode groups.
+// mode currently enabled, in the order the program set them — which
+// makes the output deterministic (tests compare it byte-for-byte).
+// Order carries no meaning beyond that: at most one member of each
+// exclusive group is ever enabled, so no replay order can land the
+// terminal in a mode the program did not ask for.
 //
 // Disabled modes emit nothing: a snapshot's DECSTR has already cleared
 // them in the receiving terminal, so an explicit reset would be bytes

--- a/internal/session/decmodes_test.go
+++ b/internal/session/decmodes_test.go
@@ -45,10 +45,8 @@ func TestSnapshotRestoresMouseAndCursorModes(t *testing.T) {
 	}
 }
 
-func TestSnapshotOmitsDisabledModes(t *testing.T) {
+func TestSnapshotResetsDisabledModes(t *testing.T) {
 	v := NewVT(80, 24)
-	// Enabled then disabled: DECSTR already leaves the client with the
-	// mode off, so re-asserting anything would be wrong.
 	v.Write([]byte("\x1b[?2004h\x1b[?1002h"))
 	v.Write([]byte("\x1b[?2004l"))
 
@@ -56,8 +54,50 @@ func TestSnapshotOmitsDisabledModes(t *testing.T) {
 	if bytes.Contains(snap, []byte("\x1b[?2004h")) {
 		t.Error("snapshot re-enables a mode the program turned off")
 	}
+	if !bytes.Contains(snap, []byte("\x1b[?2004l")) {
+		t.Error("snapshot must state the off mode explicitly, not stay silent")
+	}
 	if !bytes.Contains(snap, []byte("\x1b[?1002h")) {
 		t.Error("snapshot dropped a mode that is still on")
+	}
+}
+
+// The defect the ever-seen gate closes, and the one an "omits disabled
+// modes" assertion written only against 2004 could never catch.
+//
+// The ordinary reattach path does NOT term.reset() the tile — it reuses
+// the live xterm and leans on the snapshot's DECSTR preamble. But
+// xterm's softReset() restores coreService.decPrivateModes only; it
+// never calls into CoreMouseService. So for 2004 silence happens to be
+// correct, and for 1002/1006 it is a bug: a TUI that enables mouse
+// tracking, then exits and sends the reset while the sink is
+// unregistered, leaves the reattached tile still reporting clicks —
+// \x1b[<0;12;5M typed into a plain shell.
+func TestSnapshotResetsDisabledGroupedModes(t *testing.T) {
+	v := NewVT(80, 24)
+	// A TUI's opening, then its exit sequence.
+	v.Write([]byte("\x1b[?1002h\x1b[?1006h"))
+	v.Write([]byte("\x1b[?1006l\x1b[?1002l"))
+
+	snap := v.RenderSnapshot()
+	for _, want := range []string{"\x1b[?1002l", "\x1b[?1006l"} {
+		if !bytes.Contains(snap, []byte(want)) {
+			t.Errorf("snapshot must turn %q off explicitly; DECSTR does not "+
+				"reach xterm's CoreMouseService.\nsnapshot: %q", want, snap)
+		}
+	}
+}
+
+// Never-seen modes stay silent. This is what keeps a session that used
+// no sticky mode replaying byte-identical to the ring (and emitting no
+// CAN either) — see TestReplayWithNoModesIsJustTheRing.
+func TestRestoreIsSilentForUntouchedModes(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("\x1b[?2004h\x1b[?2004l"))
+
+	got := v.decModes.restoreBytes()
+	if want := "\x1b[?2004l"; string(got) != want {
+		t.Fatalf("only the touched mode should speak: got %q, want %q", got, want)
 	}
 }
 
@@ -125,7 +165,7 @@ func TestReplayWithNoModesIsJustTheRing(t *testing.T) {
 	v := NewVT(80, 24)
 	v.Write([]byte("plain output\r\n"))
 
-	if got, want := v.ReplayBytes(), v.RingBytes(); !bytes.Equal(got, want) {
+	if got, want := v.ReplayBytes(), v.ringBytes(); !bytes.Equal(got, want) {
 		t.Fatalf("got %q, want %q", got, want)
 	}
 }
@@ -143,7 +183,7 @@ func TestReplayRestoresModesAfterRingOverflow(t *testing.T) {
 		v.Write(chunk)
 	}
 
-	if bytes.Contains(v.RingBytes(), []byte("\x1b[?2004h")) {
+	if bytes.Contains(v.ringBytes(), []byte("\x1b[?2004h")) {
 		t.Fatal("ring did not overflow past the mode sequence; this test is no " +
 			"longer exercising the case it exists for — check ringCap and the write loop")
 	}
@@ -180,18 +220,22 @@ func TestRestoreKeepsOnlyTheLastModeOfAnExclusiveGroup(t *testing.T) {
 // memory of an earlier member. Uncovering the previous occupant would
 // turn mouse reporting back on for a program that switched it off, and
 // the client would then feed it mouse escapes as keyboard input.
+// The group is ONE slot, so a reset of any member leaves the group with
+// one thing to say and it is `l` — never an `h` for some earlier member
+// uncovered by the reset, and never silence (see
+// TestSnapshotResetsDisabledGroupedModes for why silence is wrong).
 func TestRestoreDropsTheWholeGroupOnReset(t *testing.T) {
-	for _, tc := range []struct{ name, in string }{
-		{"reset the current member", "\x1b[?1000h\x1b[?1002h\x1b[?1002l"},
-		{"reset a superseded member", "\x1b[?1000h\x1b[?1002h\x1b[?1000l"},
-		{"encoding group", "\x1b[?1015h\x1b[?1006h\x1b[?1006l"},
+	for _, tc := range []struct{ name, in, want string }{
+		{"reset the current member", "\x1b[?1000h\x1b[?1002h\x1b[?1002l", "\x1b[?1002l"},
+		{"reset a superseded member", "\x1b[?1000h\x1b[?1002h\x1b[?1000l", "\x1b[?1000l"},
+		{"encoding group", "\x1b[?1015h\x1b[?1006h\x1b[?1006l", "\x1b[?1006l"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			v := NewVT(80, 24)
 			v.Write([]byte(tc.in))
 
-			if got := v.decModes.restoreBytes(); len(got) != 0 {
-				t.Fatalf("mouse mode survived a group reset: %q", got)
+			if got := v.decModes.restoreBytes(); !bytes.Equal(got, []byte(tc.want)) {
+				t.Fatalf("got %q, want %q", got, tc.want)
 			}
 		})
 	}
@@ -213,9 +257,9 @@ func TestTrackerClearsUngroupedModesOnDECSTR(t *testing.T) {
 	v.Write([]byte("\x1b[!p"))
 
 	got := v.decModes.restoreBytes()
-	for _, gone := range []string{"\x1b[?1h", "\x1b[?1004h", "\x1b[?2004h"} {
-		if bytes.Contains(got, []byte(gone)) {
-			t.Errorf("DECSTR should have cleared %q; restore is %q", gone, got)
+	for _, off := range []string{"\x1b[?1l", "\x1b[?1004l", "\x1b[?2004l"} {
+		if !bytes.Contains(got, []byte(off)) {
+			t.Errorf("DECSTR should have cleared %q; restore is %q", off, got)
 		}
 	}
 	// The mouse slots survive a DECSTR in the real client. Forgetting
@@ -233,8 +277,17 @@ func TestTrackerClearsEverythingOnRIS(t *testing.T) {
 	v.Write([]byte("\x1b[?1h\x1b[?1004h\x1b[?2004h\x1b[?1002h\x1b[?1006h"))
 	v.Write([]byte("\x1bc"))
 
-	if got := v.decModes.restoreBytes(); len(got) != 0 {
-		t.Fatalf("modes survived a RIS from the program: %q", got)
+	// RIS clears every enabled flag, but the modes stay SEEN: the client
+	// we reattach is not the one the program RIS'd, so the snapshot still
+	// has to say "off" out loud.
+	got := v.decModes.restoreBytes()
+	if bytes.ContainsRune(got, 'h') {
+		t.Fatalf("a mode survived a RIS from the program: %q", got)
+	}
+	for _, off := range []string{"\x1b[?1l", "\x1b[?1004l", "\x1b[?2004l", "\x1b[?1002l", "\x1b[?1006l"} {
+		if !bytes.Contains(got, []byte(off)) {
+			t.Errorf("RIS restore is missing %q; got %q", off, got)
+		}
 	}
 }
 

--- a/internal/session/decmodes_test.go
+++ b/internal/session/decmodes_test.go
@@ -1,0 +1,138 @@
+package session
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The bug these guard: a program enables bracketed paste (and mouse
+// tracking, and app-cursor keys) once at startup. Any reattach or
+// width-changing replay repaints the client from RenderSnapshot, whose
+// DECSTR preamble clears exactly those modes — and nothing re-asserted
+// them, so the tile lost them for the life of the session. Symptom:
+// a >1 KiB paste arrives unframed and the agent splits it at the macOS
+// PTY input-buffer boundary into several "pasted text" chunks.
+
+func TestSnapshotRestoresBracketedPaste(t *testing.T) {
+	v := NewVT(80, 24)
+	// What a real agent sends on startup, interleaved with output so the
+	// scanner has to find it in a stream rather than at a chunk boundary.
+	v.Write([]byte("hello\x1b[?2004h world\r\n"))
+
+	snap := v.RenderSnapshot()
+	if !bytes.Contains(snap, []byte("\x1b[?2004h")) {
+		t.Fatalf("snapshot does not re-enable bracketed paste.\nsnapshot: %q", snap)
+	}
+	// Ordering is the whole point: DECSTR must not land after the
+	// re-assert, or it clears what we just restored.
+	if bytes.Index(snap, []byte("\x1b[!p")) > bytes.Index(snap, []byte("\x1b[?2004h")) {
+		t.Fatal("soft reset comes after the mode restore; it would clear it")
+	}
+}
+
+func TestSnapshotRestoresMouseAndCursorModes(t *testing.T) {
+	v := NewVT(80, 24)
+	// A TUI's typical opening: app cursor keys, button-event mouse
+	// tracking with SGR encoding, focus reporting, bracketed paste.
+	v.Write([]byte("\x1b[?1h\x1b[?1002;1006h\x1b[?1004h\x1b[?2004h"))
+
+	snap := v.RenderSnapshot()
+	for _, mode := range []string{"\x1b[?1h", "\x1b[?1002h", "\x1b[?1006h", "\x1b[?1004h", "\x1b[?2004h"} {
+		if !bytes.Contains(snap, []byte(mode)) {
+			t.Errorf("snapshot is missing %q", mode)
+		}
+	}
+}
+
+func TestSnapshotOmitsDisabledModes(t *testing.T) {
+	v := NewVT(80, 24)
+	// Enabled then disabled: DECSTR already leaves the client with the
+	// mode off, so re-asserting anything would be wrong.
+	v.Write([]byte("\x1b[?2004h\x1b[?1002h"))
+	v.Write([]byte("\x1b[?2004l"))
+
+	snap := v.RenderSnapshot()
+	if bytes.Contains(snap, []byte("\x1b[?2004h")) {
+		t.Error("snapshot re-enables a mode the program turned off")
+	}
+	if !bytes.Contains(snap, []byte("\x1b[?1002h")) {
+		t.Error("snapshot dropped a mode that is still on")
+	}
+}
+
+// A PTY read is cut wherever the kernel happens to cut it, so a mode
+// sequence routinely arrives in two pieces. Scanning each Write in
+// isolation would miss it — and miss it silently.
+func TestModeSequenceSplitAcrossWrites(t *testing.T) {
+	for _, split := range []int{1, 2, 3, 4, 5, 6, 7} {
+		seq := "\x1b[?2004h"
+		v := NewVT(80, 24)
+		v.Write([]byte(seq[:split]))
+		v.Write([]byte(seq[split:]))
+
+		if !bytes.Contains(v.RenderSnapshot(), []byte("\x1b[?2004h")) {
+			t.Errorf("split after %d byte(s): mode was not tracked", split)
+		}
+	}
+}
+
+func TestReplayBytesAppendsModesAfterRing(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("\x1b[?2004hsome output\r\n"))
+
+	replay := v.ReplayBytes()
+	if !bytes.HasSuffix(replay, []byte("\x1b[?2004h")) {
+		t.Fatalf("replay must end with the mode restore so the ring cannot\n"+
+			"overwrite it; got tail %q", tail(replay, 24))
+	}
+	if !bytes.Contains(replay, []byte("some output")) {
+		t.Error("replay dropped the ring contents")
+	}
+}
+
+// The ring is capped, so on a long session the original mode sequences
+// scroll out of it entirely. That is precisely when a re-replay used to
+// produce a tile with bracketed paste off, and it is why ReplayBytes
+// appends live state instead of trusting the ring.
+func TestReplayRestoresModesAfterRingOverflow(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("\x1b[?2004h"))
+	// Overflow the ring so the set sequence is trimmed away.
+	chunk := []byte(strings.Repeat("x", 64<<10) + "\r\n")
+	for written := 0; written < ringCap+(1<<20); written += len(chunk) {
+		v.Write(chunk)
+	}
+
+	if bytes.Contains(v.RingBytes(), []byte("\x1b[?2004h")) {
+		t.Skip("ring did not overflow past the mode sequence; test is not exercising the case")
+	}
+	if !bytes.Contains(v.ReplayBytes(), []byte("\x1b[?2004h")) {
+		t.Fatal("mode was trimmed out of the ring and never re-asserted")
+	}
+}
+
+// Guard against the scanner mistaking ordinary output for a mode change.
+func TestTrackerIgnoresNonModeSequences(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte(
+		"\x1b[31mred\x1b[m" + // SGR
+			"\x1b[10;20H" + // CUP
+			"\x1b]0;a title\x07" + // OSC
+			"\x1b[?25l" + // DECTCEM: snapshot owns this one
+			"\x1b[?1049h" + // alt screen: snapshot owns this one too
+			"\x1b[?2004$p", // a mode *query*, not a set
+	))
+
+	restore := v.decModes.restoreBytes()
+	if len(restore) != 0 {
+		t.Fatalf("tracker claimed modes from non-set sequences: %q", restore)
+	}
+}
+
+func tail(b []byte, n int) []byte {
+	if len(b) <= n {
+		return b
+	}
+	return b[len(b)-n:]
+}

--- a/internal/session/decmodes_test.go
+++ b/internal/session/decmodes_test.go
@@ -105,10 +105,58 @@ func TestReplayRestoresModesAfterRingOverflow(t *testing.T) {
 	}
 
 	if bytes.Contains(v.RingBytes(), []byte("\x1b[?2004h")) {
-		t.Skip("ring did not overflow past the mode sequence; test is not exercising the case")
+		t.Fatal("ring did not overflow past the mode sequence; this test is no " +
+			"longer exercising the case it exists for — check ringCap and the write loop")
 	}
 	if !bytes.Contains(v.ReplayBytes(), []byte("\x1b[?2004h")) {
 		t.Fatal("mode was trimmed out of the ring and never re-asserted")
+	}
+}
+
+// 1000/1002/1003 are an exclusive group: the terminal honours whichever
+// was set last. A program that downgrades 1003 -> 1002 without sending
+// \x1b[?1003l leaves both marked on, so replaying them in numeric order
+// would end on 1003 and feed the program motion events it never asked
+// for. The restore has to replay in set order.
+func TestRestoreKeepsSetOrderWithinExclusiveGroup(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("\x1b[?1003h\x1b[?1002h"))
+
+	got := v.decModes.restoreBytes()
+	if want := []byte("\x1b[?1003h\x1b[?1002h"); !bytes.Equal(got, want) {
+		t.Fatalf("restore reordered an exclusive group: got %q, want %q", got, want)
+	}
+}
+
+// Re-setting a mode that is already on makes it the most recent again.
+func TestRestoreMovesResetModeToTheEnd(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("\x1b[?1002h\x1b[?1003h\x1b[?1002h"))
+
+	got := v.decModes.restoreBytes()
+	if want := []byte("\x1b[?1003h\x1b[?1002h"); !bytes.Equal(got, want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// The mirror image of the bug this file exists for: when the *program*
+// resets the terminal, the modes are gone in the receiving terminal too,
+// and re-asserting them would push bracketed paste onto a plain shell
+// that never enabled it — pastes then arrive wrapped in literal \x1b[200~.
+func TestTrackerClearsOnProgramReset(t *testing.T) {
+	for name, reset := range map[string]string{
+		"DECSTR": "\x1b[!p",
+		"RIS":    "\x1bc",
+	} {
+		t.Run(name, func(t *testing.T) {
+			v := NewVT(80, 24)
+			v.Write([]byte("\x1b[?2004h\x1b[?1002h"))
+			v.Write([]byte(reset))
+
+			if got := v.decModes.restoreBytes(); len(got) != 0 {
+				t.Fatalf("modes survived a %s from the program: %q", name, got)
+			}
+		})
 	}
 }
 

--- a/internal/session/decmodes_test.go
+++ b/internal/session/decmodes_test.go
@@ -91,6 +91,45 @@ func TestReplayBytesAppendsModesAfterRing(t *testing.T) {
 	}
 }
 
+// appendRing only normalises the FRONT of the ring to a safe replay
+// boundary. The tail is wherever the last PTY read stopped, so the ring
+// routinely ends mid-sequence — and a mode restore concatenated straight
+// onto that is consumed as the unterminated sequence's payload, which is
+// the restore silently doing nothing. CAN (0x18) aborts whatever the cut
+// left open, in every parser state, and is inert in plain text.
+func TestReplayAbortsAnUnterminatedRingTail(t *testing.T) {
+	for _, tc := range []struct{ name, tail string }{
+		{"mid-CSI", "\x1b[3"},
+		{"mid-CSI-private", "\x1b[?10"},
+		{"mid-OSC", "\x1b]0;a par"},
+		{"mid-DCS", "\x1bP1;2|payloa"},
+		{"clean text", "all done"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewVT(80, 24)
+			v.Write([]byte("\x1b[?2004h"))
+			v.Write([]byte(tc.tail))
+
+			want := "\x18\x1b[?2004h"
+			if got := v.ReplayBytes(); !bytes.HasSuffix(got, []byte(want)) {
+				t.Fatalf("replay must end with CAN + the mode restore so a cut\n"+
+					"sequence cannot swallow it; got tail %q", tail(got, 24))
+			}
+		})
+	}
+}
+
+// No modes set means nothing to protect, so no CAN either — a bare
+// re-replay of the ring must stay byte-identical to the ring.
+func TestReplayWithNoModesIsJustTheRing(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("plain output\r\n"))
+
+	if got, want := v.ReplayBytes(), v.RingBytes(); !bytes.Equal(got, want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 // The ring is capped, so on a long session the original mode sequences
 // scroll out of it entirely. That is precisely when a re-replay used to
 // produce a tile with bracketed paste off, and it is why ReplayBytes
@@ -162,20 +201,40 @@ func TestRestoreDropsTheWholeGroupOnReset(t *testing.T) {
 // resets the terminal, the modes are gone in the receiving terminal too,
 // and re-asserting them would push bracketed paste onto a plain shell
 // that never enabled it — pastes then arrive wrapped in literal \x1b[200~.
-func TestTrackerClearsOnProgramReset(t *testing.T) {
-	for name, reset := range map[string]string{
-		"DECSTR": "\x1b[!p",
-		"RIS":    "\x1bc",
-	} {
-		t.Run(name, func(t *testing.T) {
-			v := NewVT(80, 24)
-			v.Write([]byte("\x1b[?2004h\x1b[?1002h"))
-			v.Write([]byte(reset))
+//
+// The two resets are NOT the same amount, and the tracker has to mirror
+// the real client rather than pick the tidier rule. In xterm.js 5.5.0
+// softReset() resets coreService.decPrivateModes only (1, 1004, 2004)
+// and leaves CoreMouseService alone; fullReset() goes through
+// CoreTerminal.reset(), which resets the mouse service too.
+func TestTrackerClearsUngroupedModesOnDECSTR(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("\x1b[?1h\x1b[?1004h\x1b[?2004h\x1b[?1002h\x1b[?1006h"))
+	v.Write([]byte("\x1b[!p"))
 
-			if got := v.decModes.restoreBytes(); len(got) != 0 {
-				t.Fatalf("modes survived a %s from the program: %q", name, got)
-			}
-		})
+	got := v.decModes.restoreBytes()
+	for _, gone := range []string{"\x1b[?1h", "\x1b[?1004h", "\x1b[?2004h"} {
+		if bytes.Contains(got, []byte(gone)) {
+			t.Errorf("DECSTR should have cleared %q; restore is %q", gone, got)
+		}
+	}
+	// The mouse slots survive a DECSTR in the real client. Forgetting
+	// them here would leave a reattach unable to re-assert mouse
+	// reporting the program still has on.
+	for _, kept := range []string{"\x1b[?1002h", "\x1b[?1006h"} {
+		if !bytes.Contains(got, []byte(kept)) {
+			t.Errorf("DECSTR must not clear %q; restore is %q", kept, got)
+		}
+	}
+}
+
+func TestTrackerClearsEverythingOnRIS(t *testing.T) {
+	v := NewVT(80, 24)
+	v.Write([]byte("\x1b[?1h\x1b[?1004h\x1b[?2004h\x1b[?1002h\x1b[?1006h"))
+	v.Write([]byte("\x1bc"))
+
+	if got := v.decModes.restoreBytes(); len(got) != 0 {
+		t.Fatalf("modes survived a RIS from the program: %q", got)
 	}
 }
 

--- a/internal/session/decmodes_test.go
+++ b/internal/session/decmodes_test.go
@@ -113,29 +113,48 @@ func TestReplayRestoresModesAfterRingOverflow(t *testing.T) {
 	}
 }
 
-// 1000/1002/1003 are an exclusive group: the terminal honours whichever
-// was set last. A program that downgrades 1003 -> 1002 without sending
-// \x1b[?1003l leaves both marked on, so replaying them in numeric order
-// would end on 1003 and feed the program motion events it never asked
-// for. The restore has to replay in set order.
-func TestRestoreKeepsSetOrderWithinExclusiveGroup(t *testing.T) {
-	v := NewVT(80, 24)
-	v.Write([]byte("\x1b[?1003h\x1b[?1002h"))
+// 9/1000/1002/1003 share one slot in the receiving terminal
+// (xterm.js: coreMouseService.activeProtocol), so setting one supersedes
+// whichever was on. A program that downgrades 1003 -> 1002 without
+// sending \x1b[?1003l must not have 1003 replayed at it, in any order.
+func TestRestoreKeepsOnlyTheLastModeOfAnExclusiveGroup(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"protocol downgrade", "\x1b[?1003h\x1b[?1002h", "\x1b[?1002h"},
+		{"protocol re-set", "\x1b[?1002h\x1b[?1003h\x1b[?1002h", "\x1b[?1002h"},
+		{"x10 supersedes", "\x1b[?1000h\x1b[?9h", "\x1b[?9h"},
+		{"encoding group", "\x1b[?1015h\x1b[?1006h", "\x1b[?1006h"},
+		{"groups are independent", "\x1b[?1002h\x1b[?1006h", "\x1b[?1002h\x1b[?1006h"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewVT(80, 24)
+			v.Write([]byte(tc.in))
 
-	got := v.decModes.restoreBytes()
-	if want := []byte("\x1b[?1003h\x1b[?1002h"); !bytes.Equal(got, want) {
-		t.Fatalf("restore reordered an exclusive group: got %q, want %q", got, want)
+			if got := v.decModes.restoreBytes(); !bytes.Equal(got, []byte(tc.want)) {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
-// Re-setting a mode that is already on makes it the most recent again.
-func TestRestoreMovesResetModeToTheEnd(t *testing.T) {
-	v := NewVT(80, 24)
-	v.Write([]byte("\x1b[?1002h\x1b[?1003h\x1b[?1002h"))
+// Resetting ANY member of an exclusive group empties the slot — xterm.js
+// maps 9/1000/1002/1003 in DECRST to activeProtocol="NONE" flat, with no
+// memory of an earlier member. Uncovering the previous occupant would
+// turn mouse reporting back on for a program that switched it off, and
+// the client would then feed it mouse escapes as keyboard input.
+func TestRestoreDropsTheWholeGroupOnReset(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"reset the current member", "\x1b[?1000h\x1b[?1002h\x1b[?1002l"},
+		{"reset a superseded member", "\x1b[?1000h\x1b[?1002h\x1b[?1000l"},
+		{"encoding group", "\x1b[?1015h\x1b[?1006h\x1b[?1006l"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := NewVT(80, 24)
+			v.Write([]byte(tc.in))
 
-	got := v.decModes.restoreBytes()
-	if want := []byte("\x1b[?1003h\x1b[?1002h"); !bytes.Equal(got, want) {
-		t.Fatalf("got %q, want %q", got, want)
+			if got := v.decModes.restoreBytes(); len(got) != 0 {
+				t.Fatalf("mouse mode survived a group reset: %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -397,8 +397,9 @@ func (s *Session) SubscribeWithAtomicReplay(sink Sink, writeFn func(replay []byt
 	// types get a compact snapshot (alt-screen: one screen, no scrollback;
 	// normal: one screen + historyRows of history, sized to match xterm's
 	// own scrollback cap), avoiding the many-tile startup flood. Only the
-	// resize-driven re-replay (EmitAtomicReplay) still streams the raw ring,
-	// and only for reflow recovery.
+	// resize-driven re-replay (EmitAtomicReplay) streams the ring, and only
+	// for reflow recovery — with the live DEC private modes appended, since
+	// the ring may have trimmed the original set sequences away.
 	replay, snapshot := s.vt.InitialReplayBytes()
 	// Logged so hived.log proves which path ran per attach — a snapshot
 	// line here (vs a multi-MB ring) is the unconfounded signal that the
@@ -415,8 +416,9 @@ func (s *Session) SubscribeWithAtomicReplay(sink Sink, writeFn func(replay []byt
 	}, nil
 }
 
-// EmitAtomicReplay runs writeFn with the current ring snapshot under
-// s.mu, so no deliver runs while writeFn writes. Used by clients
+// EmitAtomicReplay runs writeFn with the current replay bytes (the ring
+// plus the DEC private modes still in force) under s.mu, so no deliver
+// runs while writeFn writes. Used by clients
 // asking for a re-replay mid-attach (FrameRequestReplay) where the
 // sink is already registered — we still need the snapshot to be
 // captured atomically with the wire write to prevent live bytes from

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -424,7 +424,7 @@ func (s *Session) SubscribeWithAtomicReplay(sink Sink, writeFn func(replay []byt
 func (s *Session) EmitAtomicReplay(writeFn func(replay []byte) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return writeFn(s.vt.RingBytes())
+	return writeFn(s.vt.ReplayBytes())
 }
 
 // Write forwards bytes from a client to the PTY (i.e. keystrokes).

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -82,6 +82,11 @@ type VT struct {
 	// mid-multibyte rune. Used by clients to repaint xterm.js from a
 	// clean slate after a width-changing resize.
 	ring []byte
+
+	// decModes tracks the DEC private modes a reattaching client has to
+	// be told about again, because our snapshot preamble (DECSTR) clears
+	// them and the program never re-sends them. See decmodes.go.
+	decModes decModeTracker
 }
 
 // Title returns the window title the program most recently set via
@@ -137,6 +142,7 @@ func (v *VT) Write(p []byte) (int, error) {
 	defer v.mu.Unlock()
 
 	v.appendRing(p)
+	v.decModes.feed(p)
 
 	cols, rows := v.term.Size()
 	// The eviction heuristic can only see rows-1 lines of scroll per pass
@@ -482,6 +488,29 @@ func (v *VT) RingBytes() []byte {
 	return out
 }
 
+// ReplayBytes returns the ring followed by the DEC private modes that
+// are currently set — what a client should render to rebuild a tile
+// from scratch on a width-changing re-replay.
+//
+// The mode bytes go last, and they are needed even though the ring is a
+// full byte history, for two reasons: the client term.reset()s before
+// consuming the replay, and the ring is capped (ringCap), so on a
+// long-lived session the original set sequences have usually been
+// trimmed off the front. Appending the live state rather than trusting
+// the ring makes the outcome independent of how much history survived.
+func (v *VT) ReplayBytes() []byte {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	modes := v.decModes.restoreBytes()
+	if len(v.ring) == 0 && len(modes) == 0 {
+		return nil
+	}
+	out := make([]byte, 0, len(v.ring)+len(modes))
+	out = append(out, v.ring...)
+	out = append(out, modes...)
+	return out
+}
+
 // Resize updates the emulator's grid dimensions. Returns nil for now;
 // vt10x.Resize doesn't surface errors. History rows captured at the old
 // width remain in the ring as-is — re-laying them out is not worth the
@@ -581,6 +610,13 @@ func (v *VT) RenderSnapshot() []byte {
 	} else {
 		buf.WriteString("\x1b[?25l")
 	}
+
+	// Last, so nothing above can clobber it: re-assert the DEC private
+	// modes the program set and our own \x1b[!p just cleared. Without
+	// this a reattached tile loses bracketed paste, mouse tracking and
+	// app-cursor keys for the life of the session — the program has no
+	// idea a new client arrived and never sends them again.
+	buf.Write(v.decModes.restoreBytes())
 
 	return buf.Bytes()
 }

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -474,10 +474,13 @@ func (v *VT) InitialReplayBytes() (replay []byte, snapshot bool) {
 	return v.RenderSnapshot(), true
 }
 
-// RingBytes returns a defensive copy of the raw-byte scrollback ring.
-// Callers can stream the result to a client that wants to repaint
-// xterm.js from a clean slate after a width-changing resize.
-func (v *VT) RingBytes() []byte {
+// ringBytes returns a defensive copy of the raw-byte scrollback ring.
+//
+// Unexported on purpose: nothing outside this package streams the bare
+// ring any more. Every replay path goes through ReplayBytes, which
+// appends the DEC mode restore the ring cannot be trusted to contain.
+// This accessor exists so the ring's own tests can inspect it.
+func (v *VT) ringBytes() []byte {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	if len(v.ring) == 0 {

--- a/internal/session/vt.go
+++ b/internal/session/vt.go
@@ -498,6 +498,19 @@ func (v *VT) RingBytes() []byte {
 // long-lived session the original set sequences have usually been
 // trimmed off the front. Appending the live state rather than trusting
 // the ring makes the outcome independent of how much history survived.
+//
+// CAN (0x18) separates the two. appendRing only normalises the FRONT of
+// the ring to a safe replay boundary; the tail is wherever the last PTY
+// read happened to stop, which can be mid-CSI, mid-OSC or mid-DCS. Our
+// mode bytes would then be swallowed as that sequence's payload and the
+// restore would silently do nothing — the exact failure this whole file
+// exists to prevent. CAN aborts any in-progress sequence: xterm.js
+// registers it as an "anywhere" rule for every parser state (and it is
+// excluded from EXECUTABLES, so the OSC/SOS overrides do not shadow it),
+// landing the parser in GROUND with no handler bound to it, i.e. inert.
+// ST ("\x1b\\") is weaker — it terminates only string sequences, and in
+// xterm.js an ESC inside OSC dispatches OSC_END into GROUND, so the
+// trailing backslash would print as literal text.
 func (v *VT) ReplayBytes() []byte {
 	v.mu.Lock()
 	defer v.mu.Unlock()
@@ -505,9 +518,12 @@ func (v *VT) ReplayBytes() []byte {
 	if len(v.ring) == 0 && len(modes) == 0 {
 		return nil
 	}
-	out := make([]byte, 0, len(v.ring)+len(modes))
+	out := make([]byte, 0, len(v.ring)+len(modes)+1)
 	out = append(out, v.ring...)
-	out = append(out, modes...)
+	if len(modes) > 0 {
+		out = append(out, 0x18) // CAN — abort any sequence the ring cut in half
+		out = append(out, modes...)
+	}
 	return out
 }
 

--- a/internal/session/vt_test.go
+++ b/internal/session/vt_test.go
@@ -153,7 +153,7 @@ func TestInitialReplayBytesAltScreen(t *testing.T) {
 	if _, err := v.Write(big); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	ring := v.RingBytes()
+	ring := v.ringBytes()
 	initial, snapshot := v.InitialReplayBytes()
 	if len(ring) < 50_000 {
 		t.Fatalf("test setup: ring too small (%d) to prove the point", len(ring))
@@ -187,7 +187,7 @@ func TestInitialReplayBytesNormalScreen(t *testing.T) {
 			t.Fatalf("write: %v", err)
 		}
 	}
-	ring := v.RingBytes()
+	ring := v.ringBytes()
 	if len(ring) < 2<<20 {
 		t.Fatalf("test setup: ring too small (%d B) to prove the point", len(ring))
 	}
@@ -619,7 +619,7 @@ func TestVT_RingCapturesAllBytes(t *testing.T) {
 		}
 		want.Write(c)
 	}
-	got := v.RingBytes()
+	got := v.ringBytes()
 	if !bytes.Equal(got, want.Bytes()) {
 		t.Errorf("ring mismatch:\n  got  %q\n  want %q", got, want.Bytes())
 	}
@@ -641,7 +641,7 @@ func TestVT_RingOverflowDropsAtSafeBoundary(t *testing.T) {
 	if _, err := v.Write(stream.Bytes()); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got := v.RingBytes()
+	got := v.ringBytes()
 	if len(got) == 0 {
 		t.Fatalf("ring empty after overflowing write")
 	}
@@ -675,7 +675,7 @@ func TestVT_ReplayReproducesScreen(t *testing.T) {
 			t.Fatalf("write: %v", err)
 		}
 	}
-	ring := src.RingBytes()
+	ring := src.ringBytes()
 	if len(ring) == 0 {
 		t.Fatal("ring empty")
 	}
@@ -739,7 +739,7 @@ func TestVT_RingOverflowPrefersNewlineBoundary(t *testing.T) {
 	if _, err := v.Write(stream.Bytes()); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	got := v.RingBytes()
+	got := v.ringBytes()
 	if len(got) == 0 {
 		t.Fatalf("ring empty")
 	}


### PR DESCRIPTION
## The bug

Pasting >1 KiB of multi-line text into an agent produced **two** `[Pasted text #N]` entries instead of one, splitting at an arbitrary-looking line. It was consistent per session — the same clipboard pasted fine in one session and split every time in another — and it was not a regression from any recent commit.

## Root cause

`RenderSnapshot` opens every reattach repaint with `\x1b[!p` (DECSTR), which clears DEC private modes in the receiving terminal. It restored only alt-screen and cursor visibility. Every other mode the program had enabled was dropped, and the program never re-sends them — it has no idea a new client attached. So any tile that had been reattached or resized across a width change lost those modes **for the life of the session**, which is exactly the per-session consistency observed.

`vt10x` models none of these modes (`grep -c ModeBracket` → `0`), so the VT mirror could not have restored them even in principle.

Bracketed paste (2004) is the one that bit. Without it, xterm writes the paste unframed, the agent falls back to inferring paste boundaries from read sizes, and the macOS PTY input buffer caps a read at 1022 bytes. Measured with a probe against a real PTY:

```
write  912 bytes -> child reads: 912
write 2012 bytes -> child reads: 1022, 990
write 8012 bytes -> child reads: 1022 x7, 858
```

`Write()` returns the full count every time — the chunking happens in the kernel and is invisible to the writer, which is why nothing upstream looked wrong. Confirmed end to end with frontend instrumentation: pre-fix `write len=2199 bracket_start=false bracket_end=false`; post-fix `write len=6101 bracket_start=true bracket_end=true`, holding across repeated grid toggles at cols 34 ↔ 73.

Mouse tracking, mouse encoding, app-cursor keys and focus reporting were lost the same way.

## The fix

- **`internal/session/decmodes.go`** (new) — a streaming scanner for the private-mode form (`\x1b[?<params>h|l`) tracking the modes that must survive a repaint: 2004, 1000/1002/1003, 1005/1006/1015, 1, 1004. Parser state carries across `Write` calls, because a PTY read splits wherever the kernel cuts and these sequences do arrive in two pieces. It ignores SGR, CUP, OSC and mode *queries*.
- **`vt.go`** — `Write` feeds the tracker; `RenderSnapshot` re-asserts the live modes as its **last** bytes, after the DECSTR that clears them. New `ReplayBytes()` = ring + restore, appended after the ring.
- **`session.go`** — `EmitAtomicReplay` uses `ReplayBytes()`. This path matters independently: the ring is capped at 8 MiB, so on a long session the original set sequences have been trimmed off the front, and trusting the ring would make the outcome depend on how much history survived.

Modes 25 and 1049 are deliberately excluded — `RenderSnapshot` already emits those from emulator state, and listing them here would double-emit and fight that logic. Mode 7 is excluded because its DECSTR default is already "on".

## Tests

Eight, covering both ends — Go proves the daemon emits the restore bytes, jsdom proves xterm honours them.

`internal/session/decmodes_test.go`: snapshot restores 2004 (asserting DECSTR *precedes* the restore, since ordering is the whole bug); mouse/cursor/focus restored from a realistic TUI opening; a mode turned back off is not re-asserted; sequence split across writes at all 7 boundaries; `ReplayBytes` ends with the restore; restore survives a ring overflow that trims the original sequence; scanner ignores non-mode sequences.

`test/dom/paste.test.ts`: feeding a snapshot preamble into a real xterm loses framing **without** the restore (the bug, pinned so the mechanism stays visible) and keeps it **with** it.

Verified non-vacuous: stubbing `restoreBytes()` to return `nil` fails all six Go tests.

## Checks

`go build ./...`, `go vet ./...`, `go test ./internal/session ./internal/daemon`, `biome ci`, `tsc`, full vitest — all pass.

Unrelated pre-existing failure, not touched here: `TestTerminalQueriesAreNotWork` in `internal/registry` fails identically on an unmodified tree at `HEAD`. It spawns `zsh -l -i`, so it may be picking up shell-rc output locally.

## Note on scope

This is **not** a regression from #387. That fix only touches the `Ctrl+Shift+V` branch, which `⌘V` never enters (it returns early on `metaKey`), and it was already present in builds where paste worked. The fix here is platform-independent — no per-OS branches — so macOS and Windows are covered by the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved terminal settings when reconnecting sessions or changing layout width.
  - Pasting, mouse tracking, arrow keys, focus reporting, and related terminal behaviors now continue working after reattachment.
  - Large pastes remain grouped correctly instead of being split into multiple paste events.

- **Tests**
  - Added regression coverage for terminal mode restoration across reconnects, resizing, resets, and replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->