### PR TITLE
chore(395): gate-pass bookkeeping + the one test the gate flagged

### DIFF
--- a/cmd/hivegui/frontend/test/dom/sidebar-group-rename.test.tsx
+++ b/cmd/hivegui/frontend/test/dom/sidebar-group-rename.test.tsx
@@ -13,6 +13,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { fireEvent } from '@testing-library/react';
 import { inlineRenameActive } from '../../src/app/inline-rename.js';
+import type { SessionInfo } from '../../src/app/state.js';
 import { appStore } from '../../src/store/store.js';
 import * as store from '../../src/store/store.js';
 import { loadSidebar, mountSidebar, seed, update } from './sidebar-harness.js';
@@ -46,7 +47,11 @@ const BRANCH = 'feat/sidebar';
 const DEFAULT_NAME = 'feat-sidebar';
 
 // Two sessions sharing a worktree — the minimum that paints a group.
-function groupSeed(labels?: Record<string, string>, secondName = DEFAULT_NAME) {
+function groupSeed(
+  labels?: Record<string, string>,
+  secondName = DEFAULT_NAME,
+  extra: Partial<SessionInfo> = {},
+) {
   seed({
     projects: [
       { id: 'p1', name: 'proj', color: '#888', worktree_labels: labels },
@@ -71,6 +76,7 @@ function groupSeed(labels?: Record<string, string>, secondName = DEFAULT_NAME) {
         worktree_path: WT,
         worktree_branch: BRANCH,
         title: 'npm test',
+        ...extra,
       },
     ],
     collapsed: new Set(),
@@ -266,14 +272,40 @@ describe('worktree group rename', () => {
     expect(editor()).not.toBeNull();
   });
 
+  // The guard is an allowlist on `.hv-worktree-group__title`, so every
+  // header control outside that cell must be inert. Asserting the element
+  // exists first is load-bearing: an `if (el)` would turn a renamed
+  // selector into a silently passing test that dblclicks nothing.
   it('does not open from the chevron or the member count', () => {
     groupSeed();
     const chevron = document.querySelector('.hv-worktree-group__chevron');
+    expect(chevron, 'no chevron to click; selector drifted').not.toBeNull();
     if (chevron) fireEvent.dblClick(chevron);
     expect(editor()).toBeNull();
 
     const count = document.querySelector('.hv-worktree-group__count');
+    expect(count, 'no member count to click; selector drifted').not.toBeNull();
     if (count) fireEvent.dblClick(count);
+    expect(editor()).toBeNull();
+  });
+
+  // The third control the spec names, and the one the merge gate flagged
+  // as covered only by the shared structural guard. It renders solely
+  // while the group is COLLAPSED and a member wants attention, so the
+  // fixture has to produce both before the assertion means anything.
+  it('does not open from the collapsed-state attention badge', () => {
+    groupSeed(undefined, DEFAULT_NAME, { needs_attention: true });
+
+    const chevron = document.querySelector('.hv-worktree-group__chevron');
+    expect(chevron, 'no chevron to collapse with').not.toBeNull();
+    if (chevron) fireEvent.click(chevron);
+
+    const alert = document.querySelector('.hv-worktree-group__alert');
+    expect(
+      alert,
+      'no attention badge rendered; fixture did not reach the state under test',
+    ).not.toBeNull();
+    if (alert) fireEvent.dblClick(alert);
     expect(editor()).toBeNull();
   });
 

--- a/docs/exec-plans/completed/395-rename-sessions-from-worktree-group-title.md
+++ b/docs/exec-plans/completed/395-rename-sessions-from-worktree-group-title.md
@@ -4,7 +4,7 @@
 - **Issue:** #395
 - **PR:** #396
 - **Branch:** feature/395-name-a-worktree-group
-- **Status:** active
+- **Status:** completed
 
 ## Summary
 
@@ -302,7 +302,17 @@ Append-only, one line per `/hs-review-loop` iteration.
 - **2026-09-11 iter 5** — verdict: APPROVE; mergeable: MERGEABLE; findings_hash: empty (zero BLOCKING/IMPORTANT); threads_open: 1 (CodeRabbit minor); action: autofix+push; head_sha: 2da35a25.
 - **2026-09-11 iter 5b** — fix applied: deterministic alias tie-break in remapWorktreeLabel; all 5 review threads resolved, CI green on Linux/macOS/Windows; action: stop (converged); head_sha: 0ce1af56.
 
+## Gate verdict
+
+- **2026-09-12** — verdict: PASS; phase: —; checks: 12 passed / 0 failed / 0 followups; followups: none; one-line: all three dimensions pass against the merged squash 795fa4fc; one criterion (attention-badge dblclick suppression) is covered structurally by the `closest('.hv-worktree-group__title')` allowlist rather than by a dedicated assertion, recorded rather than silently passed.
+  - 2026-09-12 dimensions:
+    - acceptance — PASS — every success criterion exercised against the merged range; 12/12 registry + 4/4 daemon + 15/15 sidebar-group-rename + 6/6 e2e (incl. the measured 220px-floor case); `check-daemon-contract.sh` reports 8 -> 9; `ui-lint.sh --strict` clean. Gap noted: the attention badge has no dedicated dblclick test, only the shared structural guard.
+    - non-goals — PASS — no `UpdateSession` on the group path, member names byte-identical, `titleOnly` untouched, branch/directory not renamed, label not derived from member names, nothing outside the sidebar header touched; no scope bleed in the 34-file diff.
+    - doc accuracy — PASS — changeset present (`type: added`, `bump: minor`) and matching shipped behaviour, `CHANGELOG.md` not hand-edited, `components.md` prop signature matches `WorktreeGroupProps`, `DaemonContract` history entry accurate. README/AGENTS.md checked and correctly unchanged (double-click is not a keybinding). `regression_of` not applicable (`type: added`).
+
 ## Progress
+
+- **2026-09-12** — Gate PASS (acceptance / non-goals / doc accuracy). PR #396 was squash-merged as 795fa4fc at 07:13Z before the gate ran, so the gate took its degraded post-merge path; the merged tree was byte-identical to the branch head, so nothing was lost.
 
 - **2026-09-11** — Spec created, triaged M/P2. Research complete (frontend + brain: no prior lessons). Plan drafted; two reviewer rounds, both `revise`.
 - **2026-09-11** — Implemented on feature/395-name-a-worktree-group; PR #396 opened. Go + frontend + tests green (one pre-existing `internal/registry` failure, `TestTerminalQueriesAreNotWork`, confirmed on origin/main).

--- a/docs/product-specs/395-rename-sessions-from-worktree-group-title.md
+++ b/docs/product-specs/395-rename-sessions-from-worktree-group-title.md
@@ -5,7 +5,8 @@ type: enhancement
 complexity: L
 priority: P2
 pr: 396
-stage: GATE
+shipped: 2026-09-12
+stage: DONE
 ---
 
 # Name a worktree group by double-clicking its title
@@ -14,7 +15,7 @@ stage: GATE
 - **Type:** enhancement
 - **Complexity:** L
 - **Priority:** P2
-- **Exec plan:** [docs/exec-plans/active/395-rename-sessions-from-worktree-group-title.md](../exec-plans/active/395-rename-sessions-from-worktree-group-title.md)
+- **Exec plan:** [docs/exec-plans/completed/395-rename-sessions-from-worktree-group-title.md](../exec-plans/completed/395-rename-sessions-from-worktree-group-title.md)
 
 ## Problem
 


### PR DESCRIPTION
Follow-up to #396, which shipped the feature. That PR was squash-merged as `795fa4fc` before `/hs-merge-gate` ran and the branch was deleted with it, so the gate took its documented post-merge path and its bookkeeping had nowhere to ride. This lands it.

## What's here

**Gate bookkeeping** (`67d3ce63`) — the verdict, and the state transition that normally travels inside the feature PR:

- `## Gate verdict` entry on the exec plan: **PASS**, all three dimensions.
- Spec advances to `stage: DONE`, gains `shipped: 2026-09-12` (the real merge date, per the gate's post-merge rule — not today-by-default).
- Exec plan moves to `docs/exec-plans/completed/` and the spec's `Exec plan:` link follows it.

`docs/product-specs/index.md` is deliberately untouched — it's generated, and `regenerate-generated` rebuilds it on merge.

**One test** (`cf13bdcc`) — closing the single gap the gate recorded rather than passing silently.

The spec requires that double-clicking the chevron, the member count, **or the collapsed-state attention badge** does not open the rename editor. The first two had explicit assertions; the third had none. The `closest(".hv-worktree-group__title")` guard is an allowlist, so the badge was protected by construction — but protected-by-construction and asserted are not the same thing, and the gate is the wrong place to find out which one a criterion has.

The badge renders only while the group is collapsed *and* a member wants attention, so the fixture produces both states and fails loudly if it reaches neither — a double-click on a null element is exactly the silent pass this test exists to prevent.

Same reasoning applied to the existing chevron/count case, which used a bare `if (el)`: a drifted selector would have turned it into a test that passes while clicking nothing. It now asserts the elements are present first.

Both cases verified to fail with the guard removed.

## Gate verdict being recorded

| Dimension | Verdict |
|---|---|
| Acceptance criteria | PASS — 12/12 against `795fa4fc~1..795fa4fc` |
| Non-goals | PASS — all 6, no scope bleed across 34 files |
| Doc accuracy | PASS — changeset, `components.md` signature, contract history all match what shipped |

## Verification

```
npm run typecheck && npm run ci   # clean
scripts/test.sh unit dom          # 756 passed
scripts/ui-lint.sh --strict       # clean
```

## No changeset

Docs plus one test; nothing user-visible. The feature's own changeset shipped in #396, and a second entry would announce a release that already happened. Pushed with `--no-verify` per the pre-push hook's own instruction for this case — applying the `no-changeset` label accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to ensure double-clicking the collapsed-state attention badge does not open the rename editor.
  - Strengthened UI assertions so missing group controls or member counts are detected reliably.

- **Documentation**
  - Updated the rename-session documentation to reflect completed status.
  - Recorded successful post-merge validation and linked the specification to the completed execution plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->