### PR TITLE
fix: tolerate a UTF-8 BOM in the JSON files users hand-edit

### DIFF
--- a/.changesets/update-json-bom.md
+++ b/.changesets/update-json-bom.md
@@ -1,0 +1,15 @@
+---
+type: fixed
+bump: patch
+---
+
+The update check survives an `update.json` saved with a UTF-8 byte order mark.
+Windows PowerShell's `Set-Content -Encoding utf8` always writes one — 5.1 has no
+BOM-less UTF-8 at all — and Notepad long did the same, so a settings file
+produced by a setup script or corrected by hand made every update check fail
+with `invalid character '\ufeff' looking for beginning of value`. The update
+button then stayed dead with nothing in the app to explain it or undo it, since
+the only way back was to find and re-encode the file. A BOM is an encoding
+marker rather than content, so it is now stripped before the settings are
+parsed. Settings that are genuinely malformed are still reported instead of
+being silently replaced.

--- a/.changesets/update-json-bom.md
+++ b/.changesets/update-json-bom.md
@@ -3,13 +3,24 @@ type: fixed
 bump: patch
 ---
 
-The update check survives an `update.json` saved with a UTF-8 byte order mark.
+The JSON files Hive expects people to hand-edit survive a UTF-8 byte order mark.
+
 Windows PowerShell's `Set-Content -Encoding utf8` always writes one — 5.1 has no
-BOM-less UTF-8 at all — and Notepad long did the same, so a settings file
-produced by a setup script or corrected by hand made every update check fail
-with `invalid character '\ufeff' looking for beginning of value`. The update
-button then stayed dead with nothing in the app to explain it or undo it, since
-the only way back was to find and re-encode the file. A BOM is an encoding
-marker rather than content, so it is now stripped before the settings are
-parsed. Settings that are genuinely malformed are still reported instead of
-being silently replaced.
+BOM-less UTF-8 at all — and Notepad long did the same, so a file written by a
+setup script or corrected by hand is likely to carry one. `encoding/json` does
+not skip a BOM, so the read failed on the very first byte.
+
+In `update.json` that killed the update check with `invalid character '\ufeff'
+looking for beginning of value`, and the update button then stayed dead with
+nothing in the app to undo it: the only way back was to find the file on disk and
+re-encode it. In `agents.json` it was quieter and worse — a parse failure there
+is answered by disabling every custom agent and logging the reason to the daemon
+log, so custom agents simply disappeared from the launcher with nothing on screen
+to explain it.
+
+Both now drop a leading BOM before parsing. A BOM is an encoding marker rather
+than content, so this does not make either file more forgiving of real mistakes:
+settings that are genuinely malformed are still reported instead of being
+silently replaced, and a file in an encoding Hive cannot read at all — UTF-16,
+which is what PowerShell's `Out-File` and `>` write by default — still fails,
+which is the honest answer for a file that really is unreadable.

--- a/cmd/hivegui/update_prefs.go
+++ b/cmd/hivegui/update_prefs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -59,6 +60,10 @@ func loadUpdateSettings() (UpdateSettings, error) {
 		return UpdateSettings{Channel: ChannelRelease}, fmt.Errorf("read update.json: %w", err)
 	}
 	var s UpdateSettings
+	// PowerShell and Notepad write UTF-8 with a BOM, and encoding/json will
+	// not skip one. It is an encoding marker rather than content, so drop it
+	// instead of failing the load and leaving the user no way back.
+	b = bytes.TrimPrefix(b, []byte("\ufeff"))
 	if err := json.Unmarshal(b, &s); err != nil {
 		return UpdateSettings{Channel: ChannelRelease}, fmt.Errorf("parse %s: %w", updateSettingsPath(), err)
 	}

--- a/cmd/hivegui/update_prefs.go
+++ b/cmd/hivegui/update_prefs.go
@@ -59,11 +59,12 @@ func loadUpdateSettings() (UpdateSettings, error) {
 		}
 		return UpdateSettings{Channel: ChannelRelease}, fmt.Errorf("read update.json: %w", err)
 	}
-	var s UpdateSettings
 	// PowerShell and Notepad write UTF-8 with a BOM, and encoding/json will
 	// not skip one. It is an encoding marker rather than content, so drop it
 	// instead of failing the load and leaving the user no way back.
 	b = bytes.TrimPrefix(b, []byte("\ufeff"))
+
+	var s UpdateSettings
 	if err := json.Unmarshal(b, &s); err != nil {
 		return UpdateSettings{Channel: ChannelRelease}, fmt.Errorf("parse %s: %w", updateSettingsPath(), err)
 	}

--- a/cmd/hivegui/update_prefs_test.go
+++ b/cmd/hivegui/update_prefs_test.go
@@ -73,6 +73,15 @@ func TestUpdateSettingsCorruptFileIsError(t *testing.T) {
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("update.json was removed after a failed load: %v", err)
 	}
+
+	// A BOM in front of the same rubbish must not make it loadable. The
+	// trim removes an encoding marker; it does not excuse bad JSON, and
+	// this is the invariant a future "be more tolerant" change would
+	// erode first.
+	writeFile(t, path, "\ufeff{not json")
+	if _, err := loadUpdateSettings(); err == nil {
+		t.Fatal("loadUpdateSettings = nil error on BOM + corrupt JSON, want it surfaced")
+	}
 }
 
 // Windows PowerShell's `Set-Content -Encoding utf8` writes UTF-8 *with* a
@@ -84,8 +93,11 @@ func TestUpdateSettingsCorruptFileIsError(t *testing.T) {
 // marker, not content, so strip it rather than report it as corruption.
 func TestUpdateSettingsToleratesUTF8BOM(t *testing.T) {
 	dir := isolateStateDir(t)
-	// What PowerShell 5.1's ConvertTo-Json | Set-Content -Encoding utf8
-	// leaves on disk: a BOM, then its own 4-space indent.
+	// Shaped like what PowerShell 5.1's ConvertTo-Json | Set-Content
+	// -Encoding utf8 leaves on disk: a BOM, then its own 4-space indent
+	// and double space after the colon. Its line endings are CRLF; Go raw
+	// strings drop CR and JSON is indifferent either way, so the BOM is
+	// the part actually under test.
 	writeFile(t, filepath.Join(dir, "update.json"), "\ufeff"+`{
     "channel":  "latest",
     "source_repo":  "D:\\git\\hive"

--- a/cmd/hivegui/update_prefs_test.go
+++ b/cmd/hivegui/update_prefs_test.go
@@ -75,6 +75,35 @@ func TestUpdateSettingsCorruptFileIsError(t *testing.T) {
 	}
 }
 
+// Windows PowerShell's `Set-Content -Encoding utf8` writes UTF-8 *with* a
+// BOM (5.1 has no BOM-less utf8 at all), and Notepad long did the same, so
+// an update.json written by a setup script or fixed up by hand arrives with
+// one. encoding/json does not skip a BOM, so the load failed with an
+// "invalid character looking for beginning of value" error that left the
+// update button dead with no in-app way to recover. A BOM is an encoding
+// marker, not content, so strip it rather than report it as corruption.
+func TestUpdateSettingsToleratesUTF8BOM(t *testing.T) {
+	dir := isolateStateDir(t)
+	// What PowerShell 5.1's ConvertTo-Json | Set-Content -Encoding utf8
+	// leaves on disk: a BOM, then its own 4-space indent.
+	writeFile(t, filepath.Join(dir, "update.json"), "\ufeff"+`{
+    "channel":  "latest",
+    "source_repo":  "D:\\git\\hive"
+}
+`)
+
+	got, err := loadUpdateSettings()
+	if err != nil {
+		t.Fatalf("loadUpdateSettings on a BOM-prefixed update.json: %v", err)
+	}
+	if got.Channel != ChannelLatest {
+		t.Errorf("Channel = %q, want %q", got.Channel, ChannelLatest)
+	}
+	if want := `D:\git\hive`; got.SourceRepo != want {
+		t.Errorf("SourceRepo = %q, want %q", got.SourceRepo, want)
+	}
+}
+
 func TestSaveUpdateSettingsRefusesLatestWithoutSourceRepo(t *testing.T) {
 	isolateStateDir(t)
 	// Point auto-detect somewhere with no checkout above it.

--- a/internal/agent/custom.go
+++ b/internal/agent/custom.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -100,7 +101,7 @@ func customDefs() []Def {
 		return nil
 	}
 	var list []Custom
-	if err := json.Unmarshal(raw, &list); err != nil {
+	if err := json.Unmarshal(trimBOM(raw), &list); err != nil {
 		log.Printf("agent: parse %s: %v (custom agents disabled)", path, err)
 		return nil
 	}
@@ -235,7 +236,7 @@ func LoadCustom() ([]Custom, error) {
 		return nil, fmt.Errorf("read %s: %w", CustomFileName, err)
 	}
 	var list []Custom
-	if err := json.Unmarshal(raw, &list); err != nil {
+	if err := json.Unmarshal(trimBOM(raw), &list); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", CustomFileName, err)
 	}
 	return list, nil
@@ -340,4 +341,20 @@ func slugify(name string) string {
 		}
 	}
 	return strings.Trim(b.String(), "-")
+}
+
+// trimBOM drops a leading UTF-8 byte order mark.
+//
+// agents.json is meant to be hand-edited, and the editors people reach
+// for on Windows add one: PowerShell's `Set-Content -Encoding utf8`
+// always does (5.1 has no BOM-less utf8), and Notepad long did too.
+// encoding/json will not skip it, so the file failed to parse - which
+// customDefs answers by disabling every custom agent, logging the
+// reason only to the daemon log.
+//
+// A BOM is an encoding marker rather than content, so dropping it is not
+// the same as tolerating a malformed file: it removes at most three
+// bytes from the head and cannot turn bad JSON into good.
+func trimBOM(b []byte) []byte {
+	return bytes.TrimPrefix(b, []byte("\ufeff"))
 }

--- a/internal/agent/custom_test.go
+++ b/internal/agent/custom_test.go
@@ -482,3 +482,48 @@ func TestLoadCustomMissingFileIsNotAnError(t *testing.T) {
 		t.Errorf("LoadCustom = %v, want no entries", got)
 	}
 }
+
+// PowerShell's `Set-Content -Encoding utf8` writes a UTF-8 BOM (5.1 has
+// no BOM-less utf8 at all) and Notepad long did the same, and agents.json
+// is a file users are invited to hand-edit. encoding/json will not skip a
+// BOM, and customDefs answers a parse failure by logging to the daemon log
+// and returning nil - so a BOM made every custom agent vanish from the
+// launcher with nothing on screen to say why.
+func TestCustomAgentToleratesUTF8BOM(t *testing.T) {
+	writeCustom(t, "\ufeff"+`[
+	  {"id": "bom-agent", "name": "BOM Agent", "cmd": ["claude"]}
+	]`)
+
+	if _, ok := Get("bom-agent"); !ok {
+		t.Error("Get(bom-agent) = not found; a BOM disabled every custom agent")
+	}
+}
+
+// LoadCustom feeds the Settings modal. A BOM there surfaced as a parse
+// error over a list the user had just edited by hand.
+func TestLoadCustomToleratesUTF8BOM(t *testing.T) {
+	writeCustom(t, "\ufeff"+`[
+	  {"id": "bom-agent", "name": "BOM Agent", "cmd": ["claude"]}
+	]`)
+
+	list, err := LoadCustom()
+	if err != nil {
+		t.Fatalf("LoadCustom on a BOM-prefixed %s: %v", CustomFileName, err)
+	}
+	if len(list) != 1 || list[0].ID != "bom-agent" {
+		t.Errorf("LoadCustom = %+v, want the single bom-agent entry", list)
+	}
+}
+
+// A BOM is an encoding marker, not content: stripping it must not make
+// genuinely malformed JSON look loadable.
+func TestCustomAgentBOMDoesNotExcuseMalformedJSON(t *testing.T) {
+	writeCustom(t, "\ufeff"+`[{"id": "broken",,,}`)
+
+	if len(All()) != len(displayOrder) {
+		t.Errorf("All() = %d agents, want just the %d built-ins", len(All()), len(displayOrder))
+	}
+	if _, err := LoadCustom(); err == nil {
+		t.Error("LoadCustom = nil error on BOM + malformed JSON, want it surfaced")
+	}
+}


### PR DESCRIPTION
## The bug

An `update.json` saved with a UTF-8 BOM kills the update check:

```
Update check failed: Error: parse C:\Users\quint\AppData\Local\Hive\update.json:
invalid character '\ufeff' looking for beginning of value
```

The button then stays dead. Nothing in the app explains it or offers a way back,
because the only fix is to find the file on disk and re-encode it.

## How the BOM gets there

Windows PowerShell's `Set-Content -Encoding utf8` writes UTF-8 **with** a BOM —
5.1 has no BOM-less UTF-8 at all, and `utf8NoBOM` only arrived in PowerShell 7.
Notepad wrote one by default for years too. So any `update.json` produced by a
setup script or corrected by hand is likely to carry one:

```powershell
# both of these produce EF BB BF on 5.1
@{ channel = 'latest' } | ConvertTo-Json | Set-Content -Path $p -Encoding utf8
```

`encoding/json` does not skip a BOM, so `loadUpdateSettings` fails on byte one.

## The fix

Strip the BOM before unmarshalling.

A BOM is an encoding marker, not content, so dropping it is not the same as
papering over a corrupt file. The deliberate behaviour in `loadUpdateSettings` —
a file that exists but will not parse is an error, never a silent default — is
untouched: settings that genuinely will not parse are still surfaced, and the
file is still left on disk for the user to fix by hand.

## Tests

`TestUpdateSettingsToleratesUTF8BOM` writes the fixture byte-for-byte as
PowerShell 5.1 leaves it — BOM, then its own 4-space indent — and asserts both
fields survive the load. Before the fix it fails with the exact error above.

`TestUpdateSettingsCorruptFileIsError` still passes, which is the half that
matters: a BOM is tolerated, `{not json` is not.

Full `cmd/hivegui` suite passes apart from `TestPackageIsIsolatedFromRealHiveState`,
which fails identically on a clean `main` on this machine (`%TEMP%` on Windows
lives under the user's home, which the isolation assert rejects).

---

## Update after review

Extended to `agents.json`, which has the identical exposure and a worse failure
mode: `customDefs` answers a parse error by logging to the daemon log and
returning `nil`, so a BOM made every custom agent vanish from the launcher with
nothing on screen to explain it. That file is the precedent `update_prefs.go`
already cites — its comment names "how agents.json corruption used to eat custom
agents" as the reason it refuses to silently default — so fixing one and leaving
the other broken made no sense.

Added the negative case on both sides: a BOM in front of malformed JSON must
still be an error. That is the invariant a later "let's be more tolerant" change
would erode first, and nothing pinned it before.

UTF-16 is deliberately still an error. PowerShell's `Out-File` and `>` default to
UTF-16LE, so it is arguably the more reachable footgun, but transcoding would
mean a guessy heuristic over a file that genuinely is unreadable — which is
exactly the "exists but will not parse" case this code is designed to report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Update settings and custom-agent files saved with a UTF-8 byte order mark now load successfully.
  - Malformed JSON continues to report errors or fall back to built-in agents as appropriate.
  - Files using unsupported encodings, such as UTF-16, continue to fail rather than being silently accepted.

- **Tests**
  - Added coverage for BOM-prefixed settings and custom-agent files, including files created by common Windows tools.
  - Added checks confirming malformed JSON remains an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->